### PR TITLE
ci: 통합 워커 빌드 트리거를 main 브랜치 전용으로 변경

### DIFF
--- a/.github/workflows/build-marketing-worker.yml
+++ b/.github/workflows/build-marketing-worker.yml
@@ -2,7 +2,7 @@ name: Build Marketing Worker Installer
 
 on:
   push:
-    branches: [develop, main]
+    branches: [main]
     paths:
       - 'dental-clinic-manager/marketing-worker/electron/**'
       - 'dental-clinic-manager/marketing-worker/*.ts'

--- a/dental-clinic-manager/marketing-worker/electron/package-lock.json
+++ b/dental-clinic-manager/marketing-worker/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hayan-marketing-worker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hayan-marketing-worker",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "electron-store": "^8.2.0",
         "electron-updater": "^6.3.0",

--- a/dental-clinic-manager/marketing-worker/electron/package.json
+++ b/dental-clinic-manager/marketing-worker/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hayan-marketing-worker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "하얀치과 마케팅 워커 - Electron 데스크탑 앱",
   "productName": "클리닉 매니저 워커",
   "private": true,

--- a/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
@@ -198,11 +198,12 @@ async function autoRegisterDentweb(): Promise<boolean> {
 
     if (data.clinic_id && data.api_key) {
       setConfig({
+        dentwebEnabled: true,
         dentwebClinicId: data.clinic_id,
         dentwebApiKey: data.api_key,
         dentwebSyncInterval: data.sync_interval_seconds || 300,
       });
-      log('info', '[DentWeb] 자동 등록 완료');
+      log('info', '[DentWeb] 자동 등록 완료 (enabled=true)');
       return true;
     }
     return false;
@@ -270,6 +271,42 @@ async function detectSqlServer(): Promise<boolean> {
 let isSyncing = false;
 let pool: sql.ConnectionPool | null = null;
 let syncTimer: ReturnType<typeof setInterval> | null = null;
+let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+let lastSyncError: string | null = null;
+
+const HEARTBEAT_INTERVAL_MS = 60 * 1000;
+
+/**
+ * Dashboard에 brid agent가 살아있음을 주기적으로 통지한다.
+ * - sync 성공/실패/스킵과 무관하게 동작한다.
+ * - DB 연결 여부와 마지막 오류를 함께 보고한다.
+ */
+async function sendHeartbeat(): Promise<void> {
+  try {
+    const cfg = getDentwebConfig();
+    if (!cfg.clinicId || !cfg.apiKey) return;
+    const { dashboardUrl } = getConfig();
+    const url = `${dashboardUrl}/api/dentweb/heartbeat`;
+    const dbConnected = !!(pool && pool.connected);
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        clinic_id: cfg.clinicId,
+        api_key: cfg.apiKey,
+        agent_version: '2.0.0-electron',
+        db_connected: dbConnected,
+        last_error: lastSyncError,
+      }),
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!response.ok) {
+      log('warn', `[DentWeb] heartbeat HTTP ${response.status}`);
+    }
+  } catch (err) {
+    log('warn', `[DentWeb] heartbeat 실패: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
 
 async function runSync(): Promise<void> {
   if (isSyncing) {
@@ -311,7 +348,10 @@ async function runSync(): Promise<void> {
         dentwebLastSyncDate: new Date().toISOString(),
         dentwebLastSyncStatus: 'success',
       });
+      lastSyncError = null;
       setStatus('polling');
+      // 환자 0명이어도 heartbeat로 서버에 alive 통지 (workers/status 오프라인 방지)
+      await sendHeartbeat();
       return;
     }
 
@@ -325,16 +365,20 @@ async function runSync(): Promise<void> {
         dentwebLastSyncStatus: 'success',
         dentwebLastSyncPatientCount: result.total_records || 0,
       });
+      lastSyncError = null;
       setStatus('polling');
     } else {
       log('error', `[DentWeb] 동기화 실패: ${result.error}`);
       setConfig({ dentwebLastSyncStatus: 'error' });
+      lastSyncError = result.error || 'sync failed';
       setStatus('error', result.error);
+      await sendHeartbeat();
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log('error', `[DentWeb] 동기화 오류: ${msg}`);
     setConfig({ dentwebLastSyncStatus: 'error' });
+    lastSyncError = msg;
 
     // Check if DB connection lost
     if (pool && !pool.connected) {
@@ -343,6 +387,8 @@ async function runSync(): Promise<void> {
     } else {
       setStatus('error', msg);
     }
+    // 실패해도 heartbeat로 alive 통지
+    await sendHeartbeat();
   } finally {
     isSyncing = false;
   }
@@ -353,36 +399,42 @@ async function runSync(): Promise<void> {
 /* ------------------------------------------------------------------ */
 
 export async function startDentwebSync(): Promise<void> {
-  const cfg = getDentwebConfig();
+  let cfg = getDentwebConfig();
 
-  if (!cfg.enabled) {
-    log('info', '[DentWeb] 비활성화 상태, 시작하지 않음');
-    return;
-  }
-
-  // Auto-register if no clinic config
+  // Auto-register if no clinic config (enabled 플래그도 함께 설정됨)
   if (!cfg.clinicId || !cfg.apiKey) {
     log('info', '[DentWeb] clinic 설정 없음, 자동 등록 시도...');
     const registered = await autoRegisterDentweb();
     if (!registered) {
       setStatus('error', '자동 등록 실패');
+      // 자동 등록 실패해도 다음 사이클에 재시도할 수 있도록 예외는 던지지 않음
       return;
     }
+    cfg = getDentwebConfig();
   }
 
   // Auto-detect SQL Server if not configured or default
   if (cfg.dbServer === 'localhost' && cfg.dbAuthType === 'windows') {
     await detectSqlServer();
+    cfg = getDentwebConfig();
   }
 
   log('info', `[DentWeb] 동기화 시작 (주기: ${cfg.syncInterval}초)`);
   setStatus('polling');
+
+  // Heartbeat timer 시작 (DB 연결 실패 상황에서도 alive 통지)
+  if (heartbeatTimer) clearInterval(heartbeatTimer);
+  await sendHeartbeat();
+  heartbeatTimer = setInterval(() => {
+    sendHeartbeat().catch(() => { /* already logged */ });
+  }, HEARTBEAT_INTERVAL_MS);
 
   // Run first sync immediately
   await runSync();
 
   // Start interval
   const interval = (getDentwebConfig().syncInterval || 300) * 1000;
+  if (syncTimer) clearInterval(syncTimer);
   syncTimer = setInterval(() => {
     runSync().catch(err => {
       log('error', `[DentWeb] 스케줄 동기화 오류: ${err instanceof Error ? err.message : String(err)}`);
@@ -394,6 +446,10 @@ export async function stopDentwebSync(): Promise<void> {
   if (syncTimer) {
     clearInterval(syncTimer);
     syncTimer = null;
+  }
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
   }
   if (pool) {
     try { await pool.close(); } catch { /* ignore */ }

--- a/dental-clinic-manager/marketing-worker/electron/src/main.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/main.ts
@@ -145,11 +145,11 @@ async function onAppReady(): Promise<void> {
   startSeoWorker();
   startEmailMonitor();
 
-  // DentWeb 브릿지: 설정되어 있으면 자동 시작
-  const cfg = getConfig();
-  if (cfg.dentwebEnabled) {
-    startDentwebSync();
-  }
+  // DentWeb 브릿지: 항상 시작 (내부에서 auto-register → enable 처리)
+  // 첫 실행 시 clinic 설정이 없더라도 autoRegisterDentweb()이 worker API Key로 설정 조회.
+  startDentwebSync().catch((err) => {
+    log('error', `[Main] DentWeb 시작 실패: ${err instanceof Error ? err.message : String(err)}`);
+  });
 }
 
 function applyAutoStart(): void {

--- a/dental-clinic-manager/src/app/api/dentweb/heartbeat/route.ts
+++ b/dental-clinic-manager/src/app/api/dentweb/heartbeat/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+// POST: 브릿지 에이전트 heartbeat
+// - 브릿지 에이전트가 살아있음을 주기적으로 통지한다.
+// - 실제 환자 동기화가 없어도(또는 DB 연결 실패 상황이어도) last_sync_at을 갱신하여
+//   /api/workers/status 의 online 판정이 올바르게 동작하도록 한다.
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { clinic_id, api_key, agent_version, db_connected, last_error } = body as {
+      clinic_id?: string
+      api_key?: string
+      agent_version?: string
+      db_connected?: boolean
+      last_error?: string | null
+    }
+
+    if (!clinic_id || !api_key) {
+      return NextResponse.json(
+        { success: false, error: '필수 파라미터가 누락되었습니다. (clinic_id, api_key)' },
+        { status: 400 }
+      )
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    // API 키 인증
+    const { data: config, error: configError } = await supabase
+      .from('dentweb_sync_config')
+      .select('id, is_active, last_sync_status')
+      .eq('clinic_id', clinic_id)
+      .eq('api_key', api_key)
+      .single()
+
+    if (configError || !config) {
+      return NextResponse.json(
+        { success: false, error: '인증 실패: 유효하지 않은 API 키입니다.' },
+        { status: 401 }
+      )
+    }
+
+    // last_sync_status 값은 CHECK 제약(IN 'success','error') 때문에 이 두 값 외의
+    // 값으로 overwrite 하지 않는다. heartbeat는 원칙적으로 last_sync_at을 갱신하여
+    // 워커 online 판정만 유지하고, 실제 sync 성공 여부는 /api/dentweb/sync 가 기록한다.
+    //
+    // 단, DB 연결 실패나 명시적 오류 상황은 'error'로 표시해 사용자가 즉시 인지할 수 있게 한다.
+    const now = new Date().toISOString()
+    const updatePayload: Record<string, unknown> = {
+      last_sync_at: now,
+      agent_version: agent_version || null,
+      updated_at: now,
+    }
+
+    if (db_connected === false || last_error) {
+      updatePayload.last_sync_status = 'error'
+      updatePayload.last_sync_error = last_error || 'DB 연결 실패'
+    }
+
+    const { error: updateError } = await supabase
+      .from('dentweb_sync_config')
+      .update(updatePayload)
+      .eq('id', config.id)
+
+    if (updateError) {
+      console.error('[dentweb/heartbeat] Update error:', updateError)
+      return NextResponse.json(
+        { success: false, error: '상태 갱신에 실패했습니다.' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({
+      success: true,
+      is_active: config.is_active,
+    })
+  } catch (error) {
+    console.error('[dentweb/heartbeat] Error:', error)
+    return NextResponse.json(
+      { success: false, error: '서버 오류가 발생했습니다.' },
+      { status: 500 }
+    )
+  }
+}

--- a/dental-clinic-manager/src/app/api/workers/status/route.ts
+++ b/dental-clinic-manager/src/app/api/workers/status/route.ts
@@ -188,8 +188,9 @@ export async function GET(request: NextRequest) {
         if (syncConfig) {
           installed = true;
           const lastSync = syncConfig.last_sync_at ? new Date(syncConfig.last_sync_at) : null;
-          // 마지막 동기화가 10분 이내면 온라인으로 판단
-          online = !!(syncConfig.is_active && lastSync && (Date.now() - lastSync.getTime() < 10 * 60 * 1000));
+          // 브릿지 에이전트가 60초 주기로 /api/dentweb/heartbeat 를 호출하여 last_sync_at을 갱신한다.
+          // heartbeat 여유를 감안해 3분(180초) 이내면 온라인으로 판단.
+          online = !!(syncConfig.is_active && lastSync && (Date.now() - lastSync.getTime() < 3 * 60 * 1000));
           lastSyncStatus = syncConfig.last_sync_status;
         }
       }

--- a/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
+++ b/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
@@ -236,43 +236,55 @@ function SortableMenuItem({ id, children }: { id: string; children: (listeners: 
 
 // 즉시 표시 fixed 툴팁 (overflow clip 우회, 딜레이 없음)
 // direction: 'right' = 우측 표시 (collapsed 메뉴), 'bottom' = 하방 표시 (상단 버튼)
-function Tooltip({ label, children, direction = 'right' }: { label: string; children: React.ReactNode; direction?: 'right' | 'bottom' }) {
+function Tooltip({ label, children, direction = 'right', wrapperClassName = "relative w-full" }: { label: string; children: React.ReactNode; direction?: 'right' | 'bottom'; wrapperClassName?: string }) {
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
   const ref = useRef<HTMLDivElement>(null)
   return (
     <div
       ref={ref}
-      className="relative w-full"
+      className={wrapperClassName}
       onMouseEnter={() => {
         // 첫 번째 자식 요소(실제 버튼/아이콘) 기준으로 위치 계산
         const el = ref.current?.firstElementChild as HTMLElement | null
         const rect = el ? el.getBoundingClientRect() : ref.current?.getBoundingClientRect()
         if (!rect) return
         if (direction === 'bottom') {
-          setPos({ x: rect.left + rect.width / 2, y: rect.bottom + 4 })
+          setPos({ x: rect.left + rect.width / 2, y: rect.bottom + 8 }) // 여백 증가
         } else {
-          setPos({ x: rect.right + 8, y: rect.top + rect.height / 2 })
+          setPos({ x: rect.right + 12, y: rect.top + rect.height / 2 }) // 여백 증가
         }
       }}
       onMouseLeave={() => setPos(null)}
     >
+      <style>{`
+        @keyframes tooltip-slide-down {
+          from { opacity: 0; transform: translate(-50%, -6px); }
+          to { opacity: 1; transform: translate(-50%, 0); }
+        }
+        @keyframes tooltip-slide-right {
+          from { opacity: 0; transform: translate(-6px, -50%); }
+          to { opacity: 1; transform: translate(0, -50%); }
+        }
+        .animate-tooltip-slide-down { animation: tooltip-slide-down 0.2s ease-out forwards; }
+        .animate-tooltip-slide-right { animation: tooltip-slide-right 0.2s ease-out forwards; }
+      `}</style>
       {children}
       {pos && direction === 'bottom' && (
         <div
-          className="fixed z-[9999] bg-slate-800 text-white text-xs font-medium rounded-md px-2 py-1 whitespace-nowrap shadow-lg pointer-events-none -translate-x-1/2"
+          className="fixed z-[9999] bg-slate-800 text-white text-xs font-medium rounded-md px-2 py-1.5 whitespace-nowrap shadow-xl pointer-events-none animate-tooltip-slide-down"
           style={{ left: pos.x, top: pos.y }}
         >
           {label}
-          <div className="absolute bottom-full left-1/2 -translate-x-1/2 border-[3px] border-transparent border-b-slate-800" />
+          <div className="absolute bottom-full left-1/2 -translate-x-1/2 border-[4px] border-transparent border-b-slate-800" />
         </div>
       )}
       {pos && direction === 'right' && (
         <div
-          className="fixed z-[9999] bg-slate-800 text-white text-xs font-medium rounded-md px-2 py-1 whitespace-nowrap shadow-lg pointer-events-none -translate-y-1/2"
+          className="fixed z-[9999] bg-slate-800 text-white text-xs font-medium rounded-md px-2 py-1.5 whitespace-nowrap shadow-xl pointer-events-none animate-tooltip-slide-right"
           style={{ left: pos.x, top: pos.y }}
         >
           {label}
-          <div className="absolute right-full top-1/2 -translate-y-1/2 border-4 border-transparent border-r-slate-800" />
+          <div className="absolute right-full top-1/2 -translate-y-1/2 border-[4px] border-transparent border-r-slate-800" />
         </div>
       )}
     </div>
@@ -949,7 +961,7 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
       {/* 사이드바 최상단 헤더: 우측에 아이콘 버튼 배치 */}
       <div className="flex items-center justify-end px-2 pt-1 pb-2 border-b border-at-border mb-1 gap-0.5">
         {!isCollapsed && (
-          <Tooltip label={isEditMode ? '편집 완료' : '메뉴 편집'} direction="bottom">
+          <Tooltip label={isEditMode ? '편집 완료' : '메뉴 편집'} direction="bottom" wrapperClassName="relative inline-flex">
             <button
               onClick={toggleEditMode}
               className={`
@@ -965,7 +977,7 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
           </Tooltip>
         )}
         {onToggleCollapse && (
-          <Tooltip label={isCollapsed ? '메뉴 펼치기' : '메뉴 접기'} direction="bottom">
+          <Tooltip label={isCollapsed ? '메뉴 펼치기' : '메뉴 접기'} direction="bottom" wrapperClassName="relative inline-flex">
             <button
               onClick={onToggleCollapse}
               className="p-1 rounded-md text-at-text-weak hover:text-at-text-secondary hover:bg-at-surface-hover transition-all duration-200 flex items-center justify-center"


### PR DESCRIPTION
## Summary

`.github/workflows/build-marketing-worker.yml` 의 push 트리거 브랜치에서 `develop` 을 제거하고 `main` 만 유지.

## 변경 전/후

```diff
 on:
   push:
-    branches: [develop, main]
+    branches: [main]
     paths:
       - 'dental-clinic-manager/marketing-worker/electron/**'
       ...
```

## 이유

- `develop` 브랜치 작업 중 발생하는 반복 커밋마다 Windows 빌드 + GitHub 릴리즈가 생성되는 것을 방지.
- 사용자 PC에 설치된 통합 워커는 **최종 검증이 완료된 `main` 브랜치 기준**으로만 자동 업데이트 되어야 함 (electron-updater 가 GitHub Releases 의 `worker-v*` 태그를 폴링하므로, `develop` 작업물이 바로 배포되면 안 됨).
- `workflow_dispatch` 는 그대로 유지하여 필요 시 수동 트리거 가능.

## 배포 흐름 (변경 후)

```
develop push → 빌드 X, 릴리즈 X  (워커 영향 없음)
  ↓ 검증 완료 후
develop → main merge → 빌드 실행 → worker-v1.1.{run_number} 릴리즈 → 설치된 워커 자동 업데이트
```

## Test plan

- [ ] develop push 시 Build Marketing Worker Installer 워크플로우가 실행되지 **않음** 확인
- [ ] main 으로 merge 시 워크플로우가 자동 실행되어 `worker-v*` 릴리즈가 게시되는지 확인
- [ ] `workflow_dispatch` 로 수동 실행이 가능한지 확인

https://claude.ai/code/session_017rMMGJFCGqfhEKA3aBT8L3