### PR TITLE
fix: 비밀번호 재설정 서버사이드 API + 워커 상태 확장

### DIFF
--- a/dental-clinic-manager/src/app/api/auth/reset-password/route.ts
+++ b/dental-clinic-manager/src/app/api/auth/reset-password/route.ts
@@ -1,0 +1,85 @@
+import { createClient } from '@/lib/supabase/server'
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { rateLimit, getClientIp } from '@/lib/utils/rateLimit'
+
+/**
+ * 비밀번호 재설정 이메일 발송 API (서버사이드)
+ *
+ * 서버사이드에서 VERCEL_URL을 사용하여 redirectTo를 설정.
+ * VERCEL_URL은 *.vercel.app 도메인이므로 PWA scope(hi-clinic.co.kr) 밖이라
+ * 이메일 링크 클릭 시 PWA가 가로채지 않고 브라우저에서 열림.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const clientIp = getClientIp(request)
+    const rateLimitResult = rateLimit(`reset-password:${clientIp}`, { windowMs: 15 * 60 * 1000, max: 5 })
+    if (!rateLimitResult.success) {
+      return NextResponse.json(
+        { error: '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.' },
+        { status: 429 }
+      )
+    }
+
+    const { email } = await request.json()
+
+    if (!email) {
+      return NextResponse.json({ error: '이메일을 입력해주세요.' }, { status: 400 })
+    }
+
+    const supabase = await createClient()
+
+    // 이메일 존재 여부 확인
+    const { data: userExists } = await supabase
+      .from('users')
+      .select('id')
+      .eq('email', email.toLowerCase().trim())
+      .maybeSingle()
+
+    if (!userExists) {
+      return NextResponse.json(
+        { error: '입력하신 이메일 주소로 가입된 계정이 없습니다. 이메일 주소를 다시 확인해주세요.' },
+        { status: 404 }
+      )
+    }
+
+    // redirectTo를 VERCEL_URL (*.vercel.app)로 설정하여 PWA scope 밖으로
+    // PWA는 hi-clinic.co.kr에 설치되므로 *.vercel.app 링크는 브라우저에서 열림
+    const getRedirectUrl = () => {
+      // VERCEL_URL: Vercel이 서버사이드에서 자동 주입 (*.vercel.app)
+      if (process.env.VERCEL_URL) {
+        return `https://${process.env.VERCEL_URL}/api/auth/reset-callback?intent=recovery`
+      }
+      // NEXT_PUBLIC_VERCEL_URL 도 확인 (빌드 시 주입)
+      if (process.env.NEXT_PUBLIC_VERCEL_URL) {
+        return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}/api/auth/reset-callback?intent=recovery`
+      }
+      // fallback: SITE_URL 사용
+      if (process.env.NEXT_PUBLIC_SITE_URL) {
+        return `${process.env.NEXT_PUBLIC_SITE_URL}/api/auth/reset-callback?intent=recovery`
+      }
+      // 개발 환경
+      const host = request.headers.get('host') || 'localhost:3000'
+      const protocol = host.includes('localhost') ? 'http' : 'https'
+      return `${protocol}://${host}/api/auth/reset-callback?intent=recovery`
+    }
+
+    const redirectUrl = getRedirectUrl()
+    console.log('[ResetPassword] Redirect URL:', redirectUrl)
+
+    const { error: resetError } = await supabase.auth.resetPasswordForEmail(
+      email.toLowerCase().trim(),
+      { redirectTo: redirectUrl }
+    )
+
+    if (resetError) {
+      console.error('[ResetPassword] 재설정 오류:', resetError)
+      return NextResponse.json({ error: '이메일 전송에 실패했습니다.' }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error('[ResetPassword] 처리 오류:', err)
+    return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 })
+  }
+}

--- a/dental-clinic-manager/src/app/api/workers/status/route.ts
+++ b/dental-clinic-manager/src/app/api/workers/status/route.ts
@@ -32,8 +32,8 @@ async function getLatestWorkerVersion(): Promise<string | null> {
   return cachedLatestVersion;
 }
 
-// GET: 워커 상태 조회 (마케팅 워커, 스크래핑 워커)
-// ?type=marketing | scraping | all (기본값: all)
+// GET: 워커 상태 조회 (마케팅, 스크래핑, SEO, 이메일)
+// ?type=marketing | scraping | seo | email | all (기본값: all)
 export async function GET(request: NextRequest) {
   try {
     // 인증 확인 (일반 사용자도 조회 가능)
@@ -55,6 +55,8 @@ export async function GET(request: NextRequest) {
         updateAvailable: boolean;
       };
       scraping?: { installed: boolean; online: boolean; workerCount: number };
+      seo?: { installed: boolean; online: boolean; workerCount: number };
+      email?: { installed: boolean; online: boolean };
     } = {};
 
     // 마케팅 워커 상태 (DB 기반 - Electron 워커가 heartbeat 업데이트)
@@ -110,6 +112,57 @@ export async function GET(request: NextRequest) {
         }
       }
       result.scraping = { installed, online, workerCount };
+    }
+
+    // SEO 워커 상태 (seo_workers 테이블 heartbeat 기반)
+    if (type === 'seo' || type === 'all') {
+      let installed = false;
+      let online = false;
+      let workerCount = 0;
+      const admin = getSupabaseAdmin();
+      if (admin) {
+        const { data: workers } = await admin
+          .from('seo_workers')
+          .select('status, last_heartbeat')
+          .order('last_heartbeat', { ascending: false });
+
+        if (workers && workers.length > 0) {
+          installed = true;
+          const onlineWorkers = workers.filter((w) => {
+            if (w.status === 'offline') return false;
+            const lastBeat = new Date(w.last_heartbeat);
+            return Date.now() - lastBeat.getTime() < 2 * 60 * 1000;
+          });
+          workerCount = onlineWorkers.length;
+          online = workerCount > 0;
+        }
+      }
+      result.seo = { installed, online, workerCount };
+    }
+
+    // 이메일 모니터 상태 (마케팅 워커의 서브 모듈 — 별도 heartbeat 없이 마케팅 워커 상태로 판단)
+    if (type === 'email' || type === 'all') {
+      // 마케팅 워커가 온라인이면 이메일 모니터도 동작 중으로 판단
+      let marketingOnline = result.marketing?.online ?? false;
+      let marketingInstalled = result.marketing?.installed ?? false;
+      // 마케팅 상태를 아직 조회하지 않은 경우 (type=email 단독 호출)
+      if (!result.marketing) {
+        const admin = getSupabaseAdmin();
+        if (admin) {
+          const { data: controlData } = await admin
+            .from('marketing_worker_control')
+            .select('watchdog_online, last_updated')
+            .eq('id', 'main')
+            .single();
+          if (controlData) {
+            marketingInstalled = true;
+            const lastUpdated = controlData.last_updated ? new Date(controlData.last_updated) : null;
+            const isRecent = lastUpdated && (Date.now() - lastUpdated.getTime() < 60_000);
+            marketingOnline = !!(controlData.watchdog_online && isRecent);
+          }
+        }
+      }
+      result.email = { installed: marketingInstalled, online: marketingOnline };
     }
 
     return NextResponse.json(result);

--- a/dental-clinic-manager/src/components/Auth/ForgotPasswordForm.tsx
+++ b/dental-clinic-manager/src/components/Auth/ForgotPasswordForm.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import { createClient } from '@/lib/supabase/client'
 
 interface ForgotPasswordFormProps {
   onBackToLogin: () => void
@@ -19,67 +18,20 @@ export default function ForgotPasswordForm({ onBackToLogin }: ForgotPasswordForm
     setMessage('')
     setLoading(true)
 
-    const supabase = createClient()
-
     try {
-      console.log('[ForgotPassword] 비밀번호 재설정 요청:', email);
-
-      // 이메일 존재 여부 확인
-      const checkRes = await fetch('/api/auth/check-email', {
+      // 서버사이드 API로 비밀번호 재설정 이메일 발송
+      // 서버에서 VERCEL_URL(*.vercel.app)을 redirectTo로 사용하여
+      // PWA scope(hi-clinic.co.kr) 밖으로 설정 → 브라우저에서 열림
+      const res = await fetch('/api/auth/reset-password', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: email.trim() }),
       })
-      const checkData = await checkRes.json()
+      const data = await res.json()
 
-      if (!checkRes.ok) {
-        setError(checkData.error || '이메일 확인 중 오류가 발생했습니다.')
-        setLoading(false)
-        return
-      }
-
-      if (!checkData.exists) {
-        setError('입력하신 이메일 주소로 가입된 계정이 없습니다. 이메일 주소를 다시 확인해주세요.')
-        setLoading(false)
-        return
-      }
-
-      // 환경에 따라 동적으로 Redirect URL 결정
-      // /api/auth/reset-callback API 라우트로 리다이렉트
-      // API 라우트는 서버사이드에서 실행되므로 PWA가 가로채도 정상 작동
-      const getRedirectUrl = () => {
-        // Vercel 배포 환경 (preview/production)
-        if (process.env.NEXT_PUBLIC_VERCEL_URL) {
-          return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}/api/auth/reset-callback?intent=recovery`;
-        }
-
-        // 프로덕션 환경 (명시적 Site URL 설정)
-        if (process.env.NEXT_PUBLIC_SITE_URL) {
-          return `${process.env.NEXT_PUBLIC_SITE_URL}/api/auth/reset-callback?intent=recovery`;
-        }
-
-        // 개발 환경 (localhost) - 현재 접속한 도메인 사용
-        return `${window.location.origin}/api/auth/reset-callback?intent=recovery`;
-      };
-
-      const redirectUrl = getRedirectUrl();
-      console.log('[ForgotPassword] Redirect URL:', redirectUrl);
-
-      const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: redirectUrl,
-      })
-
-      if (resetError) {
-        console.error('[ForgotPassword] 재설정 오류:', resetError)
-
-        // SMTP 설정이 안 되어 있는 경우
-        if (resetError.message.includes('SMTP') || resetError.message.includes('email')) {
-          setError('이메일 서비스가 설정되지 않았습니다. 관리자에게 문의해주세요.')
-        } else {
-          setError(`이메일 전송에 실패했습니다: ${resetError.message}`)
-        }
+      if (!res.ok) {
+        setError(data.error || '비밀번호 재설정 요청 중 오류가 발생했습니다.')
       } else {
-        console.log('[ForgotPassword] 재설정 이메일 전송 성공');
         setMessage('비밀번호 재설정 요청이 처리되었습니다. 이메일을 확인해주세요. (링크는 24시간 동안 유효합니다)')
       }
     } catch (err) {

--- a/dental-clinic-manager/src/components/Layout/WorkerStatusMenuItem.tsx
+++ b/dental-clinic-manager/src/components/Layout/WorkerStatusMenuItem.tsx
@@ -17,6 +17,15 @@ interface WorkerStatusResponse {
     online: boolean
     workerCount: number
   }
+  seo?: {
+    installed: boolean
+    online: boolean
+    workerCount: number
+  }
+  email?: {
+    installed: boolean
+    online: boolean
+  }
 }
 
 type Status = 'online' | 'offline' | 'not-installed' | 'loading'
@@ -41,19 +50,53 @@ function resolveStatus(installed: boolean | undefined, online: boolean | undefin
   return online ? 'online' : 'offline'
 }
 
+/** 워커 항목 정의 (표시 순서) */
+interface WorkerDef {
+  key: 'marketing' | 'scraping' | 'seo' | 'email'
+  label: string
+  /** 이 워커가 필요한 프리미엄 기능 ID */
+  premiumId: string
+  /** 온라인 시 부가 정보 (예: workerCount) */
+  getExtra?: (status: WorkerStatusResponse) => string
+}
+
+const WORKER_DEFS: WorkerDef[] = [
+  {
+    key: 'marketing',
+    label: '마케팅 (발행)',
+    premiumId: 'marketing',
+  },
+  {
+    key: 'seo',
+    label: 'SEO 분석',
+    premiumId: 'marketing',
+    getExtra: (s) => s.seo?.online && s.seo.workerCount ? ` (${s.seo.workerCount})` : '',
+  },
+  {
+    key: 'email',
+    label: '이메일 모니터',
+    premiumId: 'financial',
+  },
+  {
+    key: 'scraping',
+    label: '홈택스 스크래핑',
+    premiumId: 'financial',
+    getExtra: (s) => s.scraping?.online && s.scraping.workerCount ? ` (${s.scraping.workerCount})` : '',
+  },
+]
+
 /**
  * 좌측 메뉴 하단에 워커 상태를 표시하는 아이템
  *
  * - 통합 워커가 필요한 프리미엄 기능(`financial`, `marketing`)이 활성화된 사용자에게만 표시
  * - 30초마다 자동 갱신, 수동 새로고침 가능
- * - 클릭 시 상세(마케팅/스크래핑 각각) 토글
- * - 상태: 온라인(녹색) / 오프라인(주황) / 미설치(빨강) / 확인 중(회색)
+ * - 클릭 시 4개 워커 각각의 상태 토글
  */
 export default function WorkerStatusMenuItem() {
   const { hasPremiumFeature, isLoading: premiumLoading } = usePremiumFeatures()
   const needsMarketing = hasPremiumFeature('marketing')
-  const needsScraping = hasPremiumFeature('financial')
-  const needsAny = needsMarketing || needsScraping
+  const needsFinancial = hasPremiumFeature('financial')
+  const needsAny = needsMarketing || needsFinancial
 
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
@@ -85,20 +128,27 @@ export default function WorkerStatusMenuItem() {
     return () => clearInterval(interval)
   }, [needsAny, fetchStatus])
 
