### PR TITLE
feat(worker): 상태 창 헤더에 현재 버전 뱃지 표시

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/renderer/status.html
+++ b/dental-clinic-manager/marketing-worker/electron/renderer/status.html
@@ -30,7 +30,17 @@
       flex-shrink: 0;
     }
 
-    .header h1 { font-size: 15px; font-weight: 600; letter-spacing: -0.3px; }
+    .header h1 { font-size: 15px; font-weight: 600; letter-spacing: -0.3px; display: flex; align-items: center; gap: 8px; }
+    .header h1 .version-badge {
+      font-size: 11px;
+      font-weight: 500;
+      color: #d4d4d8;
+      background: #27272a;
+      border: 1px solid #3f3f46;
+      padding: 2px 8px;
+      border-radius: 999px;
+      letter-spacing: 0;
+    }
     .header .last-updated { font-size: 11px; color: #a1a1aa; }
 
     .body {
@@ -219,7 +229,10 @@
 </head>
 <body>
   <div class="header">
-    <h1>클리닉 매니저 워커</h1>
+    <h1>
+      클리닉 매니저 워커
+      <span class="version-badge" id="headerVersion">v-</span>
+    </h1>
     <span class="last-updated" id="lastUpdated">불러오는 중...</span>
   </div>
 
@@ -456,7 +469,9 @@
     function refreshVersionInfo() {
       if (!api || !api.getVersionInfo) return;
       api.getVersionInfo().then(function(info) {
-        document.getElementById('currentVersion').textContent = 'v' + (info.currentVersion || '-');
+        var versionText = 'v' + (info.currentVersion || '-');
+        document.getElementById('currentVersion').textContent = versionText;
+        document.getElementById('headerVersion').textContent = versionText;
 
         var latestEl = document.getElementById('latestVersion');
         latestEl.textContent = info.latestVersion ? 'v' + info.latestVersion : '-';

--- a/dental-clinic-manager/marketing-worker/electron/src/status-window.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/status-window.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain } from 'electron';
+import { BrowserWindow, ipcMain, app } from 'electron';
 import path from 'path';
 import { getStatus as getWorkerStatus, start as startWorker, stop as stopWorker } from './worker-bridge';
 import { getScrapingStatus } from './scraping-bridge';
@@ -28,12 +28,17 @@ export function createStatusWindow(): void {
     height: 500,
     resizable: true,
     frame: true,
-    title: '클리닉 매니저 워커',
+    title: `클리닉 매니저 워커 v${app.getVersion()}`,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
       preload: path.join(__dirname, 'preload.js'),
     },
+  });
+
+  // loadFile 후 page가 title을 overwrite하지 않도록 명시적으로 유지
+  statusWindow.on('page-title-updated', (event) => {
+    event.preventDefault();
   });
 
   const htmlPath = path.join(__dirname, '..', 'renderer', 'status.html');


### PR DESCRIPTION
## Summary

트레이 아이콘 더블클릭으로 열리는 상태 창에서 현재 워커 버전이 즉시 눈에 띄도록 상단 타이틀 영역에 버전 뱃지를 추가.

## 배경

기존에도 상태 창 중앙의 "버전 정보" 카드 안에 "현재 버전" 항목이 있었지만, 상단 헤더 타이틀 옆에는 버전이 표시되지 않아 창을 열자마자 버전을 확인하기 어려웠음. 사용자가 "현재 버전이 보이도록 해달라"고 요청.

## 변경 내용

### `marketing-worker/electron/renderer/status.html`
- `<h1>클리닉 매니저 워커</h1>` 옆에 `<span class="version-badge" id="headerVersion">v-</span>` 추가
- `.version-badge` CSS: 다크 헤더 위에 가벼운 pill 스타일 (zinc-900/zinc-300 톤)
- `refreshVersionInfo()` 가 `#currentVersion` 뿐 아니라 `#headerVersion` 도 함께 갱신

### `marketing-worker/electron/src/status-window.ts`
- `electron.app` import 추가
- `BrowserWindow` 의 `title` 에 `v${app.getVersion()}` 포함 (예: `클리닉 매니저 워커 v1.1.69`)
- `page-title-updated` 이벤트 `preventDefault()` 처리 — HTML `<title>` 태그가 윈도 타이틀을 덮어쓰지 않도록 차단 (Windows 작업표시줄, macOS 윈도 제목에서도 버전 확인 가능)

## 표시 위치 (3군데)

1. **윈도 타이틀 바** (Windows/macOS 공통): `클리닉 매니저 워커 v1.1.69`
2. **헤더 pill 뱃지** (창 좌상단): `v1.1.69`
3. **버전 정보 카드** (기존): `현재 버전: v1.1.69`

## Test plan

- [ ] `cd marketing-worker/electron && npx tsc --noEmit` — 통과 확인 (이미 통과)
- [ ] 트레이 아이콘 더블클릭 → 상태 창 헤더에 `v1.1.XX` 뱃지 표시
- [ ] 창 타이틀 (Windows 작업표시줄) 에 버전 표시 확인
- [ ] 기존 "버전 정보" 카드의 현재/최신 버전도 여전히 표시되는지 확인

https://claude.ai/code/session_017rMMGJFCGqfhEKA3aBT8L3