### PR TITLE
ci(worker): 통합 워커 버전 자동 증가 (run_number 기반)

### DIFF
--- a/.github/workflows/build-marketing-worker.yml
+++ b/.github/workflows/build-marketing-worker.yml
@@ -38,6 +38,17 @@ jobs:
         run: npm ci
         working-directory: dental-clinic-manager/marketing-worker
 
+      - name: Auto-bump worker version
+        shell: bash
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          # MAJOR.MINOR은 package.json에서 유지, PATCH는 GitHub Actions run_number로 자동 증가
+          MAJOR_MINOR=$(node -p "require('./package.json').version.split('.').slice(0,2).join('.')")
+          NEW_VERSION="${MAJOR_MINOR}.${RUN_NUMBER}"
+          npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version
+          echo "Bumped worker version to $NEW_VERSION"
+
       - name: Build TypeScript + Scheduler Bundle
         run: npm run build
 


### PR DESCRIPTION
## Summary
- `build-marketing-worker` 워크플로우에 Auto-bump 스텝 추가
- `package.json`의 MAJOR.MINOR 유지, PATCH는 `github.run_number`로 자동 갱신
- 워커 코드 수정 후 푸시 시마다 유니크한 릴리스 태그 생성 → electron-updater가 새 버전 감지해 사용자 앱 자동 업데이트

## Test plan
- [ ] Actions 탭에서 `Build Marketing Worker Installer` 워크플로우 실행 확인
- [ ] 로그에 `Bumped worker version to 1.1.{run_number}` 출력 확인
- [ ] Releases에 새 `worker-v1.1.{run_number}` 태그 및 `latest.yml` 생성 확인
- [ ] 설치된 워커 앱에서 "업데이트 확인" → 새 버전 감지/다운로드 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)