### PR TITLE
feat(daily-report): 리뷰 작성 여부 다중 옵션 추가 (네이버/구글/게시판)

### DIFF
--- a/dental-clinic-manager/.claude/settings.local.json
+++ b/dental-clinic-manager/.claude/settings.local.json
@@ -82,6 +82,9 @@
       "mcp__supabase__apply_migration"
     ],
     "deny": [],
-    "ask": []
+    "ask": [],
+    "additionalDirectories": [
+      "/tmp"
+    ]
   }
 }

--- a/dental-clinic-manager/.omc/project-memory.json
+++ b/dental-clinic-manager/.omc/project-memory.json
@@ -315,20 +315,38 @@
   "hotPaths": [
     {
       "path": "src/components/Contract/ContractForm.tsx",
-      "accessCount": 21,
-      "lastAccessed": 1776148525931,
+      "accessCount": 26,
+      "lastAccessed": 1776181555477,
+      "type": "file"
+    },
+    {
+      "path": "src/components/marketing/clinical/ClinicalForm.tsx",
+      "accessCount": 16,
+      "lastAccessed": 1776181464709,
+      "type": "file"
+    },
+    {
+      "path": "src/lib/contractService.ts",
+      "accessCount": 15,
+      "lastAccessed": 1776158548068,
       "type": "file"
     },
     {
       "path": "src/components/Contract/ContractDetail.tsx",
-      "accessCount": 12,
-      "lastAccessed": 1776148733406,
+      "accessCount": 14,
+      "lastAccessed": 1776158559138,
       "type": "directory"
     },
     {
       "path": "src/app/dashboard/marketing/page.tsx",
+      "accessCount": 14,
+      "lastAccessed": 1776180411011,
+      "type": "file"
+    },
+    {
+      "path": "src/components/marketing/ImageEditModal.tsx",
       "accessCount": 10,
-      "lastAccessed": 1776151119457,
+      "lastAccessed": 1776182042203,
       "type": "file"
     },
     {
@@ -344,12 +362,6 @@
       "type": "directory"
     },
     {
-      "path": "src/lib/contractService.ts",
-      "accessCount": 6,
-      "lastAccessed": 1776148540647,
-      "type": "file"
-    },
-    {
       "path": "src/types/contract.ts",
       "accessCount": 4,
       "lastAccessed": 1776148496421,
@@ -363,8 +375,32 @@
     },
     {
       "path": "src/components/marketing/clinical/imageUtils.ts",
+      "accessCount": 4,
+      "lastAccessed": 1776181390141,
+      "type": "file"
+    },
+    {
+      "path": "src/components/Contract/ContractList.tsx",
       "accessCount": 2,
-      "lastAccessed": 1776148759570,
+      "lastAccessed": 1776157909426,
+      "type": "file"
+    },
+    {
+      "path": "src/types/marketing.ts",
+      "accessCount": 2,
+      "lastAccessed": 1776181875562,
+      "type": "file"
+    },
+    {
+      "path": "src/app/api/marketing/regenerate-image/route.ts",
+      "accessCount": 2,
+      "lastAccessed": 1776181924495,
+      "type": "file"
+    },
+    {
+      "path": "src/lib/marketing/image-generator.ts",
+      "accessCount": 2,
+      "lastAccessed": 1776181945627,
       "type": "file"
     },
     {
@@ -386,12 +422,6 @@
       "type": "file"
     },
     {
-      "path": "src/components/Contract/ContractList.tsx",
-      "accessCount": 1,
-      "lastAccessed": 1776148503462,
-      "type": "file"
-    },
-    {
       "path": "src/app/dashboard/contracts/page.tsx",
       "accessCount": 1,
       "lastAccessed": 1776148519613,
@@ -407,6 +437,42 @@
       "path": "src/app/dashboard/contracts/new/page.tsx",
       "accessCount": 1,
       "lastAccessed": 1776148519703,
+      "type": "file"
+    },
+    {
+      "path": "src/components/marketing/ContentEditor.tsx",
+      "accessCount": 1,
+      "lastAccessed": 1776180403779,
+      "type": "file"
+    },
+    {
+      "path": ".env.local",
+      "accessCount": 1,
+      "lastAccessed": 1776181875301,
+      "type": "file"
+    },
+    {
+      "path": "src/app/api/marketing/generate/route.ts",
+      "accessCount": 1,
+      "lastAccessed": 1776181875438,
+      "type": "file"
+    },
+    {
+      "path": "src/lib/marketing/content-generator.ts",
+      "accessCount": 1,
+      "lastAccessed": 1776181881975,
+      "type": "file"
+    },
+    {
+      "path": "src/lib/marketing/seed-prompts.ts",
+      "accessCount": 1,
+      "lastAccessed": 1776181882147,
+      "type": "file"
+    },
+    {
+      "path": "src/lib/marketing/default-prompts.ts",
+      "accessCount": 1,
+      "lastAccessed": 1776181884896,
       "type": "file"
     }
   ],

--- a/dental-clinic-manager/.omc/sessions/4c31ec61-8b9c-4ff7-926a-7ffacbc161a6.json
+++ b/dental-clinic-manager/.omc/sessions/4c31ec61-8b9c-4ff7-926a-7ffacbc161a6.json
@@ -1,0 +1,8 @@
+{
+  "session_id": "4c31ec61-8b9c-4ff7-926a-7ffacbc161a6",
+  "ended_at": "2026-04-14T14:11:30.281Z",
+  "reason": "other",
+  "agents_spawned": 2,
+  "agents_completed": 2,
+  "modes_used": []
+}

--- a/dental-clinic-manager/.omc/sessions/9d3e59ff-12f6-41a2-a22a-ea6bf1708ebf.json
+++ b/dental-clinic-manager/.omc/sessions/9d3e59ff-12f6-41a2-a22a-ea6bf1708ebf.json
@@ -1,0 +1,8 @@
+{
+  "session_id": "9d3e59ff-12f6-41a2-a22a-ea6bf1708ebf",
+  "ended_at": "2026-04-14T14:11:54.305Z",
+  "reason": "other",
+  "agents_spawned": 2,
+  "agents_completed": 2,
+  "modes_used": []
+}

--- a/dental-clinic-manager/.omc/state/agent-replay-3c2bf9f8-d009-47c9-ba14-f309b6d8f2d1.jsonl
+++ b/dental-clinic-manager/.omc/state/agent-replay-3c2bf9f8-d009-47c9-ba14-f309b6d8f2d1.jsonl
@@ -1,2 +1,9 @@
 {"t":0,"agent":"a1b0976","agent_type":"Explore","event":"agent_start","parent_mode":"none"}
 {"t":0,"agent":"a1b0976","agent_type":"Explore","event":"agent_stop","success":true,"duration_ms":76374}
+{"t":0,"agent":"af34863","agent_type":"unknown","event":"agent_stop","success":true}
+{"t":0,"agent":"ac0a77b","agent_type":"Explore","event":"agent_start","parent_mode":"none"}
+{"t":0,"agent":"ac0a77b","agent_type":"Explore","event":"agent_stop","success":true,"duration_ms":30198}
+{"t":0,"agent":"a47f3bb","agent_type":"Plan","event":"agent_start","parent_mode":"none"}
+{"t":0,"agent":"a47f3bb","agent_type":"Plan","event":"agent_stop","success":true,"duration_ms":59875}
+{"t":0,"agent":"aaa8bf2","agent_type":"Explore","event":"agent_start","parent_mode":"none"}
+{"t":0,"agent":"aaa8bf2","agent_type":"Explore","event":"agent_stop","success":true,"duration_ms":47341}

--- a/dental-clinic-manager/.omc/state/agent-replay-738a1c12-47c3-409c-98ba-bd1850395bbc.jsonl
+++ b/dental-clinic-manager/.omc/state/agent-replay-738a1c12-47c3-409c-98ba-bd1850395bbc.jsonl
@@ -1,2 +1,4 @@
 {"t":0,"agent":"a98f382","agent_type":"Explore","event":"agent_start","parent_mode":"none"}
 {"t":0,"agent":"a85f81f","agent_type":"unknown","event":"agent_stop","success":true}
+{"t":0,"agent":"a85ee9b","agent_type":"Explore","event":"agent_start","parent_mode":"none"}
+{"t":0,"agent":"a85ee9b","agent_type":"Explore","event":"agent_stop","success":true,"duration_ms":46326}

--- a/dental-clinic-manager/.omc/state/agent-replay-889d01f3-f164-4050-8346-82316b1b9e56.jsonl
+++ b/dental-clinic-manager/.omc/state/agent-replay-889d01f3-f164-4050-8346-82316b1b9e56.jsonl
@@ -9,3 +9,4 @@
 {"t":0,"agent":"a3dc4a5","agent_type":"Plan","event":"agent_start","parent_mode":"none"}
 {"t":0,"agent":"a3dc4a5","agent_type":"Plan","event":"agent_stop","success":true,"duration_ms":112659}
 {"t":0,"agent":"af92e32","agent_type":"unknown","event":"agent_stop","success":true}
+{"t":0,"agent":"ac03ffd","agent_type":"unknown","event":"agent_stop","success":true}

--- a/dental-clinic-manager/.omc/state/checkpoints/checkpoint-2026-04-14T13-54-10-451Z.json
+++ b/dental-clinic-manager/.omc/state/checkpoints/checkpoint-2026-04-14T13-54-10-451Z.json
@@ -1,0 +1,16 @@
+{
+  "created_at": "2026-04-14T13:54:10.446Z",
+  "trigger": "manual",
+  "active_modes": {},
+  "todo_summary": {
+    "pending": 0,
+    "in_progress": 0,
+    "completed": 0
+  },
+  "wisdom_exported": false,
+  "background_jobs": {
+    "active": [],
+    "recent": [],
+    "stats": null
+  }
+}