-  // 프리미엄 로딩 중이거나, 워커가 필요한 기능이 없으면 표시하지 않음
+  // 프리미엄 로딩 중이거나 워커가 필요한 기능이 없으면 미노출
   if (premiumLoading || !needsAny) return null
 
-  const marketingStatus = resolveStatus(status.marketing?.installed, status.marketing?.online, loading)
-  const scrapingStatus = resolveStatus(status.scraping?.installed, status.scraping?.online, loading)
+  // 활성화된 프리미엄에 해당하는 워커만 필터
+  const activeWorkers = WORKER_DEFS.filter((w) => hasPremiumFeature(w.premiumId))
 
-  // 통합 상태: 필요한 워커 중 하나라도 문제 있으면 전체 문제로 표기
+  // 개별 상태 계산
+  const workerStatuses = activeWorkers.map((w) => {
+    const s = status[w.key]
+    return {
+      ...w,
+      status: resolveStatus(s?.installed, s?.online, loading),
+    }
+  })
+
+  // 통합 상태
   const overallStatus: Status = (() => {
-    const relevant: Status[] = []
-    if (needsMarketing) relevant.push(marketingStatus)
-    if (needsScraping) relevant.push(scrapingStatus)
-    if (relevant.length === 0 || relevant.includes('loading')) return 'loading'
-    if (relevant.every((s) => s === 'online')) return 'online'
-    if (relevant.some((s) => s === 'not-installed')) return 'not-installed'
+    const statuses = workerStatuses.map((w) => w.status)
+    if (statuses.length === 0 || statuses.includes('loading')) return 'loading'
+    if (statuses.every((s) => s === 'online')) return 'online'
+    if (statuses.some((s) => s === 'not-installed')) return 'not-installed'
     return 'offline'
   })()
 
