### PR TITLE
feat: 통합 워커 다운로드 버튼에 버전/업데이트 날짜 표시

### DIFF
--- a/dental-clinic-manager/src/app/api/workers/status/route.ts
+++ b/dental-clinic-manager/src/app/api/workers/status/route.ts
@@ -4,12 +4,13 @@ import { getSupabaseAdmin } from '@/lib/supabase/admin';
 
 // GitHub 최신 워커 릴리즈 버전 캐시 (5분 TTL)
 let cachedLatestVersion: string | null = null;
+let cachedReleaseDate: string | null = null;
 let cacheTimestamp = 0;
 const CACHE_TTL = 5 * 60 * 1000;
 
-async function getLatestWorkerVersion(): Promise<string | null> {
+async function getLatestWorkerInfo(): Promise<{ version: string | null; releaseDate: string | null }> {
   if (cachedLatestVersion && Date.now() - cacheTimestamp < CACHE_TTL) {
-    return cachedLatestVersion;
+    return { version: cachedLatestVersion, releaseDate: cachedReleaseDate };
   }
   try {
     const res = await fetch('https://api.github.com/repos/huisu-hwang/dental-clinic-manager/releases', {
@@ -17,19 +18,20 @@ async function getLatestWorkerVersion(): Promise<string | null> {
       signal: AbortSignal.timeout(5000),
       next: { revalidate: 300 },
     });
-    if (!res.ok) return cachedLatestVersion;
+    if (!res.ok) return { version: cachedLatestVersion, releaseDate: cachedReleaseDate };
     const releases = await res.json();
     const workerRelease = releases.find((r: { tag_name?: string }) =>
       r.tag_name?.startsWith('worker-v')
     );
     if (workerRelease?.tag_name) {
       cachedLatestVersion = workerRelease.tag_name.replace('worker-v', '');
+      cachedReleaseDate = workerRelease.published_at || null;
       cacheTimestamp = Date.now();
     }
   } catch {
     // GitHub API 실패 시 캐시된 값 반환
   }
-  return cachedLatestVersion;
+  return { version: cachedLatestVersion, releaseDate: cachedReleaseDate };
 }
 
 // GET: 워커 상태 조회 (마케팅, 스크래핑, SEO, 이메일)
@@ -54,6 +56,7 @@ export async function GET(request: NextRequest) {
         latestVersion: string | null;
         updateAvailable: boolean;
         updateStatus: string | null;
+        latestReleaseDate: string | null;
       };
       scraping?: { installed: boolean; online: boolean; workerCount: number };
       seo?: { installed: boolean; online: boolean; workerCount: number };
@@ -85,10 +88,10 @@ export async function GET(request: NextRequest) {
         }
       }
 
-      const latestVersion = await getLatestWorkerVersion();
+      const { version: latestVersion, releaseDate: latestReleaseDate } = await getLatestWorkerInfo();
       const updateAvailable = !!(currentVersion && latestVersion && currentVersion !== latestVersion);
 
-      result.marketing = { installed, online, currentVersion, latestVersion, updateAvailable, updateStatus };
+      result.marketing = { installed, online, currentVersion, latestVersion, updateAvailable, updateStatus, latestReleaseDate };
     }
 
     // 스크래핑 워커 상태

--- a/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
+++ b/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
@@ -495,6 +495,39 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
   const [workerInstallCommand, setWorkerInstallCommand] = useState('')
   const [copiedWorkerCmd, setCopiedWorkerCmd] = useState(false)
 
+  const [workerVersionInfo, setWorkerVersionInfo] = useState<{
+    currentVersion: string | null
+    latestVersion: string | null
+    latestReleaseDate: string | null
+    online: boolean
+  } | null>(null)
+
+  useEffect(() => {
+    const fetchWorkerVersion = async () => {
+      try {
+        const res = await fetch('/api/workers/status?type=marketing', {
+          signal: AbortSignal.timeout(5000),
+        })
+        if (res.ok) {
+          const data = await res.json()
+          if (data.marketing) {
+            setWorkerVersionInfo({
+              currentVersion: data.marketing.currentVersion,
+              latestVersion: data.marketing.latestVersion,
+              latestReleaseDate: data.marketing.latestReleaseDate,
+              online: data.marketing.online,
+            })
+          }
+        }
+      } catch {
+        // ignore
+      }
+    }
+    fetchWorkerVersion()
+    const interval = setInterval(fetchWorkerVersion, 60_000) // 1분마다 갱신
+    return () => clearInterval(interval)
+  }, [])
+
   const handleWorkerDownload = async () => {
     if (isDownloadingWorker) return
     setIsDownloadingWorker(true)
@@ -1401,14 +1434,24 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
             </button>
           </Tooltip>
         ) : (
-          <button
-            onClick={handleWorkerDownload}
-            disabled={isDownloadingWorker}
-            className="group flex items-center space-x-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 w-full text-at-text-weak hover:bg-at-success-bg hover:text-at-success disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <Download className={`w-5 h-5 flex-shrink-0 text-at-text-weak group-hover:text-at-success ${isDownloadingWorker ? 'animate-bounce' : ''}`} />
-            <span className="truncate">{isDownloadingWorker ? '다운로드 중...' : '통합 워커 다운로드'}</span>
-          </button>
+          <div>
+            <button
+              onClick={handleWorkerDownload}
+              disabled={isDownloadingWorker}
+              className="group flex items-center space-x-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 w-full text-at-text-weak hover:bg-at-success-bg hover:text-at-success disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <Download className={`w-5 h-5 flex-shrink-0 text-at-text-weak group-hover:text-at-success ${isDownloadingWorker ? 'animate-bounce' : ''}`} />
+              <span className="truncate">{isDownloadingWorker ? '다운로드 중...' : '통합 워커 다운로드'}</span>
+            </button>
+            {workerVersionInfo?.latestVersion && (
+              <div className="px-3 pb-1 flex items-center justify-between text-[11px] text-at-text-weak">
+                <span>v{workerVersionInfo.latestVersion}</span>
+                {workerVersionInfo.latestReleaseDate && (
+                  <span>{new Date(workerVersionInfo.latestReleaseDate).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })} 업데이트</span>
+                )}
+              </div>
+            )}
+          </div>
         )}
         {bottomFixedMenus.map(tab => {
           const isActive = activeTab === tab.id


### PR DESCRIPTION
## Summary
- 좌측 탭 통합 워커 다운로드 버튼 하단에 워커 버전과 최근 업데이트 날짜 표시
- `/api/workers/status`에 GitHub 릴리즈 날짜(`latestReleaseDate`) 필드 추가

## Test plan
- [ ] 좌측 사이드바 확장 시 다운로드 버튼 아래 `v1.x.x` + `x월 x일 업데이트` 표시 확인
- [ ] 축소 모드에서는 아이콘만 표시 (기존 동작 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)