--- a/dental-clinic-manager/.omc/state/checkpoints/checkpoint-2026-04-14T14-13-27-799Z.json
+++ b/dental-clinic-manager/.omc/state/checkpoints/checkpoint-2026-04-14T14-13-27-799Z.json
@@ -1,0 +1,16 @@
+{
+  "created_at": "2026-04-14T14:13:27.796Z",
+  "trigger": "auto",
+  "active_modes": {},
+  "todo_summary": {
+    "pending": 0,
+    "in_progress": 0,
+    "completed": 0
+  },
+  "wisdom_exported": false,
+  "background_jobs": {
+    "active": [],
+    "recent": [],
+    "stats": null
+  }
+}

--- a/dental-clinic-manager/.omc/state/subagent-tracking.json
+++ b/dental-clinic-manager/.omc/state/subagent-tracking.json
@@ -1,26 +1,44 @@
 {
   "agents": [
     {
-      "agent_id": "a4eeb0c4f2a14c43b",
-      "agent_type": "oh-my-claudecode:explore",
-      "started_at": "2026-04-14T03:52:28.079Z",
+      "agent_id": "ac0a77b854ace4e70",
+      "agent_type": "Explore",
+      "started_at": "2026-04-14T15:26:40.355Z",
       "parent_mode": "none",
       "status": "completed",
-      "completed_at": "2026-04-14T03:52:44.076Z",
-      "duration_ms": 15997
+      "completed_at": "2026-04-14T15:27:10.553Z",
+      "duration_ms": 30198
     },
     {
-      "agent_id": "a388371a6f4f53e40",
-      "agent_type": "Explore",
-      "started_at": "2026-04-14T06:34:48.780Z",
+      "agent_id": "a47f3bb8b6b5f3892",
+      "agent_type": "Plan",
+      "started_at": "2026-04-14T15:27:31.510Z",
       "parent_mode": "none",
       "status": "completed",
-      "completed_at": "2026-04-14T06:36:11.349Z",
-      "duration_ms": 82569
+      "completed_at": "2026-04-14T15:28:31.385Z",
+      "duration_ms": 59875
+    },
+    {
+      "agent_id": "a85ee9babe6021412",
+      "agent_type": "Explore",
+      "started_at": "2026-04-14T15:32:26.138Z",
+      "parent_mode": "none",
+      "status": "completed",
+      "completed_at": "2026-04-14T15:33:12.464Z",
+      "duration_ms": 46326
+    },
+    {
+      "agent_id": "aaa8bf29df1239438",
+      "agent_type": "Explore",
+      "started_at": "2026-04-14T15:51:07.771Z",
+      "parent_mode": "none",
+      "status": "completed",
+      "completed_at": "2026-04-14T15:51:55.112Z",
+      "duration_ms": 47341
     }
   ],
-  "total_spawned": 2,
-  "total_completed": 2,
+  "total_spawned": 4,
+  "total_completed": 4,
   "total_failed": 0,
-  "last_updated": "2026-04-14T06:38:14.898Z"
+  "last_updated": "2026-04-14T15:51:55.215Z"
 }

--- a/dental-clinic-manager/marketing-worker/electron/package.json
+++ b/dental-clinic-manager/marketing-worker/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hayan-marketing-worker",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "하얀치과 마케팅 워커 - Electron 데스크탑 앱",
   "productName": "클리닉 매니저 워커",
   "private": true,

