### PR TITLE
fix: Gmail OAuth 콜백 DB 컬럼명 및 upsert 로직 수정

### DIFF
--- a/dental-clinic-manager/src/app/api/integrations/gmail/callback/route.ts
+++ b/dental-clinic-manager/src/app/api/integrations/gmail/callback/route.ts
@@ -134,25 +134,34 @@ export async function GET(request: NextRequest) {
       return NextResponse.redirect(url.toString());
     }
 
-    // clinic_email_integrations에 저장 (upsert)
-    const { error: upsertError } = await admin
-      .from('clinic_email_integrations')
-      .upsert(
-        {
-          clinic_id: clinicId,
-          provider: 'gmail',
-          email_address: emailAddress,
-          access_token_encrypted: encryptedAccessToken,
-          refresh_token_encrypted: encryptedRefreshToken,
-          token_expires_at: new Date(Date.now() + tokenData.expires_in * 1000).toISOString(),
-          is_active: true,
-          updated_at: new Date().toISOString(),
-        },
-        { onConflict: 'clinic_id,provider' }
-      );
+    // clinic_email_integrations에 저장 (unique constraint 없으므로 select 후 update/insert)
+    const payload = {
+      clinic_id: clinicId,
+      provider: 'gmail' as const,
+      email_address: emailAddress,
+      encrypted_access_token: encryptedAccessToken,
+      encrypted_refresh_token: encryptedRefreshToken,
+      token_expires_at: new Date(Date.now() + tokenData.expires_in * 1000).toISOString(),
+      is_active: true,
+      updated_at: new Date().toISOString(),
+    };
 
-    if (upsertError) {
-      console.error('[gmail/callback] DB upsert error:', upsertError);
+    const { data: existingRow } = await admin
+      .from('clinic_email_integrations')
+      .select('id')
+      .eq('clinic_id', clinicId)
+      .eq('provider', 'gmail')
+      .maybeSingle();
+
+    const saveResult = existingRow
+      ? await admin
+          .from('clinic_email_integrations')
+          .update(payload)
+          .eq('id', existingRow.id)
+      : await admin.from('clinic_email_integrations').insert(payload);
+
+    if (saveResult.error) {
+      console.error('[gmail/callback] DB save error:', saveResult.error);
       const url = new URL(baseRedirect, request.url);
       url.searchParams.set('gmail_error', 'db_error');
       return NextResponse.redirect(url.toString());

--- a/dental-clinic-manager/src/app/api/marketing/worker-api/email/attachment/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/worker-api/email/attachment/route.ts
@@ -47,7 +47,7 @@ export async function POST(request: NextRequest) {
     }
 
     // access token 갱신
-    const decryptedRefreshToken = decrypt(integration.refresh_token_encrypted as string);
+    const decryptedRefreshToken = decrypt(integration.encrypted_refresh_token as string);
     const tokenData = await refreshToken(clientId, clientSecret, decryptedRefreshToken);
 
     // 첨부파일 다운로드

--- a/dental-clinic-manager/src/app/api/marketing/worker-api/email/check/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/worker-api/email/check/route.ts
@@ -79,7 +79,7 @@ async function handleGmailCheck(
   }
 
   // refresh token으로 access token 갱신
-  const decryptedRefreshToken = decrypt(integration.refresh_token_encrypted as string);
+  const decryptedRefreshToken = decrypt(integration.encrypted_refresh_token as string);
   const tokenData = await refreshToken(clientId, clientSecret, decryptedRefreshToken);
 
   // 갱신된 access token 저장
@@ -89,7 +89,7 @@ async function handleGmailCheck(
   await admin
     .from('clinic_email_integrations')
     .update({
-      access_token_encrypted: encryptedAccessToken,
+      encrypted_access_token: encryptedAccessToken,
       token_expires_at: new Date(Date.now() + tokenData.expires_in * 1000).toISOString(),
       updated_at: new Date().toISOString(),
     })


### PR DESCRIPTION
db_error 원인: 컬럼명 불일치(access_token_encrypted → encrypted_access_token)와 누락된 유니크 제약. 컬럼명 수정 + upsert 대신 select/update/insert 패턴으로 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)