### PR TITLE
fix(worker-download): 다운로드 API가 최신 Electron 워커 릴리즈를 반환하도록 수정

### DIFF
--- a/dental-clinic-manager/src/app/api/marketing/worker-api/download/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/worker-api/download/route.ts
@@ -4,6 +4,9 @@ import { createClient } from '@/lib/supabase/server';
 // GitHub Release URL for Windows installer (fallback)
 const FALLBACK_INSTALLER_URL_WIN = 'https://github.com/huisu-hwang/dental-clinic-manager/releases/download/marketing-worker-v1.0.0/clinic-manager-worker-1.0.0-setup.exe';
 
+type GhAsset = { name?: string; browser_download_url?: string };
+type GhRelease = { tag_name?: string; draft?: boolean; assets?: GhAsset[] };
+
 async function getLatestInstallerUrl(platform: 'windows' | 'mac'): Promise<string | null> {
   try {
     const res = await fetch('https://api.github.com/repos/huisu-hwang/dental-clinic-manager/releases', {
@@ -11,17 +14,31 @@ async function getLatestInstallerUrl(platform: 'windows' | 'mac'): Promise<strin
       signal: AbortSignal.timeout(5000),
     });
     if (!res.ok) throw new Error(`GitHub API ${res.status}`);
-    const releases = await res.json();
+    const releases = (await res.json()) as GhRelease[];
 
-    // worker-v로 시작하는 최신 release 찾기
-    const workerRelease = releases.find((r: any) =>
-      r.tag_name?.startsWith('worker-v') && r.assets?.length > 0
-    );
+    // Electron 워커 릴리즈 식별:
+    // electron-builder 가 생성하는 에셋 파일명 `clinic-manager-worker-<ver>-setup.<ext>`
+    // 를 에셋에 포함한 릴리즈만 워커 릴리즈로 간주.
+    // - 과거 'worker-v*' 태그 형식과 신 'v*' 태그 형식 모두 지원
+    // - draft 릴리즈 제외
+    const ext = platform === 'mac' ? '.dmg' : '.exe';
+    const workerRelease = releases.find((r) => {
+      if (r.draft) return false;
+      return !!r.assets?.some(
+        (a) =>
+          typeof a.name === 'string' &&
+          /^clinic-manager-worker-.+-setup\.(exe|dmg)$/.test(a.name)
+      );
+    });
 
-    if (workerRelease) {
-      const ext = platform === 'mac' ? '.dmg' : '.exe';
-      const asset = workerRelease.assets.find((a: any) => a.name.endsWith(ext));
-      if (asset) return asset.browser_download_url;
+    if (workerRelease?.assets) {
+      const asset = workerRelease.assets.find(
+        (a) =>
+          typeof a.name === 'string' &&
+          a.name.startsWith('clinic-manager-worker-') &&
+          a.name.endsWith(`-setup${ext}`)
+      );
+      if (asset?.browser_download_url) return asset.browser_download_url;
     }
   } catch {
     // 폴백


### PR DESCRIPTION
## Summary

"통합 워커 다운로드" 버튼 클릭 시 다운로드 되는 파일이 구버전(`clinic-manager-worker-1.1.65-setup.exe`) 으로 고정되는 문제 수정.

## Root Cause

`src/app/api/marketing/worker-api/download/route.ts` 의 `getLatestInstallerUrl()` 함수가 PR huisu-hwang/dental-clinic-manager#299 에서 수정한 `workers/status` 와 동일한 버그를 갖고 있었음:

```ts
const workerRelease = releases.find((r: any) =>
  r.tag_name?.startsWith('worker-v') && r.assets?.length > 0
);
```

- `build-marketing-worker.yml` + `electron-builder --publish always` 가 생성하는 실제 릴리즈 태그는 **`v1.1.X`** 형식
- `worker-v` 접두사 필터는 과거 수동 릴리즈인 `worker-v1.1.65` 까지만 매칭
- 결과적으로 항상 구버전 `clinic-manager-worker-1.1.65-setup.exe` URL 을 반환

(#299 는 UI 표시용 `workers/status` 만 수정했고, 이 파일은 별도 라우트라 수정이 누락되어 있었음)

## Fix

#299 와 동일한 방식으로 **에셋 파일명 패턴** 으로 워커 릴리즈를 식별:

```ts
const workerRelease = releases.find((r) => {
  if (r.draft) return false;
  return !!r.assets?.some(
    (a) => typeof a.name === 'string' &&
           /^clinic-manager-worker-.+-setup\.(exe|dmg)$/.test(a.name)
  );
});
```

- 과거 `worker-v*` 태그 형식과 신 `v*` 태그 형식 **모두 지원**
- `draft` 릴리즈 제외
- TypeScript 타입 명시 (`GhAsset`, `GhRelease`)

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx next lint` 통과 (ESLint 경고 없음)
- [ ] 배포 후 "통합 워커 다운로드" 버튼 클릭 시 최신 버전 (예: `clinic-manager-worker-1.1.69-setup.exe`) 다운로드 확인
- [ ] Mac 에서도 `.dmg` 가 있는 경우 최신 버전 다운로드되는지 확인

https://claude.ai/code/session_017rMMGJFCGqfhEKA3aBT8L3