--- a/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
@@ -186,27 +186,54 @@ async function syncPatientsToServer(patients: Record<string, unknown>[], syncTyp
 async function autoRegisterDentweb(): Promise<boolean> {
   try {
     const { dashboardUrl, workerApiKey } = getConfig();
-    if (!workerApiKey) return false;
+    if (!workerApiKey) {
+      log('warn', '[DentWeb] 자동 등록 실패: workerApiKey 가 비어있음');
+      return false;
+    }
 
-    const res = await fetch(`${dashboardUrl}/api/dentweb/worker-config`, {
+    // 통합 워커 API 경로 사용 (verifyWorkerApiKey 헬퍼를 통해 인증).
+    // 이전에 사용하던 /api/dentweb/worker-config 는 존재하지 않는
+    // marketing_worker_control.clinic_id 컬럼을 조회하여 PostgREST 에러로
+    // 항상 401 을 반환함 — /api/marketing/worker-api/dentweb/config 가 정상 경로.
+    const url = `${dashboardUrl}/api/marketing/worker-api/dentweb/config`;
+    log('info', `[DentWeb] 자동 등록 요청: ${url}`);
+    const res = await fetch(url, {
       headers: { 'Authorization': `Bearer ${workerApiKey}` },
       signal: AbortSignal.timeout(10000),
     });
 
-    if (!res.ok) return false;
-    const data = await res.json();
-
-    if (data.clinic_id && data.api_key) {
-      setConfig({
-        dentwebEnabled: true,
-        dentwebClinicId: data.clinic_id,
-        dentwebApiKey: data.api_key,
-        dentwebSyncInterval: data.sync_interval_seconds || 300,
-      });
-      log('info', '[DentWeb] 자동 등록 완료 (enabled=true)');
-      return true;
+    if (!res.ok) {
+      const errText = await res.text().catch(() => '');
+      log('error', `[DentWeb] 자동 등록 실패: HTTP ${res.status} ${res.statusText} — ${errText.slice(0, 200)}`);
+      return false;
     }
-    return false;
+
+    const data = await res.json();
+    if (!data?.success || !data?.config) {
+      log('error', `[DentWeb] 자동 등록 실패: 응답 형식 오류 ${JSON.stringify(data).slice(0, 200)}`);
+      return false;
+    }
+
+    const config = data.config as {
+      clinic_id?: string;
+      api_key?: string;
+      sync_interval_seconds?: number;
+      is_active?: boolean;
+    };
+
+    if (!config.clinic_id || !config.api_key) {
+      log('error', `[DentWeb] 자동 등록 실패: clinic_id/api_key 누락 (${JSON.stringify(config).slice(0, 200)})`);
+      return false;
+    }
+
+    setConfig({
+      dentwebEnabled: true,
+      dentwebClinicId: config.clinic_id,
+      dentwebApiKey: config.api_key,
+      dentwebSyncInterval: config.sync_interval_seconds || 300,
+    });
+    log('info', `[DentWeb] 자동 등록 완료 (clinic=${config.clinic_id.slice(0, 8)}..., enabled=true)`);
+    return true;
   } catch (err) {
     log('error', `[DentWeb] 자동 등록 실패: ${err instanceof Error ? err.message : String(err)}`);
     return false;

--- a/dental-clinic-manager/marketing-worker/electron/src/updater.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/updater.ts
@@ -36,7 +36,10 @@ export function initAutoUpdater(): void {
   // 자동 다운로드 활성화
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
-  autoUpdater.allowPrerelease = true;
+  // allowPrerelease=false: /releases/latest 엔드포인트 사용하여 'Latest' 마크된 non-prerelease 만 감지.
+  // true 로 두면 releases.atom 피드가 사용되는데, GitHub 피드가 구 prerelease(worker-v1.1.65 등)를
+  // 최신 non-prerelease(v1.1.X) 보다 앞에 배치하는 quirk 때문에 downgrade 오판이 발생함.
+  autoUpdater.allowPrerelease = false;
 
   // Private repo 토큰 설정
   const ghToken = getGithubToken();
@@ -61,6 +64,8 @@ export function initAutoUpdater(): void {
     setUpdateMeta({
       latestVersion: info.version,
       updateStatus: 'downloading',
+      // 최신 버전이 서버에 업로드된 시각
+      currentVersionReleasedAt: info.releaseDate || '',
     });
     notify('클리닉 매니저 워커', `새 버전 v${info.version}을 다운로드 중입니다.`);
     isManualCheck = false;
@@ -71,7 +76,7 @@ export function initAutoUpdater(): void {
     setUpdateMeta({
       latestVersion: info.version,
       updateStatus: 'up-to-date',
-      // 현재 버전의 GitHub 릴리즈 날짜 (서버에 배포된 날짜)
+      // 최신 버전(=현재 버전)이 서버에 업로드된 시각
       currentVersionReleasedAt: info.releaseDate || '',
     });
     if (isManualCheck) {
@@ -90,6 +95,8 @@ export function initAutoUpdater(): void {
       latestVersion: info.version,
       updateStatus: 'downloaded',
       lastUpdatedAt: new Date().toISOString(),
+      // 최신 버전이 서버에 업로드된 시각
+      currentVersionReleasedAt: info.releaseDate || '',
     });
     notify('클리닉 매니저 워커 업데이트', `v${info.version} 다운로드 완료. 10초 후 자동 재시작됩니다.`);
     isManualCheck = false;

--- a/dental-clinic-manager/src/components/Contract/ContractForm.tsx
+++ b/dental-clinic-manager/src/components/Contract/ContractForm.tsx
@@ -31,6 +31,8 @@ export default function ContractForm({ currentUser, employees, onSuccess, onCanc
   const [selectedEmployee, setSelectedEmployee] = useState<User | null>(null)
   const [salaryType, setSalaryType] = useState<'gross' | 'net'>('gross')
   const [periodType, setPeriodType] = useState<'unset' | 'permanent' | 'fixed'>('unset')
+  const [fixedPeriodUnit, setFixedPeriodUnit] = useState<'years' | 'months' | 'custom'>('years')
+  const [fixedPeriodValue, setFixedPeriodValue] = useState<number>(1)
   const [formData, setFormData] = useState<Partial<ContractData>>({
     employment_period_start: new Date().toISOString().split('T')[0],
     salary_base: 0,
@@ -42,6 +44,26 @@ export default function ContractForm({ currentUser, employees, onSuccess, onCanc
     pension_insurance: true,
     is_permanent: false
   })
+
+  // 기한 정함(년/월)일 때 시작일 기준으로 종료일 자동 계산
+  useEffect(() => {
+    if (periodType !== 'fixed') return
+    if (fixedPeriodUnit === 'custom') return
+    if (!formData.employment_period_start) return
+
+    const start = new Date(formData.employment_period_start)
+    if (isNaN(start.getTime())) return
+
+    const endDate = new Date(start)
+    if (fixedPeriodUnit === 'years') {
+      endDate.setFullYear(endDate.getFullYear() + fixedPeriodValue)
+    } else if (fixedPeriodUnit === 'months') {
+      endDate.setMonth(endDate.getMonth() + fixedPeriodValue)
+    }
+    endDate.setDate(endDate.getDate() - 1)
+    
+    setFormData(prev => ({ ...prev, employment_period_end: endDate.toISOString().split('T')[0] }))
+  }, [periodType, fixedPeriodUnit, fixedPeriodValue, formData.employment_period_start])
 
   // Debug logging for employees prop
   useEffect(() => {
@@ -182,6 +204,16 @@ export default function ContractForm({ currentUser, employees, onSuccess, onCanc
 
     if (!formData.employment_period_start || !formData.salary_base) {
       await appAlert('필수 항목을 입력해주세요.')
+      return
+    }
+
+    if (periodType === 'unset') {
+      await appAlert('근로 기한을 선택해주세요 (무기한 또는 기간 있음).')
+      return
+    }
+    
+    if (periodType === 'fixed' && !formData.employment_period_end) {
+      await appAlert('계약 기간(종료일)을 설정해주세요.')
       return
     }
 
@@ -350,65 +382,83 @@ export default function ContractForm({ currentUser, employees, onSuccess, onCanc
 
           {/* 기간 있음 선택 시 */}
           {periodType === 'fixed' && (
-            <div className="pl-0 space-y-3">
-              {/* 년 단위 빠른 선택 */}
-              <div>
-                <p className="text-xs text-at-text-secondary mb-1.5">년 단위</p>
-                <div className="flex flex-wrap gap-2">
-                  {[1, 2, 3].map(years => (
-                    <button
-                      key={years}
-                      type="button"
-                      onClick={() => {
-                        const start = formData.employment_period_start
-                        if (!start) return
-                        const endDate = new Date(start)
-                        endDate.setFullYear(endDate.getFullYear() + years)
-                        endDate.setDate(endDate.getDate() - 1)
-                        setFormData(prev => ({ ...prev, employment_period_end: endDate.toISOString().split('T')[0] }))
-                      }}
-                      className="px-3 py-1 text-xs border border-at-border rounded hover:border-at-accent hover:text-at-accent transition-colors"
-                    >
-                      {years}년
-                    </button>
-                  ))}
+            <div className="mt-3 p-4 bg-at-surface-alt border border-at-border rounded-xl space-y-4">
+              <div className="flex flex-wrap gap-4">
+                <label className="inline-flex items-center gap-1.5 cursor-pointer">
+                  <input
+                    type="radio"
+                    checked={fixedPeriodUnit === 'years'}
+                    onChange={() => setFixedPeriodUnit('years')}
+                    className="text-at-accent focus:ring-at-accent"
+                  />
+                  <span className="text-sm">년 단위</span>
+                </label>
+                <label className="inline-flex items-center gap-1.5 cursor-pointer">
+                  <input
+                    type="radio"
+                    checked={fixedPeriodUnit === 'months'}
+                    onChange={() => setFixedPeriodUnit('months')}
+                    className="text-at-accent focus:ring-at-accent"
+                  />
+                  <span className="text-sm">월 단위</span>
+                </label>
+                <label className="inline-flex items-center gap-1.5 cursor-pointer">
+                  <input
+                    type="radio"
+                    checked={fixedPeriodUnit === 'custom'}
+                    onChange={() => setFixedPeriodUnit('custom')}
+                    className="text-at-accent focus:ring-at-accent"
+                  />
+                  <span className="text-sm">직접 입력</span>
+                </label>
+              </div>
+
+              {fixedPeriodUnit === 'years' && (
+                <div className="flex items-center gap-2">
+                  <input
+                    type="number"
+                    min="1"
+                    value={fixedPeriodValue}
+                    onChange={e => setFixedPeriodValue(parseInt(e.target.value) || 1)}
+                    className="w-24 px-3 py-1.5 border border-at-border rounded focus:ring-2 focus:ring-at-accent text-right"
+                  />
+                  <span className="text-sm">년 설정</span>
+                  <div className="ml-4 text-sm text-at-accent bg-blue-50 px-3 py-1.5 rounded-lg border border-blue-100 flex items-center">
+                    <span className="font-semibold mr-1">종료일:</span> 
+                    {formData.employment_period_end || '시작일을 먼저 선택해주세요'}
+                  </div>
                 </div>
-              </div>
-              {/* 월 단위 빠른 선택 */}
-              <div>
-                <p className="text-xs text-at-text-secondary mb-1.5">월 단위</p>
-                <div className="flex flex-wrap gap-2">
-                  {[3, 6, 12].map(months => (
-                    <button
-                      key={months}
-                      type="button"
-                      onClick={() => {
-                        const start = formData.employment_period_start
-                        if (!start) return
-                        const endDate = new Date(start)
-                        endDate.setMonth(endDate.getMonth() + months)
-                        endDate.setDate(endDate.getDate() - 1)
-                        setFormData(prev => ({ ...prev, employment_period_end: endDate.toISOString().split('T')[0] }))
-                      }}
-                      className="px-3 py-1 text-xs border border-at-border rounded hover:border-at-accent hover:text-at-accent transition-colors"
-                    >
-                      {months}개월
-                    </button>
-                  ))}
-                  <span className="text-xs text-at-text-secondary self-center">시작일 기준 자동 계산</span>
+              )}
+
+              {fixedPeriodUnit === 'months' && (
+                <div className="flex items-center gap-2">
+                  <input
+                    type="number"
+                    min="1"
+                    value={fixedPeriodValue}
+                    onChange={e => setFixedPeriodValue(parseInt(e.target.value) || 1)}
+                    className="w-24 px-3 py-1.5 border border-at-border rounded focus:ring-2 focus:ring-at-accent text-right"
+                  />
+                  <span className="text-sm">개월 설정</span>
+                  <div className="ml-4 text-sm text-at-accent bg-blue-50 px-3 py-1.5 rounded-lg border border-blue-100 flex items-center">
+                    <span className="font-semibold mr-1">종료일:</span> 
+                    {formData.employment_period_end || '시작일을 먼저 선택해주세요'}
+                  </div>
                 </div>
-              </div>
-              {/* 직접 입력 */}
-              <div>
-                <label className="block text-xs text-at-text-secondary mb-1">종료일 직접 입력</label>
-                <input
-                  type="date"
-                  name="employment_period_end"
-                  value={formData.employment_period_end || ''}
-                  onChange={handleInputChange}
-                  className="w-full px-3 py-2 border border-at-border rounded focus:ring-2 focus:ring-at-accent"
-                />
-              </div>
+              )}
+
+              {fixedPeriodUnit === 'custom' && (
+                <div>
+                  <label className="block text-xs text-at-text-secondary mb-1">종료일 직접 입력</label>
+                  <input
+                    type="date"
+                    name="employment_period_end"
+                    value={formData.employment_period_end || ''}
+                    onChange={handleInputChange}
+                    className="w-full px-3 py-2 border border-at-border rounded focus:ring-2 focus:ring-at-accent"
+                  />
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/dental-clinic-manager/src/components/Contract/ContractForm.tsx
+++ b/dental-clinic-manager/src/components/Contract/ContractForm.tsx
@@ -30,6 +30,7 @@ export default function ContractForm({ currentUser, employees, onSuccess, onCanc
   const [loading, setLoading] = useState(false)
   const [selectedEmployee, setSelectedEmployee] = useState<User | null>(null)
   const [salaryType, setSalaryType] = useState<'gross' | 'net'>('gross')
+  const [periodType, setPeriodType] = useState<'unset' | 'permanent' | 'fixed'>('unset')
   const [formData, setFormData] = useState<Partial<ContractData>>({
     employment_period_start: new Date().toISOString().split('T')[0],
     salary_base: 0,
@@ -39,7 +40,7 @@ export default function ContractForm({ currentUser, employees, onSuccess, onCanc
     health_insurance: true,
     employment_insurance: true,
     pension_insurance: true,
-    is_permanent: true
+    is_permanent: false
   })
 
   // Debug logging for employees prop
@@ -298,65 +299,116 @@ export default function ContractForm({ currentUser, employees, onSuccess, onCanc
               </p>
             </div>
           )}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-at-text-secondary mb-1">
-                시작일 <span className="text-red-500">*</span>
-              </label>
-              <input
-                type="date"
-                name="employment_period_start"
-                value={formData.employment_period_start || ''}
-                onChange={handleInputChange}
-                required
-                className="w-full px-3 py-2 border border-at-border rounded focus:ring-2 focus:ring-at-accent"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-at-text-secondary mb-1">종료일</label>
-              <input
-                type="date"
-                name="employment_period_end"
-                value={formData.employment_period_end || ''}
-                onChange={handleInputChange}
-                disabled={formData.is_permanent}
-                className="w-full px-3 py-2 border border-at-border rounded focus:ring-2 focus:ring-at-accent disabled:bg-at-surface-alt"
-              />
-            </div>
-          </div>
-          <div className="mt-2">
-            <label className="inline-flex items-center">
-              <input
-                type="checkbox"
-                name="is_permanent"
-                checked={formData.is_permanent || false}
-                onChange={handleInputChange}
-                className="rounded border-at-border text-at-accent focus:ring-at-accent"
-              />
-              <span className="ml-2 text-sm text-at-text-secondary">무기한 계약 (종료일 없음)</span>
+
+          {/* 시작일 */}
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-at-text-secondary mb-1">
+              시작일 <span className="text-red-500">*</span>
             </label>
+            <input
+              type="date"
+              name="employment_period_start"
+              value={formData.employment_period_start || ''}
+              onChange={handleInputChange}
+              required
+              className="w-full px-3 py-2 border border-at-border rounded focus:ring-2 focus:ring-at-accent"
+            />
           </div>
-          {/* 1년 단위 빠른 선택 */}
-          {!formData.is_permanent && (
-            <div className="mt-2 flex flex-wrap gap-2">
-              {[1, 2, 3].map(years => (
-                <button
-                  key={years}
-                  type="button"
-                  onClick={() => {
-                    const start = formData.employment_period_start
-                    if (!start) return
-                    const endDate = new Date(start)
-                    endDate.setFullYear(endDate.getFullYear() + years)
-                    endDate.setDate(endDate.getDate() - 1)
-                    setFormData(prev => ({ ...prev, employment_period_end: endDate.toISOString().split('T')[0] }))
+
+          {/* 기간 유형 선택 */}
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-at-text-secondary mb-2">계약 유형</label>
+            <div className="flex gap-3">
+              <label className="inline-flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="radio"
+                  name="periodType"
+                  checked={periodType === 'permanent'}
+                  onChange={() => {
+                    setPeriodType('permanent')
+                    setFormData(prev => ({ ...prev, is_permanent: true, employment_period_end: undefined }))
                   }}
-                  className="px-3 py-1 text-xs border border-at-border rounded hover:border-at-accent hover:text-at-accent transition-colors"
-                >
-                  {years}년
-                </button>
-              ))}
-              <span className="text-xs text-at-text-secondary self-center">시작일 기준 자동 계산</span>
+                  className="text-at-accent focus:ring-at-accent"
+                />
+                <span className="text-sm">무기한 (종료일 없음)</span>
+              </label>
+              <label className="inline-flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="radio"
+                  name="periodType"
+                  checked={periodType === 'fixed'}
+                  onChange={() => {
+                    setPeriodType('fixed')
+                    setFormData(prev => ({ ...prev, is_permanent: false }))
+                  }}
+                  className="text-at-accent focus:ring-at-accent"
+                />
+                <span className="text-sm">기간 있음 (종료일 지정)</span>
+              </label>
+            </div>
+          </div>
+
+          {/* 기간 있음 선택 시 */}
+          {periodType === 'fixed' && (
+            <div className="pl-0 space-y-3">
+              {/* 년 단위 빠른 선택 */}
+              <div>
+                <p className="text-xs text-at-text-secondary mb-1.5">년 단위</p>
+                <div className="flex flex-wrap gap-2">
+                  {[1, 2, 3].map(years => (
+                    <button
+                      key={years}
+                      type="button"
+                      onClick={() => {
+                        const start = formData.employment_period_start
+                        if (!start) return
+                        const endDate = new Date(start)
+                        endDate.setFullYear(endDate.getFullYear() + years)
+                        endDate.setDate(endDate.getDate() - 1)
+                        setFormData(prev => ({ ...prev, employment_period_end: endDate.toISOString().split('T')[0] }))
+                      }}
+                      className="px-3 py-1 text-xs border border-at-border rounded hover:border-at-accent hover:text-at-accent transition-colors"
+                    >
+                      {years}년
+                    </button>
+                  ))}
+                </div>
+              </div>
+              {/* 월 단위 빠른 선택 */}
+              <div>
+                <p className="text-xs text-at-text-secondary mb-1.5">월 단위</p>
+                <div className="flex flex-wrap gap-2">
+                  {[3, 6, 12].map(months => (
+                    <button
+                      key={months}
+                      type="button"
+                      onClick={() => {
+                        const start = formData.employment_period_start
+                        if (!start) return
+                        const endDate = new Date(start)
+                        endDate.setMonth(endDate.getMonth() + months)
+                        endDate.setDate(endDate.getDate() - 1)
+                        setFormData(prev => ({ ...prev, employment_period_end: endDate.toISOString().split('T')[0] }))
+                      }}
+                      className="px-3 py-1 text-xs border border-at-border rounded hover:border-at-accent hover:text-at-accent transition-colors"
+                    >
+                      {months}개월
+                    </button>
+                  ))}
+                  <span className="text-xs text-at-text-secondary self-center">시작일 기준 자동 계산</span>
+                </div>
+              </div>
+              {/* 직접 입력 */}
+              <div>
+                <label className="block text-xs text-at-text-secondary mb-1">종료일 직접 입력</label>
+                <input
+                  type="date"
+                  name="employment_period_end"
+                  value={formData.employment_period_end || ''}
+                  onChange={handleInputChange}
+                  className="w-full px-3 py-2 border border-at-border rounded focus:ring-2 focus:ring-at-accent"
+                />
+              </div>
             </div>
           )}
         </div>

--- a/dental-clinic-manager/src/components/DailyInput/DailyInputForm.tsx
+++ b/dental-clinic-manager/src/components/DailyInput/DailyInputForm.tsx
@@ -52,7 +52,7 @@ export default function DailyInputForm({ giftInventory, giftCategories = [], gif
     { patient_name: '', consult_content: '', consult_status: 'O', remarks: '' }
   ])
   const [giftRows, setGiftRows] = useState<GiftRowData[]>([
-    { patient_name: '', gift_type: '없음', quantity: 1, naver_review: 'X', notes: '' }
+    { patient_name: '', gift_type: '없음', quantity: 1, naver_review: '미작성', notes: '' }
   ])
   const [happyCallRows, setHappyCallRows] = useState<HappyCallRowData[]>([
     { patient_name: '', treatment: '', notes: '' }
@@ -82,7 +82,7 @@ export default function DailyInputForm({ giftInventory, giftCategories = [], gif
   // 폼 데이터 리셋
   const resetFormData = useCallback(() => {
     setConsultRows([{ patient_name: '', consult_content: '', consult_status: 'O', remarks: '' }])
-    setGiftRows([{ patient_name: '', gift_type: '없음', quantity: 1, naver_review: 'X', notes: '' }])
+    setGiftRows([{ patient_name: '', gift_type: '없음', quantity: 1, naver_review: '미작성', notes: '' }])
     setHappyCallRows([{ patient_name: '', treatment: '', notes: '' }])
     setCashRegisterData({
       prev_bill_50000: 0, prev_bill_10000: 0, prev_bill_5000: 0, prev_bill_1000: 0, prev_coin_500: 0, prev_coin_100: 0,
@@ -186,12 +186,12 @@ export default function DailyInputForm({ giftInventory, giftCategories = [], gif
               patient_name: typeof log.patient_name === 'string' ? log.patient_name : '',
               gift_type: typeof log.gift_type === 'string' ? log.gift_type : '없음',
               quantity: loadedQty,
-              naver_review: (log.naver_review as 'O' | 'X') || 'X',
+              naver_review: (log.naver_review as '미작성' | '네이버' | '구글' | '게시판') || '미작성',
               notes: typeof log.notes === 'string' ? log.notes : ''
             }
           }))
         } else {
-          setGiftRows([{ patient_name: '', gift_type: '없음', quantity: 1, naver_review: 'X', notes: '' }])
+          setGiftRows([{ patient_name: '', gift_type: '없음', quantity: 1, naver_review: '미작성', notes: '' }])
         }
 
         if (happyCallLogs.length > 0) {

--- a/dental-clinic-manager/src/components/DailyInput/GiftTable.tsx
+++ b/dental-clinic-manager/src/components/DailyInput/GiftTable.tsx
@@ -69,7 +69,7 @@ export default function GiftTable({ giftRows, onGiftRowsChange, giftInventory, g
       patient_name: '',
       gift_type: '없음',
       quantity: 1,
-      naver_review: 'X',
+      naver_review: '미작성',
       notes: ''
     }
     onGiftRowsChange([...giftRows, newRow])
@@ -247,11 +247,13 @@ export default function GiftTable({ giftRows, onGiftRowsChange, giftInventory, g
                       className="w-full px-3 py-1.5 border border-at-border rounded-lg text-sm focus:ring-2 focus:ring-at-accent focus:border-at-accent bg-white appearance-none cursor-pointer"
                       style={{ backgroundImage: `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e")`, backgroundPosition: 'right 0.5rem center', backgroundRepeat: 'no-repeat', backgroundSize: '1.5em 1.5em', paddingRight: '2.5rem' }}
                       value={row.naver_review}
-                      onChange={(e) => updateRow(index, 'naver_review', e.target.value as 'O' | 'X')}
+                      onChange={(e) => updateRow(index, 'naver_review', e.target.value as '미작성' | '네이버' | '구글' | '게시판')}
                       disabled={isReadOnly}
                     >
-                      <option value="X">X</option>
-                      <option value="O">O</option>
+                      <option value="미작성">리뷰 미작성</option>
+                      <option value="네이버">네이버 리뷰 작성</option>
+                      <option value="구글">구글 리뷰 작성</option>
+                      <option value="게시판">게시판 리뷰 작성</option>
                     </select>
                   </td>
                   <td className="px-4 py-2">
@@ -404,11 +406,13 @@ export default function GiftTable({ giftRows, onGiftRowsChange, giftInventory, g
                       className="w-full px-2 py-2 border border-at-border rounded-lg text-sm focus:ring-2 focus:ring-at-accent focus:border-at-accent bg-white appearance-none cursor-pointer"
                       style={{ backgroundImage: `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e")`, backgroundPosition: 'right 0.25rem center', backgroundRepeat: 'no-repeat', backgroundSize: '1.25em 1.25em', paddingRight: '1.5rem' }}
                       value={row.naver_review}
-                      onChange={(e) => updateRow(index, 'naver_review', e.target.value as 'O' | 'X')}
+                      onChange={(e) => updateRow(index, 'naver_review', e.target.value as '미작성' | '네이버' | '구글' | '게시판')}
                       disabled={isReadOnly}
                     >
-                      <option value="X">X</option>
-                      <option value="O">O</option>
+                      <option value="미작성">미작성</option>
+                      <option value="네이버">네이버</option>
+                      <option value="구글">구글</option>
+                      <option value="게시판">게시판</option>
                     </select>
                   </div>
                   <div>

--- a/dental-clinic-manager/src/components/Dashboard/DashboardHome.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/DashboardHome.tsx
@@ -648,7 +648,7 @@ export default function DashboardHome() {
                         <div key={g.id ?? i} className="flex items-center gap-2 px-4 py-2 text-sm">
                           <span className="font-medium text-at-text w-16 truncate tracking-[0.08px]">{g.patient_name}</span>
                           <span className="text-at-text-secondary flex-1 truncate tracking-[0.07px]">{g.gift_type} × {g.quantity}</span>
-                          {g.naver_review === 'O' ? (
+                          {g.naver_review !== '미작성' ? (
                             <span className="text-xs bg-at-warning-bg text-at-warning px-2 py-0.5 rounded-full font-medium">리뷰 ✓</span>
                           ) : (
                             <span className="text-xs text-at-text-weak">리뷰 없음</span>

--- a/dental-clinic-manager/src/components/Stats/StatsContainer.tsx
+++ b/dental-clinic-manager/src/components/Stats/StatsContainer.tsx
@@ -100,7 +100,7 @@ const GiftList = ({ logs }: { logs: GiftLog[] }) => {
             <td className="px-3 py-2 whitespace-nowrap text-at-text-secondary">{log.gift_type}</td>
             <td className="px-3 py-2 whitespace-nowrap text-at-text-secondary">{log.quantity}</td>
             <td className="px-3 py-2 whitespace-nowrap">
-              <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-semibold ${log.naver_review === 'O' ? 'bg-at-success-bg text-at-success' : 'bg-at-error-bg text-at-error'}`}>
+              <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-semibold ${log.naver_review !== '미작성' ? 'bg-at-success-bg text-at-success' : 'bg-at-error-bg text-at-error'}`}>
                 {log.naver_review}
               </span>
             </td>
@@ -336,7 +336,7 @@ export default function StatsContainer({
   }
 
   const openNaverReviewModal = () => {
-    const data = filteredGiftLogs.filter(g => g.naver_review === 'O')
+    const data = filteredGiftLogs.filter(g => g.naver_review !== '미작성')
     setModal({ title: `네이버 리뷰 목록 (${data.length}건)`, item: { kind: 'gift', data } })
   }
 

--- a/dental-clinic-manager/src/components/marketing/ImageEditModal.tsx
+++ b/dental-clinic-manager/src/components/marketing/ImageEditModal.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import {
   XMarkIcon,
   ArrowPathIcon,
   CheckIcon,
   SparklesIcon,
   PhotoIcon,
+  ArrowsPointingOutIcon,
 } from '@heroicons/react/24/outline'
 import {
   IMAGE_VISUAL_STYLE_LABELS,
@@ -31,7 +32,8 @@ export default function ImageEditModal({
   const [isRegenerating, setIsRegenerating] = useState(false)
   const [newImage, setNewImage] = useState<{ fileName: string; prompt: string; path: string } | null>(null)
   const [error, setError] = useState('')
-  const [lightboxOpen, setLightboxOpen] = useState(false)
+  const [compareOpen, setCompareOpen] = useState(false)
+  const [compareActiveImg, setCompareActiveImg] = useState<'current' | 'new'>('current')
 
   // 모달 열릴 때 상태 초기화
   useEffect(() => {
@@ -40,8 +42,22 @@ export default function ImageEditModal({
       setNewImage(null)
       setError('')
       setIsRegenerating(false)
+      setCompareOpen(false)
+      setCompareActiveImg('current')
     }
   }, [isOpen, image.prompt])
+
+  // ESC 키로 비교 오버레이 닫기
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape' && compareOpen) {
+      setCompareOpen(false)
+    }
+  }, [compareOpen])
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [handleKeyDown])
 
   const handleRegenerate = async () => {
     if (!editedPrompt.trim()) {
@@ -87,6 +103,11 @@ export default function ImageEditModal({
     }
   }
 
+  const handleOpenCompare = () => {
+    setCompareActiveImg('current')
+    setCompareOpen(true)
+  }
+
   if (!isOpen) return null
 
   return (
@@ -98,7 +119,7 @@ export default function ImageEditModal({
       />
 
       {/* 모달 본체 */}
-      <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-2xl mx-4 max-h-[90vh] overflow-y-auto">
+      <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-3xl mx-4 max-h-[90vh] overflow-y-auto">
         {/* 헤더 */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-at-border">
           <div className="flex items-center gap-2">
@@ -119,13 +140,24 @@ export default function ImageEditModal({
             {/* 현재 이미지 */}
             <div className="space-y-2">
               <span className="text-xs font-medium text-at-text">현재 이미지</span>
-              <div className="relative aspect-square rounded-xl border border-at-border overflow-hidden bg-at-surface-alt">
+              <div
+                className={`relative aspect-square sm:aspect-[4/3] rounded-xl border border-at-border overflow-hidden bg-at-surface-alt ${image.path && newImage ? 'cursor-pointer group' : ''}`}
+                onClick={image.path && newImage ? handleOpenCompare : undefined}
+                title={image.path && newImage ? '클릭하여 비교 보기' : undefined}
+              >
                 {image.path ? (
-                  <img
-                    src={image.path}
-                    alt={image.prompt}
-                    className="w-full h-full object-cover"
-                  />
+                  <>
+                    <img
+                      src={image.path}
+                      alt={image.prompt}
+                      className="w-full h-full object-cover"
+                    />
+                    {newImage && (
+                      <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-black/30">
+                        <span className="text-white text-xs font-medium bg-black/50 px-3 py-1.5 rounded-lg">비교 보기</span>
+                      </div>
+                    )}
+                  </>
                 ) : (
                   <div className="flex items-center justify-center h-full text-at-text">
                     <PhotoIcon className="h-12 w-12" />
@@ -142,7 +174,7 @@ export default function ImageEditModal({
               <span className="text-xs font-medium text-at-text">
                 {newImage ? '새 이미지' : '재생성 미리보기'}
               </span>
-              <div className="relative aspect-square rounded-xl border border-dashed border-at-border overflow-hidden bg-at-surface-alt">
+              <div className="relative aspect-square sm:aspect-[4/3] rounded-xl border border-dashed border-at-border overflow-hidden bg-at-surface-alt">
                 {isRegenerating ? (
                   <div className="flex flex-col items-center justify-center h-full gap-3">
                     <div className="relative">
@@ -152,13 +184,24 @@ export default function ImageEditModal({
                     <span className="text-[10px] text-at-text">30초 정도 소요됩니다</span>
                   </div>
                 ) : newImage ? (
-                  <img
-                    src={newImage.path}
-                    alt={newImage.prompt}
-                    className="w-full h-full object-cover cursor-zoom-in"
-                    onClick={() => setLightboxOpen(true)}
-                    title="클릭하여 전체 이미지 보기"
-                  />
+                  <div className="group relative w-full h-full">
+                    <img
+                      src={newImage.path}
+                      alt={newImage.prompt}
+                      className="w-full h-full object-cover"
+                    />
+                    {/* 호버 오버레이 버튼 */}
+                    <div className="absolute inset-0 flex items-end justify-end p-2 opacity-0 group-hover:opacity-100 transition-opacity bg-gradient-to-t from-black/50 to-transparent">
+                      <button
+                        type="button"
+                        onClick={handleOpenCompare}
+                        className="flex items-center gap-1.5 bg-white/90 hover:bg-white text-slate-700 rounded-lg px-2.5 py-1.5 text-xs font-medium shadow-sm transition-colors"
+                      >
+                        <ArrowsPointingOutIcon className="h-3.5 w-3.5" />
+                        나란히 비교
+                      </button>
+                    </div>
+                  </div>
                 ) : (
                   <div className="flex flex-col items-center justify-center h-full gap-2 text-at-text">
                     <SparklesIcon className="h-10 w-10" />
@@ -246,6 +289,16 @@ export default function ImageEditModal({
 
             {newImage && (
               <button
+                onClick={handleOpenCompare}
+                className="flex items-center justify-center gap-2 px-4 py-2.5 bg-slate-100 text-slate-700 rounded-xl hover:bg-slate-200 transition-colors text-sm font-medium"
+              >
+                <ArrowsPointingOutIcon className="h-4 w-4" />
+                비교
+              </button>
+            )}
+
+            {newImage && (
+              <button
                 onClick={handleApply}
                 className="flex-1 flex items-center justify-center gap-2 py-2.5 bg-green-600 text-white rounded-xl hover:bg-green-700 transition-colors text-sm font-medium"
               >
@@ -257,24 +310,148 @@ export default function ImageEditModal({
         </div>
       </div>
 
-      {/* 라이트박스 */}
-      {lightboxOpen && newImage && (
+      {/* 풀스크린 비교 오버레이 */}
+      {compareOpen && newImage && (
         <div
-          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/90"
-          onClick={() => setLightboxOpen(false)}
+          className="fixed inset-0 z-[60] bg-black/95 flex flex-col"
+          onClick={() => setCompareOpen(false)}
         >
-          <button
-            className="absolute top-4 right-4 p-2 text-white hover:text-gray-300 transition-colors"
-            onClick={() => setLightboxOpen(false)}
-          >
-            <XMarkIcon className="h-8 w-8" />
-          </button>
-          <img
-            src={newImage.path}
-            alt={newImage.prompt}
-            className="max-w-[90vw] max-h-[90vh] object-contain rounded-lg shadow-2xl"
+          {/* 헤더 */}
+          <div
+            className="flex-shrink-0 flex items-center justify-between px-6 py-4 border-b border-white/10"
             onClick={(e) => e.stopPropagation()}
-          />
+          >
+            <div className="flex items-center gap-2">
+              <ArrowsPointingOutIcon className="h-5 w-5 text-white/70" />
+              <span className="text-white font-semibold">이미지 비교</span>
+            </div>
+            <button
+              className="p-2 text-white/70 hover:text-white transition-colors rounded-lg hover:bg-white/10"
+              onClick={() => setCompareOpen(false)}
+            >
+              <XMarkIcon className="h-6 w-6" />
+            </button>
+          </div>
+
+          {/* 데스크탑: 나란히 비교 */}
+          <div
+            className="hidden md:flex flex-1 min-h-0 gap-0"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* 현재 이미지 패널 */}
+            <div className="flex-1 flex flex-col gap-3 p-6">
+              <span className="flex-shrink-0 text-xs font-semibold text-gray-400 uppercase tracking-wider">현재 이미지</span>
+              <div className="flex-1 min-h-0 flex items-center justify-center">
+                {image.path ? (
+                  <img
+                    src={image.path}
+                    alt={image.prompt}
+                    className="max-w-full max-h-full object-contain rounded-lg shadow-lg"
+                  />
+                ) : (
+                  <div className="flex flex-col items-center gap-3 text-gray-600">
+                    <PhotoIcon className="h-16 w-16" />
+                    <span className="text-sm">이미지 없음</span>
+                  </div>
+                )}
+              </div>
+              <p className="flex-shrink-0 text-xs text-gray-500 truncate text-center" title={image.fileName}>
+                {image.fileName}
+              </p>
+            </div>
+
+            {/* 구분선 */}
+            <div className="w-px bg-white/20 self-stretch" />
+
+            {/* 새 이미지 패널 */}
+            <div className="flex-1 flex flex-col gap-3 p-6">
+              <span className="flex-shrink-0 text-xs font-semibold text-indigo-400 uppercase tracking-wider">새 이미지</span>
+              <div className="flex-1 min-h-0 flex items-center justify-center">
+                <img
+                  src={newImage.path}
+                  alt={newImage.prompt}
+                  className="max-w-full max-h-full object-contain rounded-lg shadow-lg"
+                />
+              </div>
+              <p className="flex-shrink-0 text-xs text-gray-500 truncate text-center" title={newImage.fileName}>
+                {newImage.fileName}
+              </p>
+            </div>
+          </div>
+
+          {/* 모바일: 탭 전환 */}
+          <div
+            className="md:hidden flex flex-col flex-1 min-h-0 p-4 gap-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* 탭 버튼 */}
+            <div className="flex-shrink-0 flex rounded-xl overflow-hidden border border-white/20">
+              <button
+                className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
+                  compareActiveImg === 'current'
+                    ? 'bg-white text-black'
+                    : 'text-gray-400 hover:text-white'
+                }`}
+                onClick={() => setCompareActiveImg('current')}
+              >
+                현재 이미지
+              </button>
+              <button
+                className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
+                  compareActiveImg === 'new'
+                    ? 'bg-indigo-500 text-white'
+                    : 'text-gray-400 hover:text-white'
+                }`}
+                onClick={() => setCompareActiveImg('new')}
+              >
+                새 이미지
+              </button>
+            </div>
+
+            {/* 이미지 */}
+            <div className="flex-1 min-h-0 flex items-center justify-center">
+              {compareActiveImg === 'current' ? (
+                image.path ? (
+                  <img
+                    src={image.path}
+                    alt={image.prompt}
+                    className="max-w-full max-h-full object-contain rounded-lg"
+                  />
+                ) : (
+                  <div className="flex flex-col items-center gap-3 text-gray-600">
+                    <PhotoIcon className="h-16 w-16" />
+                    <span className="text-sm">이미지 없음</span>
+                  </div>
+                )
+              ) : (
+                <img
+                  src={newImage.path}
+                  alt={newImage.prompt}
+                  className="max-w-full max-h-full object-contain rounded-lg"
+                />
+              )}
+            </div>
+          </div>
+
+          {/* 하단 액션 바 */}
+          <div
+            className="flex-shrink-0 flex items-center justify-center gap-4 px-6 py-4 border-t border-white/10"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={() => setCompareOpen(false)}
+              className="px-5 py-2.5 text-sm font-medium text-gray-300 hover:text-white rounded-xl border border-white/20 hover:bg-white/10 transition-colors"
+            >
+              닫기
+            </button>
+            <button
+              onClick={handleApply}
+              className="flex items-center gap-2 px-6 py-2.5 bg-green-600 text-white rounded-xl hover:bg-green-700 transition-colors text-sm font-medium"
+            >
+              <CheckIcon className="h-4 w-4" />
+              이 이미지 적용
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/dental-clinic-manager/src/components/marketing/ImageEditModal.tsx
+++ b/dental-clinic-manager/src/components/marketing/ImageEditModal.tsx
@@ -8,11 +8,15 @@ import {
   SparklesIcon,
   PhotoIcon,
   ArrowsPointingOutIcon,
+  PencilSquareIcon,
+  ArrowUturnLeftIcon,
 } from '@heroicons/react/24/outline'
 import {
   IMAGE_VISUAL_STYLE_LABELS,
   type ImageVisualStyle,
 } from '@/types/marketing'
+
+type EditMode = 'modify' | 'regenerate'
 
 interface ImageEditModalProps {
   isOpen: boolean
@@ -21,12 +25,28 @@ interface ImageEditModalProps {
   onImageUpdated: (newImage: { fileName: string; prompt: string; path: string }) => void
 }
 
+async function fetchImageAsBase64(url: string): Promise<string> {
+  const response = await fetch(url)
+  const blob = await response.blob()
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onloadend = () => {
+      const base64 = (reader.result as string).split(',')[1]
+      resolve(base64)
+    }
+    reader.onerror = reject
+    reader.readAsDataURL(blob)
+  })
+}
+
 export default function ImageEditModal({
   isOpen,
   onClose,
   image,
   onImageUpdated,
 }: ImageEditModalProps) {
+  const [editMode, setEditMode] = useState<EditMode>('modify')
+  const [modifyInstruction, setModifyInstruction] = useState('')
   const [editedPrompt, setEditedPrompt] = useState(image.prompt)
   const [selectedVisualStyle, setSelectedVisualStyle] = useState<ImageVisualStyle>('realistic')
   const [isRegenerating, setIsRegenerating] = useState(false)
@@ -38,6 +58,8 @@ export default function ImageEditModal({
   // 모달 열릴 때 상태 초기화
   useEffect(() => {
     if (isOpen) {
+      setEditMode('modify')
+      setModifyInstruction('')
       setEditedPrompt(image.prompt)
       setNewImage(null)
       setError('')
@@ -60,7 +82,11 @@ export default function ImageEditModal({
   }, [handleKeyDown])
 
   const handleRegenerate = async () => {
-    if (!editedPrompt.trim()) {
+    if (editMode === 'modify' && !modifyInstruction.trim()) {
+      setError('수정할 내용을 입력해주세요.')
+      return
+    }
+    if (editMode === 'regenerate' && !editedPrompt.trim()) {
       setError('프롬프트를 입력해주세요.')
       return
     }
@@ -69,28 +95,51 @@ export default function ImageEditModal({
     setError('')
 
     try {
+      let prompt: string
+      let referenceImageBase64: string | undefined
+
+      if (editMode === 'modify') {
+        // 수정 모드: 원본 이미지 기반 + 수정 지침
+        prompt = `원본 이미지 설명: ${image.prompt}\n\n수정 요청: ${modifyInstruction.trim()}\n\n위 원본 이미지를 참고하여 수정 요청 사항을 반영한 새 이미지를 생성해주세요.`
+
+        // 원본 이미지가 있으면 base64로 변환하여 참조 이미지로 전달
+        if (image.path && !image.path.startsWith('data:')) {
+          try {
+            referenceImageBase64 = await fetchImageAsBase64(image.path)
+          } catch {
+            // 이미지 로드 실패 시 프롬프트만으로 진행
+          }
+        } else if (image.path?.startsWith('data:')) {
+          referenceImageBase64 = image.path.split(',')[1]
+        }
+      } else {
+        // 완전 재생성 모드: 새 프롬프트로 처음부터 생성
+        prompt = editedPrompt.trim()
+      }
+
       const res = await fetch('/api/marketing/regenerate-image', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          prompt: editedPrompt.trim(),
+          prompt,
           imageVisualStyle: selectedVisualStyle,
+          ...(referenceImageBase64 ? { referenceImageBase64 } : {}),
         }),
       })
 
       if (!res.ok) {
         const data = await res.json()
-        throw new Error(data.error || '이미지 재생성에 실패했습니다.')
+        throw new Error(data.error || '이미지 생성에 실패했습니다.')
       }
 
       const data = await res.json()
       setNewImage({
         fileName: data.fileName,
-        prompt: data.prompt,
+        prompt: editMode === 'modify' ? image.prompt : editedPrompt.trim(),
         path: data.path,
       })
     } catch (err) {
-      setError(err instanceof Error ? err.message : '이미지 재생성 중 오류가 발생했습니다.')
+      setError(err instanceof Error ? err.message : '이미지 생성 중 오류가 발생했습니다.')
     } finally {
       setIsRegenerating(false)
     }
@@ -107,6 +156,10 @@ export default function ImageEditModal({
     setCompareActiveImg('current')
     setCompareOpen(true)
   }
+
+  const canGenerate = editMode === 'modify'
+    ? modifyInstruction.trim().length > 0
+    : editedPrompt.trim().length > 0
 
   if (!isOpen) return null
 
@@ -135,6 +188,41 @@ export default function ImageEditModal({
         </div>
 
         <div className="p-6 space-y-5">
+          {/* 편집 모드 선택 */}
+          <div className="flex rounded-xl border border-at-border overflow-hidden">
+            <button
+              type="button"
+              onClick={() => { setEditMode('modify'); setNewImage(null); setError('') }}
+              className={`flex-1 flex items-center justify-center gap-2 py-2.5 text-sm font-medium transition-colors ${
+                editMode === 'modify'
+                  ? 'bg-indigo-600 text-white'
+                  : 'text-at-text hover:bg-at-surface-alt'
+              }`}
+            >
+              <PencilSquareIcon className="h-4 w-4" />
+              원본 기반 수정
+            </button>
+            <button
+              type="button"
+              onClick={() => { setEditMode('regenerate'); setNewImage(null); setError('') }}
+              className={`flex-1 flex items-center justify-center gap-2 py-2.5 text-sm font-medium transition-colors border-l border-at-border ${
+                editMode === 'regenerate'
+                  ? 'bg-indigo-600 text-white'
+                  : 'text-at-text hover:bg-at-surface-alt'
+              }`}
+            >
+              <ArrowUturnLeftIcon className="h-4 w-4" />
+              완전 재생성
+            </button>
+          </div>
+
+          {/* 모드 설명 */}
+          <p className="text-xs text-at-text bg-at-surface-alt rounded-xl px-4 py-2.5">
+            {editMode === 'modify'
+              ? '기존 이미지를 참고하여 수정 사항만 적용합니다. 원본의 스타일과 구성을 최대한 유지합니다.'
+              : '프롬프트를 새로 작성하여 이미지를 처음부터 다시 생성합니다.'}
+          </p>
+
           {/* 이미지 비교 영역 */}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {/* 현재 이미지 */}
@@ -172,7 +260,7 @@ export default function ImageEditModal({
             {/* 새 이미지 (재생성 후) */}
             <div className="space-y-2">
               <span className="text-xs font-medium text-at-text">
-                {newImage ? '새 이미지' : '재생성 미리보기'}
+                {newImage ? '수정된 이미지' : '미리보기'}
               </span>
               <div className="relative aspect-square sm:aspect-[4/3] rounded-xl border border-dashed border-at-border overflow-hidden bg-at-surface-alt">
                 {isRegenerating ? (
@@ -190,7 +278,6 @@ export default function ImageEditModal({
                       alt={newImage.prompt}
                       className="w-full h-full object-cover"
                     />
-                    {/* 호버 오버레이 버튼 */}
                     <div className="absolute inset-0 flex items-end justify-end p-2 opacity-0 group-hover:opacity-100 transition-opacity bg-gradient-to-t from-black/50 to-transparent">
                       <button
                         type="button"
@@ -205,8 +292,10 @@ export default function ImageEditModal({
                 ) : (
                   <div className="flex flex-col items-center justify-center h-full gap-2 text-at-text">
                     <SparklesIcon className="h-10 w-10" />
-                    <span className="text-xs">프롬프트를 수정하고</span>
-                    <span className="text-xs">재생성 해보세요</span>
+                    <span className="text-xs">
+                      {editMode === 'modify' ? '수정 내용을 입력하고' : '프롬프트를 작성하고'}
+                    </span>
+                    <span className="text-xs">생성 버튼을 눌러보세요</span>
                   </div>
                 )}
               </div>
@@ -218,17 +307,34 @@ export default function ImageEditModal({
             </div>
           </div>
 
-          {/* 프롬프트 편집 */}
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-at-text">이미지 프롬프트</label>
-            <textarea
-              value={editedPrompt}
-              onChange={(e) => setEditedPrompt(e.target.value)}
-              rows={3}
-              placeholder="생성할 이미지를 설명해주세요..."
-              className="w-full px-3 py-2 border border-at-border rounded-xl text-sm focus:ring-2 focus:ring-at-accent focus:border-at-accent resize-none"
-            />
-          </div>
+          {/* 수정 모드: 수정 프롬프트 입력 */}
+          {editMode === 'modify' && (
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-at-text">수정 내용</label>
+              <textarea
+                value={modifyInstruction}
+                onChange={(e) => setModifyInstruction(e.target.value)}
+                rows={3}
+                placeholder="예: 배경을 파란 하늘로 바꿔줘, 치아를 더 밝게 해줘, 스타일을 좀 더 밝고 친근하게..."
+                className="w-full px-3 py-2 border border-at-border rounded-xl text-sm focus:ring-2 focus:ring-at-accent focus:border-at-accent resize-none"
+              />
+              <p className="text-[11px] text-at-text">원본 이미지({image.prompt.slice(0, 40)}{image.prompt.length > 40 ? '...' : ''})를 기반으로 수정합니다.</p>
+            </div>
+          )}
+
+          {/* 재생성 모드: 전체 프롬프트 편집 */}
+          {editMode === 'regenerate' && (
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-at-text">이미지 프롬프트</label>
+              <textarea
+                value={editedPrompt}
+                onChange={(e) => setEditedPrompt(e.target.value)}
+                rows={3}
+                placeholder="생성할 이미지를 설명해주세요..."
+                className="w-full px-3 py-2 border border-at-border rounded-xl text-sm focus:ring-2 focus:ring-at-accent focus:border-at-accent resize-none"
+              />
+            </div>
+          )}
 
           {/* 시각적 스타일 선택 */}
           <div className="space-y-2">
@@ -268,7 +374,7 @@ export default function ImageEditModal({
           <div className="flex gap-3 pt-2">
             <button
               onClick={handleRegenerate}
-              disabled={isRegenerating || !editedPrompt.trim()}
+              disabled={isRegenerating || !canGenerate}
               className="flex-1 flex items-center justify-center gap-2 py-2.5 bg-indigo-600 text-white rounded-xl hover:bg-indigo-700 disabled:bg-at-border disabled:cursor-not-allowed transition-colors text-sm font-medium"
             >
               {isRegenerating ? (
@@ -282,7 +388,9 @@ export default function ImageEditModal({
               ) : (
                 <>
                   <ArrowPathIcon className="h-4 w-4" />
-                  {newImage ? '다시 생성' : '재생성'}
+                  {newImage
+                    ? (editMode === 'modify' ? '다시 수정' : '다시 생성')
+                    : (editMode === 'modify' ? '수정 생성' : '재생성')}
                 </>
               )}
             </button>
@@ -365,7 +473,9 @@ export default function ImageEditModal({
 
             {/* 새 이미지 패널 */}
             <div className="flex-1 flex flex-col gap-3 p-6">
-              <span className="flex-shrink-0 text-xs font-semibold text-indigo-400 uppercase tracking-wider">새 이미지</span>
+              <span className="flex-shrink-0 text-xs font-semibold text-indigo-400 uppercase tracking-wider">
+                {editMode === 'modify' ? '수정된 이미지' : '새 이미지'}
+              </span>
               <div className="flex-1 min-h-0 flex items-center justify-center">
                 <img
                   src={newImage.path}
@@ -384,13 +494,10 @@ export default function ImageEditModal({
             className="md:hidden flex flex-col flex-1 min-h-0 p-4 gap-4"
             onClick={(e) => e.stopPropagation()}
           >
-            {/* 탭 버튼 */}
             <div className="flex-shrink-0 flex rounded-xl overflow-hidden border border-white/20">
               <button
                 className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
-                  compareActiveImg === 'current'
-                    ? 'bg-white text-black'
-                    : 'text-gray-400 hover:text-white'
+                  compareActiveImg === 'current' ? 'bg-white text-black' : 'text-gray-400 hover:text-white'
                 }`}
                 onClick={() => setCompareActiveImg('current')}
               >
@@ -398,25 +505,18 @@ export default function ImageEditModal({
               </button>
               <button
                 className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
-                  compareActiveImg === 'new'
-                    ? 'bg-indigo-500 text-white'
-                    : 'text-gray-400 hover:text-white'
+                  compareActiveImg === 'new' ? 'bg-indigo-500 text-white' : 'text-gray-400 hover:text-white'
                 }`}
                 onClick={() => setCompareActiveImg('new')}
               >
-                새 이미지
+                {editMode === 'modify' ? '수정된 이미지' : '새 이미지'}
               </button>
             </div>
 
-            {/* 이미지 */}
             <div className="flex-1 min-h-0 flex items-center justify-center">
               {compareActiveImg === 'current' ? (
                 image.path ? (
-                  <img
-                    src={image.path}
-                    alt={image.prompt}
-                    className="max-w-full max-h-full object-contain rounded-lg"
-                  />
+                  <img src={image.path} alt={image.prompt} className="max-w-full max-h-full object-contain rounded-lg" />
                 ) : (
                   <div className="flex flex-col items-center gap-3 text-gray-600">
                     <PhotoIcon className="h-16 w-16" />
@@ -424,11 +524,7 @@ export default function ImageEditModal({
                   </div>
                 )
               ) : (
-                <img
-                  src={newImage.path}
-                  alt={newImage.prompt}
-                  className="max-w-full max-h-full object-contain rounded-lg"
-                />
+                <img src={newImage.path} alt={newImage.prompt} className="max-w-full max-h-full object-contain rounded-lg" />
               )}
             </div>
           </div>

--- a/dental-clinic-manager/src/components/marketing/clinical/ClinicalForm.tsx
+++ b/dental-clinic-manager/src/components/marketing/clinical/ClinicalForm.tsx
@@ -117,6 +117,7 @@ export default function ClinicalForm({ onChange, isGenerating }: ClinicalFormPro
   const [selectedTeeth, setSelectedTeeth] = useState<number[]>([])
   const [photos, setPhotos] = useState<LocalClinicalPhoto[]>([])
   const [editingPhoto, setEditingPhoto] = useState<LocalClinicalPhoto | null>(null)
+  const [isNormalizing, setIsNormalizing] = useState(false)
 
   const fileInputRefs = useRef<Record<string, HTMLInputElement | null>>({})
 
@@ -281,13 +282,18 @@ export default function ClinicalForm({ onChange, isGenerating }: ClinicalFormPro
 
   // 전체 사진 밝기/색조 통일
   const handleBatchNormalize = async () => {
-    if (photos.length < 2) return
+    if (photos.length < 2 || isNormalizing) return
 
+    setIsNormalizing(true)
     try {
-      // 모든 사진 이미지 로드
+      // 현재 photos 스냅샷 (stale closure 방지)
+      const currentPhotos = photos
+
+      // 모든 사진 이미지 로드 (병렬)
       const loaded = await Promise.all(
-        photos.map(async (p) => ({
+        currentPhotos.map(async (p) => ({
           id: p.id,
+          file: p.file,
           image: await loadImageFromFile(p.file),
         }))
       )
@@ -296,13 +302,12 @@ export default function ClinicalForm({ onChange, isGenerating }: ClinicalFormPro
       const { computeBatchNormalization } = await import('./imageUtils')
       const adjustments = computeBatchNormalization(loaded)
 
-      // 각 사진에 보정값 적용
-      for (const [photoId, adj] of adjustments.entries()) {
-        const photo = photos.find((p) => p.id === photoId)
-        if (!photo || (adj.brightness === 0 && adj.contrast === 0)) continue
+      // 각 사진에 보정값 적용 (순차 처리 — 업로드 순서 보장)
+      for (const { id: photoId, image: img } of loaded) {
+        const adj = adjustments.get(photoId)
+        if (!adj || (adj.brightness === 0 && adj.contrast === 0)) continue
 
         try {
-          const img = loaded.find((l) => l.id === photoId)!.image
           const newFile = await applyImageTransforms(img, {
             brightness: adj.brightness,
             contrast: adj.contrast,
@@ -331,10 +336,17 @@ export default function ClinicalForm({ onChange, isGenerating }: ClinicalFormPro
           )
         } catch (err) {
           console.error(`사진 ${photoId} 정규화 실패:`, err)
+          setPhotos((prev) =>
+            prev.map((p) =>
+              p.id === photoId ? { ...p, uploading: false, uploadError: '정규화 실패' } : p
+            )
+          )
         }
       }
     } catch (err) {
       console.error('일괄 정규화 실패:', err)
+    } finally {
+      setIsNormalizing(false)
     }
   }
 
@@ -595,11 +607,20 @@ export default function ClinicalForm({ onChange, isGenerating }: ClinicalFormPro
           <button
             type="button"
             onClick={() => handleBatchNormalize()}
-            disabled={isGenerating}
-            className="flex items-center gap-2 px-5 py-2.5 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-40 rounded-xl shadow-sm transition-colors"
+            disabled={isGenerating || isNormalizing}
+            className="flex items-center gap-2 px-5 py-2.5 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed rounded-xl shadow-sm transition-colors"
           >
-            <SparklesIcon className="h-4 w-4" />
-            밝기/색조 통일 ({totalPhotos}장 일괄 적용)
+            {isNormalizing ? (
+              <>
+                <span className="h-4 w-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                처리 중...
+              </>
+            ) : (
+              <>
+                <SparklesIcon className="h-4 w-4" />
+                밝기/색조 통일 ({totalPhotos}장 일괄 적용)
+              </>
+            )}
           </button>
         </div>
       )}

--- a/dental-clinic-manager/src/lib/aiAnalysisService.ts
+++ b/dental-clinic-manager/src/lib/aiAnalysisService.ts
@@ -43,7 +43,7 @@ const DATABASE_SCHEMA: DatabaseSchema = {
         { name: 'patient_name', type: 'text', description: '환자 이름' },
         { name: 'gift_type', type: 'text', description: '선물 종류' },
         { name: 'quantity', type: 'integer', description: '수량' },
-        { name: 'naver_review', type: 'text', description: '네이버 리뷰 작성 여부 (O/X)' },
+        { name: 'naver_review', type: 'text', description: '네이버 리뷰 작성 여부 (미작성, 네이버, 구글, 게시판)' },
         { name: 'notes', type: 'text', description: '비고' },
       ],
     },
@@ -735,7 +735,7 @@ ${JSON.stringify(data.consultLogs, null, 2)}`);
 
   if (data.giftLogs && data.giftLogs.length > 0) {
     const totalGifts = data.giftLogs.reduce((sum, g) => sum + (g.quantity || 1), 0);
-    const withReview = data.giftLogs.filter((g) => g.naver_review === 'O').length;
+    const withReview = data.giftLogs.filter((g) => g.naver_review !== '미작성').length;
     const giftTypes = data.giftLogs.reduce(
       (acc, g) => {
         acc[g.gift_type] = (acc[g.gift_type] || 0) + (g.quantity || 1);

--- a/dental-clinic-manager/src/lib/aiAnalysisServiceV2.ts
+++ b/dental-clinic-manager/src/lib/aiAnalysisServiceV2.ts
@@ -52,7 +52,7 @@ const DATABASE_SCHEMA = {
         patient_name: 'VARCHAR(100) (환자 이름)',
         gift_type: 'VARCHAR(100) (선물 종류)',
         quantity: 'INTEGER (수량, 기본값 1)',
-        naver_review: 'VARCHAR(1) (네이버 리뷰 작성 여부: O/X)',
+        naver_review: 'VARCHAR(20) (리뷰 작성 여부: 미작성/네이버/구글/게시판)',
         notes: 'TEXT (비고)',
         created_at: 'TIMESTAMP',
       },

--- a/dental-clinic-manager/src/lib/dataService.ts
+++ b/dental-clinic-manager/src/lib/dataService.ts
@@ -716,7 +716,7 @@ export const dataService = {
         recall_booking_names: recallBookingNames.trim() || null,
         consult_proceed: validConsults.filter(c => c.consult_status === 'O').length,
         consult_hold: validConsults.filter(c => c.consult_status === 'X').length,
-        naver_review_count: validGifts.filter(g => g.naver_review === 'O').length,
+        naver_review_count: validGifts.filter(g => g.naver_review !== '미작성').length,
       }
 
       const { error: dailyReportError } = await supabase.from('daily_reports').insert([dailyReport] as any)
@@ -1035,7 +1035,7 @@ export const dataService = {
       const updatedStats = {
         consult_proceed: consultLogs.filter(c => c.consult_status === 'O').length,
         consult_hold: consultLogs.filter(c => c.consult_status === 'X').length,
-        naver_review_count: giftLogs.filter(g => g.naver_review === 'O').length
+        naver_review_count: giftLogs.filter(g => g.naver_review !== '미작성').length
       }
 
       // 일일 보고서 업데이트

--- a/dental-clinic-manager/src/types/index.ts
+++ b/dental-clinic-manager/src/types/index.ts
@@ -27,7 +27,7 @@ export interface GiftLog {
   patient_name: string;
   gift_type: string;
   quantity: number;
-  naver_review: 'O' | 'X';
+  naver_review: '미작성' | '네이버' | '구글' | '게시판';
   notes: string;
   clinic_id?: string | null;
 }
@@ -117,7 +117,7 @@ export interface GiftRowData {
   patient_name: string;
   gift_type: string;
   quantity: number;
-  naver_review: 'O' | 'X';
+  naver_review: '미작성' | '네이버' | '구글' | '게시판';
   notes: string;
 }
 

--- a/dental-clinic-manager/supabase/migrations/20260415_alter_naver_review.sql
+++ b/dental-clinic-manager/supabase/migrations/20260415_alter_naver_review.sql
@@ -1,0 +1,21 @@
+-- 1. gift_logs 테이블의 naver_review 컬럼에 걸려있는 제약조건(CHECK) 동적 삭제
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN (
+         SELECT conname
+         FROM pg_constraint
+         INNER JOIN pg_attribute ON attrelid = conrelid AND attnum = ANY(conkey)
+         WHERE conrelid = 'gift_logs'::regclass AND attname = 'naver_review' AND contype = 'c'
+    ) LOOP
+         EXECUTE 'ALTER TABLE gift_logs DROP CONSTRAINT ' || quote_ident(r.conname);
+    END LOOP;
+END $$;
+
+-- 2. naver_review 컬럼 데이터 타입 변경 (문자열 길이를 20으로 늘림)
+ALTER TABLE gift_logs ALTER COLUMN naver_review TYPE VARCHAR(20);
+
+-- 3. 기존 'X'와 'O' 데이터를 새로운 분류인 '미작성'과 '네이버'로 변환
+UPDATE gift_logs SET naver_review = '미작성' WHERE naver_review = 'X';
+UPDATE gift_logs SET naver_review = '네이버' WHERE naver_review = 'O';

--- a/dental-clinic-manager/test-db.js
+++ b/dental-clinic-manager/test-db.js
@@ -1,0 +1,25 @@
+const { Client } = require('pg');
+const client = new Client({
+  connectionString: 'postgresql://postgres.beahjntkmkfhpcbhfnrr:tNjSUoCUJcX3nPXg@aws-1-ap-southeast-1.pooler.supabase.com:5432/postgres'
+});
+
+async function run() {
+  await client.connect();
+  const res = await client.query(`
+    SELECT conname
+    FROM pg_constraint
+    WHERE conrelid = 'gift_logs'::regclass;
+  `);
+  console.log(res.rows);
+  
+  // get column types
+  const colRes = await client.query(`
+    SELECT column_name, data_type, character_maximum_length 
+    FROM information_schema.columns 
+    WHERE table_name = 'gift_logs';
+  `);
+  console.log(colRes.rows);
+  
+  await client.end();
+}
+run();


### PR DESCRIPTION
## 변경 사항

### 리뷰 작성 여부 다중 옵션 추가
- 기존 O/X 두 가지 선택에서 4가지 옵션으로 세분화
  - 리뷰 미작성
  - 네이버 리뷰 작성
  - 구글 리뷰 작성
  - 게시판 리뷰 작성

### 수정된 파일
- `src/types/index.ts` - GiftLog, GiftRowData 타입 변경
- `src/components/DailyInput/GiftTable.tsx` - 드롭다운 옵션 4가지로 변경
- `src/components/DailyInput/DailyInputForm.tsx` - 기본값 및 로딩 로직 업데이트
- `src/components/Stats/StatsContainer.tsx` - 통계 집계 로직 업데이트
- `src/components/Dashboard/DashboardHome.tsx` - 대시보드 표시 로직 업데이트
- `src/lib/dataService.ts` - 리뷰 카운트 로직 업데이트
- `src/lib/aiAnalysisService.ts` - AI 분석 스키마 업데이트
- `src/lib/aiAnalysisServiceV2.ts` - AI 분석 V2 스키마 업데이트
- `supabase/migrations/20260415_alter_naver_review.sql` - DB 마이그레이션 (CHECK 제약 삭제, VARCHAR(20) 확장, 기존 데이터 변환)