### PR TITLE
fix(worker-status): 최신 통합 워커 릴리즈 감지 로직 개선 + 업데이트 시각 분단위 표시

### DIFF
--- a/dental-clinic-manager/src/app/api/workers/status/route.ts
+++ b/dental-clinic-manager/src/app/api/workers/status/route.ts
@@ -20,13 +20,45 @@ async function getLatestWorkerInfo(): Promise<{ version: string | null; releaseD
     });
     if (!res.ok) return { version: cachedLatestVersion, releaseDate: cachedReleaseDate };
     const releases = await res.json();
-    const workerRelease = releases.find((r: { tag_name?: string }) =>
-      r.tag_name?.startsWith('worker-v')
-    );
-    if (workerRelease?.tag_name) {
-      cachedLatestVersion = workerRelease.tag_name.replace('worker-v', '');
-      cachedReleaseDate = workerRelease.published_at || null;
-      cacheTimestamp = Date.now();
+
+    // Electron 워커 릴리즈 식별:
+    // - electron-builder 가 생성하는 에셋 파일명 패턴 `clinic-manager-worker-<ver>-setup.exe` 를 찾는다.
+    // - 과거 `worker-v*` 태그 형식과 신 `v*` 태그 형식을 모두 지원한다.
+    // - 태그에 버전 정보가 있는 경우 우선 사용하고, 없으면 에셋 파일명에서 추출한다.
+    type GhAsset = { name?: string };
+    type GhRelease = { tag_name?: string; published_at?: string; draft?: boolean; assets?: GhAsset[] };
+
+    const workerRelease = (releases as GhRelease[]).find((r) => {
+      if (r.draft) return false;
+      return !!r.assets?.some(
+        (a) => typeof a.name === 'string' && /^clinic-manager-worker-.+-setup\.exe$/.test(a.name)
+      );
+    });
+
+    if (workerRelease) {
+      // 버전 추출: tag_name 에서 우선 시도 (worker-v1.2.3 / v1.2.3 → 1.2.3)
+      let version: string | null = null;
+      if (workerRelease.tag_name) {
+        const tagMatch = workerRelease.tag_name.match(/^(?:worker-)?v?(.+)$/);
+        if (tagMatch) version = tagMatch[1];
+      }
+      // tag_name 에서 못 얻으면 에셋 파일명에서 파싱
+      if (!version && workerRelease.assets) {
+        for (const a of workerRelease.assets) {
+          if (!a.name) continue;
+          const m = a.name.match(/^clinic-manager-worker-(.+?)-setup\.exe$/);
+          if (m) {
+            version = m[1];
+            break;
+          }
+        }
+      }
+
+      if (version) {
+        cachedLatestVersion = version;
+        cachedReleaseDate = workerRelease.published_at || null;
+        cacheTimestamp = Date.now();
+      }
     }
   } catch {
     // GitHub API 실패 시 캐시된 값 반환

--- a/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
+++ b/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
@@ -1455,7 +1455,7 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
               <div className="px-3 pb-1 flex items-center justify-between text-[11px] text-at-text-weak">
                 <span>v{workerVersionInfo.latestVersion}</span>
                 {workerVersionInfo.latestReleaseDate && (
-                  <span>{new Date(workerVersionInfo.latestReleaseDate).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })} 업데이트</span>
+                  <span>{new Date(workerVersionInfo.latestReleaseDate).toLocaleString('ko-KR', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })} 업데이트</span>
                 )}
               </div>
             )}


### PR DESCRIPTION
## Summary

좌측 사이드바 "통합 워커 다운로드" 버튼 아래 **최신 버전 표시가 구버전에 고정**되던 문제를 수정하고, **업데이트 시각을 분단위까지** 보이도록 변경.

## Root Cause

`src/app/api/workers/status/route.ts` 의 `getLatestWorkerInfo()` 함수가 GitHub 릴리즈 중 `tag_name` 이 **`worker-v`** 접두사로 시작하는 것만 필터링함:

```ts
const workerRelease = releases.find((r) =>
  r.tag_name?.startsWith('worker-v')
);
```

그러나 `build-marketing-worker.yml` 이 `electron-builder --publish always` 로 실제 생성하는 릴리즈 태그는 **`v1.1.X`** 형식 (electron-builder 기본값). 따라서 필터에 매칭되는 릴리즈는 구버전인 `worker-v1.1.65` 까지만 찾아지고, 이후 생성된 `v1.1.66`, `v1.1.67`, `v1.1.68`, `v1.1.69`, … 는 무시됨.

결과적으로 UI에는 `worker-v1.1.65` 또는 5분 TTL 캐시의 null 값이 표시되어 항상 구버전으로 보임.

## Fix

### 1. `src/app/api/workers/status/route.ts`

릴리즈 감지를 **태그 이름 접두사 → 에셋 파일명 패턴** 으로 변경. `clinic-manager-worker-<version>-setup.exe` 파일을 에셋으로 포함한 릴리즈만 Electron 워커 릴리즈로 간주.

```ts
const workerRelease = (releases as GhRelease[]).find((r) => {
  if (r.draft) return false;
  return !!r.assets?.some(
    (a) => typeof a.name === 'string' &&
           /^clinic-manager-worker-.+-setup\.exe$/.test(a.name)
  );
});
```

- 버전 추출: `tag_name` 에서 우선 (`worker-v1.2.3` / `v1.2.3` 모두 → `1.2.3`)
- `tag_name` 실패 시 에셋 파일명 `clinic-manager-worker-X.Y.Z-setup.exe` 에서 파싱
- `draft` 릴리즈 제외
- 과거 `worker-v*` 태그 형식과 신 `v*` 태그 형식 **모두 지원** (하위 호환)

### 2. `src/components/Layout/TabNavigation.tsx`

다운로드 버튼 하단 업데이트 시각 표시를 **분단위까지** 포함:

```diff
- {new Date(workerVersionInfo.latestReleaseDate).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })} 업데이트
+ {new Date(workerVersionInfo.latestReleaseDate).toLocaleString('ko-KR', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })} 업데이트
```

예: `4월 14일 14:23 업데이트`

## 5 Whys

1. 왜 구버전으로 보이나? → API가 오래된 `worker-v1.1.65` 만 반환
2. 왜 오래된 릴리즈를 반환하나? → `worker-v` 접두사 필터가 최신 `v1.1.X` 태그를 무시
3. 왜 태그 형식이 다르나? → electron-builder `--publish always` 는 `v${version}` 기본값 사용, 과거에만 수동으로 `worker-` 접두사를 부여했음
4. 왜 이전에 발견되지 않았나? → 가장 최근 `worker-v*` 릴리즈가 당일 오전에 존재해서 캐시에 값이 있었고, 사용자 눈에는 "아주 오래된 건 아닌" 상태로 보였음
5. 어떻게 재발을 막나? → 태그 형식에 의존하지 않고 에셋 파일명(electron-builder 의 `artifactName` 기반)으로 식별

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx next lint` 변경 파일 통과 (기존 warning 만 존재)
- [ ] Vercel 프리뷰에서 좌측 "통합 워커 다운로드" 버튼 아래 최신 버전 표시 (`v1.1.XX`) 확인
- [ ] 업데이트 시각이 `4월 14일 HH:MM 업데이트` 형식으로 표시되는지 확인
- [ ] 향후 새 워커 릴리즈 게시 시 5분 이내 반영되는지 확인 (API 캐시 TTL)

https://claude.ai/code/session_017rMMGJFCGqfhEKA3aBT8L3