### PR TITLE
fix(worker): 최신 버전 오판 및 DentWeb 자동 등록 실패 해결

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/package.json
+++ b/dental-clinic-manager/marketing-worker/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hayan-marketing-worker",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "하얀치과 마케팅 워커 - Electron 데스크탑 앱",
   "productName": "클리닉 매니저 워커",
   "private": true,

--- a/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
@@ -186,27 +186,54 @@ async function syncPatientsToServer(patients: Record<string, unknown>[], syncTyp
 async function autoRegisterDentweb(): Promise<boolean> {
   try {
     const { dashboardUrl, workerApiKey } = getConfig();
-    if (!workerApiKey) return false;
+    if (!workerApiKey) {
+      log('warn', '[DentWeb] 자동 등록 실패: workerApiKey 가 비어있음');
+      return false;
+    }
 
-    const res = await fetch(`${dashboardUrl}/api/dentweb/worker-config`, {
+    // 통합 워커 API 경로 사용 (verifyWorkerApiKey 헬퍼를 통해 인증).
+    // 이전에 사용하던 /api/dentweb/worker-config 는 존재하지 않는
+    // marketing_worker_control.clinic_id 컬럼을 조회하여 PostgREST 에러로
+    // 항상 401 을 반환함 — /api/marketing/worker-api/dentweb/config 가 정상 경로.
+    const url = `${dashboardUrl}/api/marketing/worker-api/dentweb/config`;
+    log('info', `[DentWeb] 자동 등록 요청: ${url}`);
+    const res = await fetch(url, {
       headers: { 'Authorization': `Bearer ${workerApiKey}` },
       signal: AbortSignal.timeout(10000),
     });
 
-    if (!res.ok) return false;
-    const data = await res.json();
-
-    if (data.clinic_id && data.api_key) {
-      setConfig({
-        dentwebEnabled: true,
-        dentwebClinicId: data.clinic_id,
-        dentwebApiKey: data.api_key,
-        dentwebSyncInterval: data.sync_interval_seconds || 300,
-      });
-      log('info', '[DentWeb] 자동 등록 완료 (enabled=true)');
-      return true;
+    if (!res.ok) {
+      const errText = await res.text().catch(() => '');
+      log('error', `[DentWeb] 자동 등록 실패: HTTP ${res.status} ${res.statusText} — ${errText.slice(0, 200)}`);
+      return false;
     }
-    return false;
+
+    const data = await res.json();
+    if (!data?.success || !data?.config) {
+      log('error', `[DentWeb] 자동 등록 실패: 응답 형식 오류 ${JSON.stringify(data).slice(0, 200)}`);
+      return false;
+    }
+
+    const config = data.config as {
+      clinic_id?: string;
+      api_key?: string;
+      sync_interval_seconds?: number;
+      is_active?: boolean;
+    };
+
+    if (!config.clinic_id || !config.api_key) {
+      log('error', `[DentWeb] 자동 등록 실패: clinic_id/api_key 누락 (${JSON.stringify(config).slice(0, 200)})`);
+      return false;
+    }
+
+    setConfig({
+      dentwebEnabled: true,
+      dentwebClinicId: config.clinic_id,
+      dentwebApiKey: config.api_key,
+      dentwebSyncInterval: config.sync_interval_seconds || 300,
+    });
+    log('info', `[DentWeb] 자동 등록 완료 (clinic=${config.clinic_id.slice(0, 8)}..., enabled=true)`);
+    return true;
   } catch (err) {
     log('error', `[DentWeb] 자동 등록 실패: ${err instanceof Error ? err.message : String(err)}`);
     return false;

--- a/dental-clinic-manager/marketing-worker/electron/src/updater.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/updater.ts
@@ -36,7 +36,10 @@ export function initAutoUpdater(): void {
   // 자동 다운로드 활성화
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
-  autoUpdater.allowPrerelease = true;
+  // allowPrerelease=false: /releases/latest 엔드포인트 사용하여 'Latest' 마크된 non-prerelease 만 감지.
+  // true 로 두면 releases.atom 피드가 사용되는데, GitHub 피드가 구 prerelease(worker-v1.1.65 등)를
+  // 최신 non-prerelease(v1.1.X) 보다 앞에 배치하는 quirk 때문에 downgrade 오판이 발생함.
+  autoUpdater.allowPrerelease = false;
 
   // Private repo 토큰 설정
   const ghToken = getGithubToken();
@@ -61,6 +64,8 @@ export function initAutoUpdater(): void {
     setUpdateMeta({
       latestVersion: info.version,
       updateStatus: 'downloading',
+      // 최신 버전이 서버에 업로드된 시각
+      currentVersionReleasedAt: info.releaseDate || '',
     });
     notify('클리닉 매니저 워커', `새 버전 v${info.version}을 다운로드 중입니다.`);
     isManualCheck = false;
@@ -71,7 +76,7 @@ export function initAutoUpdater(): void {
     setUpdateMeta({
       latestVersion: info.version,
       updateStatus: 'up-to-date',
-      // 현재 버전의 GitHub 릴리즈 날짜 (서버에 배포된 날짜)
+      // 최신 버전(=현재 버전)이 서버에 업로드된 시각
       currentVersionReleasedAt: info.releaseDate || '',
     });
     if (isManualCheck) {
@@ -90,6 +95,8 @@ export function initAutoUpdater(): void {
       latestVersion: info.version,
       updateStatus: 'downloaded',
       lastUpdatedAt: new Date().toISOString(),
+      // 최신 버전이 서버에 업로드된 시각
+      currentVersionReleasedAt: info.releaseDate || '',
     });
     notify('클리닉 매니저 워커 업데이트', `v${info.version} 다운로드 완료. 10초 후 자동 재시작됩니다.`);
     isManualCheck = false;


### PR DESCRIPTION
## Summary

통합 워커 설치 후 발견된 두 가지 문제를 해결.

## Issue 1: 최신 버전 표시가 구버전(v1.1.65)으로 고정

**증상** (사용자 로그)
```
[Updater] Update for version 1.1.70 is not available
         (latest version: 1.1.65, downgrade is disallowed).
```
상태창 "최신 버전" 에 `v1.1.65` 가 표시되고 "업데이트 날짜" 도 해당 시각(09:14 UTC)으로 표시됨.

**Root Cause**
- `updater.ts:39` 에서 `autoUpdater.allowPrerelease = true`
- 이 모드에서 electron-updater 는 `releases.atom` 피드를 사용해 "최신 릴리즈" 를 찾음
- GitHub `releases.atom` 피드가 **prerelease 인 `worker-v1.1.65` 를 `v1.1.70` (최신 non-prerelease) 보다 앞에 배치**하는 quirk 존재 (실제 atom 피드 확인 완료)
- electron-updater 가 atom 피드의 첫 엔트리인 `worker-v1.1.65` 를 "latest" 로 판단 → 현재 버전 1.1.70 > 1.1.65 이므로 "downgrade disallowed" 오류

**Fix**
- `updater.ts`: `allowPrerelease = false` 로 변경
- 이제 `/releases/latest` (GitHub API) 를 사용 → non-prerelease 중 가장 최신(v1.1.70)을 정확히 반환
- `update-available` / `update-downloaded` 이벤트에서도 `currentVersionReleasedAt = info.releaseDate` 저장하여 UI "업데이트 날짜" 가 항상 **최신 버전의 서버 업로드 시각**을 반영

## Issue 2: 덴트웹 자동 등록 실패

**증상** (사용자 로그)
```
[DentWeb] clinic 설정 없음, 자동 등록 시도...
[Main] 덴트웹: 자동 등록 실패
```

**Root Cause (5 Whys)**
1. 왜 자동 등록 실패? → `autoRegisterDentweb()` 의 `/api/dentweb/worker-config` 호출이 non-OK 반환
2. 왜 non-OK? → 엔드포인트가 `marketing_worker_control.clinic_id` 를 SELECT 하는데 해당 컬럼이 **존재하지 않음** (Supabase 실제 스키마 검증 완료)
3. 왜 컬럼이 없나? → `marketing_worker_control` 은 `id='main'` 단일 행 공유 구조 (multi-tenant 아님), 초기 설계상 `clinic_id` 미포함
4. 왜 다른 엔드포인트가 있나? → `/api/marketing/worker-api/dentweb/config` 가 정상 경로: `verifyWorkerApiKey` 로 인증 후 `dentweb_sync_config` 를 직접 조회/자동생성
5. 어떻게 재발 방지? → 브릿지가 정상 경로를 호출하고, 실패 시 상세 진단 로그 출력

**Fix**
- `dentweb-bridge.ts autoRegisterDentweb()`:
  - 엔드포인트 교체: `/api/dentweb/worker-config` → `/api/marketing/worker-api/dentweb/config`
  - 응답 shape 변경: `{clinic_id, api_key}` → `{success, config: {clinic_id, api_key, ...}}`
  - 모든 실패 경로에 상세 로그 추가:
    - `workerApiKey` 누락
    - HTTP status/statusText/body 앞 200자
    - 응답 형식 오류
    - `clinic_id`/`api_key` 누락
  - 성공 로그에 clinic_id prefix 8자 포함 (디버깅용, 개인정보 최소화)

## Version Bump

- `marketing-worker/electron/package.json`: 1.1.1 → 1.1.2
- main merge 후 `build-marketing-worker.yml` 자동 트리거 → 새 `v1.1.X` 릴리즈 → 설치된 워커 자동 업데이트 후 재시작 시 반영

## Test plan

- [x] `npx tsc --noEmit` 통과
- [ ] 설치된 워커 자동 업데이트 후 재시작
- [ ] 상태창 "최신 버전" 에 실제 최신 버전 (v1.1.71 이상) 표시 확인
- [ ] 상태창 "업데이트 날짜" 에 최신 버전 릴리즈 시각 표시 확인
- [ ] 로그에 `[DentWeb] 자동 등록 요청: https://.../api/marketing/worker-api/dentweb/config` 기록 확인
- [ ] 로그에 `[DentWeb] 자동 등록 완료 (clinic=..., enabled=true)` 기록 확인
- [ ] 만약 실패하면 상세 에러 로그 기반으로 추가 수정

https://claude.ai/code/session_017rMMGJFCGqfhEKA3aBT8L3