@@ -153,29 +203,18 @@ export default function WorkerStatusMenuItem() {
 
       {expanded && (
         <div className="ml-3 mr-1 mt-1 mb-2 space-y-1.5 px-3 py-2 rounded-lg bg-slate-50 border border-slate-100">
-          {needsMarketing && (
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-slate-600">마케팅 워커</span>
+          {workerStatuses.map((w) => (
+            <div key={w.key} className="flex items-center justify-between text-xs">
+              <span className="text-slate-600">{w.label}</span>
               <div className="flex items-center space-x-1.5">
-                <span className={`w-2 h-2 rounded-full ${STATUS_COLOR[marketingStatus]}`} />
-                <span className="text-slate-500">{STATUS_LABEL[marketingStatus]}</span>
-              </div>
-            </div>
-          )}
-          {needsScraping && (
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-slate-600">스크래핑 워커</span>
-              <div className="flex items-center space-x-1.5">
-                <span className={`w-2 h-2 rounded-full ${STATUS_COLOR[scrapingStatus]}`} />
+                <span className={`w-2 h-2 rounded-full ${STATUS_COLOR[w.status]}`} />
                 <span className="text-slate-500">
-                  {STATUS_LABEL[scrapingStatus]}
-                  {scrapingStatus === 'online' && status.scraping?.workerCount
-                    ? ` (${status.scraping.workerCount})`
-                    : ''}
+                  {STATUS_LABEL[w.status]}
+                  {w.status === 'online' && w.getExtra ? w.getExtra(status) : ''}
                 </span>
               </div>
             </div>
-          )}
+          ))}
           {overallStatus !== 'online' && overallStatus !== 'loading' && (
             <div className="pt-1 mt-1 border-t border-slate-200 text-[11px] text-slate-400 leading-snug">
               워커에 문제가 있습니다. 관리자에게 설치/실행을 요청하세요.

--- a/dental-clinic-manager/src/components/SEO/KeywordAnalysis.tsx
+++ b/dental-clinic-manager/src/components/SEO/KeywordAnalysis.tsx
@@ -142,7 +142,7 @@ export default function KeywordAnalysis() {
       alert('마케팅 자동화 프리미엄 기능이 활성화되어 있지 않습니다.')
       return
     }
-    if (!await requireWorker('marketing', 'SEO 키워드 분석')) return
+    if (!await requireWorker('seo', 'SEO 키워드 분석')) return
 
     setLoading(true)
     try {

--- a/dental-clinic-manager/src/hooks/useWorkerGuard.ts
+++ b/dental-clinic-manager/src/hooks/useWorkerGuard.ts
@@ -3,7 +3,7 @@
 import { useCallback } from 'react'
 import { appAlert } from '@/components/ui/AppDialog'
 
-type WorkerType = 'marketing' | 'scraping'
+type WorkerType = 'marketing' | 'scraping' | 'seo'
 
 interface WorkerGuardOptions {
   /** 워커 타입 */
@@ -25,6 +25,10 @@ const WORKER_LABELS: Record<WorkerType, { name: string; defaultFeature: string }
   scraping: {
     name: '스크래핑 워커',
     defaultFeature: '데이터 연동',
+  },
+  seo: {
+    name: 'SEO 분석 워커',
+    defaultFeature: 'SEO 키워드 분석',
   },
 }
 
@@ -49,6 +53,12 @@ async function checkWorkerState(type: WorkerType): Promise<WorkerState> {
       return {
         installed: data.scraping?.installed ?? false,
         online: data.scraping?.online ?? false,
+      }
+    }
+    if (type === 'seo') {
+      return {
+        installed: data.seo?.installed ?? false,
+        online: data.seo?.online ?? false,
       }
     }
     return { installed: false, online: false }

--- a/dental-clinic-manager/src/hooks/useWorkerStatus.ts
+++ b/dental-clinic-manager/src/hooks/useWorkerStatus.ts
@@ -2,11 +2,12 @@
 
 import { useState, useCallback, useEffect } from 'react'
 
-type WorkerType = 'marketing' | 'scraping'
+type WorkerType = 'marketing' | 'scraping' | 'seo'
 
 interface WorkerStatusResult {
   marketing?: { online: boolean }
   scraping?: { online: boolean; workerCount: number }
+  seo?: { online: boolean; workerCount: number }
 }
 
 /**
@@ -76,6 +77,11 @@ export function useWorkerStatus(options?: {
       
       if (type === 'scraping') {
         isDbOnline = data.scraping?.online ?? false
+        return isDbOnline
+      }
+
+      if (type === 'seo') {
+        isDbOnline = data.seo?.online ?? false
         return isDbOnline
       }
 


### PR DESCRIPTION
## Summary
- 비밀번호 재설정을 서버사이드 API로 이동하여 VERCEL_URL(*.vercel.app) 사용 → PWA scope 밖에서 브라우저로 열림
- 워커 상태 4종(마케팅/스크래핑/SEO/이메일) 표시로 확장

## Test plan
- [x] /api/auth/reset-password API 정상 작동 확인 (미가입 이메일 → 에러, 가입 이메일 → 성공)
- [ ] 배포 후 PWA 환경에서 비밀번호 재설정 이메일 링크 E2E 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)