### PR TITLE
chore: sync develop → main (worker download latest version fix)

### DIFF
--- a/dental-clinic-manager/src/app/api/marketing/worker-api/download/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/worker-api/download/route.ts
@@ -4,6 +4,9 @@ import { createClient } from '@/lib/supabase/server';
 // GitHub Release URL for Windows installer (fallback)
 const FALLBACK_INSTALLER_URL_WIN = 'https://github.com/huisu-hwang/dental-clinic-manager/releases/download/marketing-worker-v1.0.0/clinic-manager-worker-1.0.0-setup.exe';
 
+type GhAsset = { name?: string; browser_download_url?: string };
+type GhRelease = { tag_name?: string; draft?: boolean; assets?: GhAsset[] };
+
 async function getLatestInstallerUrl(platform: 'windows' | 'mac'): Promise<string | null> {
   try {
     const res = await fetch('https://api.github.com/repos/huisu-hwang/dental-clinic-manager/releases', {
@@ -11,17 +14,31 @@ async function getLatestInstallerUrl(platform: 'windows' | 'mac'): Promise<strin
       signal: AbortSignal.timeout(5000),
     });
     if (!res.ok) throw new Error(`GitHub API ${res.status}`);
-    const releases = await res.json();
+    const releases = (await res.json()) as GhRelease[];
 
-    // worker-v로 시작하는 최신 release 찾기
-    const workerRelease = releases.find((r: any) =>
-      r.tag_name?.startsWith('worker-v') && r.assets?.length > 0
-    );
+    // Electron 워커 릴리즈 식별:
+    // electron-builder 가 생성하는 에셋 파일명 `clinic-manager-worker-<ver>-setup.<ext>`
+    // 를 에셋에 포함한 릴리즈만 워커 릴리즈로 간주.
+    // - 과거 'worker-v*' 태그 형식과 신 'v*' 태그 형식 모두 지원
+    // - draft 릴리즈 제외
+    const ext = platform === 'mac' ? '.dmg' : '.exe';
+    const workerRelease = releases.find((r) => {
+      if (r.draft) return false;
+      return !!r.assets?.some(
+        (a) =>
+          typeof a.name === 'string' &&
+          /^clinic-manager-worker-.+-setup\.(exe|dmg)$/.test(a.name)
+      );
+    });
 
-    if (workerRelease) {
-      const ext = platform === 'mac' ? '.dmg' : '.exe';
-      const asset = workerRelease.assets.find((a: any) => a.name.endsWith(ext));
-      if (asset) return asset.browser_download_url;
+    if (workerRelease?.assets) {
+      const asset = workerRelease.assets.find(
+        (a) =>
+          typeof a.name === 'string' &&
+          a.name.startsWith('clinic-manager-worker-') &&
+          a.name.endsWith(`-setup${ext}`)
+      );
+      if (asset?.browser_download_url) return asset.browser_download_url;
     }
   } catch {
     // 폴백


### PR DESCRIPTION
## Summary

PR huisu-hwang/dental-clinic-manager#301 (워커 다운로드 API 최신 릴리즈 반환 수정)을 main 에 반영하는 sync PR.

## 포함 변경

- `32f92d9e` fix(worker-download): 다운로드 API가 최신 Electron 워커 릴리즈를 반환하도록 수정 (#301)

## Test plan

- [ ] 배포 후 "통합 워커 다운로드" 버튼 클릭 시 최신 버전 파일명으로 다운로드 확인

https://claude.ai/code/session_017rMMGJFCGqfhEKA3aBT8L3