### PR TITLE
release: develop → main (PWA 자동 업데이트 수정 포함)

### DIFF
--- a/dental-clinic-manager/docs/superpowers/plans/2026-04-19-dual-landing-pages.md
+++ b/dental-clinic-manager/docs/superpowers/plans/2026-04-19-dual-landing-pages.md
@@ -1,0 +1,1860 @@
+# Dual Landing Pages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 단일 랜딩 페이지를 대표원장(`/owner`)·실장(`/staff`) 분리 랜딩 + 역할 선택 라우터(`/`)로 교체한다.
+
+**Architecture:** Next.js App Router 3개 페이지(`/`, `/owner`, `/staff`) + 공유 `AuthFlow` 래퍼로 기존 로그인/회원가입 플로우 재사용. localStorage(`clinicmgr.visitor_role`)로 선택 기억 후 `/`에서 자동 리디렉션.
+
+**Tech Stack:** Next.js 15, React 19, TypeScript, Tailwind CSS 4, Heroicons. 기존 `useAuth`(Supabase), `LoginForm`, `SignupForm`, `ForgotPasswordForm`, `Footer` 재사용.
+
+**Verification:** 프로젝트에 자동화된 unit test가 없으므로 각 Task 후 `npm run build`와 `npm run lint`로 타입/빌드 검증. 최종 Task에서 `npm run dev` + 브라우저 수동 테스트.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-dual-landing-pages-design.md`
+
+---
+
+## File Structure
+
+**생성:**
+- `src/components/Landing/shared/useVisitorRole.ts` — localStorage 헬퍼
+- `src/components/Landing/shared/useScrollAnimation.ts` — 스크롤 인터섹션 훅
+- `src/components/Landing/shared/TypeWriter.tsx` — 타이핑 애니메이션
+- `src/components/Landing/shared/CountUp.tsx` — 카운트업 애니메이션
+- `src/components/Landing/shared/LandingHeader.tsx` — 공통 헤더 (dark/light)
+- `src/components/Landing/shared/AuthFlow.tsx` — 로그인/가입 래퍼 (render prop)
+- `src/components/Landing/RoleSelector.tsx` — 역할 선택 카드 UI
+- `src/components/Landing/OwnerLanding.tsx` — 대표원장 랜딩
+- `src/components/Landing/StaffLanding.tsx` — 실장·직원 랜딩
+- `src/app/owner/page.tsx` — `/owner` 라우트
+- `src/app/staff/page.tsx` — `/staff` 라우트
+
+**수정:**
+- `src/app/page.tsx` — `RoleSelector` + `AuthFlow`로 교체
+
+**삭제:**
+- `src/app/AuthApp.tsx`
+- `src/components/Landing/LandingPage.tsx`
+
+---
+
+## Task 1: useVisitorRole 훅
+
+**Files:**
+- Create: `src/components/Landing/shared/useVisitorRole.ts`
+
+- [ ] **Step 1: 훅 작성**
+
+`src/components/Landing/shared/useVisitorRole.ts`:
+
+```ts
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+export type VisitorRole = 'owner' | 'staff'
+const STORAGE_KEY = 'clinicmgr.visitor_role'
+
+function isVisitorRole(value: unknown): value is VisitorRole {
+  return value === 'owner' || value === 'staff'
+}
+
+export function useVisitorRole() {
+  const [role, setRoleState] = useState<VisitorRole | null>(null)
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY)
+      if (isVisitorRole(stored)) {
+        setRoleState(stored)
+      }
+    } catch {
+      // localStorage 접근 실패 시 무시
+    }
+    setHydrated(true)
+  }, [])
+
+  const setRole = useCallback((next: VisitorRole) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next)
+    } catch {
+      // 무시
+    }
+    setRoleState(next)
+  }, [])
+
+  const clearRole = useCallback(() => {
+    try {
+      window.localStorage.removeItem(STORAGE_KEY)
+    } catch {
+      // 무시
+    }
+    setRoleState(null)
+  }, [])
+
+  return { role, setRole, clearRole, hydrated }
+}
+```
+
+- [ ] **Step 2: 빌드 및 타입 체크**
+
+```bash
+npm run lint -- src/components/Landing/shared/useVisitorRole.ts
+```
+Expected: lint 에러 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Landing/shared/useVisitorRole.ts
+git commit -m "feat(landing): useVisitorRole 훅 추가"
+```
+
+---
+
+## Task 2: 애니메이션 훅·컴포넌트 추출
+
+기존 `LandingPage.tsx`에 인라인으로 있던 `useScrollAnimation`, `TypeWriter`, `CountUp`을 공용 모듈로 추출.
+
+**Files:**
+- Create: `src/components/Landing/shared/useScrollAnimation.ts`
+- Create: `src/components/Landing/shared/TypeWriter.tsx`
+- Create: `src/components/Landing/shared/CountUp.tsx`
+
+- [ ] **Step 1: useScrollAnimation 훅 작성**
+
+`src/components/Landing/shared/useScrollAnimation.ts`:
+
+```ts
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+export function useScrollAnimation() {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+        }
+      },
+      { threshold: 0.1, rootMargin: '0px 0px -50px 0px' }
+    )
+
+    if (ref.current) {
+      observer.observe(ref.current)
+    }
+
+    return () => observer.disconnect()
+  }, [])
+
+  return { ref, isVisible }
+}
+```
+
+- [ ] **Step 2: TypeWriter 컴포넌트 작성**
+
+`src/components/Landing/shared/TypeWriter.tsx`:
+
+```tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useScrollAnimation } from './useScrollAnimation'
+
+export default function TypeWriter({ text, delay = 50 }: { text: string; delay?: number }) {
+  const [displayText, setDisplayText] = useState('')
+  const [isStarted, setIsStarted] = useState(false)
+  const { ref, isVisible } = useScrollAnimation()
+
+  useEffect(() => {
+    if (isVisible && !isStarted) {
+      setIsStarted(true)
+      let i = 0
+      const timer = setInterval(() => {
+        if (i < text.length) {
+          setDisplayText(text.slice(0, i + 1))
+          i++
+        } else {
+          clearInterval(timer)
+        }
+      }, delay)
+      return () => clearInterval(timer)
+    }
+  }, [isVisible, isStarted, text, delay])
+
+  return (
+    <span ref={ref}>
+      {displayText}
+      {displayText.length < text.length && isStarted && (
+        <span className="animate-pulse">|</span>
+      )}
+    </span>
+  )
+}
+```
+
+- [ ] **Step 3: CountUp 컴포넌트 작성**
+
+`src/components/Landing/shared/CountUp.tsx`:
+
+```tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useScrollAnimation } from './useScrollAnimation'
+
+interface CountUpProps {
+  end: number
+  suffix?: string
+  duration?: number
+}
+
+export default function CountUp({ end, suffix = '', duration = 2000 }: CountUpProps) {
+  const [count, setCount] = useState(0)
+  const { ref, isVisible } = useScrollAnimation()
+
+  useEffect(() => {
+    if (!isVisible) return
+
+    let startTime: number
+    const animate = (currentTime: number) => {
+      if (!startTime) startTime = currentTime
+      const progress = Math.min((currentTime - startTime) / duration, 1)
+      setCount(Math.floor(progress * end))
+      if (progress < 1) {
+        requestAnimationFrame(animate)
+      }
+    }
+    requestAnimationFrame(animate)
+  }, [isVisible, end, duration])
+
+  return <span ref={ref}>{count}{suffix}</span>
+}
+```
+
+- [ ] **Step 4: lint 체크**
+
+```bash
+npm run lint
+```
+Expected: 새 파일에 관한 lint 에러 없음
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/components/Landing/shared/useScrollAnimation.ts src/components/Landing/shared/TypeWriter.tsx src/components/Landing/shared/CountUp.tsx
+git commit -m "refactor(landing): 스크롤 애니메이션 훅/컴포넌트를 shared로 분리"
+```
+
+---
+
+## Task 3: LandingHeader 공통 헤더
+
+**Files:**
+- Create: `src/components/Landing/shared/LandingHeader.tsx`
+
+- [ ] **Step 1: 컴포넌트 작성**
+
+`src/components/Landing/shared/LandingHeader.tsx`:
+
+```tsx
+'use client'
+
+import Image from 'next/image'
+
+export type LandingHeaderVariant = 'dark' | 'light'
+
+interface LandingHeaderProps {
+  variant: LandingHeaderVariant
+  onShowLogin: () => void
+  onShowSignup: () => void
+}
+
+export default function LandingHeader({ variant, onShowLogin, onShowSignup }: LandingHeaderProps) {
+  const isDark = variant === 'dark'
+  const wrapperClass = isDark
+    ? 'bg-slate-950/80 border-b border-white/10'
+    : 'bg-white/80 border-b border-at-border/50 shadow-at-card'
+  const logoTextClass = isDark ? 'text-white' : 'text-at-text'
+  const loginClass = isDark
+    ? 'text-slate-300 hover:text-white'
+    : 'text-at-text-secondary hover:text-at-text'
+  const signupClass = isDark
+    ? 'bg-gradient-to-r from-blue-500 to-indigo-500 hover:from-blue-600 hover:to-indigo-600 text-white'
+    : 'bg-slate-900 hover:bg-slate-800 text-white'
+
+  return (
+    <header className={`fixed top-0 left-0 right-0 backdrop-blur-xl z-50 ${wrapperClass}`}>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          <div className="flex items-center gap-3">
+            <Image
+              src="/icons/icon-192x192.png"
+              alt="클리닉 매니저 로고"
+              width={40}
+              height={40}
+              className="w-10 h-10 rounded-xl shadow-at-card"
+            />
+            <span className={`text-xl font-bold ${logoTextClass}`}>클리닉 매니저</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={onShowLogin}
+              className={`px-4 py-2 font-medium transition-colors ${loginClass}`}
+            >
+              로그인
+            </button>
+            <button
+              onClick={onShowSignup}
+              className={`px-5 py-2.5 font-semibold rounded-xl transition-all shadow-at-card hover:shadow-lg ${signupClass}`}
+            >
+              시작하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </header>
+  )
+}
+```
+
+- [ ] **Step 2: lint 체크**
+
+```bash
+npm run lint
+```
+Expected: lint 에러 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Landing/shared/LandingHeader.tsx
+git commit -m "feat(landing): LandingHeader 공통 컴포넌트 추가"
+```
+
+---
+
+## Task 4: AuthFlow 래퍼
+
+기존 `AuthApp.tsx`의 로그인/회원가입/비밀번호 상태 관리 로직을 재사용 가능한 래퍼로 이식한다. 렌더 프롭으로 랜딩 컴포넌트에 `onShowLogin`/`onShowSignup` 콜백을 주입한다.
+
+**Files:**
+- Create: `src/components/Landing/shared/AuthFlow.tsx`
+
+- [ ] **Step 1: 컴포넌트 작성**
+
+`src/components/Landing/shared/AuthFlow.tsx`:
+
+```tsx
+'use client'
+
+import { useEffect, useState, type ReactNode } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useAuth } from '@/contexts/AuthContext'
+import LoginForm from '@/components/Auth/LoginForm'
+import SignupForm from '@/components/Auth/SignupForm'
+import ForgotPasswordForm from '@/components/Auth/ForgotPasswordForm'
+import Footer from '@/components/Layout/Footer'
+
+type AppState = 'landing' | 'login' | 'signup' | 'forgotPassword'
+
+export interface AuthFlowRenderProps {
+  onShowLogin: () => void
+  onShowSignup: () => void
+}
+
+interface AuthFlowProps {
+  children: (props: AuthFlowRenderProps) => ReactNode
+}
+
+export default function AuthFlow({ children }: AuthFlowProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { isAuthenticated, user, loading } = useAuth()
+  const [appState, setAppState] = useState<AppState>('landing')
+
+  useEffect(() => {
+    const show = searchParams.get('show')
+    if (show === 'login') {
+      setAppState('login')
+    } else if (show === 'signup') {
+      setAppState('signup')
+    }
+  }, [searchParams])
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      if (user?.status === 'pending' || user?.status === 'rejected') {
+        router.push('/pending-approval')
+        return
+      }
+      const redirect = searchParams.get('redirect')
+      router.push(redirect || '/dashboard')
+    }
+  }, [isAuthenticated, user, router, searchParams])
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-at-surface-alt flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-at-accent mx-auto mb-4"></div>
+          <p className="text-at-text-secondary">로딩 중...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (isAuthenticated) {
+    return null
+  }
+
+  const showLogin = () => setAppState('login')
+  const showSignup = () => setAppState('signup')
+  const showLanding = () => setAppState('landing')
+  const showForgot = () => setAppState('forgotPassword')
+
+  let content: ReactNode
+  switch (appState) {
+    case 'login':
+      content = (
+        <LoginForm
+          onBackToLanding={showLanding}
+          onShowSignup={showSignup}
+          onShowForgotPassword={showForgot}
+          onLoginSuccess={() => {
+            setTimeout(() => { window.location.reload() }, 150)
+          }}
+        />
+      )
+      break
+    case 'signup':
+      content = (
+        <SignupForm
+          onBackToLanding={showLanding}
+          onShowLogin={showLogin}
+          onSignupSuccess={() => { setAppState('login') }}
+        />
+      )
+      break
+    case 'forgotPassword':
+      content = <ForgotPasswordForm onBackToLogin={showLogin} />
+      break
+    default:
+      content = children({ onShowLogin: showLogin, onShowSignup: showSignup })
+  }
+
+  return (
+    <>
+      {content}
+      <Footer />
+    </>
+  )
+}
+```
+
+- [ ] **Step 2: lint + 타입체크**
+
+```bash
+npm run lint
+```
+Expected: lint 에러 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Landing/shared/AuthFlow.tsx
+git commit -m "feat(landing): AuthFlow 래퍼 컴포넌트 추가 (기존 AuthApp 로직 이식)"
+```
+
+---
+
+## Task 5: RoleSelector 컴포넌트
+
+**Files:**
+- Create: `src/components/Landing/RoleSelector.tsx`
+
+- [ ] **Step 1: 컴포넌트 작성**
+
+`src/components/Landing/RoleSelector.tsx`:
+
+```tsx
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useVisitorRole, type VisitorRole } from './shared/useVisitorRole'
+import LandingHeader from './shared/LandingHeader'
+
+interface RoleSelectorProps {
+  onShowLogin: () => void
+  onShowSignup: () => void
+}
+
+interface RoleCardProps {
+  role: VisitorRole
+  emoji: string
+  title: string
+  tagline: string
+  accent: 'owner' | 'staff'
+  onSelect: (role: VisitorRole) => void
+}
+
+function RoleCard({ role, emoji, title, tagline, accent, onSelect }: RoleCardProps) {
+  const accentClasses = accent === 'owner'
+    ? 'from-indigo-50 to-white border-indigo-200 hover:border-indigo-400 hover:shadow-indigo-200/50'
+    : 'from-cyan-50 to-white border-cyan-200 hover:border-cyan-400 hover:shadow-cyan-200/50'
+  const labelClasses = accent === 'owner'
+    ? 'text-indigo-600'
+    : 'text-cyan-700'
+
+  return (
+    <button
+      onClick={() => onSelect(role)}
+      className={`group text-left bg-gradient-to-b ${accentClasses} border-2 rounded-3xl p-8 sm:p-10 transition-all hover:-translate-y-1 hover:shadow-2xl`}
+    >
+      <div className="text-5xl mb-4">{emoji}</div>
+      <div className={`text-xs font-bold tracking-wider uppercase mb-2 ${labelClasses}`}>
+        {accent === 'owner' ? 'FOR OWNERS' : 'FOR STAFF'}
+      </div>
+      <div className="text-2xl sm:text-3xl font-bold text-at-text mb-3">{title}</div>
+      <div className="text-at-text-secondary leading-relaxed">{tagline}</div>
+      <div className={`mt-6 inline-flex items-center gap-2 font-semibold ${labelClasses} group-hover:gap-3 transition-all`}>
+        페이지 보기 <span>→</span>
+      </div>
+    </button>
+  )
+}
+
+export default function RoleSelector({ onShowLogin, onShowSignup }: RoleSelectorProps) {
+  const router = useRouter()
+  const { role, setRole, clearRole, hydrated } = useVisitorRole()
+
+  // 저장된 역할이 있으면 자동 리디렉션
+  useEffect(() => {
+    if (!hydrated) return
+    if (role === 'owner') {
+      router.replace('/owner')
+    } else if (role === 'staff') {
+      router.replace('/staff')
+    }
+  }, [hydrated, role, router])
+
+  const handleSelect = (selected: VisitorRole) => {
+    setRole(selected)
+    router.push(selected === 'owner' ? '/owner' : '/staff')
+  }
+
+  // 하이드레이션 완료 전이거나 리디렉션 중일 때 플래시 방지
+  if (!hydrated || role) {
+    return (
+      <div className="min-h-screen bg-white flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-at-accent" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-white">
+      <LandingHeader variant="light" onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
+
+      <main className="pt-32 pb-24 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="text-center mb-14">
+            <h1 className="text-3xl sm:text-5xl font-bold text-at-text leading-tight mb-4">
+              먼저 알려주세요 —{' '}
+              <span className="bg-gradient-to-r from-indigo-600 to-cyan-600 bg-clip-text text-transparent">
+                누구신가요?
+              </span>
+            </h1>
+            <p className="text-lg text-at-text-secondary">
+              역할에 맞는 페이지로 안내해드립니다
+            </p>
+          </div>
+
+          <div className="grid sm:grid-cols-2 gap-6">
+            <RoleCard
+              role="owner"
+              emoji="👨‍⚕️"
+              title="대표원장"
+              tagline="병원 경영·매출 중심 뷰. 실장을 매출에만 집중하게 하는 시스템."
+              accent="owner"
+              onSelect={handleSelect}
+            />
+            <RoleCard
+              role="staff"
+              emoji="🧑‍💼"
+              title="실장 · 직원"
+              tagline="출퇴근·스케쥴·연차까지 간단하게 끝내고 정시 퇴근하는 업무 앱."
+              accent="staff"
+              onSelect={handleSelect}
+            />
+          </div>
+
+          <div className="text-center mt-10 text-sm text-at-text-weak">
+            선택한 페이지는 다음 방문 시 자동으로 열립니다 ·{' '}
+            <button
+              onClick={clearRole}
+              className="underline hover:text-at-text-secondary"
+            >
+              선택 기억 해제
+            </button>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: lint 체크**
+
+```bash
+npm run lint
+```
+Expected: lint 에러 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Landing/RoleSelector.tsx
+git commit -m "feat(landing): RoleSelector 역할 선택 컴포넌트 추가"
+```
+
+---
+
+## Task 6: `/` 페이지를 RoleSelector로 교체
+
+**Files:**
+- Modify: `src/app/page.tsx`
+
+- [ ] **Step 1: page.tsx 교체**
+
+`src/app/page.tsx`의 전체 내용을 다음으로 교체:
+
+```tsx
+import AuthFlow from '@/components/Landing/shared/AuthFlow'
+import RoleSelector from '@/components/Landing/RoleSelector'
+
+export const dynamic = 'force-dynamic'
+
+export default function RootPage() {
+  return (
+    <AuthFlow>
+      {({ onShowLogin, onShowSignup }) => (
+        <RoleSelector onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
+      )}
+    </AuthFlow>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 체크**
+
+```bash
+npm run build
+```
+Expected: 빌드 성공 (`/` 라우트가 새 구성으로 컴파일됨). `AuthApp.tsx`는 아직 존재하지만 import 되지 않으므로 빌드는 성공.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/app/page.tsx
+git commit -m "feat(landing): / 루트를 RoleSelector로 교체"
+```
+
+---
+
+## Task 7: OwnerLanding — Hero + Problem 섹션
+
+OwnerLanding은 섹션 수가 많아 3단계로 나눠 작성한다. Task 7은 Hero + Problem, Task 8은 Solution + Features + Premium, Task 9는 Trust + CTA + FAQ.
+
+**Files:**
+- Create: `src/components/Landing/OwnerLanding.tsx`
+
+- [ ] **Step 1: 뼈대 + Hero + Problem 작성**
+
+`src/components/Landing/OwnerLanding.tsx`:
+
+```tsx
+'use client'
+
+import { useState } from 'react'
+import {
+  ArrowRightIcon,
+  BoltIcon,
+  ChartBarIcon,
+  ChevronDownIcon,
+  ClockIcon,
+  DocumentTextIcon,
+  CalendarDaysIcon,
+  UserGroupIcon,
+  CurrencyDollarIcon,
+  HeartIcon,
+  SparklesIcon,
+  CheckCircleIcon,
+  CpuChipIcon,
+  PresentationChartLineIcon,
+  PencilSquareIcon,
+} from '@heroicons/react/24/outline'
+import LandingHeader from './shared/LandingHeader'
+import { useScrollAnimation } from './shared/useScrollAnimation'
+
+interface OwnerLandingProps {
+  onShowLogin: () => void
+  onShowSignup: () => void
+}
+
+function StoryBlock({ children }: { children: React.ReactNode }) {
+  const { ref, isVisible } = useScrollAnimation()
+  return (
+    <div
+      ref={ref}
+      className={`transition-all duration-1000 ${
+        isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
+      }`}
+    >
+      {children}
+    </div>
+  )
+}
+
+const problemItems = [
+  { icon: CalendarDaysIcon, label: '엑셀 연차 계산' },
+  { icon: ClockIcon, label: '출퇴근 수기 집계' },
+  { icon: UserGroupIcon, label: '스케쥴 수동 조율' },
+  { icon: CurrencyDollarIcon, label: '급여 명세서 취합' },
+  { icon: HeartIcon, label: '환자 리콜 추적' },
+  { icon: DocumentTextIcon, label: '상담 기록 정리' },
+]
+
+export default function OwnerLanding({ onShowLogin, onShowSignup }: OwnerLandingProps) {
+  const [openFaq, setOpenFaq] = useState<number | null>(null)
+
+  return (
+    <div className="min-h-screen bg-white overflow-x-hidden">
+      <LandingHeader variant="dark" onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
+
+      {/* HERO */}
+      <section className="relative min-h-screen flex items-center justify-center pt-16 overflow-hidden bg-slate-950">
+        <div className="absolute inset-0 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950" />
+        <div className="absolute top-1/4 -left-32 w-96 h-96 bg-blue-500/20 rounded-full filter blur-[120px] opacity-40" />
+        <div className="absolute bottom-1/4 -right-32 w-96 h-96 bg-indigo-500/20 rounded-full filter blur-[120px] opacity-40" />
+
+        <div className="relative max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center z-10">
+          <div className="mb-10">
+            <span className="inline-flex items-center gap-2 px-5 py-2.5 bg-white/5 backdrop-blur-sm border border-white/10 text-blue-300 rounded-full text-sm font-medium">
+              <SparklesIcon className="w-4 h-4" />
+              FOR CLINIC OWNERS
+            </span>
+          </div>
+
+          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-white leading-[1.15] tracking-tight mb-8">
+            <span className="block mb-2 sm:mb-4">능력있는 실장을</span>
+            <span className="block bg-gradient-to-r from-blue-400 via-indigo-400 to-purple-400 bg-clip-text text-transparent pb-2">
+              엑셀과 연차 계산에
+            </span>
+            <span className="block">낭비하지 마세요</span>
+          </h1>
+
+          <p className="text-slate-300 text-lg sm:text-xl max-w-2xl mx-auto mb-12 leading-relaxed">
+            잡무는 시스템에 맡기고,{' '}
+            <span className="text-white font-medium">실장은 매출에만 집중</span>하게 하세요.
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-16">
+            <button
+              onClick={onShowSignup}
+              className="group px-8 py-4 bg-gradient-to-r from-blue-500 to-indigo-500 hover:from-blue-600 hover:to-indigo-600 text-white font-bold text-lg rounded-2xl transition-all shadow-lg shadow-blue-500/25 hover:shadow-blue-500/40 hover:-translate-y-1 flex items-center gap-2"
+            >
+              무료로 시작하기
+              <ArrowRightIcon className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
+            </button>
+            <button
+              onClick={() => document.getElementById('owner-problem')?.scrollIntoView({ behavior: 'smooth' })}
+              className="px-8 py-4 text-slate-300 hover:text-white font-medium transition-colors flex items-center gap-2"
+            >
+              기능 살펴보기
+              <ChevronDownIcon className="w-5 h-5" />
+            </button>
+          </div>
+
+          <div className="flex justify-center items-center gap-6 sm:gap-10">
+            <div className="flex items-center gap-2.5 px-4 py-2 bg-white/5 backdrop-blur-sm rounded-full border border-white/10">
+              <div className="w-2.5 h-2.5 rounded-full bg-green-400 shadow-lg shadow-green-400/50" />
+              <span className="text-sm text-slate-300 font-medium">현직 원장 개발</span>
+            </div>
+            <div className="flex items-center gap-2.5 px-4 py-2 bg-white/5 backdrop-blur-sm rounded-full border border-white/10">
+              <div className="w-2.5 h-2.5 rounded-full bg-blue-400 shadow-lg shadow-blue-400/50" />
+              <span className="text-sm text-slate-300 font-medium">실제 병원 운영 중</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
+          <ChevronDownIcon className="w-5 h-5 text-slate-400" />
+        </div>
+      </section>
+
+      {/* PROBLEM */}
+      <section id="owner-problem" className="relative py-32 bg-slate-900">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <StoryBlock>
+            <div className="flex items-center gap-4 mb-10">
+              <div className="w-16 h-16 bg-gradient-to-br from-amber-400 to-orange-500 rounded-2xl flex items-center justify-center shadow-lg">
+                <BoltIcon className="w-8 h-8 text-white" />
+              </div>
+              <div>
+                <span className="text-amber-400 font-semibold text-sm tracking-wider uppercase">The Problem</span>
+                <h2 className="text-2xl font-bold text-white">실장이 하루에 버리는 시간</h2>
+              </div>
+            </div>
+
+            <p className="text-2xl sm:text-3xl lg:text-4xl font-medium text-white leading-relaxed mb-10">
+              능력있는 실장이 매일 처리하는{' '}
+              <span className="text-amber-400">반복 잡무</span>들.
+            </p>
+
+            <div className="grid sm:grid-cols-2 gap-3 mb-10">
+              {problemItems.map(({ icon: Icon, label }) => (
+                <div
+                  key={label}
+                  className="flex items-center gap-3 bg-slate-800/50 backdrop-blur-sm rounded-xl p-4 border border-slate-700/50"
+                >
+                  <Icon className="w-5 h-5 text-amber-400 flex-shrink-0" />
+                  <span className="text-slate-200">{label}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="bg-slate-800/50 backdrop-blur-sm rounded-2xl p-6 sm:p-8 border border-slate-700/50 shadow-xl">
+              <p className="text-xl text-slate-200 leading-relaxed text-center">
+                이 시간에 실장은{' '}
+                <span className="text-amber-400 font-semibold">상담 한 건을 더</span> 받을 수 있었습니다.
+              </p>
+            </div>
+          </StoryBlock>
+        </div>
+      </section>
+
+      {/* 나머지 섹션은 다음 Task에서 추가 */}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: lint + 빌드 체크**
+
+```bash
+npm run lint
+```
+Expected: lint 에러 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Landing/OwnerLanding.tsx
+git commit -m "feat(landing): OwnerLanding Hero + Problem 섹션 추가"
+```
+
+---
+
+## Task 8: OwnerLanding — Solution + Features + Premium
+
+**Files:**
+- Modify: `src/components/Landing/OwnerLanding.tsx`
+
+- [ ] **Step 1: Features 배열과 Premium 배열을 `problemItems` 아래에 추가**
+
+`src/components/Landing/OwnerLanding.tsx`의 `problemItems` 아래에 다음을 추가:
+
+```tsx
+const ownerFeatures = [
+  {
+    icon: ChartBarIcon,
+    title: '일일 업무 보고서',
+    description: '상담·선물·해피콜·리콜 자동 집계와 통계 분석',
+    color: 'from-blue-500 to-cyan-500',
+  },
+  {
+    icon: ClockIcon,
+    title: '출퇴근 · 근태',
+    description: 'QR 체크인, 팀 현황, 스케쥴을 한 화면에서',
+    color: 'from-green-500 to-emerald-500',
+  },
+  {
+    icon: DocumentTextIcon,
+    title: '근로계약서 관리',
+    description: '템플릿 기반 계약서 생성과 체계적 보관',
+    color: 'from-purple-500 to-pink-500',
+  },
+  {
+    icon: CalendarDaysIcon,
+    title: '연차 자동 계산',
+    description: '정책·발생·잔여·승인 워크플로우까지',
+    color: 'from-orange-500 to-amber-500',
+  },
+  {
+    icon: CurrencyDollarIcon,
+    title: '급여 명세서',
+    description: '월별 급여 자동 생성과 직원 배포',
+    color: 'from-rose-500 to-pink-500',
+  },
+  {
+    icon: UserGroupIcon,
+    title: '직원 권한 · 프로토콜',
+    description: '역할별 접근 통제와 업무 표준 문서화',
+    color: 'from-indigo-500 to-violet-500',
+  },
+]
+
+const premiumItems = [
+  {
+    icon: CpuChipIcon,
+    title: 'AI 데이터 분석',
+    description: '매출·상담 지표에서 인사이트를 자동 추출',
+  },
+  {
+    icon: PresentationChartLineIcon,
+    title: '경영현황 대시보드',
+    description: '재무·매출·KPI를 한 화면에서 실시간 확인',
+  },
+  {
+    icon: PencilSquareIcon,
+    title: '마케팅 자동화',
+    description: '네이버 블로그 자동 기획·발행·KPI 추적',
+  },
+]
+```
+
+- [ ] **Step 2: Solution 섹션을 Problem 섹션 뒤에 추가**
+
+`OwnerLanding.tsx`에서 `{/* 나머지 섹션은 다음 Task에서 추가 */}` 주석을 아래로 교체:
+
+```tsx
+      {/* SOLUTION */}
+      <section className="relative py-32 bg-white">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <StoryBlock>
+            <div className="flex items-center gap-4 mb-10">
+              <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-2xl flex items-center justify-center shadow-lg">
+                <HeartIcon className="w-8 h-8 text-white" />
+              </div>
+              <div>
+                <span className="text-at-accent font-semibold text-sm tracking-wider uppercase">The Solution</span>
+                <h2 className="text-2xl font-bold text-at-text">잡무는 시스템에게, 실장은 매출에게</h2>
+              </div>
+            </div>
+
+            <div className="grid sm:grid-cols-2 gap-6 mb-8">
+              <div className="bg-at-surface-alt rounded-2xl p-6 border border-at-border shadow-at-card">
+                <div className="text-4xl mb-4">🔁</div>
+                <h3 className="font-bold text-at-text mb-2">Before</h3>
+                <p className="text-at-text-secondary">
+                  반복 업무에 <span className="text-red-500 font-semibold">70%</span>의 집중력 소진,
+                  상담·매출에는 30%만 남습니다.
+                </p>
+              </div>
+              <div className="bg-gradient-to-br from-blue-50 to-indigo-50 rounded-2xl p-6 border border-at-border shadow-at-card">
+                <div className="text-4xl mb-4">✨</div>
+                <h3 className="font-bold text-at-text mb-2">After</h3>
+                <p className="text-at-text-secondary">
+                  잡무는 시스템이 처리하고, 실장은{' '}
+                  <span className="text-at-accent font-semibold">상담·해피콜·매출 관리</span>에 집중합니다.
+                </p>
+              </div>
+            </div>
+
+            <div className="text-center">
+              <p className="text-xl text-at-text-secondary font-medium">
+                실장의 에너지가{' '}
+                <span className="text-at-accent font-bold">매출로 전환</span>됩니다.
+              </p>
+            </div>
+          </StoryBlock>
+        </div>
+      </section>
+
+      {/* FEATURES */}
+      <section id="owner-features" className="py-32 bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-16">
+            <span className="inline-block px-4 py-1.5 bg-at-surface-alt text-at-text-secondary font-semibold text-sm rounded-full mb-4">
+              FEATURES
+            </span>
+            <h2 className="text-3xl sm:text-4xl font-bold text-at-text mb-4">
+              병원 운영에 필요한 모든 것
+            </h2>
+            <p className="text-lg text-at-text-secondary max-w-2xl mx-auto">
+              반복 업무를 시스템이 처리하는 6가지 핵심 기능
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {ownerFeatures.map((feature) => {
+              const Icon = feature.icon
+              return (
+                <div
+                  key={feature.title}
+                  className="group bg-at-surface-alt hover:bg-white rounded-2xl p-8 transition-all duration-500 hover:shadow-2xl hover:-translate-y-1 border border-at-border"
+                >
+                  <div className={`w-14 h-14 rounded-2xl bg-gradient-to-br ${feature.color} flex items-center justify-center mb-6 shadow-lg`}>
+                    <Icon className="w-7 h-7 text-white" />
+                  </div>
+                  <h3 className="text-xl font-bold text-at-text mb-3">{feature.title}</h3>
+                  <p className="text-at-text-secondary leading-relaxed">{feature.description}</p>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* PREMIUM */}
+      <section className="py-32 bg-gradient-to-br from-indigo-950 via-slate-900 to-slate-950 relative overflow-hidden">
+        <div className="absolute top-0 left-1/3 w-96 h-96 bg-purple-500/10 rounded-full filter blur-3xl" />
+        <div className="absolute bottom-0 right-1/3 w-96 h-96 bg-blue-500/10 rounded-full filter blur-3xl" />
+
+        <div className="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-16">
+            <span className="inline-flex items-center gap-2 px-4 py-1.5 bg-gradient-to-r from-amber-400/20 to-orange-400/20 border border-amber-400/30 text-amber-300 font-bold text-xs tracking-wider uppercase rounded-full mb-4">
+              <SparklesIcon className="w-4 h-4" /> PREMIUM · 월 ₩499,000
+            </span>
+            <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+              경영자의 시간을 위해 준비된 한 단계 더
+            </h2>
+            <p className="text-lg text-slate-300 max-w-2xl mx-auto">
+              기본 기능에 더해, 매출 성장을 직접 끌어올리는 도구
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-3 gap-6">
+            {premiumItems.map((item) => {
+              const Icon = item.icon
+              return (
+                <div
+                  key={item.title}
+                  className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-8 hover:bg-white/10 transition-all"
+                >
+                  <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-amber-400 to-orange-500 flex items-center justify-center mb-6 shadow-lg">
+                    <Icon className="w-7 h-7 text-white" />
+                  </div>
+                  <h3 className="text-xl font-bold text-white mb-3">{item.title}</h3>
+                  <p className="text-slate-300 leading-relaxed">{item.description}</p>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* 나머지 섹션은 다음 Task에서 추가 */}
+```
+
+- [ ] **Step 3: lint 체크**
+
+```bash
+npm run lint
+```
+Expected: lint 에러 없음
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/components/Landing/OwnerLanding.tsx
+git commit -m "feat(landing): OwnerLanding Solution/Features/Premium 섹션 추가"
+```
+
+---
+
+## Task 9: OwnerLanding — Trust + CTA + FAQ
+
+**Files:**
+- Modify: `src/components/Landing/OwnerLanding.tsx`
+
+- [ ] **Step 1: FAQ 배열 추가**
+
+`premiumItems` 아래에 다음을 추가:
+
+```tsx
+const ownerFaqs = [
+  {
+    q: '설치가 필요한가요?',
+    a: '아니요. 웹 브라우저에서 바로 사용 가능합니다. PC·태블릿·스마트폰 어디서든 접속됩니다.',
+  },
+  {
+    q: '데이터는 안전한가요?',
+    a: '글로벌 클라우드 인프라에서 암호화되어 저장되며, 자동 백업으로 손실 없이 보관됩니다.',
+  },
+  {
+    q: '직원 권한 설정이 가능한가요?',
+    a: '원장·부원장·실장·팀장·일반 직원 등 역할별 권한을 세분화해 설정할 수 있습니다.',
+  },
+  {
+    q: '기존 데이터 이전이 가능한가요?',
+    a: 'Excel 파일 등을 통한 기존 데이터 이전을 지원합니다.',
+  },
+  {
+    q: '프리미엄 패키지는 무엇이 다른가요?',
+    a: '기본 기능은 그대로 사용 가능하며, 월 ₩499,000에 AI 데이터 분석·경영현황 대시보드·마케팅 자동화(네이버 블로그)가 포함됩니다.',
+  },
+]
+```
+
+- [ ] **Step 2: Trust + CTA + FAQ 섹션 추가**
+
+`{/* 나머지 섹션은 다음 Task에서 추가 */}` 주석을 아래로 교체:
+
+```tsx
+      {/* TRUST */}
+      <section className="relative py-32 bg-gradient-to-br from-slate-50 to-blue-50">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <StoryBlock>
+            <div className="text-center mb-12">
+              <span className="inline-flex items-center gap-2 px-4 py-2 bg-at-tag text-at-accent rounded-full text-sm font-semibold mb-6">
+                <SparklesIcon className="w-4 h-4" />
+                Why Clinic Manager?
+              </span>
+              <h2 className="text-3xl sm:text-4xl font-bold text-at-text leading-tight">
+                현장의 필요를 느낀{' '}
+                <span className="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
+                  치과 원장이 직접 개발
+                </span>
+                했습니다
+              </h2>
+            </div>
+
+            <div className="bg-white rounded-3xl p-8 sm:p-10 shadow-xl border border-at-border">
+              <div className="flex flex-col sm:flex-row items-center gap-6 mb-8">
+                <div className="w-20 h-20 bg-gradient-to-br from-slate-700 to-slate-900 rounded-2xl flex items-center justify-center shadow-lg">
+                  <span className="text-3xl">👨‍⚕️</span>
+                </div>
+                <div className="text-center sm:text-left">
+                  <p className="text-at-text-weak text-sm mb-1">개발자이자 사용자</p>
+                  <p className="text-2xl font-bold text-at-text">현직 치과 원장</p>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div className="flex items-start gap-3">
+                  <CheckCircleIcon className="w-6 h-6 text-green-500 flex-shrink-0 mt-0.5" />
+                  <p className="text-lg text-at-text-secondary">
+                    <span className="font-semibold">현장의 불편함</span>을 직접 경험하고 해결한 솔루션
+                  </p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <CheckCircleIcon className="w-6 h-6 text-green-500 flex-shrink-0 mt-0.5" />
+                  <p className="text-lg text-at-text-secondary">
+                    <span className="font-semibold">본인 병원에서 매일 사용</span>하며 지속 개선 중
+                  </p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <CheckCircleIcon className="w-6 h-6 text-green-500 flex-shrink-0 mt-0.5" />
+                  <p className="text-lg text-at-text-secondary">
+                    치과 업무 흐름을 <span className="font-semibold">정확히 이해</span>한 맞춤형 설계
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-8 pt-8 border-t border-at-border">
+                <p className="text-at-text-secondary italic text-center">
+                  "직접 쓰면서 불편한 건 바로바로 고칩니다.<br />제가 매일 쓰니까요."
+                </p>
+              </div>
+            </div>
+          </StoryBlock>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-32 bg-gradient-to-br from-blue-600 via-indigo-600 to-purple-600 relative overflow-hidden">
+        <div className="absolute top-0 left-0 w-96 h-96 bg-white/10 rounded-full filter blur-3xl -translate-x-1/2 -translate-y-1/2" />
+        <div className="absolute bottom-0 right-0 w-96 h-96 bg-white/10 rounded-full filter blur-3xl translate-x-1/2 translate-y-1/2" />
+
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-6">
+            실장의 시간을 매출로 전환할 때입니다
+          </h2>
+          <p className="text-xl text-white/80 mb-10 max-w-2xl mx-auto">
+            복잡한 설치 없이, 웹 브라우저로 바로 시작하세요.
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <button
+              onClick={onShowSignup}
+              className="group px-10 py-4 bg-white text-at-text font-bold text-lg rounded-2xl transition-all shadow-xl hover:shadow-2xl hover:-translate-y-1 flex items-center gap-2 justify-center"
+            >
+              무료로 시작하기
+              <ArrowRightIcon className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
+            </button>
+            <button
+              onClick={onShowLogin}
+              className="px-10 py-4 border-2 border-white/30 text-white hover:bg-white/10 font-semibold text-lg rounded-2xl transition-all backdrop-blur-sm"
+            >
+              로그인
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section id="owner-faq" className="py-24 bg-at-surface-alt">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-16">
+            <h2 className="text-3xl font-bold text-at-text mb-4">자주 묻는 질문</h2>
+          </div>
+
+          <div className="space-y-4">
+            {ownerFaqs.map((faq, i) => (
+              <div key={i} className="bg-white rounded-2xl overflow-hidden shadow-at-card border border-at-border">
+                <button
+                  onClick={() => setOpenFaq(openFaq === i ? null : i)}
+                  className="w-full px-6 py-5 flex items-center justify-between text-left hover:bg-at-surface-alt transition-colors"
+                >
+                  <span className="font-semibold text-at-text pr-4">{faq.q}</span>
+                  <ChevronDownIcon
+                    className={`w-5 h-5 text-at-text-weak transition-transform duration-300 flex-shrink-0 ${openFaq === i ? 'rotate-180' : ''}`}
+                  />
+                </button>
+                <div className={`overflow-hidden transition-all duration-300 ${openFaq === i ? 'max-h-48' : 'max-h-0'}`}>
+                  <div className="px-6 pb-5">
+                    <p className="text-at-text-secondary leading-relaxed">{faq.a}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+```
+
+- [ ] **Step 3: lint 체크**
+
+```bash
+npm run lint
+```
+Expected: lint 에러 없음
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/components/Landing/OwnerLanding.tsx
+git commit -m "feat(landing): OwnerLanding Trust/CTA/FAQ 섹션 추가"
+```
+
+---
+
+## Task 10: `/owner` 라우트
+
+**Files:**
+- Create: `src/app/owner/page.tsx`
+
+- [ ] **Step 1: 페이지 작성**
+
+`src/app/owner/page.tsx`:
+
+```tsx
+'use client'
+
+import { useEffect } from 'react'
+import AuthFlow from '@/components/Landing/shared/AuthFlow'
+import OwnerLanding from '@/components/Landing/OwnerLanding'
+import { useVisitorRole } from '@/components/Landing/shared/useVisitorRole'
+
+export default function OwnerPage() {
+  const { setRole, hydrated, role } = useVisitorRole()
+
+  // 첫 방문 시 localStorage에 저장
+  useEffect(() => {
+    if (!hydrated) return
+    if (role !== 'owner') {
+      setRole('owner')
+    }
+  }, [hydrated, role, setRole])
+
+  return (
+    <AuthFlow>
+      {({ onShowLogin, onShowSignup }) => (
+        <OwnerLanding onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
+      )}
+    </AuthFlow>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 체크**
+
+```bash
+npm run build
+```
+Expected: `/owner` 라우트가 성공적으로 컴파일됨
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/app/owner/page.tsx
+git commit -m "feat(landing): /owner 라우트 추가"
+```
+
+---
+
+## Task 11: StaffLanding — Hero + 공감 + 해결 섹션
+
+**Files:**
+- Create: `src/components/Landing/StaffLanding.tsx`
+
+- [ ] **Step 1: 뼈대 + Hero + 공감 + 해결 작성**
+
+`src/components/Landing/StaffLanding.tsx`:
+
+```tsx
+'use client'
+
+import { useState } from 'react'
+import {
+  ArrowRightIcon,
+  ChevronDownIcon,
+  ClockIcon,
+  CalendarDaysIcon,
+  ChartBarIcon,
+  CheckCircleIcon,
+  GiftIcon,
+  ChatBubbleLeftRightIcon,
+  SparklesIcon,
+  QrCodeIcon,
+} from '@heroicons/react/24/outline'
+import LandingHeader from './shared/LandingHeader'
+import { useScrollAnimation } from './shared/useScrollAnimation'
+
+interface StaffLandingProps {
+  onShowLogin: () => void
+  onShowSignup: () => void
+}
+
+function StoryBlock({ children }: { children: React.ReactNode }) {
+  const { ref, isVisible } = useScrollAnimation()
+  return (
+    <div
+      ref={ref}
+      className={`transition-all duration-1000 ${
+        isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
+      }`}
+    >
+      {children}
+    </div>
+  )
+}
+
+const staffFeatures = [
+  {
+    icon: QrCodeIcon,
+    title: 'QR 출퇴근',
+    description: '스마트폰으로 1초 체크인. 수기 기록 없이 자동 집계.',
+    color: 'from-pink-400 to-rose-500',
+  },
+  {
+    icon: CalendarDaysIcon,
+    title: '스케쥴 · 연차',
+    description: '신청부터 승인까지 앱에서. 잔여일도 한눈에.',
+    color: 'from-violet-400 to-purple-500',
+  },
+  {
+    icon: ChartBarIcon,
+    title: '일일 업무 보고',
+    description: '상담·해피콜·리콜을 탭 한 번으로 기록.',
+    color: 'from-amber-400 to-orange-500',
+  },
+  {
+    icon: CheckCircleIcon,
+    title: '업무 체크리스트',
+    description: '오늘 할 일과 완료 현황을 팀 단위로 공유.',
+    color: 'from-emerald-400 to-teal-500',
+  },
+  {
+    icon: GiftIcon,
+    title: '선물 재고',
+    description: '실시간 수량 확인·알림. 부족분 체크 걱정 끝.',
+    color: 'from-rose-400 to-pink-500',
+  },
+  {
+    icon: ChatBubbleLeftRightIcon,
+    title: '팀 커뮤니티 · 텔레그램',
+    description: '공지·질문·빠른 소통을 한 채널에서.',
+    color: 'from-cyan-400 to-sky-500',
+  },
+]
+
+const staffFaqs = [
+  {
+    q: '개인정보가 안전한가요?',
+    a: '모든 데이터는 암호화되어 저장되며, 원장님과 권한이 있는 관리자만 접근할 수 있습니다.',
+  },
+  {
+    q: '휴대폰으로도 잘 되나요?',
+    a: '모바일 최적화 웹앱이라 스마트폰에서 바로 사용 가능하고, 홈 화면에 추가해 앱처럼 쓸 수 있습니다.',
+  },
+  {
+    q: '연차 잔여일은 어떻게 확인하나요?',
+    a: '연차 메뉴에서 발생·사용·잔여일이 자동 계산되어 실시간으로 표시됩니다.',
+  },
+  {
+    q: '실수로 출근 체크를 빼먹으면요?',
+    a: '관리자에게 수정 요청을 보낼 수 있고, 승인되면 반영됩니다. 놓치지 않게 알림도 설정할 수 있습니다.',
+  },
+]
+
+export default function StaffLanding({ onShowLogin, onShowSignup }: StaffLandingProps) {
+  const [openFaq, setOpenFaq] = useState<number | null>(null)
+
+  return (
+    <div className="min-h-screen bg-white overflow-x-hidden">
+      <LandingHeader variant="light" onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
+
+      {/* HERO */}
+      <section className="relative min-h-screen flex items-center justify-center pt-16 overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-br from-amber-50 via-rose-100 to-violet-100" />
+        <div className="absolute top-1/4 -left-20 w-80 h-80 bg-rose-300/30 rounded-full filter blur-[120px]" />
+        <div className="absolute bottom-1/4 -right-20 w-80 h-80 bg-violet-300/30 rounded-full filter blur-[120px]" />
+
+        <div className="absolute top-24 left-10 text-3xl opacity-50 animate-bounce" style={{ animationDuration: '3s' }}>☕</div>
+        <div className="absolute top-32 right-16 text-3xl opacity-50 animate-bounce" style={{ animationDuration: '4s', animationDelay: '0.5s' }}>✨</div>
+        <div className="absolute bottom-32 left-20 text-3xl opacity-50 animate-bounce" style={{ animationDuration: '3.5s', animationDelay: '1s' }}>🎈</div>
+
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center z-10">
+          <div className="mb-8">
+            <span className="inline-flex items-center gap-2 px-5 py-2.5 bg-white/70 backdrop-blur-sm border border-pink-200 text-pink-600 rounded-full text-sm font-semibold">
+              <SparklesIcon className="w-4 h-4" />
+              FOR STAFF · 실장님, 팀원님
+            </span>
+          </div>
+
+          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-slate-900 leading-[1.2] tracking-tight mb-8">
+            <span className="block mb-2 sm:mb-4">출퇴근부터 연차까지</span>
+            <span className="block bg-gradient-to-r from-pink-500 via-rose-500 to-violet-500 bg-clip-text text-transparent pb-2">
+              간단하게 끝내고
+            </span>
+            <span className="block">정시 퇴근하세요 ~</span>
+          </h1>
+
+          <p className="text-slate-700 text-lg sm:text-xl max-w-xl mx-auto mb-12 leading-relaxed">
+            반복 업무는 앱이 대신합니다.{' '}
+            <span className="text-slate-900 font-semibold">손 덜 쓰는 하루 루틴.</span>
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+            <button
+              onClick={onShowSignup}
+              className="group px-8 py-4 bg-slate-900 hover:bg-slate-800 text-white font-bold text-lg rounded-2xl transition-all shadow-xl hover:shadow-2xl hover:-translate-y-1 flex items-center gap-2"
+            >
+              지금 시작하기
+              <ArrowRightIcon className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
+            </button>
+            <button
+              onClick={() => document.getElementById('staff-empathy')?.scrollIntoView({ behavior: 'smooth' })}
+              className="px-8 py-4 bg-white border border-slate-200 text-slate-700 hover:bg-slate-50 font-medium text-lg rounded-2xl transition-all flex items-center gap-2"
+            >
+              기능 살펴보기
+              <ChevronDownIcon className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+
+        <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
+          <ChevronDownIcon className="w-5 h-5 text-slate-500" />
+        </div>
+      </section>
+
+      {/* EMPATHY */}
+      <section id="staff-empathy" className="py-28 bg-gradient-to-b from-rose-50 to-white">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <StoryBlock>
+            <p className="text-3xl sm:text-4xl font-bold text-slate-900 leading-snug mb-6">
+              혹시 오늘도…<br />
+              <span className="text-rose-500">퇴근하고 엑셀 켜셨나요?</span>
+            </p>
+            <p className="text-lg text-slate-600 leading-relaxed">
+              연차 계산, 스케쥴 조율, 업무 집계…<br />
+              이제 그만 하셔도 됩니다.
+            </p>
+          </StoryBlock>
+        </div>
+      </section>
+
+      {/* SOLUTION */}
+      <section className="py-28 bg-white">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <StoryBlock>
+            <div className="text-center mb-14">
+              <h2 className="text-3xl sm:text-4xl font-bold text-slate-900 leading-snug">
+                클릭 몇 번이면{' '}
+                <span className="bg-gradient-to-r from-pink-500 to-violet-500 bg-clip-text text-transparent">
+                  끝.
+                </span>
+              </h2>
+            </div>
+
+            <div className="grid sm:grid-cols-3 gap-4">
+              {[
+                { n: '1', title: 'QR로 출근', desc: '스마트폰으로 1초', color: 'from-pink-400 to-rose-500' },
+                { n: '2', title: '하루 업무 관리', desc: '앱에서 탭 한 번', color: 'from-violet-400 to-purple-500' },
+                { n: '3', title: 'QR로 퇴근', desc: '정시에 귀가 ~', color: 'from-amber-400 to-orange-500' },
+              ].map((step) => (
+                <div
+                  key={step.n}
+                  className="relative bg-white border border-slate-100 rounded-3xl p-8 shadow-at-card hover:shadow-xl transition-all"
+                >
+                  <div className={`w-12 h-12 rounded-2xl bg-gradient-to-br ${step.color} text-white font-bold text-xl flex items-center justify-center shadow-lg mb-4`}>
+                    {step.n}
+                  </div>
+                  <h3 className="text-xl font-bold text-slate-900 mb-2">{step.title}</h3>
+                  <p className="text-slate-600">{step.desc}</p>
+                </div>
+              ))}
+            </div>
+          </StoryBlock>
+        </div>
+      </section>
+
+      {/* 나머지 섹션은 다음 Task에서 추가 */}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: lint 체크**
+
+```bash
+npm run lint
+```
+Expected: lint 에러 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Landing/StaffLanding.tsx
+git commit -m "feat(landing): StaffLanding Hero/공감/해결 섹션 추가"
+```
+
+---
+
+## Task 12: StaffLanding — Features + CTA + FAQ
+
+**Files:**
+- Modify: `src/components/Landing/StaffLanding.tsx`
+
+- [ ] **Step 1: Features + CTA + FAQ 섹션 추가**
+
+`{/* 나머지 섹션은 다음 Task에서 추가 */}` 주석을 아래로 교체:
+
+```tsx
+      {/* FEATURES */}
+      <section className="py-28 bg-gradient-to-b from-white to-rose-50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-14">
+            <span className="inline-block px-4 py-1.5 bg-pink-100 text-pink-700 font-semibold text-sm rounded-full mb-4">
+              FEATURES
+            </span>
+            <h2 className="text-3xl sm:text-4xl font-bold text-slate-900 mb-3">
+              하루 업무가 앱 하나로
+            </h2>
+            <p className="text-lg text-slate-600 max-w-2xl mx-auto">
+              실장·직원이 매일 쓰는 6가지 기능
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {staffFeatures.map((feature) => {
+              const Icon = feature.icon
+              return (
+                <div
+                  key={feature.title}
+                  className="group bg-white rounded-3xl p-8 transition-all hover:shadow-xl hover:-translate-y-1 border border-slate-100"
+                >
+                  <div className={`w-14 h-14 rounded-2xl bg-gradient-to-br ${feature.color} flex items-center justify-center mb-6 shadow-lg`}>
+                    <Icon className="w-7 h-7 text-white" />
+                  </div>
+                  <h3 className="text-xl font-bold text-slate-900 mb-3">{feature.title}</h3>
+                  <p className="text-slate-600 leading-relaxed">{feature.description}</p>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-28 bg-gradient-to-br from-cyan-500 via-teal-500 to-emerald-500 relative overflow-hidden">
+        <div className="absolute top-0 left-0 w-96 h-96 bg-white/10 rounded-full filter blur-3xl -translate-x-1/2 -translate-y-1/2" />
+        <div className="absolute bottom-0 right-0 w-96 h-96 bg-white/10 rounded-full filter blur-3xl translate-x-1/2 translate-y-1/2" />
+
+        <div className="relative max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-6">
+            오늘 퇴근은 정시에 🕕
+          </h2>
+          <p className="text-xl text-white/90 mb-10">
+            앱 하나로 오늘 업무를 깔끔하게 끝내세요.
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <button
+              onClick={onShowSignup}
+              className="group px-10 py-4 bg-white text-slate-900 font-bold text-lg rounded-2xl transition-all shadow-xl hover:shadow-2xl hover:-translate-y-1 flex items-center gap-2 justify-center"
+            >
+              지금 바로 시작
+              <ArrowRightIcon className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
+            </button>
+            <button
+              onClick={onShowLogin}
+              className="px-10 py-4 border-2 border-white/40 text-white hover:bg-white/10 font-semibold text-lg rounded-2xl transition-all backdrop-blur-sm"
+            >
+              로그인
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="py-24 bg-white">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-14">
+            <h2 className="text-3xl font-bold text-slate-900 mb-4">자주 묻는 질문</h2>
+          </div>
+
+          <div className="space-y-4">
+            {staffFaqs.map((faq, i) => (
+              <div key={i} className="bg-rose-50/50 rounded-2xl overflow-hidden border border-rose-100">
+                <button
+                  onClick={() => setOpenFaq(openFaq === i ? null : i)}
+                  className="w-full px-6 py-5 flex items-center justify-between text-left hover:bg-rose-50 transition-colors"
+                >
+                  <span className="font-semibold text-slate-900 pr-4">{faq.q}</span>
+                  <ChevronDownIcon
+                    className={`w-5 h-5 text-slate-500 transition-transform duration-300 flex-shrink-0 ${openFaq === i ? 'rotate-180' : ''}`}
+                  />
+                </button>
+                <div className={`overflow-hidden transition-all duration-300 ${openFaq === i ? 'max-h-48' : 'max-h-0'}`}>
+                  <div className="px-6 pb-5">
+                    <p className="text-slate-600 leading-relaxed">{faq.a}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+```
+
+- [ ] **Step 2: lint 체크**
+
+```bash
+npm run lint
+```
+Expected: lint 에러 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Landing/StaffLanding.tsx
+git commit -m "feat(landing): StaffLanding Features/CTA/FAQ 섹션 추가"
+```
+
+---
+
+## Task 13: `/staff` 라우트
+
+**Files:**
+- Create: `src/app/staff/page.tsx`
+
+- [ ] **Step 1: 페이지 작성**
+
+`src/app/staff/page.tsx`:
+
+```tsx
+'use client'
+
+import { useEffect } from 'react'
+import AuthFlow from '@/components/Landing/shared/AuthFlow'
+import StaffLanding from '@/components/Landing/StaffLanding'
+import { useVisitorRole } from '@/components/Landing/shared/useVisitorRole'
+
+export default function StaffPage() {
+  const { setRole, hydrated, role } = useVisitorRole()
+
+  useEffect(() => {
+    if (!hydrated) return
+    if (role !== 'staff') {
+      setRole('staff')
+    }
+  }, [hydrated, role, setRole])
+
+  return (
+    <AuthFlow>
+      {({ onShowLogin, onShowSignup }) => (
+        <StaffLanding onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
+      )}
+    </AuthFlow>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 체크**
+
+```bash
+npm run build
+```
+Expected: `/staff` 라우트가 성공적으로 컴파일됨. 전체 빌드 성공.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/app/staff/page.tsx
+git commit -m "feat(landing): /staff 라우트 추가"
+```
+
+---
+
+## Task 14: 기존 AuthApp·LandingPage 제거
+
+**Files:**
+- Delete: `src/app/AuthApp.tsx`
+- Delete: `src/components/Landing/LandingPage.tsx`
+
+- [ ] **Step 1: 사용처 확인**
+
+```bash
+npm run lint 2>&1 | head -30
+```
+
+추가로 검색으로 남은 참조가 없는지 확인:
+
+```bash
+grep -r "from '@/app/AuthApp'" src/ 2>/dev/null
+grep -r "from './AuthApp'" src/ 2>/dev/null
+grep -r "from '@/components/Landing/LandingPage'" src/ 2>/dev/null
+grep -r "from './LandingPage'" src/components/Landing/ 2>/dev/null
+```
+
+Expected: 아무 결과 없음. 있으면 해당 파일들을 먼저 수정해 참조 제거.
+
+- [ ] **Step 2: 파일 삭제**
+
+```bash
+rm src/app/AuthApp.tsx
+rm src/components/Landing/LandingPage.tsx
+```
+
+- [ ] **Step 3: 빌드 체크**
+
+```bash
+npm run build
+```
+Expected: 전체 빌드 성공. 타입 에러나 import 에러 없음.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add -A src/app/AuthApp.tsx src/components/Landing/LandingPage.tsx
+git commit -m "refactor(landing): 기존 AuthApp·LandingPage 제거 (신규 구조로 대체)"
+```
+
+---
+
+## Task 15: 최종 수동 검증 및 푸시
+
+**검증 시나리오**: `npm run dev`로 실행하고 브라우저에서 다음을 확인.
+
+- [ ] **Step 1: 개발 서버 실행**
+
+```bash
+npm run dev
+```
+백그라운드에서 실행하여 서버 로그 확인. `http://localhost:3000` 접속 가능해야 함.
+
+- [ ] **Step 2: localStorage 초기 상태에서 `/` 확인**
+
+1. 브라우저 DevTools → Application → Local Storage → `clinicmgr.visitor_role` 삭제
+2. `http://localhost:3000/` 접속
+3. 기대: 역할 선택 카드 2개가 보이고, 헤더에 로그인/시작하기 버튼 존재
+4. 콘솔 에러 없음
+
+- [ ] **Step 3: 역할 선택 → `/owner` 이동 확인**
+
+1. "대표원장" 카드 클릭
+2. 기대: `/owner`로 이동, localStorage에 `clinicmgr.visitor_role=owner` 저장됨
+3. OwnerLanding 전체 섹션이 Hero → Problem → Solution → Features → Premium → Trust → CTA → FAQ 순으로 렌더링
+4. "기능 살펴보기" 버튼 → Problem 섹션으로 스크롤
+5. FAQ 항목 클릭 → 펼침/접힘 작동
+
+- [ ] **Step 4: `/`로 돌아가 자동 리디렉션 확인**
+
+1. 주소창에 `http://localhost:3000/` 입력
+2. 기대: localStorage에 저장된 `owner` 값으로 자동 `/owner`로 리디렉션 (플래시 최소)
+
+- [ ] **Step 5: localStorage 초기화 후 `/staff` 직접 접속**
+
+1. DevTools에서 `clinicmgr.visitor_role` 삭제
+2. `http://localhost:3000/staff` 접속
+3. 기대: StaffLanding 렌더링, localStorage에 `staff` 저장됨
+4. Hero → 공감 → 해결 → Features → CTA → FAQ 순 렌더링 확인
+5. CTA/헤더 색상이 파스텔·시안 톤인지 확인
+
+- [ ] **Step 6: 로그인/회원가입 플로우 확인**
+
+1. `/owner`에서 "로그인" 클릭 → LoginForm 렌더링 확인
+2. "뒤로" 또는 랜딩 복귀 → OwnerLanding 다시 보임
+3. 테스트 계정 `whitedc0902@gmail.com` / `ghkdgmltn81!`로 로그인
+4. 기대: `/dashboard`로 자동 리디렉션 (기존 동작 유지)
+5. 로그아웃 후 `/staff`에서도 동일 확인
+
+- [ ] **Step 7: 쿼리 파라미터 동작 확인**
+
+1. `http://localhost:3000/owner?show=signup` 접속 → SignupForm 바로 표시
+2. `http://localhost:3000/staff?show=login` 접속 → LoginForm 바로 표시
+
+- [ ] **Step 8: 선택 기억 해제 버튼 확인**
+
+1. localStorage에 값이 없는 상태에서 `/`에 접속
+2. footer의 "선택 기억 해제" 버튼 클릭
+3. 기대: 페이지 유지(리디렉션 안 됨), localStorage에 값 없음 유지
+
+- [ ] **Step 9: 모바일 뷰 간단 확인**
+
+DevTools 디바이스 모드로 폭 375px에서:
+- `/`, `/owner`, `/staff` 모두 세로 스크롤만 생기고 가로 오버플로 없음
+- CTA 버튼들이 세로로 쌓임
+- Features 그리드가 1열로 변경됨
+
+- [ ] **Step 10: 전체 빌드 최종 확인**
+
+```bash
+npm run build
+npm run lint
+```
+Expected: 둘 다 에러 없이 성공
+
+- [ ] **Step 11: develop 브랜치에 푸시**
+
+```bash
+git push origin develop
+```
+Expected: 성공. 실패 시 `git pull --rebase origin develop` 후 재시도.
+
+---
+
+## Rollback 전략
+
+빌드 실패나 심각한 렌더링 이슈 발생 시:
+
+```bash
+# 마지막 안전 커밋 ID 확인 (4bb7cb6f: spec commit 직전)
+git log --oneline -n 20
+
+# 해당 커밋으로 소프트 리셋 후 변경사항 검토
+git reset --soft 4bb7cb6f
+```
+
+단, Task별로 커밋이 분리되어 있으므로 실패한 Task만 해당 커밋을 `git revert`하는 것이 1차 선택이다.

--- a/dental-clinic-manager/docs/superpowers/plans/2026-04-19-subscription-headcount-gating.md
+++ b/dental-clinic-manager/docs/superpowers/plans/2026-04-19-subscription-headcount-gating.md
@@ -1,0 +1,2243 @@
+# 구독 플랜 개편: 직원 수 기반 게이팅 + 통합 화면 구현 플랜
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 기본 기능을 직원 수 구간별로 과금하고, 인원 상한 초과 시 원장 승인을 홀드 + 결제 게이트로 강제하며, 플랜 선택 UI를 단일 화면 3섹션으로 통합한다.
+
+**Architecture:** 신규 서버 API `/api/staff/approve`에 인원 상한 가드를 심고 기존 클라이언트 승인 경로(`dataService.approveUser`)를 이 API 호출로 리팩터한다. 포트원 웹훅에서 결제 성공 시 `subscription_payment_succeeded` 알림을 생성해 원장 대시보드가 자동 승인 모달을 띄운다. 기존 `PlanSelectModal`의 탭 구조를 제거하고 3섹션(파랑/보라/초록) 단일 화면으로 재구성한다.
+
+**Tech Stack:** Next.js 15 · React 19 · TypeScript · Supabase (PostgreSQL) · Tailwind CSS 4 · shadcn/ui · 포트원(PortOne) v2 · Vercel Cron · Chrome DevTools MCP (수동 E2E)
+
+**Spec:** [`docs/superpowers/specs/2026-04-19-subscription-headcount-gating-design.md`](../specs/2026-04-19-subscription-headcount-gating-design.md)
+
+**Test Policy:** 이 리포지토리에는 Jest/Vitest 등 자동 테스트 러너가 없다. 각 Task의 "검증" 단계는 `npm run build` 통과 + Chrome DevTools MCP 수동 E2E로 대체한다 (CLAUDE.md 최상위 지시사항).
+
+---
+
+## 파일 구조
+
+### 신규 파일
+- `supabase/migrations/20260419_subscription_headcount_gating.sql` — 플랜 경계 조정, premium-bundle, feature-investment, 환불 컬럼
+- `supabase/migrations/20260419_investment_profit_snapshots.sql` — 스냅샷 테이블 및 RLS
+- `src/lib/subscriptionPlans.ts` — `findPlanByHeadcount`, `formatPlanPrice` 순수 유틸
+- `src/lib/investmentProfit.ts` — 월별 수익 계산 stub + 시그니처 고정
+- `src/lib/subscriptionReconciler.ts` — 퇴사/삭제 시 플랜 재조정 헬퍼
+- `src/app/api/staff/approve/route.ts` — 원장용 승인 API (인원 상한 가드)
+- `src/app/api/staff/approve-bulk-auto/route.ts` — 결제 후 전체 자동 승인
+- `src/app/api/subscription/downgrade/route.ts` — 다운그레이드 + 부분 환불
+- `src/app/api/investment/profit-snapshot/route.ts` — 월말 크론
+- `src/app/api/investment/profit-snapshot/refresh/route.ts` — 수동 재집계
+- `src/components/Subscription/UpgradeRequiredModal.tsx` — 결제 게이트 모달
+- `src/components/Subscription/PostPaymentApprovalModal.tsx` — 결제 후 자동/개별 승인 토글
+- `src/components/Subscription/PerformanceSection.tsx` — 주식 자동매매 카드
+- `src/components/Subscription/BasicPlansSection.tsx` — 기본 5개 플랜 카드 섹션
+- `src/components/Subscription/PremiumBundleSection.tsx` — 프리미엄 패키지 카드 섹션
+- `src/components/Subscription/DowngradeConfirmModal.tsx` — 퇴사/다운그레이드 환불 확인
+- `src/components/Dashboard/PendingApprovalBanner.tsx` — 대시보드 상단 고정 배너
+
+### 수정 파일
+- `src/lib/portone.ts` — `partialRefund` 추가
+- `src/lib/dataService.ts` — `approveUser`를 `/api/staff/approve` 호출로 리팩터
+- `src/lib/subscriptionService.ts` — `countActiveEmployees`, `getActivePaymentForCurrentPeriod` 추가
+- `src/app/api/webhooks/portone/route.ts` — 결제 성공 시 알림 생성
+- `src/app/api/admin/users/approve/route.ts` — master_admin 경로에도 상한 가드 적용
+- `src/types/notification.ts` — enum에 2개 타입 추가
+- `src/components/Subscription/PlanSelectModal.tsx` — 탭 제거, 3섹션 조립
+- `src/components/Management/StaffManagement.tsx` — 승인 실패 응답 처리 + 모달 연결
+- `src/config/menuConfig.ts` — `formatPlanPrice` 적용 지점 정비 (필요 시)
+- `src/app/dashboard/page.tsx` — `PendingApprovalBanner`, `PostPaymentApprovalModal` 장착
+- `vercel.json` — `profit-snapshot` 크론 등록
+
+---
+
+## Task 0: 준비
+
+### 파일:
+- Check: `package.json`, `supabase/migrations/`, 현재 git 상태
+
+- [ ] **Step 1: develop 브랜치 최신화**
+
+Run:
+```bash
+git checkout develop
+git pull --rebase
+git status
+```
+Expected: clean working tree 또는 이미 추적 중인 수정만 표시.
+
+- [ ] **Step 2: 현재 DB 스키마 점검 (참고용)**
+
+Run (Supabase MCP 가용 가정):
+```
+mcp__supabase__list_tables({ project_id: "beahjntkmkfhpcbhfnrr", schemas: ["public"] })
+```
+확인: `clinics`, `users`, `subscriptions`, `subscription_plans`, `subscription_payments`, `user_notifications` 존재.
+
+- [ ] **Step 3: 빌드 베이스라인**
+
+Run: `npm run build`
+Expected: 성공. 실패 시 우선 원인을 기록 후 이 플랜 Task 진행 중 재발한 에러와 분리.
+
+---
+
+## Task 1: 플랜 유틸 (`subscriptionPlans.ts`)
+
+### 파일:
+- Create: `src/lib/subscriptionPlans.ts`
+
+- [ ] **Step 1: 유틸 파일 생성**
+
+```ts
+// src/lib/subscriptionPlans.ts
+import type { SubscriptionPlan } from '@/types/subscription'
+
+export type HeadcountPlanName = 'free' | 'starter' | 'growth' | 'pro' | 'enterprise'
+
+/**
+ * 총 재직자 수에 맞는 헤드카운트 플랜 이름을 반환한다.
+ * 경계: Free 1~4, Starter 5~10, Growth 11~20, Pro 21~50, Enterprise 51+
+ */
+export function findPlanByHeadcount(total: number): HeadcountPlanName {
+  if (total <= 4) return 'free'
+  if (total <= 10) return 'starter'
+  if (total <= 20) return 'growth'
+  if (total <= 50) return 'pro'
+  return 'enterprise'
+}
+
+/**
+ * 플랜 가격을 일관된 문구로 포맷한다.
+ * - 주식 자동매매(feature_id='investment'): "수익의 5%"
+ * - Enterprise: "맞춤 문의"
+ * - price=0: "무료"
+ * - 그 외: "월 N,NNN원"
+ */
+export function formatPlanPrice(plan: Pick<SubscriptionPlan, 'name' | 'price' | 'feature_id'>): string {
+  if (plan.feature_id === 'investment') return '수익의 5%'
+  if (plan.name === 'enterprise') return '맞춤 문의'
+  if (plan.price === 0) return '무료'
+  return `월 ${plan.price.toLocaleString()}원`
+}
+
+/**
+ * 현재 재직자 수와 승인 대기 중인 인원을 합산해 신규 플랜이 필요한지 판정한다.
+ */
+export function requiresUpgrade(params: {
+  currentActive: number
+  pendingToApprove: number
+  currentLimit: number
+}): boolean {
+  return params.currentActive + params.pendingToApprove > params.currentLimit
+}
+```
+
+- [ ] **Step 2: TypeScript 타입 확인**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: 신규 파일 관련 에러 0. `SubscriptionPlan` import 경로는 `src/types/subscription.ts`에서 실제 export 이름과 일치해야 한다 (필요 시 재확인 후 수정).
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/lib/subscriptionPlans.ts
+git commit -m "$(cat <<'EOF'
+feat(subscription): findPlanByHeadcount / formatPlanPrice 유틸 추가
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: DB 마이그레이션 — 플랜 경계 및 신규 플랜
+
+### 파일:
+- Create: `supabase/migrations/20260419_subscription_headcount_gating.sql`
+- Apply via: `mcp__supabase__apply_migration`
+
+- [ ] **Step 1: 마이그레이션 SQL 작성**
+
+```sql
+-- supabase/migrations/20260419_subscription_headcount_gating.sql
+-- 구독 플랜 개편: 직원 수 게이팅 + 프리미엄/주식매매 플랜 정비 + 환불 컬럼
+
+BEGIN;
+
+-- 1. Free 상한 4명, Starter 하한 5명으로 조정
+UPDATE subscription_plans
+   SET max_users = 4, description = '4인 이하 사업장 무료'
+ WHERE name = 'free';
+
+UPDATE subscription_plans
+   SET min_users = 5, description = '5~10인 사업장'
+ WHERE name = 'starter';
+
+-- 2. 프리미엄 패키지 (UI는 이미 premium-bundle 가정)
+INSERT INTO subscription_plans
+  (name, display_name, type, feature_id, price, description, features, sort_order)
+VALUES
+  ('premium-bundle', '프리미엄 패키지', 'feature', 'premium-bundle', 499000,
+   'AI 분석 + 경영 현황 + 마케팅 자동화 통합',
+   '["AI 데이터 분석","경영 현황 관리","마케팅 자동화"]'::jsonb, 9)
+ON CONFLICT (name) DO UPDATE
+   SET price = EXCLUDED.price,
+       feature_id = EXCLUDED.feature_id,
+       description = EXCLUDED.description,
+       features = EXCLUDED.features,
+       display_name = EXCLUDED.display_name,
+       sort_order = EXCLUDED.sort_order;
+
+-- 3. 주식 자동매매 플랜 (UI priceLabel: '수익의 5%' 유지)
+INSERT INTO subscription_plans
+  (name, display_name, type, feature_id, price, description, features, sort_order)
+VALUES
+  ('feature-investment', '주식 자동매매', 'feature', 'investment', 0,
+   '수익의 5% 성과 연동 과금',
+   '["AI 자동매매 전략","실시간 포트폴리오","백테스트"]'::jsonb, 13)
+ON CONFLICT (name) DO UPDATE
+   SET description = EXCLUDED.description,
+       features = EXCLUDED.features;
+
+-- 4. 환불 컬럼 (subscription_payments)
+ALTER TABLE subscription_payments
+  ADD COLUMN IF NOT EXISTS refunded_amount NUMERIC(15,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS refund_reason   TEXT,
+  ADD COLUMN IF NOT EXISTS refunded_at     TIMESTAMPTZ;
+
+COMMIT;
+```
+
+- [ ] **Step 2: 마이그레이션 적용**
+
+Run (MCP):
+```
+mcp__supabase__apply_migration({
+  project_id: "beahjntkmkfhpcbhfnrr",
+  name: "20260419_subscription_headcount_gating",
+  query: <Step 1 전체 SQL>
+})
+```
+
+- [ ] **Step 3: 적용 결과 검증**
+
+Run (MCP):
+```sql
+SELECT name, min_users, max_users, price
+  FROM subscription_plans
+ WHERE type = 'headcount'
+ ORDER BY sort_order;
+```
+Expected:
+| name | min_users | max_users | price |
+|---|---|---|---|
+| free | 0 | 4 | 0 |
+| starter | 5 | 10 | 39000 |
+| growth | 11 | 20 | 79000 |
+| pro | 21 | 50 | 149000 |
+| enterprise | 51 | 9999 | 0 |
+
+```sql
+SELECT name, price, feature_id FROM subscription_plans
+ WHERE name IN ('premium-bundle','feature-investment');
+```
+Expected: `premium-bundle` 499000 / `feature-investment` 0 · `investment`.
+
+```sql
+\d subscription_payments
+```
+Expected: `refunded_amount`, `refund_reason`, `refunded_at` 컬럼 존재.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add supabase/migrations/20260419_subscription_headcount_gating.sql
+git commit -m "$(cat <<'EOF'
+feat(db): subscription_plans 경계 조정 + premium-bundle/feature-investment 추가
+
+- Free 1~4, Starter 5~10 경계 조정
+- premium-bundle 499,000원 신규 (UI 통합)
+- feature-investment 0원 + 5% 설명 명시
+- subscription_payments 부분 환불 컬럼 추가
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: DB 마이그레이션 — `investment_profit_snapshots`
+
+### 파일:
+- Create: `supabase/migrations/20260419_investment_profit_snapshots.sql`
+
+- [ ] **Step 1: SQL 작성**
+
+```sql
+-- supabase/migrations/20260419_investment_profit_snapshots.sql
+-- 주식 자동매매 월별 수익 스냅샷 (예정 정산 5% 표시용)
+
+CREATE TABLE IF NOT EXISTS investment_profit_snapshots (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  year INT NOT NULL,
+  month INT NOT NULL CHECK (month BETWEEN 1 AND 12),
+  realized_profit NUMERIC(15,2) NOT NULL DEFAULT 0,
+  unrealized_profit NUMERIC(15,2) NOT NULL DEFAULT 0,
+  expected_fee NUMERIC(15,2) GENERATED ALWAYS AS
+    (GREATEST(realized_profit, 0) * 0.05) STORED,
+  snapshot_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (clinic_id, year, month)
+);
+
+CREATE INDEX IF NOT EXISTS idx_investment_profit_clinic_ym
+  ON investment_profit_snapshots (clinic_id, year DESC, month DESC);
+
+ALTER TABLE investment_profit_snapshots ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "클리닉 멤버만 조회" ON investment_profit_snapshots;
+CREATE POLICY "클리닉 멤버만 조회"
+  ON investment_profit_snapshots FOR SELECT
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+
+DROP POLICY IF EXISTS "서비스 롤만 기록" ON investment_profit_snapshots;
+CREATE POLICY "서비스 롤만 기록"
+  ON investment_profit_snapshots FOR INSERT
+  WITH CHECK (auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS "서비스 롤만 갱신" ON investment_profit_snapshots;
+CREATE POLICY "서비스 롤만 갱신"
+  ON investment_profit_snapshots FOR UPDATE
+  USING (auth.role() = 'service_role');
+```
+
+- [ ] **Step 2: 적용**
+
+Run:
+```
+mcp__supabase__apply_migration({
+  project_id: "beahjntkmkfhpcbhfnrr",
+  name: "20260419_investment_profit_snapshots",
+  query: <Step 1 SQL>
+})
+```
+
+- [ ] **Step 3: 검증**
+
+```sql
+SELECT column_name, data_type, generation_expression
+  FROM information_schema.columns
+ WHERE table_name = 'investment_profit_snapshots'
+ ORDER BY ordinal_position;
+```
+Expected: `expected_fee`가 `GREATEST(realized_profit, 0) * 0.05` GENERATED.
+
+테스트 삽입 + 자동 계산 확인:
+```sql
+INSERT INTO investment_profit_snapshots (clinic_id, year, month, realized_profit, unrealized_profit)
+VALUES (
+  (SELECT id FROM clinics LIMIT 1), 2099, 1, 1000000, 50000
+) RETURNING expected_fee;
+-- Expected: 50000.00
+
+INSERT INTO investment_profit_snapshots (clinic_id, year, month, realized_profit, unrealized_profit)
+VALUES (
+  (SELECT id FROM clinics LIMIT 1), 2099, 2, -500000, 0
+) RETURNING expected_fee;
+-- Expected: 0.00
+
+DELETE FROM investment_profit_snapshots WHERE year = 2099;
+```
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add supabase/migrations/20260419_investment_profit_snapshots.sql
+git commit -m "$(cat <<'EOF'
+feat(db): investment_profit_snapshots 테이블 추가
+
+- 월별 실현/평가 수익 + GENERATED expected_fee(5%) 컬럼
+- clinic_id, year, month UNIQUE
+- RLS: SELECT 클리닉 멤버, INSERT/UPDATE 서비스 롤
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: 알림 타입 확장
+
+### 파일:
+- Modify: `src/types/notification.ts`
+
+- [ ] **Step 1: 현재 enum 확인**
+
+Run: `grep -n "subscription_" src/types/notification.ts`
+확인: 기존 notification type 열거체에 추가할 위치 파악.
+
+- [ ] **Step 2: 두 타입 추가**
+
+Edit `src/types/notification.ts`의 `UserNotificationType` 유니온에 아래 두 항목 추가 (기존 마지막 타입 뒤에):
+```ts
+  | 'subscription_upgrade_required'
+  | 'subscription_payment_succeeded'
+```
+
+그리고 같은 파일의 payload 타입 정의 블록(있다면)에 추가:
+```ts
+export interface SubscriptionUpgradeRequiredPayload {
+  recommendedPlan: string       // 'starter' 등
+  currentActive: number
+  pendingCount: number
+}
+
+export interface SubscriptionPaymentSucceededPayload {
+  pendingCount: number
+  newLimit: number
+  newPlanName: string
+}
+```
+
+- [ ] **Step 3: 빌드로 타입 파급 확인**
+
+Run: `npm run build`
+Expected: 성공. 실패 시 enum 참조 누락된 switch/case를 기본 분기 추가로 수정.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/types/notification.ts
+git commit -m "feat(notifications): subscription_upgrade_required/payment_succeeded 타입 추가
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `subscriptionService` 보조 유틸 추가
+
+### 파일:
+- Modify: `src/lib/subscriptionService.ts`
+
+- [ ] **Step 1: `countActiveEmployees` 추가**
+
+`src/lib/subscriptionService.ts` 맨 아래에 append:
+```ts
+/**
+ * 해당 병원의 재직 중 승인된 직원 수를 반환한다.
+ * (status='active' AND employment_status='active')
+ */
+export async function countActiveEmployees(clinicId: string): Promise<number> {
+  const supabase = await ensureConnection()
+  const { count, error } = await supabase
+    .from('users')
+    .select('id', { count: 'exact', head: true })
+    .eq('clinic_id', clinicId)
+    .eq('status', 'active')
+    .eq('employment_status', 'active')
+  if (error) throw new Error(`countActiveEmployees: ${error.message}`)
+  return count ?? 0
+}
+
+/**
+ * 현재 구독의 마지막 성공 결제를 반환한다 (부분 환불 기준 계산용).
+ */
+export async function getLatestPaidPayment(clinicId: string) {
+  const supabase = await ensureConnection()
+  const { data, error } = await supabase
+    .from('subscription_payments')
+    .select('*')
+    .eq('clinic_id', clinicId)
+    .eq('status', 'paid')
+    .order('paid_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (error) throw new Error(`getLatestPaidPayment: ${error.message}`)
+  return data
+}
+```
+
+> `ensureConnection` import가 이미 파일 상단에 있는지 확인 후 없으면 추가.
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/lib/subscriptionService.ts
+git commit -m "feat(subscription): countActiveEmployees / getLatestPaidPayment 추가
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: 원장용 승인 API `/api/staff/approve`
+
+### 파일:
+- Create: `src/app/api/staff/approve/route.ts`
+
+- [ ] **Step 1: API 라우트 구현**
+
+```ts
+// src/app/api/staff/approve/route.ts
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import {
+  countActiveEmployees,
+  getSubscription,
+  getPlanById,
+} from '@/lib/subscriptionService'
+import { findPlanByHeadcount, requiresUpgrade } from '@/lib/subscriptionPlans'
+
+const FREE_LIMIT = 4
+
+export async function POST(req: Request) {
+  const body = await req.json()
+  const userIds: string[] = body.userIds ?? (body.userId ? [body.userId] : [])
+  const permissions: string[] | undefined = body.permissions
+  if (userIds.length === 0) {
+    return NextResponse.json({ error: 'NO_USER_IDS' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+
+  const { data: me, error: meErr } = await supabase
+    .from('users')
+    .select('id, clinic_id, role')
+    .eq('id', user.id)
+    .single()
+  if (meErr || !me?.clinic_id) {
+    return NextResponse.json({ error: 'NO_CLINIC' }, { status: 403 })
+  }
+  if (!['owner', 'master_admin'].includes(me.role)) {
+    return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 })
+  }
+
+  // 인원 상한 가드
+  const [activeCount, subscription] = await Promise.all([
+    countActiveEmployees(me.clinic_id),
+    getSubscription(me.clinic_id),
+  ])
+
+  const currentPlan = subscription?.plan_id
+    ? await getPlanById(subscription.plan_id)
+    : null
+  const currentLimit = currentPlan?.max_users ?? FREE_LIMIT
+
+  if (requiresUpgrade({
+    currentActive: activeCount,
+    pendingToApprove: userIds.length,
+    currentLimit,
+  })) {
+    const projected = activeCount + userIds.length
+    return NextResponse.json({
+      error: 'UPGRADE_REQUIRED',
+      currentPlan: currentPlan?.name ?? 'free',
+      currentLimit,
+      currentActive: activeCount,
+      pendingToApprove: userIds.length,
+      recommendedPlan: findPlanByHeadcount(projected),
+    }, { status: 403 })
+  }
+
+  // 승인 실행 (기존 dataService 로직과 동일한 업데이트)
+  const updatePayload: Record<string, unknown> = {
+    status: 'active',
+    approved_at: new Date().toISOString(),
+  }
+  if (permissions && permissions.length > 0) updatePayload.permissions = permissions
+
+  const { error: upErr } = await supabase
+    .from('users')
+    .update(updatePayload)
+    .in('id', userIds)
+    .eq('clinic_id', me.clinic_id)
+
+  if (upErr) {
+    return NextResponse.json({ error: upErr.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true, approvedCount: userIds.length })
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공. `getPlanById`/`getSubscription` import 경로가 실제 export 이름과 일치하는지 재확인 (Task 5에서 `subscriptionService.ts`를 확장한 파일).
+
+- [ ] **Step 3: 수동 검증 (DevTools MCP — 원장 계정)**
+
+`whitedc0902@gmail.com` 로그인 → 직원 관리 진입 → 승인 가능한 pending 없을 때 curl로 직접 호출:
+```
+POST /api/staff/approve  body: { "userIds": ["<임의 UUID>"] }
+```
+Expected:
+- 상한 이내 → `success: true`
+- 상한 초과(시뮬레이션 위해 pending 여러 건) → 403 + `UPGRADE_REQUIRED`
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/app/api/staff/approve/route.ts
+git commit -m "feat(api): 원장용 승인 API + 인원 상한 가드
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `dataService.approveUser`를 새 API 호출로 리팩터
+
+### 파일:
+- Modify: `src/lib/dataService.ts:1737-1778`
+
+- [ ] **Step 1: 함수 본문 교체**
+
+기존 메서드를 아래로 치환:
+```ts
+  async approveUser(userId: string, clinicId: string | null, permissions?: string[]) {
+    try {
+      const res = await fetch('/api/staff/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId,
+          userIds: [userId],
+          permissions,
+        }),
+      })
+      const data = await res.json().catch(() => ({}))
+
+      if (res.status === 403 && data?.error === 'UPGRADE_REQUIRED') {
+        // 호출부가 구분해 처리할 수 있게 구조화된 응답 반환
+        return {
+          upgradeRequired: true,
+          currentPlan: data.currentPlan,
+          currentLimit: data.currentLimit,
+          currentActive: data.currentActive,
+          pendingToApprove: data.pendingToApprove,
+          recommendedPlan: data.recommendedPlan,
+        } as const
+      }
+
+      if (!res.ok) {
+        return { error: data?.error ?? '승인 처리에 실패했습니다.' }
+      }
+      return { success: true as const }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : JSON.stringify(error)
+      return { error: errorMessage }
+    }
+  },
+```
+
+- [ ] **Step 2: 호출부 타입 호환 확인**
+
+Run:
+```
+grep -rn "approveUser(" src --include="*.ts" --include="*.tsx"
+```
+각 호출지점에서 `result.error` / `result.success` 사용을 확인. 신규 `upgradeRequired` 분기를 처리하지 않는 지점은 Task 9에서 `StaffManagement.tsx`만 업데이트하고, 다른 호출부는 기존처럼 `error`도 유지되므로 영향 없음.
+
+- [ ] **Step 3: 빌드**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/lib/dataService.ts
+git commit -m "refactor(dataService): approveUser를 /api/staff/approve 호출로 전환
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: master_admin 승인 API에 동일 가드 적용
+
+### 파일:
+- Modify: `src/app/api/admin/users/approve/route.ts`
+
+- [ ] **Step 1: 상한 가드 블록 삽입**
+
+기존 `requireMasterAdmin()` 성공 후, 사용자 정보 조회(5단계) 이전에 삽입:
+```ts
+import { countActiveEmployees, getSubscription, getPlanById } from '@/lib/subscriptionService'
+import { findPlanByHeadcount, requiresUpgrade } from '@/lib/subscriptionPlans'
+
+// ... 기존 requireMasterAdmin 통과 후
+const targetClinicId = body.clinicId
+if (targetClinicId) {
+  const [activeCount, subscription] = await Promise.all([
+    countActiveEmployees(targetClinicId),
+    getSubscription(targetClinicId),
+  ])
+  const currentPlan = subscription?.plan_id ? await getPlanById(subscription.plan_id) : null
+  const currentLimit = currentPlan?.max_users ?? 4
+  if (requiresUpgrade({ currentActive: activeCount, pendingToApprove: 1, currentLimit })) {
+    return NextResponse.json({
+      error: 'UPGRADE_REQUIRED',
+      currentPlan: currentPlan?.name ?? 'free',
+      currentLimit,
+      currentActive: activeCount,
+      pendingToApprove: 1,
+      recommendedPlan: findPlanByHeadcount(activeCount + 1),
+    }, { status: 403 })
+  }
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/app/api/admin/users/approve/route.ts
+git commit -m "feat(api): master_admin 승인 경로에도 인원 상한 가드 적용
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: `UpgradeRequiredModal` 컴포넌트
+
+### 파일:
+- Create: `src/components/Subscription/UpgradeRequiredModal.tsx`
+
+- [ ] **Step 1: 컴포넌트 생성**
+
+```tsx
+// src/components/Subscription/UpgradeRequiredModal.tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { formatPlanPrice } from '@/lib/subscriptionPlans'
+import type { SubscriptionPlan } from '@/types/subscription'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onPayNow: () => void
+  context: {
+    currentPlan: string
+    currentLimit: number
+    currentActive: number
+    pendingToApprove: number
+    recommendedPlan: string
+  }
+}
+
+export default function UpgradeRequiredModal({ open, onClose, onPayNow, context }: Props) {
+  const [plan, setPlan] = useState<SubscriptionPlan | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    fetch(`/api/subscription/plans?name=${context.recommendedPlan}`)
+      .then((r) => r.json())
+      .then((data) => {
+        const list = Array.isArray(data) ? data : data?.plans ?? []
+        setPlan(list.find((p: SubscriptionPlan) => p.name === context.recommendedPlan) ?? null)
+      })
+      .catch(() => setPlan(null))
+  }, [open, context.recommendedPlan])
+
+  const projected = context.currentActive + context.pendingToApprove
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>구독 업그레이드가 필요합니다</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 text-sm">
+          <p>
+            현재 플랜(<b>{context.currentPlan}</b>)의 상한은 <b>{context.currentLimit}명</b>입니다.
+            재직자 {context.currentActive}명 + 승인 대기 {context.pendingToApprove}명 = <b>{projected}명</b>
+            이라 승인을 진행할 수 없습니다.
+          </p>
+          {plan && (
+            <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950/30">
+              <div className="text-base font-semibold">{plan.display_name}</div>
+              <div className="text-sm text-muted-foreground">
+                {plan.min_users}~{plan.max_users}인 · {formatPlanPrice(plan)}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="flex justify-end gap-2">
+          <Button variant="outline" onClick={onClose}>나중에 결제</Button>
+          <Button onClick={onPayNow}>지금 결제하기</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Subscription/UpgradeRequiredModal.tsx
+git commit -m "feat(subscription): UpgradeRequiredModal 추가
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: `StaffManagement`에 업그레이드 모달 연결
+
+### 파일:
+- Modify: `src/components/Management/StaffManagement.tsx` (`handleApproveRequest` 근처)
+
+- [ ] **Step 1: 상태 추가**
+
+상단 훅 선언 영역에 추가:
+```tsx
+const [upgradeContext, setUpgradeContext] = useState<null | {
+  currentPlan: string
+  currentLimit: number
+  currentActive: number
+  pendingToApprove: number
+  recommendedPlan: string
+}>(null)
+const [planModalOpen, setPlanModalOpen] = useState(false)
+```
+
+import:
+```tsx
+import UpgradeRequiredModal from '@/components/Subscription/UpgradeRequiredModal'
+import PlanSelectModal from '@/components/Subscription/PlanSelectModal'
+```
+
+- [ ] **Step 2: 승인 함수 분기**
+
+`handleApproveRequest` 내부의 `dataService.approveUser` 응답 처리를 교체:
+```tsx
+const result = await dataService.approveUser(requestId, currentUser.clinic_id, permissions)
+
+if ('upgradeRequired' in result && result.upgradeRequired) {
+  setUpgradeContext({
+    currentPlan: result.currentPlan,
+    currentLimit: result.currentLimit,
+    currentActive: result.currentActive,
+    pendingToApprove: result.pendingToApprove,
+    recommendedPlan: result.recommendedPlan,
+  })
+  return
+}
+if ('error' in result && result.error) {
+  setError(result.error)
+  return
+}
+setSuccess('가입 요청이 승인되었습니다.')
+setShowPermissionModal(false)
+setSelectedRequest(null)
+fetchJoinRequests()
+fetchStaff()
+```
+
+- [ ] **Step 3: JSX 말미에 모달 렌더**
+
+컴포넌트 return 블록 최상위에 추가:
+```tsx
+{upgradeContext && (
+  <UpgradeRequiredModal
+    open={!!upgradeContext}
+    onClose={() => setUpgradeContext(null)}
+    onPayNow={() => {
+      setUpgradeContext(null)
+      setPlanModalOpen(true)
+    }}
+    context={upgradeContext}
+  />
+)}
+<PlanSelectModal
+  isOpen={planModalOpen}
+  onClose={() => setPlanModalOpen(false)}
+  onSelect={async (plan) => {
+    // 결제 진입(기존 흐름에 위임) — PlanSelectModal 내부의 결제 트리거 유지
+    setPlanModalOpen(false)
+  }}
+/>
+```
+
+- [ ] **Step 4: 빌드 + 수동 검증**
+
+Run: `npm run build`
+
+Chrome DevTools MCP로 원장 계정 로그인 → 인원 관리 → 상한 초과 pending 승인 시도 → 모달 표시 확인.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/components/Management/StaffManagement.tsx
+git commit -m "feat(staff): 승인 실패 시 UpgradeRequiredModal 연결
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: 포트원 웹훅 확장 — 결제 성공 알림 생성
+
+### 파일:
+- Modify: `src/app/api/webhooks/portone/route.ts:70-91` (`handleTransactionPaid` 또는 `handlePaymentSuccess`)
+
+- [ ] **Step 1: 알림 생성 로직 삽입**
+
+`handlePaymentSuccess` 내부에서 구독 업데이트가 성공한 다음 위치에 삽입:
+```ts
+import { countActiveEmployees, getSubscription, getPlanById } from '@/lib/subscriptionService'
+import { userNotificationService } from '@/lib/userNotificationService'
+
+// 결제 후 구독 active 전환이 끝난 뒤:
+const sub = await getSubscription(clinicId)
+const plan = sub?.plan_id ? await getPlanById(sub.plan_id) : null
+if (plan) {
+  const activeCount = await countActiveEmployees(clinicId)
+  // 대기 중 pending 수 조회
+  const supabase = await createServiceClient() // 기존 패턴 따라 service role 클라이언트
+  const { data: pendingRows } = await supabase
+    .from('users')
+    .select('id')
+    .eq('clinic_id', clinicId)
+    .eq('status', 'pending')
+  const pendingCount = pendingRows?.length ?? 0
+
+  if (pendingCount > 0) {
+    // 클리닉 owner(들)에게 알림 생성
+    const { data: owners } = await supabase
+      .from('users')
+      .select('id')
+      .eq('clinic_id', clinicId)
+      .in('role', ['owner', 'master_admin'])
+      .eq('status', 'active')
+    for (const o of owners ?? []) {
+      await userNotificationService.createNotification({
+        userId: o.id,
+        type: 'subscription_payment_succeeded',
+        payload: {
+          pendingCount,
+          newLimit: plan.max_users ?? 0,
+          newPlanName: plan.name,
+        },
+      })
+    }
+  }
+}
+```
+
+> `createServiceClient` 또는 `ensureServiceConnection` 등 기존 패턴을 이 파일 상단에서 이미 사용 중인지 확인 후 동일한 헬퍼 사용.
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 3: 수동 검증 (스테이징 결제 후)**
+
+- 테스트 병원에 pending 직원 1명 만들고 Starter 결제 완료 → `user_notifications` 테이블에서 `subscription_payment_succeeded` 레코드 확인.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/app/api/webhooks/portone/route.ts
+git commit -m "feat(portone): 결제 성공 시 subscription_payment_succeeded 알림 생성
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: 벌크 자동 승인 API
+
+### 파일:
+- Create: `src/app/api/staff/approve-bulk-auto/route.ts`
+
+- [ ] **Step 1: 라우트 구현**
+
+```ts
+// src/app/api/staff/approve-bulk-auto/route.ts
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { countActiveEmployees, getSubscription, getPlanById } from '@/lib/subscriptionService'
+
+export async function POST() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+
+  const { data: me } = await supabase
+    .from('users').select('id, clinic_id, role').eq('id', user.id).single()
+  if (!me?.clinic_id || !['owner', 'master_admin'].includes(me.role)) {
+    return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 })
+  }
+
+  const sub = await getSubscription(me.clinic_id)
+  const plan = sub?.plan_id ? await getPlanById(sub.plan_id) : null
+  const limit = plan?.max_users ?? 4
+
+  const active = await countActiveEmployees(me.clinic_id)
+  const available = Math.max(0, limit - active)
+  if (available === 0) {
+    return NextResponse.json({ approvedCount: 0, remainingPending: 0 })
+  }
+
+  const { data: pending } = await supabase
+    .from('users')
+    .select('id')
+    .eq('clinic_id', me.clinic_id)
+    .eq('status', 'pending')
+    .order('created_at', { ascending: true })
+    .limit(available)
+
+  const ids = (pending ?? []).map((p) => p.id)
+  if (ids.length === 0) return NextResponse.json({ approvedCount: 0, remainingPending: 0 })
+
+  const { error } = await supabase
+    .from('users')
+    .update({ status: 'active', approved_at: new Date().toISOString() })
+    .in('id', ids)
+    .eq('clinic_id', me.clinic_id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  // 전체 대기자 재집계
+  const { count: remaining } = await supabase
+    .from('users').select('id', { count: 'exact', head: true })
+    .eq('clinic_id', me.clinic_id).eq('status', 'pending')
+
+  return NextResponse.json({ approvedCount: ids.length, remainingPending: remaining ?? 0 })
+}
+```
+
+- [ ] **Step 2: 빌드**
+
+Run: `npm run build`
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/app/api/staff/approve-bulk-auto/route.ts
+git commit -m "feat(api): 결제 후 대기자 일괄 자동 승인 API
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: `PostPaymentApprovalModal` 컴포넌트
+
+### 파일:
+- Create: `src/components/Subscription/PostPaymentApprovalModal.tsx`
+
+- [ ] **Step 1: 구현**
+
+```tsx
+// src/components/Subscription/PostPaymentApprovalModal.tsx
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  pendingCount: number
+  newLimit: number
+  newPlanName: string
+}
+
+export default function PostPaymentApprovalModal({ open, onClose, pendingCount, newLimit }: Props) {
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<{ approved: number; remaining: number } | null>(null)
+  const router = useRouter()
+
+  const handleAutoApprove = async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/staff/approve-bulk-auto', { method: 'POST' })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data?.error ?? 'AUTO_APPROVE_FAILED')
+      setResult({ approved: data.approvedCount, remaining: data.remainingPending })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleIndividual = () => {
+    onClose()
+    router.push('/management?tab=requests')
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>결제 완료 · 대기 직원 승인</DialogTitle>
+        </DialogHeader>
+
+        {result ? (
+          <div className="space-y-2 text-sm">
+            <p><b>{result.approved}명</b>이 자동 승인되었습니다.</p>
+            {result.remaining > 0 && (
+              <p className="text-amber-600">
+                여전히 {result.remaining}명이 대기 중입니다 (신규 상한 {newLimit}명 초과).
+              </p>
+            )}
+            <DialogFooter className="pt-2">
+              <Button onClick={onClose}>확인</Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-2 text-sm">
+              <p>결제가 완료되었습니다. 대기 중인 직원 <b>{pendingCount}명</b>을 어떻게 처리할까요?</p>
+              {pendingCount > newLimit && (
+                <p className="text-amber-600">신규 상한 {newLimit}명보다 대기자가 많아 일부만 자동 승인됩니다.</p>
+              )}
+            </div>
+            <DialogFooter className="flex justify-end gap-2">
+              <Button variant="outline" onClick={handleIndividual} disabled={loading}>개별 승인</Button>
+              <Button onClick={handleAutoApprove} disabled={loading}>
+                {loading ? '승인 중…' : '전체 자동 승인'}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Step 2: 대시보드에서 트리거 연결**
+
+`src/app/dashboard/page.tsx`의 클라이언트 컴포넌트 내에서 미읽음 `subscription_payment_succeeded` 알림을 폴링/구독해 모달 open:
+```tsx
+// 대시보드 컴포넌트 내부
+const [paymentSuccessPayload, setPaymentSuccessPayload] = useState<{
+  pendingCount: number; newLimit: number; newPlanName: string
+} | null>(null)
+
+useEffect(() => {
+  let cancelled = false
+  async function check() {
+    const res = await fetch('/api/notifications/latest?type=subscription_payment_succeeded')
+    if (!res.ok) return
+    const n = await res.json()
+    if (!cancelled && n?.payload) {
+      setPaymentSuccessPayload(n.payload)
+      // 표시 후 읽음 처리
+      await fetch(`/api/notifications/${n.id}/read`, { method: 'POST' }).catch(() => {})
+    }
+  }
+  check()
+  const t = setInterval(check, 30_000)
+  return () => { cancelled = true; clearInterval(t) }
+}, [])
+
+// 렌더
+{paymentSuccessPayload && (
+  <PostPaymentApprovalModal
+    open
+    onClose={() => setPaymentSuccessPayload(null)}
+    pendingCount={paymentSuccessPayload.pendingCount}
+    newLimit={paymentSuccessPayload.newLimit}
+    newPlanName={paymentSuccessPayload.newPlanName}
+  />
+)}
+```
+
+> `/api/notifications/latest`, `/api/notifications/:id/read`가 기존에 있으면 사용, 없으면 `userNotificationService`를 직접 써서 동등한 클라이언트 함수로 대체.
+
+- [ ] **Step 3: 빌드**
+
+Run: `npm run build`
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/components/Subscription/PostPaymentApprovalModal.tsx src/app/dashboard/page.tsx
+git commit -m "feat(subscription): 결제 후 자동/개별 승인 모달 + 대시보드 트리거
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: `PendingApprovalBanner`
+
+### 파일:
+- Create: `src/components/Dashboard/PendingApprovalBanner.tsx`
+- Modify: `src/app/dashboard/page.tsx`
+
+- [ ] **Step 1: 배너 컴포넌트**
+
+```tsx
+// src/components/Dashboard/PendingApprovalBanner.tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { AlertCircle } from 'lucide-react'
+
+export default function PendingApprovalBanner({ clinicId, role }: { clinicId: string; role: string }) {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    if (!['owner', 'master_admin'].includes(role)) return
+    let cancelled = false
+    async function load() {
+      const res = await fetch(`/api/staff/pending-count?clinicId=${clinicId}`)
+      if (!res.ok) return
+      const data = await res.json()
+      if (!cancelled) setCount(data.count ?? 0)
+    }
+    load()
+    const t = setInterval(load, 60_000)
+    return () => { cancelled = true; clearInterval(t) }
+  }, [clinicId, role])
+
+  if (count === 0) return null
+
+  return (
+    <div className="mb-4 flex items-center justify-between rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm dark:border-amber-700 dark:bg-amber-950/30">
+      <div className="flex items-center gap-2">
+        <AlertCircle className="h-4 w-4 text-amber-600" />
+        <span>직원 <b>{count}명</b>이 승인 대기 중입니다.</span>
+      </div>
+      <Link
+        href="/management?tab=requests"
+        className="font-medium text-amber-700 underline dark:text-amber-300"
+      >
+        지금 확인
+      </Link>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: `/api/staff/pending-count` 라우트**
+
+```ts
+// src/app/api/staff/pending-count/route.ts
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const clinicId = url.searchParams.get('clinicId')
+  if (!clinicId) return NextResponse.json({ count: 0 })
+
+  const supabase = await createClient()
+  const { count } = await supabase
+    .from('users')
+    .select('id', { count: 'exact', head: true })
+    .eq('clinic_id', clinicId)
+    .eq('status', 'pending')
+
+  return NextResponse.json({ count: count ?? 0 })
+}
+```
+
+- [ ] **Step 3: 대시보드 페이지 상단에 삽입**
+
+`src/app/dashboard/page.tsx`에서 로그인 사용자 정보 획득 후:
+```tsx
+{user?.clinic_id && (
+  <PendingApprovalBanner clinicId={user.clinic_id} role={user.role} />
+)}
+```
+
+- [ ] **Step 4: 빌드**
+
+Run: `npm run build`
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/components/Dashboard/PendingApprovalBanner.tsx src/app/api/staff/pending-count/route.ts src/app/dashboard/page.tsx
+git commit -m "feat(dashboard): 승인 대기 직원 고정 배너 + pending-count API
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 15: 포트원 `partialRefund` 추가
+
+### 파일:
+- Modify: `src/lib/portone.ts`
+
+- [ ] **Step 1: 함수 추가**
+
+파일 끝에 append:
+```ts
+export async function partialRefund(params: {
+  portonePaymentId: string
+  amount: number
+  reason: string
+}): Promise<{ ok: boolean; error?: string }> {
+  const res = await fetch(
+    `${PORTONE_API_BASE}/payments/${encodeURIComponent(params.portonePaymentId)}/cancel`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `PortOne ${process.env.PORTONE_API_SECRET ?? ''}`,
+      },
+      body: JSON.stringify({
+        amount: params.amount,
+        reason: params.reason,
+      }),
+    }
+  )
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    return { ok: false, error: `REFUND_FAILED: ${res.status} ${body}` }
+  }
+  return { ok: true }
+}
+```
+
+> `PORTONE_API_BASE`, `PORTONE_API_SECRET` 상수/env 명은 기존 파일 상단과 맞춰 일치시킨다.
+
+- [ ] **Step 2: 빌드**
+
+Run: `npm run build`
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/lib/portone.ts
+git commit -m "feat(portone): partialRefund API 래퍼 추가
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 16: 다운그레이드 API
+
+### 파일:
+- Create: `src/app/api/subscription/downgrade/route.ts`
+- Create: `src/lib/subscriptionReconciler.ts`
+
+- [ ] **Step 1: 환불 계산 유틸**
+
+```ts
+// src/lib/subscriptionReconciler.ts
+import {
+  countActiveEmployees,
+  getSubscription,
+  getPlanById,
+  getLatestPaidPayment,
+} from '@/lib/subscriptionService'
+import { findPlanByHeadcount } from '@/lib/subscriptionPlans'
+import { partialRefund } from '@/lib/portone'
+import { createServiceClient } from '@/lib/supabase/server'
+
+const MS_PER_DAY = 86400000
+
+export async function planForClinic(clinicId: string) {
+  const active = await countActiveEmployees(clinicId)
+  const target = findPlanByHeadcount(active)
+  const sub = await getSubscription(clinicId)
+  const currentPlan = sub?.plan_id ? await getPlanById(sub.plan_id) : null
+  return { active, targetName: target, currentPlan, subscription: sub }
+}
+
+export function prorateRefund(params: {
+  currentPrice: number
+  newPrice: number
+  periodStart: string
+  periodEnd: string
+  today?: Date
+}): number {
+  const start = new Date(params.periodStart).getTime()
+  const end = new Date(params.periodEnd).getTime()
+  const today = (params.today ?? new Date()).getTime()
+  const totalDays = Math.max(1, Math.round((end - start) / MS_PER_DAY))
+  const remainDays = Math.max(0, Math.round((end - today) / MS_PER_DAY))
+  const diff = Math.max(0, params.currentPrice - params.newPrice)
+  return Math.floor(diff * (remainDays / totalDays))
+}
+
+export async function executeDowngrade(params: {
+  clinicId: string
+  newPlanName: string
+  reason: string
+}) {
+  const supabase = await createServiceClient()
+  const sub = await getSubscription(params.clinicId)
+  if (!sub) return { ok: false, error: 'NO_SUBSCRIPTION' }
+
+  const currentPlan = sub.plan_id ? await getPlanById(sub.plan_id) : null
+  if (!currentPlan) return { ok: false, error: 'NO_CURRENT_PLAN' }
+
+  const { data: newPlan } = await supabase
+    .from('subscription_plans').select('*').eq('name', params.newPlanName).single()
+  if (!newPlan) return { ok: false, error: 'NO_TARGET_PLAN' }
+
+  if (newPlan.name === currentPlan.name) {
+    return { ok: true, action: 'no_change' as const, refunded: 0 }
+  }
+
+  const latest = await getLatestPaidPayment(params.clinicId)
+  let refunded = 0
+
+  if (latest && sub.current_period_start && sub.current_period_end) {
+    refunded = prorateRefund({
+      currentPrice: currentPlan.price,
+      newPrice: newPlan.price,
+      periodStart: sub.current_period_start,
+      periodEnd: sub.current_period_end,
+    })
+
+    if (refunded > 0) {
+      const refund = await partialRefund({
+        portonePaymentId: latest.portone_payment_id,
+        amount: refunded,
+        reason: params.reason,
+      })
+      if (!refund.ok) return { ok: false, error: refund.error ?? 'REFUND_FAILED' }
+
+      await supabase.from('subscription_payments').update({
+        refunded_amount: (latest.refunded_amount ?? 0) + refunded,
+        refund_reason: params.reason,
+        refunded_at: new Date().toISOString(),
+      }).eq('id', latest.id)
+    }
+  }
+
+  await supabase.from('subscriptions').update({
+    plan_id: newPlan.id,
+    updated_at: new Date().toISOString(),
+  }).eq('id', sub.id)
+
+  return { ok: true, action: 'changed' as const, refunded, newPlan: newPlan.name }
+}
+```
+
+- [ ] **Step 2: API 라우트**
+
+```ts
+// src/app/api/subscription/downgrade/route.ts
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { executeDowngrade, planForClinic } from '@/lib/subscriptionReconciler'
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}))
+  const reason: string = body.reason ?? '플랜 다운그레이드'
+  const forceName: string | undefined = body.newPlanName
+
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+
+  const { data: me } = await supabase
+    .from('users').select('id, clinic_id, role').eq('id', user.id).single()
+  if (!me?.clinic_id || !['owner', 'master_admin'].includes(me.role)) {
+    return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 })
+  }
+
+  const snapshot = await planForClinic(me.clinic_id)
+  const target = forceName ?? snapshot.targetName
+  const result = await executeDowngrade({
+    clinicId: me.clinic_id,
+    newPlanName: target,
+    reason,
+  })
+
+  if (!result.ok) return NextResponse.json({ error: result.error }, { status: 500 })
+  return NextResponse.json(result)
+}
+```
+
+- [ ] **Step 3: 빌드**
+
+Run: `npm run build`
+
+- [ ] **Step 4: 수동 검증**
+
+테스트 병원에 Starter 결제 후 임의 직원 1명 퇴사 처리 → `POST /api/subscription/downgrade` 호출 → `refunded`가 예상 일할 금액과 근사한지 확인. DB에서 `subscription_payments.refunded_amount` 증분 확인.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/app/api/subscription/downgrade/route.ts src/lib/subscriptionReconciler.ts
+git commit -m "feat(subscription): 다운그레이드 API + 포트원 일할 부분 환불
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 17: 퇴사 처리에 환불 확인 모달 + 재조정 호출
+
+### 파일:
+- Create: `src/components/Subscription/DowngradeConfirmModal.tsx`
+- Modify: `src/components/Management/StaffManagement.tsx` (퇴사/삭제 버튼 핸들러)
+
+- [ ] **Step 1: 환불 미리보기 API**
+
+```ts
+// src/app/api/subscription/downgrade/preview/route.ts
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { planForClinic } from '@/lib/subscriptionReconciler'
+import { prorateRefund } from '@/lib/subscriptionReconciler'
+import { getLatestPaidPayment, getPlanById } from '@/lib/subscriptionService'
+
+export async function GET() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+  const { data: me } = await supabase
+    .from('users').select('clinic_id, role').eq('id', user.id).single()
+  if (!me?.clinic_id) return NextResponse.json({ error: 'NO_CLINIC' }, { status: 400 })
+
+  const snap = await planForClinic(me.clinic_id)
+  const target = snap.targetName
+  if (!snap.currentPlan || snap.currentPlan.name === target) {
+    return NextResponse.json({ changeRequired: false, refunded: 0 })
+  }
+  const newPlan = await supabase
+    .from('subscription_plans').select('*').eq('name', target).single()
+  const latest = await getLatestPaidPayment(me.clinic_id)
+  let refunded = 0
+  if (latest && snap.subscription?.current_period_start && snap.subscription?.current_period_end && newPlan.data) {
+    refunded = prorateRefund({
+      currentPrice: snap.currentPlan.price,
+      newPrice: newPlan.data.price,
+      periodStart: snap.subscription.current_period_start,
+      periodEnd: snap.subscription.current_period_end,
+    })
+  }
+  return NextResponse.json({
+    changeRequired: true,
+    currentPlan: snap.currentPlan.name,
+    targetPlan: target,
+    refunded,
+  })
+}
+```
+
+- [ ] **Step 2: 확인 모달 컴포넌트**
+
+```tsx
+// src/components/Subscription/DowngradeConfirmModal.tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onConfirm: () => Promise<void> | void
+  triggerLabel: string   // '퇴사 처리' | '직원 삭제' 등
+}
+
+export default function DowngradeConfirmModal({ open, onClose, onConfirm, triggerLabel }: Props) {
+  const [preview, setPreview] = useState<null | {
+    changeRequired: boolean; currentPlan?: string; targetPlan?: string; refunded: number
+  }>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    fetch('/api/subscription/downgrade/preview').then((r) => r.json()).then(setPreview).catch(() => setPreview({ changeRequired: false, refunded: 0 }))
+  }, [open])
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{triggerLabel} 확인</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-2 text-sm">
+          {!preview && <p>계산 중…</p>}
+          {preview && !preview.changeRequired && <p>플랜 변경 없이 처리됩니다.</p>}
+          {preview && preview.changeRequired && (
+            <p>
+              재직자가 감소하여 <b>{preview.currentPlan} → {preview.targetPlan}</b>로 전환됩니다.
+              일할 기준 환불 예상액은 <b>{preview.refunded.toLocaleString()}원</b>입니다.
+            </p>
+          )}
+        </div>
+        <DialogFooter className="flex justify-end gap-2">
+          <Button variant="outline" onClick={onClose} disabled={loading}>취소</Button>
+          <Button onClick={async () => { setLoading(true); await onConfirm(); setLoading(false); onClose() }} disabled={loading}>
+            {loading ? '처리 중…' : triggerLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Step 3: 퇴사 핸들러에 훅 연결**
+
+`StaffManagement.tsx`의 퇴사 버튼 onClick → 모달 open → 확인 시:
+```ts
+await dataService.markAsResigned(staffId)               // 기존 함수명에 맞춰 조정
+await fetch('/api/subscription/downgrade', {
+  method: 'POST', body: JSON.stringify({ reason: '직원 퇴사' })
+})
+fetchStaff()
+```
+
+- [ ] **Step 4: 빌드 + 수동 검증**
+
+Run: `npm run build`
+Chrome DevTools MCP로 퇴사 처리 실행 → 환불 금액 모달 → 확정 → `subscription.plan_id`와 `refunded_amount` 확인.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/app/api/subscription/downgrade/preview/route.ts src/components/Subscription/DowngradeConfirmModal.tsx src/components/Management/StaffManagement.tsx
+git commit -m "feat(staff): 퇴사 처리 시 다운그레이드 환불 확인 모달 연결
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 18: `PlanSelectModal` 리팩터 — 탭 제거, 3섹션 조립
+
+### 파일:
+- Create: `src/components/Subscription/BasicPlansSection.tsx`
+- Create: `src/components/Subscription/PremiumBundleSection.tsx`
+- Create: `src/components/Subscription/PerformanceSection.tsx`
+- Modify: `src/components/Subscription/PlanSelectModal.tsx`
+
+- [ ] **Step 1: `BasicPlansSection`**
+
+```tsx
+// src/components/Subscription/BasicPlansSection.tsx
+'use client'
+import { Users } from 'lucide-react'
+import type { SubscriptionPlan, Subscription } from '@/types/subscription'
+import { formatPlanPrice } from '@/lib/subscriptionPlans'
+
+interface Props {
+  plans: SubscriptionPlan[]
+  current?: Subscription | null
+  activeCount: number
+  onSelect: (plan: SubscriptionPlan) => void
+}
+
+export default function BasicPlansSection({ plans, current, activeCount, onSelect }: Props) {
+  const headcountPlans = plans.filter((p) => p.type === 'headcount').sort((a, b) => a.sort_order - b.sort_order)
+  const currentId = current?.plan_id
+  const currentPlan = headcountPlans.find((p) => p.id === currentId)
+  const limit = currentPlan?.max_users ?? 4
+  const usage = Math.min(100, Math.round((activeCount / Math.max(1, limit)) * 100))
+
+  return (
+    <section aria-labelledby="basic-plans-heading" className="space-y-3">
+      <div className="flex items-center justify-between rounded-md bg-blue-500/10 px-3 py-2">
+        <h2 id="basic-plans-heading" className="flex items-center gap-2 text-sm font-semibold text-blue-700 dark:text-blue-300">
+          <Users className="h-4 w-4" /> 기본 플랜 (직원 수 기준)
+        </h2>
+        <div className="text-xs text-blue-700 dark:text-blue-300">
+          {activeCount}/{limit}명 사용 중
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        {headcountPlans.map((plan) => {
+          const isCurrent = plan.id === currentId
+          const isDisabled = plan.max_users != null && plan.max_users < activeCount
+          return (
+            <button
+              key={plan.id}
+              type="button"
+              onClick={() => !isDisabled && onSelect(plan)}
+              disabled={isDisabled}
+              className={[
+                'flex flex-col gap-1 rounded-lg border p-4 text-left transition',
+                'bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-800',
+                isCurrent ? 'ring-2 ring-blue-500' : 'hover:ring-1 hover:ring-blue-300',
+                isDisabled ? 'opacity-50 cursor-not-allowed' : '',
+              ].join(' ')}
+              title={isDisabled ? `현재 ${activeCount}명 재직 중` : undefined}
+            >
+              {isCurrent && <span className="text-[10px] font-semibold text-blue-700">현재 이용 중</span>}
+              <div className="text-sm font-semibold">{plan.display_name}</div>
+              <div className="text-xs text-muted-foreground">
+                {plan.min_users}~{plan.max_users}인
+              </div>
+              <div className="mt-1 text-sm font-bold">{formatPlanPrice(plan)}</div>
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="h-1.5 overflow-hidden rounded bg-blue-100 dark:bg-blue-950">
+        <div className={`h-full bg-blue-500 transition-all`} style={{ width: `${usage}%` }} />
+      </div>
+    </section>
+  )
+}
+```
+
+- [ ] **Step 2: `PremiumBundleSection`**
+
+```tsx
+// src/components/Subscription/PremiumBundleSection.tsx
+'use client'
+import { Sparkles } from 'lucide-react'
+import type { SubscriptionPlan, Subscription } from '@/types/subscription'
+import { formatPlanPrice } from '@/lib/subscriptionPlans'
+
+interface Props {
+  plans: SubscriptionPlan[]
+  current?: Subscription | null
+  onSelect: (plan: SubscriptionPlan) => void
+}
+
+export default function PremiumBundleSection({ plans, current, onSelect }: Props) {
+  const bundle = plans.find((p) => p.name === 'premium-bundle')
+  if (!bundle) return null
+  const isCurrent = current?.plan_id === bundle.id
+
+  return (
+    <section aria-labelledby="premium-heading" className="space-y-3">
+      <div className="rounded-md bg-purple-500/10 px-3 py-2">
+        <h2 id="premium-heading" className="flex items-center gap-2 text-sm font-semibold text-purple-700 dark:text-purple-300">
+          <Sparkles className="h-4 w-4" /> 프리미엄 패키지
+        </h2>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onSelect(bundle)}
+        className={[
+          'w-full rounded-lg border p-5 text-left transition',
+          'bg-purple-50 dark:bg-purple-950/30 border-purple-200 dark:border-purple-800',
+          isCurrent ? 'ring-2 ring-purple-500' : 'hover:ring-1 hover:ring-purple-300',
+        ].join(' ')}
+      >
+        {isCurrent && <div className="mb-1 text-[10px] font-semibold text-purple-700">현재 이용 중</div>}
+        <div className="text-base font-semibold">{bundle.display_name}</div>
+        <ul className="mt-2 list-inside list-disc text-xs text-muted-foreground">
+          <li>AI 데이터 분석 — 매출/환자 추이 자동 분석</li>
+          <li>경영 현황 — 수입/지출 관리</li>
+          <li>마케팅 자동화 — AI 임상글 생성</li>
+        </ul>
+        <div className="mt-3 text-sm font-bold">{formatPlanPrice(bundle)}</div>
+      </button>
+    </section>
+  )
+}
+```
+
+- [ ] **Step 3: `PerformanceSection`**
+
+```tsx
+// src/components/Subscription/PerformanceSection.tsx
+'use client'
+import { useEffect, useState } from 'react'
+import { TrendingUp, RefreshCw } from 'lucide-react'
+import type { SubscriptionPlan } from '@/types/subscription'
+
+interface Props {
+  plans: SubscriptionPlan[]
+  onSelect: (plan: SubscriptionPlan) => void
+}
+
+interface Snapshot {
+  year: number
+  month: number
+  realized_profit: number
+  unrealized_profit: number
+  expected_fee: number
+}
+
+export default function PerformanceSection({ plans, onSelect }: Props) {
+  const investment = plans.find((p) => p.feature_id === 'investment')
+  const [current, setCurrent] = useState<Snapshot | null>(null)
+  const [history, setHistory] = useState<Snapshot[]>([])
+  const [refreshing, setRefreshing] = useState(false)
+
+  async function load() {
+    const res = await fetch('/api/investment/profit-snapshot/latest?months=4')
+    if (!res.ok) return
+    const data: Snapshot[] = await res.json()
+    const [first, ...rest] = data
+    setCurrent(first ?? null)
+    setHistory(rest)
+  }
+  useEffect(() => { load() }, [])
+
+  const handleRefresh = async () => {
+    setRefreshing(true)
+    try {
+      await fetch('/api/investment/profit-snapshot/refresh', { method: 'POST' })
+      await load()
+    } finally { setRefreshing(false) }
+  }
+
+  if (!investment) return null
+
+  return (
+    <section aria-labelledby="performance-heading" className="space-y-3">
+      <div className="rounded-md bg-emerald-500/10 px-3 py-2">
+        <h2 id="performance-heading" className="flex items-center gap-2 text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+          <TrendingUp className="h-4 w-4" /> 성과 연동
+        </h2>
+      </div>
+
+      <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-5 dark:border-emerald-800 dark:bg-emerald-950/30">
+        <div className="flex items-start justify-between">
+          <div>
+            <div className="text-base font-semibold">주식 자동매매</div>
+            <div className="mt-1 text-sm font-bold">구독료 0원 · 수익의 5%</div>
+            <div className="text-xs text-muted-foreground">매월 실현 수익이 있을 때만 정산됩니다.</div>
+          </div>
+          <button type="button" onClick={() => onSelect(investment)}
+            className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700">
+            시작하기
+          </button>
+        </div>
+
+        <div className="mt-4 border-t border-emerald-200 pt-3 text-sm dark:border-emerald-800">
+          <div className="flex items-center justify-between">
+            <div>이번 달 ({current ? `${current.year}-${String(current.month).padStart(2, '0')}` : '—'})</div>
+            <button type="button" onClick={handleRefresh} disabled={refreshing}
+              className="flex items-center gap-1 text-xs text-emerald-700 hover:underline">
+              <RefreshCw className={`h-3 w-3 ${refreshing ? 'animate-spin' : ''}`} /> 새로고침
+            </button>
+          </div>
+          <div className="mt-2 grid grid-cols-3 gap-2 text-xs">
+            <div>실현 수익<br/><b>{(current?.realized_profit ?? 0).toLocaleString()}원</b></div>
+            <div>평가 수익<br/><span>{(current?.unrealized_profit ?? 0).toLocaleString()}원</span></div>
+            <div>예정 정산 5%<br/><b>{(current?.expected_fee ?? 0).toLocaleString()}원</b></div>
+          </div>
+        </div>
+
+        {history.length > 0 && (
+          <div className="mt-4 border-t border-emerald-200 pt-3 text-xs dark:border-emerald-800">
+            <div className="mb-1 font-semibold">지난 3개월</div>
+            <ul className="space-y-1">
+              {history.slice(0, 3).map((h) => (
+                <li key={`${h.year}-${h.month}`} className="flex justify-between">
+                  <span>{h.year}-{String(h.month).padStart(2, '0')}</span>
+                  <span>수익 {h.realized_profit.toLocaleString()} / 정산 {h.expected_fee.toLocaleString()}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+```
+
+- [ ] **Step 4: `PlanSelectModal` 재구성**
+
+기존 파일의 탭 UI 제거. 렌더 영역 교체:
+```tsx
+// src/components/Subscription/PlanSelectModal.tsx (본문 렌더 영역만 교체)
+import BasicPlansSection from './BasicPlansSection'
+import PremiumBundleSection from './PremiumBundleSection'
+import PerformanceSection from './PerformanceSection'
+import { countActiveEmployeesClient } from '@/lib/subscriptionClient' // 아래 Step 5에서 신규
+
+// ... useState 정리: activeTab 제거, activeCount 추가
+const [activeCount, setActiveCount] = useState(0)
+useEffect(() => { countActiveEmployeesClient().then(setActiveCount).catch(() => setActiveCount(0)) }, [])
+
+// JSX
+<Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+  <DialogContent className="max-w-4xl">
+    <DialogHeader>
+      <DialogTitle>구독 플랜</DialogTitle>
+    </DialogHeader>
+    <div className="space-y-6">
+      <BasicPlansSection plans={plans} current={currentSubscription} activeCount={activeCount} onSelect={onSelect} />
+      <PremiumBundleSection plans={plans} current={currentSubscription} onSelect={onSelect} />
+      <PerformanceSection plans={plans} onSelect={onSelect} />
+    </div>
+  </DialogContent>
+</Dialog>
+```
+
+- [ ] **Step 5: 클라이언트용 인원 조회 헬퍼**
+
+```ts
+// src/lib/subscriptionClient.ts
+export async function countActiveEmployeesClient(): Promise<number> {
+  const res = await fetch('/api/staff/active-count')
+  if (!res.ok) return 0
+  const data = await res.json()
+  return data.count ?? 0
+}
+```
+
+```ts
+// src/app/api/staff/active-count/route.ts
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { countActiveEmployees } from '@/lib/subscriptionService'
+
+export async function GET() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ count: 0 })
+  const { data: me } = await supabase.from('users').select('clinic_id').eq('id', user.id).single()
+  if (!me?.clinic_id) return NextResponse.json({ count: 0 })
+  return NextResponse.json({ count: await countActiveEmployees(me.clinic_id) })
+}
+```
+
+- [ ] **Step 6: 빌드 + 수동 검증**
+
+Run: `npm run build`
+Chrome DevTools MCP: 플랜 모달 열기 → 탭 없음 · 3섹션 색 구분 확인. 모바일 뷰(375px)에서 기본 플랜 카드 1~2열로 스택되는지.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add src/components/Subscription/BasicPlansSection.tsx src/components/Subscription/PremiumBundleSection.tsx src/components/Subscription/PerformanceSection.tsx src/components/Subscription/PlanSelectModal.tsx src/lib/subscriptionClient.ts src/app/api/staff/active-count/route.ts
+git commit -m "feat(subscription): PlanSelectModal 3섹션 색 구분 통합 화면
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 19: 투자 수익 스냅샷 API + 크론 + stub 계산
+
+### 파일:
+- Create: `src/lib/investmentProfit.ts`
+- Create: `src/app/api/investment/profit-snapshot/route.ts`
+- Create: `src/app/api/investment/profit-snapshot/refresh/route.ts`
+- Create: `src/app/api/investment/profit-snapshot/latest/route.ts`
+- Modify: `vercel.json`
+
+- [ ] **Step 1: stub 계산기**
+
+```ts
+// src/lib/investmentProfit.ts
+/**
+ * 월별 실현/평가 수익을 반환한다.
+ * NOTE: 현재 투자 거래 테이블이 부재하므로 0 반환. 투자 엔진 구현 후 본체 연결.
+ */
+export async function calculateMonthlyProfit(
+  _clinicId: string, _year: number, _month: number
+): Promise<{ realized: number; unrealized: number }> {
+  return { realized: 0, unrealized: 0 }
+}
+```
+
+- [ ] **Step 2: 크론 엔드포인트**
+
+```ts
+// src/app/api/investment/profit-snapshot/route.ts
+import { NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase/server'
+import { calculateMonthlyProfit } from '@/lib/investmentProfit'
+
+function isLastDayOfMonthKST(d: Date): boolean {
+  const kst = new Date(d.getTime() + 9 * 3600_000)
+  const next = new Date(kst.getFullYear(), kst.getMonth(), kst.getDate() + 1)
+  return next.getDate() === 1
+}
+
+export async function POST(req: Request) {
+  const auth = req.headers.get('authorization')
+  if (auth !== `Bearer ${process.env.CRON_SECRET ?? ''}`) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+  const now = new Date()
+  if (!isLastDayOfMonthKST(now)) return NextResponse.json({ skipped: true })
+
+  const supabase = await createServiceClient()
+  const { data: subs } = await supabase
+    .from('subscriptions')
+    .select('clinic_id, plan_id, subscription_plans!inner(feature_id)')
+    .eq('status', 'active')
+    .eq('subscription_plans.feature_id', 'investment')
+
+  const kst = new Date(now.getTime() + 9 * 3600_000)
+  const year = kst.getFullYear()
+  const month = kst.getMonth() + 1
+
+  let count = 0
+  for (const s of subs ?? []) {
+    const { realized, unrealized } = await calculateMonthlyProfit(s.clinic_id, year, month)
+    await supabase.from('investment_profit_snapshots').upsert({
+      clinic_id: s.clinic_id, year, month,
+      realized_profit: realized, unrealized_profit: unrealized,
+      snapshot_at: new Date().toISOString(),
+    }, { onConflict: 'clinic_id,year,month' })
+    count++
+  }
+  return NextResponse.json({ snapshotted: count })
+}
+```
+
+- [ ] **Step 3: 수동 재집계 엔드포인트**
+
+```ts
+// src/app/api/investment/profit-snapshot/refresh/route.ts
+import { NextResponse } from 'next/server'
+import { createClient, createServiceClient } from '@/lib/supabase/server'
+import { calculateMonthlyProfit } from '@/lib/investmentProfit'
+
+export async function POST() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+  const { data: me } = await supabase
+    .from('users').select('clinic_id, role').eq('id', user.id).single()
+  if (!me?.clinic_id || me.role !== 'owner') {
+    return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 })
+  }
+
+  const kst = new Date(Date.now() + 9 * 3600_000)
+  const year = kst.getFullYear()
+  const month = kst.getMonth() + 1
+  const { realized, unrealized } = await calculateMonthlyProfit(me.clinic_id, year, month)
+
+  const svc = await createServiceClient()
+  const { error } = await svc.from('investment_profit_snapshots').upsert({
+    clinic_id: me.clinic_id, year, month,
+    realized_profit: realized, unrealized_profit: unrealized,
+    snapshot_at: new Date().toISOString(),
+  }, { onConflict: 'clinic_id,year,month' })
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  return NextResponse.json({ ok: true, year, month, realized, unrealized })
+}
+```
+
+- [ ] **Step 4: 최근 N개월 조회 엔드포인트**
+
+```ts
+// src/app/api/investment/profit-snapshot/latest/route.ts
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const months = Math.max(1, Math.min(12, Number(url.searchParams.get('months') ?? 4)))
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json([])
+  const { data: me } = await supabase.from('users').select('clinic_id').eq('id', user.id).single()
+  if (!me?.clinic_id) return NextResponse.json([])
+
+  const { data } = await supabase
+    .from('investment_profit_snapshots')
+    .select('year, month, realized_profit, unrealized_profit, expected_fee')
+    .eq('clinic_id', me.clinic_id)
+    .order('year', { ascending: false })
+    .order('month', { ascending: false })
+    .limit(months)
+  return NextResponse.json(data ?? [])
+}
+```
+
+- [ ] **Step 5: `vercel.json` 크론 등록**
+
+기존 `vercel.json`을 읽어 `crons` 배열에 추가:
+```json
+{
+  "crons": [
+    { "path": "/api/investment/profit-snapshot", "schedule": "5 15 * * *" }
+  ]
+}
+```
+> 기존 cron이 있으면 배열에 append. Authorization 헤더는 Vercel Cron이 자동으로 `Bearer ${CRON_SECRET}` 주입 (환경 변수 `CRON_SECRET` 등록 필요 — 이미 다른 크론에서 쓰고 있으면 동일 값 재사용).
+
+- [ ] **Step 6: 빌드 + 수동 호출**
+
+Run: `npm run build`
+원장 계정 로그인 → `/api/investment/profit-snapshot/refresh` POST → 응답 `{ ok: true, realized: 0, unrealized: 0 }` 확인 → `investment_profit_snapshots` 테이블에 레코드 생성 확인.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add src/lib/investmentProfit.ts src/app/api/investment/profit-snapshot vercel.json
+git commit -m "feat(investment): 월별 수익 스냅샷 API + 크론 (계산은 stub)
+
+- calculateMonthlyProfit stub (투자 엔진 연결은 별도 작업)
+- 크론/수동/조회 3개 엔드포인트
+- vercel.json에 profit-snapshot 스케줄 추가
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 20: 가격 표시 일관화 (`formatPlanPrice` 적용)
+
+### 파일:
+- Modify: 가격 렌더 지점 전반 (`menuConfig.ts`, 대시보드 홍보 카드, 게이트 화면 등)
+
+- [ ] **Step 1: "무료" 문구가 주식 자동매매 맥락에 남아 있는지 전수 검수**
+
+Run:
+```
+grep -rn "무료\|free" src --include="*.ts" --include="*.tsx" | grep -vi "test\|comment"
+```
+각 지점에서 주식 자동매매(`investment` / `priceLabel`) 컨텍스트이면 "수익의 5%"로 교체. 일반 Free 플랜 문구는 유지.
+
+- [ ] **Step 2: `formatPlanPrice` 일괄 적용**
+
+`PlanSelectModal` 내부 `formatPrice` 로컬 함수를 삭제하고 `import { formatPlanPrice } from '@/lib/subscriptionPlans'`로 교체. 기존 사용처(`PremiumGate`, 대시보드 홍보 카드 등)에서 `formatPlanPrice(plan)` 사용.
+
+- [ ] **Step 3: 빌드 + 시각적 확인**
+
+Run: `npm run build`
+Chrome DevTools MCP로 플랜 모달/대시보드/게이트 페이지 순회하며 "수익의 5%"가 주식 카드에만, "무료"는 Free 플랜 카드에만 노출되는지 확인.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add -p   # 변경 지점 선별
+git commit -m "refactor(pricing): formatPlanPrice 일관 적용 · 주식매매 '수익의 5%' 명확화
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 21: E2E 수동 검증 (Chrome DevTools MCP)
+
+### 파일: (테스트만)
+
+- [ ] **Step 1: 시나리오 A — Free에서 5번째 직원 승인 시도**
+
+준비:
+```sql
+-- 테스트 병원(whitedc0902 소속) 재직자 4명 세팅, pending 1명 추가 생성
+```
+동작:
+1. `mcp__playwright__browser_navigate`로 `http://localhost:3000/auth` 이동, `whitedc0902@gmail.com` 로그인
+2. `/management?tab=requests` 진입
+3. 승인 버튼 클릭
+4. `list_network_requests()`로 `/api/staff/approve` 403 + `UPGRADE_REQUIRED` 확인
+5. `browser_snapshot()`으로 모달 렌더 확인
+
+- [ ] **Step 2: 시나리오 B — 결제 후 자동 승인**
+
+1. "지금 결제하기" → PlanSelectModal → Starter 카드 클릭 → 포트원 테스트 결제
+2. 대시보드 복귀 → `PostPaymentApprovalModal` 자동 노출 확인
+3. "전체 자동 승인" → 대기자 `active` 전환 확인 (DB 또는 UI)
+
+- [ ] **Step 3: 시나리오 C — 경계 정확성**
+
+DB에 재직 10명 + pending 1명 시나리오 구성 → 승인 시도 → `recommendedPlan: 'growth'` 반환 확인.
+
+- [ ] **Step 4: 시나리오 D — 퇴사 환불**
+
+Starter 결제 후 15일 경과 상태(결제일 수동 수정) → 직원 1명 퇴사 → 환불 확인 모달에 근사 19,500원 표시 → 확정 → DB `refunded_amount` 증가.
+
+- [ ] **Step 5: 시나리오 F — 통합 UI**
+
+플랜 모달 진입 → 탭 없음, 3섹션 색 구분 확인 → 모바일 뷰(375px) 스택 확인.
+
+- [ ] **Step 6: 시나리오 G — "수익의 5%" 명확화**
+
+주식 자동매매 관련 모든 노출 지점 순회하며 "무료" 단어 잔존 없는지 확인.
+
+- [ ] **Step 7: 시나리오 H — 수동 재집계**
+
+`PerformanceSection` 🔄 클릭 → `investment_profit_snapshots`에 당월 레코드 upsert 확인 (stub이므로 0 기록).
+
+- [ ] **Step 8: 회귀 — Free 병원 일상 기능**
+
+별도 Free 병원 계정(또는 테스트 병원의 Starter 해제 상태)에서 출퇴근, 게시판, 스케줄 정상 동작 확인.
+
+- [ ] **Step 9: 검증 결과 기록**
+
+각 시나리오의 결과(PASS/FAIL + 스크린샷/네트워크 로그 경로)를 `.claude/WORK_LOG.md`에 추가:
+```markdown
+## 2026-04-19 [기능 개발] 구독 플랜 개편
+
+### 🧪 E2E 검증 결과
+- 시나리오 A: PASS (스크린샷: ...)
+...
+```
+
+- [ ] **Step 10: 발견된 이슈 수정 후 재검증**
+
+실패 시나리오 있으면 해당 Task로 복귀, 수정 → 재실행 (사이클 반복, CLAUDE.md 최상위 지시사항 준수).
+
+---
+
+## Task 22: 최종 빌드 및 develop 푸시
+
+- [ ] **Step 1: 린트**
+
+Run: `npm run lint`
+Expected: 경고 0 목표. 남은 경고는 이 스펙과 무관한 기존 경고인지 확인.
+
+- [ ] **Step 2: 빌드**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 3: 커밋 상태 정리**
+
+Run: `git status` / `git log --oneline -20`
+미커밋 변경 없음, 모든 Task 커밋이 순서대로 들어가 있는지 확인.
+
+- [ ] **Step 4: 푸시**
+
+Run:
+```bash
+git push origin develop
+```
+실패 시 (rebase 필요 등) → `git pull --rebase origin develop` → `git push origin develop` 재시도 (CLAUDE.md: 성공할 때까지).
+
+- [ ] **Step 5: WORK_LOG 최종 업데이트**
+
+`.claude/WORK_LOG.md`에 이 작업의 카테고리/키워드/변경 요약/테스트 결과/배운 점을 추가하고 `develop`로 한 번 더 커밋+푸시.
+
+---
+
+## Self-Review 체크 결과
+
+- **스펙 커버리지**: 스펙 §4.1~§4.7 전부 Task 매핑 (1→경계/가격, 2→프리미엄, 3→주식 스냅샷, 4→홀드, 5→다층 알림, 6→환불, 7→통합 UI)
+- **플레이스홀더**: "TBD/TODO" 없음. 모든 step에 실제 코드/명령/기대값 포함
+- **타입 일관성**: `findPlanByHeadcount`, `formatPlanPrice`, `requiresUpgrade`, `countActiveEmployees`, `getLatestPaidPayment`, `prorateRefund`, `executeDowngrade`, `planForClinic` — 모든 호출이 선언과 일치
+- **범위**: 22개 Task, 실제 개발자가 순서대로 실행 가능. 테스트 러너 부재 사실을 Test Policy에서 명시
+- **알려진 한계**: `investment_transactions` 부재로 `calculateMonthlyProfit`은 stub (`{realized:0, unrealized:0}`). 투자 엔진 구현 시 이 함수만 교체. 이 한계를 Task 19 Step 1 주석과 커밋 메시지에 명시함

--- a/dental-clinic-manager/docs/superpowers/plans/2026-04-19-worker-guard-modal.md
+++ b/dental-clinic-manager/docs/superpowers/plans/2026-04-19-worker-guard-modal.md
@@ -1,0 +1,833 @@
+# 통합 워커 가드 모달 강화 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 통합 워커가 미설치/오프라인일 때 단순 알럿 대신 다운로드/재시작 가이드와 자동 재시도가 포함된 모달로 사용자가 자체 해결할 수 있게 한다.
+
+**Architecture:** 신규 `WorkerGuardModal` (Promise 기반 동적 마운트 모달) + `installer.ts` (OS 감지 + 다운로드 트리거) 추가. 기존 `useWorkerGuard.ts` 내부 `showGuardDialog`만 모달 호출로 교체. 호출처 4곳은 시그니처 동일하므로 무수정.
+
+**Tech Stack:** Next.js 15 (App Router), React 19, TypeScript, Tailwind 4, lucide-react, react-dom `createRoot`, 기존 `/api/workers/status` + `/api/marketing/worker-api/download`.
+
+**Spec:** [docs/superpowers/specs/2026-04-19-worker-guard-modal-design.md](../specs/2026-04-19-worker-guard-modal-design.md)
+
+**테스트 전략:** 이 프로젝트는 Jest/Vitest 단위 테스트 인프라가 없다. 검증은 다음 3단계로 한다:
+1. `npm run lint` — TypeScript/ESLint 통과
+2. `npm run build` — 프로덕션 빌드 통과
+3. Chrome DevTools MCP 수동 통합 테스트 (Task 6)
+
+---
+
+## File Structure
+
+| 경로 | 종류 | 책임 |
+|---|---|---|
+| `src/lib/workers/installer.ts` | 신규 | OS 감지 (`detectOS`), 다운로드 트리거 (`triggerWorkerDownload`) |
+| `src/components/WorkerGuardModal.tsx` | 신규 | Promise 기반 가드 모달 + `openWorkerGuardModal()` 헬퍼 |
+| `src/hooks/useWorkerGuard.ts` | 수정 | `WorkerType` 확장, `WORKER_LABELS` 슬림화, `showGuardDialog`가 모달 호출, `checkWorkerState`에 dentweb/email 분기 추가 |
+
+---
+
+## Task 1: OS 감지 + 다운로드 트리거 유틸
+
+**Files:**
+- Create: `src/lib/workers/installer.ts`
+
+- [ ] **Step 1: 디렉토리/파일 생성 및 구현**
+
+```ts
+// src/lib/workers/installer.ts
+
+export type DetectedOS = 'windows' | 'mac' | 'unknown'
+
+/**
+ * navigator.userAgent로 OS 감지.
+ * SSR 환경에서는 'unknown' 반환.
+ */
+export function detectOS(): DetectedOS {
+  if (typeof navigator === 'undefined') return 'unknown'
+  const ua = navigator.userAgent
+  if (/Windows/i.test(ua)) return 'windows'
+  if (/Mac OS X|Macintosh/i.test(ua)) return 'mac'
+  return 'unknown'
+}
+
+export type DownloadResult =
+  | { ok: true }
+  | { ok: false; reason: 'unsupported_os' | 'api_error' }
+
+/**
+ * 통합 워커 인스톨러 다운로드를 트리거한다.
+ * - Windows: GitHub Release `.exe` URL → window.location.assign() 자동 다운로드
+ * - Mac (DMG 있음): GitHub Release `.dmg` URL → window.location.assign()
+ * - Mac (DMG 없음): /api 응답이 shell script binary → blob anchor 다운로드
+ * - Linux/모바일: unsupported_os
+ */
+export async function triggerWorkerDownload(): Promise<DownloadResult> {
+  const os = detectOS()
+  if (os === 'unknown') return { ok: false, reason: 'unsupported_os' }
+
+  try {
+    const res = await fetch(`/api/marketing/worker-api/download?os=${os}`)
+    if (!res.ok) return { ok: false, reason: 'api_error' }
+
+    const contentType = res.headers.get('content-type') || ''
+
+    // JSON 응답: { downloadUrl } → 직접 이동
+    if (contentType.includes('application/json')) {
+      const data = (await res.json()) as { downloadUrl?: string }
+      if (!data.downloadUrl) return { ok: false, reason: 'api_error' }
+      window.location.assign(data.downloadUrl)
+      return { ok: true }
+    }
+
+    // 바이너리 응답 (Mac shell script): blob 다운로드
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = os === 'mac' ? 'marketing-worker-setup.command' : 'marketing-worker-setup.sh'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+    return { ok: true }
+  } catch {
+    return { ok: false, reason: 'api_error' }
+  }
+}
+```
+
+- [ ] **Step 2: 타입/lint 검증**
+
+Run: `npx tsc --noEmit` (또는 `npm run lint`)
+Expected: 신규 파일 관련 오류 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/lib/workers/installer.ts
+git commit -m "feat(worker): OS 감지 + 통합 워커 다운로드 트리거 유틸 추가
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: WorkerGuardModal 기본 구조 + 미설치 케이스
+
+**Files:**
+- Create: `src/components/WorkerGuardModal.tsx`
+
+- [ ] **Step 1: 모달 기본 구조 + Promise 헬퍼 작성**
+
+```tsx
+// src/components/WorkerGuardModal.tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { AlertTriangle, Download, RefreshCw, X, Loader2 } from 'lucide-react'
+import { triggerWorkerDownload } from '@/lib/workers/installer'
+
+export type GuardState = 'not_installed' | 'offline'
+export type WorkerType = 'marketing' | 'scraping' | 'seo' | 'dentweb' | 'email'
+
+interface OpenOptions {
+  type: WorkerType
+  featureName: string
+  state: GuardState
+}
+
+interface ModalProps extends OpenOptions {
+  onResolve: (result: boolean) => void
+}
+
+// =====================================================
+// Singleton mount (중복 호출 방지)
+// =====================================================
+
+let activePromise: Promise<boolean> | null = null
+let activeRoot: Root | null = null
+let activeContainer: HTMLDivElement | null = null
+
+function unmountModal() {
+  if (activeRoot) {
+    activeRoot.unmount()
+    activeRoot = null
+  }
+  if (activeContainer && activeContainer.parentNode) {
+    activeContainer.parentNode.removeChild(activeContainer)
+    activeContainer = null
+  }
+  activePromise = null
+}
+
+export function openWorkerGuardModal(opts: OpenOptions): Promise<boolean> {
+  if (activePromise) return activePromise
+
+  activePromise = new Promise<boolean>((resolve) => {
+    activeContainer = document.createElement('div')
+    document.body.appendChild(activeContainer)
+    activeRoot = createRoot(activeContainer)
+
+    const handleResolve = (result: boolean) => {
+      resolve(result)
+      // 다음 tick에 unmount (React state 정리 시간 확보)
+      setTimeout(unmountModal, 0)
+    }
+
+    activeRoot.render(<WorkerGuardModal {...opts} onResolve={handleResolve} />)
+  })
+
+  return activePromise
+}
+
+// =====================================================
+// 워커 상태 재핑 (모달 내부 사용)
+// =====================================================
+
+async function pingWorkerStatus(type: WorkerType): Promise<{ installed: boolean; online: boolean }> {
+  try {
+    const res = await fetch(`/api/workers/status?type=${type}`, {
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) return { installed: false, online: false }
+    const data = await res.json()
+    const slot = data[type]
+    return {
+      installed: slot?.installed ?? false,
+      online: slot?.online ?? false,
+    }
+  } catch {
+    return { installed: false, online: false }
+  }
+}
+
+// =====================================================
+// Modal Component
+// =====================================================
+
+function WorkerGuardModal({ type, featureName, state, onResolve }: ModalProps) {
+  const [downloading, setDownloading] = useState(false)
+  const [rechecking, setRechecking] = useState(false)
+  const [downloadError, setDownloadError] = useState<string | null>(null)
+
+  const isNotInstalled = state === 'not_installed'
+
+  const handleDownload = async () => {
+    setDownloading(true)
+    setDownloadError(null)
+    const result = await triggerWorkerDownload()
+    setDownloading(false)
+    if (!result.ok) {
+      setDownloadError(
+        result.reason === 'unsupported_os'
+          ? 'Windows 또는 macOS에서만 지원됩니다.'
+          : '다운로드 URL을 가져올 수 없습니다. 잠시 후 다시 시도해주세요.'
+      )
+    }
+  }
+
+  const handleRecheck = async () => {
+    setRechecking(true)
+    const status = await pingWorkerStatus(type)
+    setRechecking(false)
+    if (status.installed && status.online) {
+      onResolve(true)
+    }
+    // else: 모달 유지 — 미설치/오프라인 상태 그대로
+  }
+
+  const handleCancel = () => onResolve(false)
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4"
+      onClick={handleCancel}
+    >
+      <div
+        className="w-full max-w-lg rounded-2xl bg-white shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-100">
+              <AlertTriangle className="h-5 w-5 text-amber-600" />
+            </div>
+            <h2 className="text-lg font-semibold text-gray-900">
+              {isNotInstalled ? '통합 워커 미설치' : '통합 워커 응답 없음'}
+            </h2>
+          </div>
+          <button
+            onClick={handleCancel}
+            className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+            aria-label="닫기"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="space-y-4 px-6 py-5">
+          <p className="text-sm text-gray-700">
+            <strong>{featureName}</strong> 기능을 사용하려면 통합 워커가{' '}
+            {isNotInstalled ? '설치되어 있어야' : '실행 중이어야'} 합니다.
+          </p>
+
+          {isNotInstalled ? (
+            <NotInstalledGuide />
+          ) : (
+            <OfflineGuide /* Task 3에서 자동 재시도 추가 */ />
+          )}
+
+          {downloadError && (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {downloadError}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 border-t border-gray-200 px-6 py-4">
+          <button
+            onClick={handleCancel}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+          >
+            취소
+          </button>
+          {!isNotInstalled && (
+            <button
+              onClick={handleDownload}
+              disabled={downloading}
+              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              {downloading ? '다운로드 중...' : '재설치'}
+            </button>
+          )}
+          <button
+            onClick={handleRecheck}
+            disabled={rechecking}
+            className="flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {rechecking ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            다시 확인
+          </button>
+          {isNotInstalled && (
+            <button
+              onClick={handleDownload}
+              disabled={downloading}
+              className="flex items-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-white hover:bg-amber-600 disabled:opacity-50"
+            >
+              {downloading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Download className="h-4 w-4" />
+              )}
+              통합 워커 다운로드
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// =====================================================
+// 가이드 컴포넌트
+// =====================================================
+
+function NotInstalledGuide() {
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm">
+      <p className="mb-2 font-medium text-amber-900">설치 방법</p>
+      <ol className="list-decimal space-y-1 pl-5 text-amber-800">
+        <li>아래 [통합 워커 다운로드] 버튼을 클릭합니다.</li>
+        <li>다운로드된 <code className="rounded bg-amber-100 px-1">clinic-manager-worker-x.x.x-setup.exe</code>를 실행합니다.</li>
+        <li>설치 마법사 안내에 따라 진행합니다.</li>
+        <li>설치 완료 후 자동 실행됩니다 (작업 표시줄 트레이 아이콘 확인).</li>
+        <li>1분 후 [다시 확인]을 눌러주세요.</li>
+      </ol>
+    </div>
+  )
+}
+
+function OfflineGuide() {
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm">
+      <p className="mb-2 font-medium text-amber-900">해결 방법</p>
+      <ol className="list-decimal space-y-1 pl-5 text-amber-800">
+        <li>작업 표시줄 우측 트레이 영역을 확인합니다.</li>
+        <li>통합 워커 아이콘을 우클릭하여 "종료"합니다.</li>
+        <li>시작 메뉴에서 통합 워커를 다시 실행합니다.</li>
+        <li>1분 후 [다시 확인]을 눌러주세요.</li>
+      </ol>
+    </div>
+  )
+}
+```
+
+> **참고:** `OfflineGuide`는 Task 3에서 자동 재시도 영역이 추가됩니다. 지금은 가이드만 표시.
+
+- [ ] **Step 2: 타입/lint 검증**
+
+Run: `npm run lint`
+Expected: WorkerGuardModal 관련 오류 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/WorkerGuardModal.tsx
+git commit -m "feat(worker): WorkerGuardModal 기본 구조 + 미설치 케이스 추가
+
+- Promise 기반 동적 마운트 (createRoot)
+- 싱글톤 보호 (중복 호출 방지)
+- 미설치/오프라인 분기 UI
+- 다운로드/재확인 액션
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: WorkerGuardModal 자동 재시도 (오프라인 케이스)
+
+**Files:**
+- Modify: `src/components/WorkerGuardModal.tsx`
+
+- [ ] **Step 1: `OfflineGuide`를 자동 재시도 포함 컴포넌트로 교체**
+
+`OfflineGuide` 함수 정의를 제거하고, 모달 본문 내 `<OfflineGuide />` 호출 위치에 `<OfflineSection ... />`을 사용하도록 변경.
+
+```tsx
+// (1) ModalProps 사용 측 - 본문 분기 부분 교체
+{isNotInstalled ? (
+  <NotInstalledGuide />
+) : (
+  <OfflineSection
+    type={type}
+    onAutoRecovered={() => onResolve(true)}
+  />
+)}
+```
+
+```tsx
+// (2) 새 컴포넌트 정의 (기존 OfflineGuide 자리 교체)
+interface OfflineSectionProps {
+  type: WorkerType
+  onAutoRecovered: () => void
+}
+
+function OfflineSection({ type, onAutoRecovered }: OfflineSectionProps) {
+  const MAX_ATTEMPTS = 3
+  const INTERVAL_MS = 5000
+
+  const [attempt, setAttempt] = useState(0) // 0..MAX_ATTEMPTS (완료 횟수)
+  const [secondsLeft, setSecondsLeft] = useState(INTERVAL_MS / 1000)
+  const [exhausted, setExhausted] = useState(false)
+
+  useEffect(() => {
+    if (exhausted) return
+    if (attempt >= MAX_ATTEMPTS) {
+      setExhausted(true)
+      return
+    }
+
+    let cancelled = false
+    let countdownTimer: ReturnType<typeof setInterval> | null = null
+    let tickRemaining = INTERVAL_MS / 1000
+
+    setSecondsLeft(tickRemaining)
+    countdownTimer = setInterval(() => {
+      tickRemaining -= 1
+      if (cancelled) return
+      setSecondsLeft(Math.max(0, tickRemaining))
+    }, 1000)
+
+    const fireTimer = setTimeout(async () => {
+      if (cancelled) return
+      const status = await pingWorkerStatus(type)
+      if (cancelled) return
+      if (status.installed && status.online) {
+        onAutoRecovered()
+        return
+      }
+      setAttempt((n) => n + 1)
+    }, INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      if (countdownTimer) clearInterval(countdownTimer)
+      clearTimeout(fireTimer)
+    }
+  }, [attempt, exhausted, type, onAutoRecovered])
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm">
+        <p className="mb-2 font-medium text-amber-900">해결 방법</p>
+        <ol className="list-decimal space-y-1 pl-5 text-amber-800">
+          <li>작업 표시줄 우측 트레이 영역을 확인합니다.</li>
+          <li>통합 워커 아이콘을 우클릭하여 "종료"합니다.</li>
+          <li>시작 메뉴에서 통합 워커를 다시 실행합니다.</li>
+          <li>1분 후 [다시 확인]을 눌러주세요.</li>
+        </ol>
+      </div>
+
+      <div className="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
+        <RefreshCw className={`h-3.5 w-3.5 ${exhausted ? '' : 'animate-spin'}`} />
+        {exhausted ? (
+          <span>자동 확인 종료. 워커를 재시작 후 [다시 확인]을 눌러주세요.</span>
+        ) : (
+          <span>
+            자동 재시도{' '}
+            <DotIndicator current={attempt} total={MAX_ATTEMPTS} />{' '}
+            ({attempt + 1}/{MAX_ATTEMPTS}) — {secondsLeft}초 후 다시 확인...
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function DotIndicator({ current, total }: { current: number; total: number }) {
+  return (
+    <span aria-hidden className="inline-flex gap-0.5">
+      {Array.from({ length: total }).map((_, i) => (
+        <span
+          key={i}
+          className={`inline-block h-1.5 w-1.5 rounded-full ${
+            i < current ? 'bg-amber-600' : 'bg-amber-300'
+          }`}
+        />
+      ))}
+    </span>
+  )
+}
+```
+
+- [ ] **Step 2: 수동 [다시 확인] 클릭 시 자동 카운터 리셋 + onAutoRecovered 안정화**
+
+`WorkerGuardModal` 컴포넌트에서 `OfflineSection`이 자체적으로 `attempt` 상태를 가지므로, 수동 재핑이 성공하면 모달이 닫혀 자동으로 cleanup된다. 실패한 경우 자동 재시도 사이클을 처음부터 재시작해야 한다.
+
+`OfflineSection`에 `key`를 부여해 부모에서 리셋 가능하게 한다. 또한 `onAutoRecovered` 콜백은 `useCallback`으로 안정화해 자식의 `useEffect` 무한 재실행을 방지한다. `useCallback` import를 추가한다.
+
+```tsx
+// 상단 import에 useCallback 추가
+import { useCallback, useEffect, useState } from 'react'
+```
+
+```tsx
+// WorkerGuardModal 함수 본문
+const [offlineCycleKey, setOfflineCycleKey] = useState(0)
+
+const handleAutoRecovered = useCallback(() => {
+  onResolve(true)
+}, [onResolve])
+
+const handleRecheck = async () => {
+  setRechecking(true)
+  const status = await pingWorkerStatus(type)
+  setRechecking(false)
+  if (status.installed && status.online) {
+    onResolve(true)
+    return
+  }
+  // 실패 시 OfflineSection 재마운트 (자동 재시도 카운터 리셋)
+  if (!isNotInstalled) {
+    setOfflineCycleKey((k) => k + 1)
+  }
+}
+
+// 본문 분기:
+{isNotInstalled ? (
+  <NotInstalledGuide />
+) : (
+  <OfflineSection
+    key={offlineCycleKey}
+    type={type}
+    onAutoRecovered={handleAutoRecovered}
+  />
+)}
+```
+
+> **주의:** 모달 컴포넌트에 전달되는 `onResolve` 자체는 `openWorkerGuardModal` 헬퍼 안에서 한 번만 생성되어 안정적이지만, 화살표 함수 `() => onResolve(true)`를 매 렌더 새로 만드는 것은 자식 useEffect 의존성에 들어가면 위험하므로 명시적으로 `useCallback`을 사용한다.
+
+- [ ] **Step 3: 타입/lint 검증**
+
+Run: `npm run lint`
+Expected: 오류 없음. (특히 `useEffect` deps 경고가 없는지 확인)
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/components/WorkerGuardModal.tsx
+git commit -m "feat(worker): 오프라인 케이스에 자동 재시도(5s×3) 추가
+
+- 모달 마운트 시 자동 시작
+- 점 인디케이터 + 카운트다운 표시
+- 수동 [다시 확인] 실패 시 자동 카운터 리셋
+- cleanup 보장 (cancelled flag + clearTimeout/clearInterval)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: useWorkerGuard 통합 + WorkerType 확장
+
+**Files:**
+- Modify: `src/hooks/useWorkerGuard.ts`
+
+- [ ] **Step 1: `WorkerType` 확장 + `WORKER_LABELS` 슬림화**
+
+기존 정의를 다음으로 교체:
+
+```ts
+type WorkerType = 'marketing' | 'scraping' | 'seo' | 'dentweb' | 'email'
+
+interface WorkerGuardOptions {
+  type: WorkerType
+  featureName?: string
+}
+
+const WORKER_LABELS: Record<WorkerType, { defaultFeature: string }> = {
+  marketing: { defaultFeature: '마케팅 기능' },
+  scraping:  { defaultFeature: '데이터 연동' },
+  seo:       { defaultFeature: 'SEO 키워드 분석' },
+  dentweb:   { defaultFeature: '덴트웹 매출 동기화' },
+  email:     { defaultFeature: '이메일 알림' },
+}
+```
+
+> **참고:** 기존 `name` 필드 (예: '마케팅 워커')는 모달 헤더가 "통합 워커 [상태]"로 고정되므로 더 이상 사용하지 않는다. `label.name` 참조가 코드에 있으면 모두 제거.
+
+- [ ] **Step 2: `checkWorkerState`에 dentweb/email 분기 추가**
+
+기존 함수에서 `if (type === 'seo')` 다음에 두 분기를 추가:
+
+```ts
+async function checkWorkerState(type: WorkerType): Promise<WorkerState> {
+  try {
+    const res = await fetch(`/api/workers/status?type=${type}`, {
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) return { installed: false, online: false }
+
+    const data = await res.json()
+    if (type === 'marketing') {
+      return {
+        installed: data.marketing?.installed ?? false,
+        online: data.marketing?.online ?? false,
+      }
+    }
+    if (type === 'scraping') {
+      return {
+        installed: data.scraping?.installed ?? false,
+        online: data.scraping?.online ?? false,
+      }
+    }
+    if (type === 'seo') {
+      return {
+        installed: data.seo?.installed ?? false,
+        online: data.seo?.online ?? false,
+      }
+    }
+    if (type === 'dentweb') {
+      return {
+        installed: data.dentweb?.installed ?? false,
+        online: data.dentweb?.online ?? false,
+      }
+    }
+    if (type === 'email') {
+      return {
+        installed: data.email?.installed ?? false,
+        online: data.email?.online ?? false,
+      }
+    }
+    return { installed: false, online: false }
+  } catch {
+    return { installed: false, online: false }
+  }
+}
+```
+
+- [ ] **Step 3: `showGuardDialog`를 모달 호출로 교체**
+
+기존 `appAlert` 호출을 모두 제거하고 다음으로 교체:
+
+```ts
+import { openWorkerGuardModal, type GuardState } from '@/components/WorkerGuardModal'
+// (기존 import { appAlert } from '@/components/ui/AppDialog' 라인 제거)
+
+async function showGuardDialog(
+  type: WorkerType,
+  feature: string,
+  state: WorkerState
+): Promise<boolean> {
+  const guardState: GuardState = !state.installed ? 'not_installed' : 'offline'
+  return openWorkerGuardModal({ type, featureName: feature, state: guardState })
+}
+```
+
+- [ ] **Step 4: `guardAction` / `requireWorker`가 모달 결과를 반환하도록 수정**
+
+```ts
+// useWorkerGuard 내부
+const guardAction = useCallback(async (): Promise<boolean> => {
+  const state = await checkWorkerState(type)
+  if (state.installed && state.online) return true
+  return await showGuardDialog(type, feature, state)
+}, [type, feature])
+```
+
+```ts
+// 모듈 함수
+export async function requireWorker(type: WorkerType, featureName?: string): Promise<boolean> {
+  const label = WORKER_LABELS[type]
+  const feature = featureName || label.defaultFeature
+  const state = await checkWorkerState(type)
+  if (state.installed && state.online) return true
+  return await showGuardDialog(type, feature, state)
+}
+```
+
+> **주의:** `useWorkerGuard` 함수 내에서 기존 `const label = WORKER_LABELS[type]`을 읽는 부분도 `name` 참조가 있으면 제거하고 `defaultFeature`만 사용하도록 정리.
+
+- [ ] **Step 5: 타입/lint 검증**
+
+Run: `npm run lint`
+Expected: 오류 없음. 특히 호출처 4곳에서 타입 호환성 유지 확인 (`requireWorker`/`guardAction` 모두 `Promise<boolean>` 반환은 이전과 동일).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add src/hooks/useWorkerGuard.ts
+git commit -m "feat(worker): useWorkerGuard를 WorkerGuardModal 호출로 강화
+
+- WorkerType에 dentweb/email 추가
+- WORKER_LABELS에서 사용하지 않는 name 필드 제거
+- checkWorkerState에 dentweb/email 분기 추가
+- showGuardDialog가 appAlert 대신 openWorkerGuardModal 호출
+- guardAction/requireWorker가 모달 결과(true/false) 반환
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: 빌드 검증
+
+**Files:** (없음 — 검증만)
+
+- [ ] **Step 1: 풀 빌드 실행**
+
+Run: `npm run build`
+Expected: 빌드 성공. 신규 모듈/컴포넌트가 번들에 포함되고 타입 오류 없음.
+
+- [ ] **Step 2: 빌드 실패 시 처리**
+
+빌드 오류가 발생하면 즉시 원인 파악 후 수정 → 다시 `npm run build` 실행. 성공할 때까지 반복 (CLAUDE.md 최상위 지시사항에 따라 멈추지 않음).
+
+- [ ] **Step 3: lint 실행**
+
+Run: `npm run lint`
+Expected: 신규/수정 파일 관련 ESLint 경고/오류 없음.
+
+> 이 단계는 별도 commit 없음 (코드 변경 없음).
+
+---
+
+## Task 6: Chrome DevTools MCP 수동 통합 테스트
+
+**Files:** (없음 — 검증만)
+
+테스트 계정으로 로그인 후 시나리오 수행. 실패 시 코드 수정 → Task 5 빌드부터 재실행.
+
+테스트 계정 (CLAUDE.md 참조):
+- 일반: `whitedc0902@gmail.com` / `ghkdgmltn81!`
+- 마스터: `sani81@gmail.com` / `ghkdgmltn81!`
+
+dev 서버 실행: `npm run dev` (background)
+
+- [ ] **시나리오 1: 미설치 케이스**
+
+1. Supabase MCP로 임시 실행: `DELETE FROM marketing_worker_control WHERE id = 'main';` (또는 별도 환경에서 진행)
+2. Chrome DevTools MCP로 `http://localhost:3000/auth` 이동 → 로그인
+3. `/dashboard/marketing/posts/new` 이동 → 발행 버튼 클릭
+4. **확인**: "통합 워커 미설치" 모달이 표시됨
+5. 모달의 [통합 워커 다운로드] 클릭
+6. **확인**: 네트워크 탭에 `/api/marketing/worker-api/download?os=windows` 요청 발생, GitHub Release `.exe` URL로 자동 이동/다운로드 시작
+7. [취소] 클릭 → 모달 닫힘, 발행 진행되지 않음
+8. 테스트 후 control 레코드 복원 (`INSERT ...`) — 또는 별도 테스트 환경 사용
+
+- [ ] **시나리오 2: 오프라인 케이스 + 자동 재시도**
+
+1. Supabase MCP로 실행: `UPDATE marketing_worker_control SET watchdog_online = false, last_updated = NOW() - INTERVAL '5 minutes' WHERE id = 'main';`
+2. 발행 시도 → "통합 워커 응답 없음" 모달 열림
+3. **확인**: 자동 재시도 영역이 5초 카운트다운 시작 (●●● 점 인디케이터)
+4. **확인**: 5초 × 3회 진행 후 "자동 확인 종료..." 메시지 표시
+5. [다시 확인] 클릭 → 즉시 1회 ping 후 실패 → 자동 사이클 다시 시작 (점 인디케이터 리셋 확인)
+6. [재설치] 클릭 → 다운로드 트리거 확인
+
+- [ ] **시나리오 3: 자동 복구**
+
+1. 시나리오 2 상태에서 모달 열어둔 채로
+2. Supabase MCP로 실행: `UPDATE marketing_worker_control SET watchdog_online = true, last_updated = NOW() WHERE id = 'main';`
+3. **확인**: 다음 자동 재시도 사이클(최대 5초 후)에 모달 자동 닫힘 + 발행 진행
+
+- [ ] **시나리오 4: 취소**
+
+1. 모달 열림 상태에서 [취소] 또는 X 또는 배경 클릭
+2. **확인**: 모달 닫힘, 호출처에서 `false` 받아 기능 차단됨
+3. **확인**: DevTools Performance/Memory에서 타이머 누수 없음 (다시 가드 호출 시 새 모달이 정상 동작)
+
+- [ ] **시나리오 5: OS 미지원**
+
+1. Chrome DevTools `Network conditions`에서 User-Agent를 `Mozilla/5.0 (X11; Linux x86_64)`로 변경
+2. 발행 시도 → 미설치 모달
+3. [통합 워커 다운로드] 클릭
+4. **확인**: 모달 본문에 "Windows 또는 macOS에서만 지원됩니다." 빨간 박스 표시
+
+- [ ] **시나리오 6: 정상 케이스 회귀**
+
+1. control 정상 복원: `UPDATE marketing_worker_control SET watchdog_online = true, last_updated = NOW() WHERE id = 'main';`
+2. 발행 시도 → 모달 표시되지 않음, 정상 발행 진행
+3. SEO 키워드 분석 페이지에서도 동일 확인 (`scraping`, `seo` 가드도 정상)
+
+> **주의:** 시나리오 6 모두 통과해야 다음 Task로 진행. 실패 시 원인 파악 → 코드 수정 → Task 5 빌드부터 재실행.
+
+---
+
+## Task 7: develop 브랜치 푸시
+
+**Files:** (없음 — Git 작업만)
+
+- [ ] **Step 1: 변경 내역 최종 확인**
+
+Run: `git log --oneline origin/develop..HEAD`
+Expected: Task 1, 2, 3, 4의 4개 커밋이 표시됨.
+
+- [ ] **Step 2: develop으로 푸시**
+
+```bash
+git push origin develop
+```
+
+푸시 실패 시 원인 파악 → 해결(예: `git pull --rebase origin develop`) → 다시 푸시. 성공할 때까지 반복.
+
+- [ ] **Step 3: 푸시 검증**
+
+Run: `gh run list --branch develop --limit 3`
+Expected: 가장 최신 커밋의 CI/Vercel 빌드가 시작됨. 실패 시 원인 파악 후 수정.
+
+---
+
+## 완료 조건
+
+- [ ] Task 1~4의 4개 커밋이 develop 브랜치에 푸시됨
+- [ ] `npm run build` 성공
+- [ ] `npm run lint` 통과
+- [ ] Chrome DevTools 시나리오 1~6 모두 통과
+- [ ] 호출처 4곳(`useWorkerGuard.ts`, `posts/new/page.tsx`, `KeywordAnalysis.tsx`, `HometaxSyncPanel.tsx`) 코드 변경 없음
+- [ ] Vercel preview 빌드 성공 확인

--- a/dental-clinic-manager/docs/superpowers/specs/2026-04-19-dual-landing-pages-design.md
+++ b/dental-clinic-manager/docs/superpowers/specs/2026-04-19-dual-landing-pages-design.md
@@ -1,0 +1,318 @@
+# Dual Landing Pages — Owner / Staff 분리 랜딩 디자인
+
+**작성일**: 2026-04-19
+**상태**: 설계 확정
+**작업자**: huisu-hwang
+
+## 1. 목표
+
+치과 경영자(대표원장)와 실무자(실장·직원)의 관심사·언어가 다르므로, 단일 랜딩을 두 개의 타깃 랜딩으로 분리한다. 외부에서 무작위로 들어오는 방문자는 역할을 먼저 선택하도록 유도하고, 선택은 재방문 시 자동 복원한다.
+
+**핵심 메시지**
+- **대표원장(`/owner`)**: *"능력있는 실장을 엑셀 작업과 연차 계산에 낭비하지 마세요. 잡무는 서비스에 맡기고, 실장은 매출에만 집중하게 하세요."*
+- **실장·직원(`/staff`)**: *"출퇴근, 직원 스케쥴에서 연차 관리까지 간단하게 끝내고 정시 퇴근하세요~"*
+
+## 2. 라우팅 & 파일 구조
+
+### 라우팅 (하이브리드)
+
+| 경로 | 역할 | 동작 |
+|---|---|---|
+| `/` | 역할 선택 페이지 | localStorage에 `clinicmgr.visitor_role`이 있으면 `/owner` 또는 `/staff`로 `router.replace()` 자동 이동. 없으면 선택 카드 2개 표시 |
+| `/owner` | 대표원장 랜딩 | 첫 방문 시 `visitor_role='owner'` 저장 |
+| `/staff` | 실장·직원 랜딩 | 첫 방문 시 `visitor_role='staff'` 저장 |
+
+- 로그인/회원가입은 기존 쿼리 파라미터 패턴 유지(`?show=login`, `?show=signup`) — 세 페이지 모두에서 동일 동작
+- 인증된 사용자가 `/`, `/owner`, `/staff` 접근 시 기존처럼 `/dashboard`로 리디렉션 (변경 없음)
+- localStorage 키: `clinicmgr.visitor_role` (값: `'owner' | 'staff'`)
+- "선택 기억 해제" 버튼(선택 페이지 footer)으로 localStorage 항목 삭제 가능
+
+### 파일 구조
+
+```
+src/app/
+  page.tsx                              # RoleSelectorPage (기존 AuthApp 대체)
+  owner/page.tsx                        # OwnerLandingPage + AuthFlow 래퍼
+  staff/page.tsx                        # StaffLandingPage + AuthFlow 래퍼
+src/components/Landing/
+  RoleSelector.tsx                      # 선택 카드 UI
+  OwnerLanding.tsx                      # 원장용 랜딩 컴포넌트
+  StaffLanding.tsx                      # 실장용 랜딩 컴포넌트
+  shared/
+    LandingHeader.tsx                   # 공통 헤더 (variant: dark | light)
+    AuthFlow.tsx                        # landing/login/signup/forgotPassword 상태 래퍼
+    useVisitorRole.ts                   # localStorage 헬퍼 (get/set/clear)
+    ScrollAnimation.tsx                 # 기존 훅 추출
+    TypeWriter.tsx                      # 기존 컴포넌트 추출
+    CountUp.tsx                         # 기존 컴포넌트 추출
+```
+
+**삭제**
+- `src/app/AuthApp.tsx` → `AuthFlow.tsx`로 대체
+- `src/components/Landing/LandingPage.tsx` → 사용처 제거 후 삭제
+
+**변경 없음**
+- `AuthContext`, `middleware.ts`, `LoginForm`, `SignupForm`, `ForgotPasswordForm`, `Footer`
+
+## 3. 역할 선택 페이지(`/`)
+
+**레이아웃**: 센터 카드 — 최대 넓이 `6xl`, 흰 배경
+
+```
+<LandingHeader variant="light" />          # 로고 + 로그인/시작하기
+<main>
+  <headline>
+    먼저 알려주세요 — <span>누구신가요?</span>
+    <subtitle>역할에 맞는 페이지로 안내해드립니다</subtitle>
+  </headline>
+  <cards 2열 그리드>
+    <OwnerCard>
+      👨‍⚕️ 대표원장
+      "병원 경영 · 매출 중심 뷰"
+      → /owner (인디고 액센트)
+    </OwnerCard>
+    <StaffCard>
+      🧑‍💼 실장 · 직원
+      "출퇴근 · 스케쥴 · 연차"
+      → /staff (시안 액센트)
+    </StaffCard>
+  </cards>
+  <foot>
+    선택한 페이지는 다음 방문 시 자동으로 열립니다 ·
+    <button>선택 기억 해제</button>
+  </foot>
+</main>
+<Footer />
+```
+
+**상호작용**
+- 카드 클릭 시 `localStorage.setItem('clinicmgr.visitor_role', ...)` 후 `router.push('/owner' | '/staff')`
+- 호버 시 약간 상승 + 액센트 컬러 강화
+- 마운트 시 `useEffect`로 localStorage 확인 → 있으면 `router.replace()` (히스토리 쌓지 않음)
+- 인증 상태 확인 → 인증 시 `/dashboard`로 이동 (기존 AuthApp 로직 유지)
+
+## 4. 대표원장 랜딩(`/owner`)
+
+**톤**: 다크 정숙형, 경영자 언어, 신뢰·무게감
+**전체 플로우**: Hero → Problem → Solution → Features → Premium → Trust → CTA → FAQ → Footer
+
+### 4.1 Hero (슬레이트 950 다크 배경)
+
+- 라벨: `FOR CLINIC OWNERS`
+- 헤드라인 (3줄, 중간줄 블루→인디고 그라데이션):
+  > "능력있는 실장을
+  > **엑셀과 연차 계산에**
+  > 낭비하지 마세요"
+- 서브카피: *"잡무는 시스템에 맡기고, 실장은 매출에만 집중하게 하세요."*
+- CTA: `무료로 시작하기` (그라데이션 solid) + `기능 살펴보기` (앵커 스크롤)
+- 뱃지: "현직 원장 개발" · "실제 병원 운영 중"
+- 스크롤 인디케이터
+
+### 4.2 Problem (슬레이트 900)
+
+- 타이틀: *"실장이 하루에 버리는 시간"*
+- 리스트 (아이콘 + 설명):
+  - 엑셀 연차 계산
+  - 출퇴근 수기 집계
+  - 스케쥴 수동 조율
+  - 급여 명세서 취합
+  - 환자 리콜 추적
+  - 선물 재고 확인
+  - 상담 기록 정리
+- 임팩트: *"이 시간에 실장은 상담 한 건을 더 받을 수 있었습니다."*
+
+### 4.3 Solution (화이트)
+
+- 타이틀: *"잡무는 시스템에게, 실장은 매출에게"*
+- Before/After 2카드:
+  - **Before**: 반복 업무에 실장의 집중력 소진 (70% 낭비)
+  - **After**: 상담·해피콜·매출 관리에 온전히 집중
+- 마무리: *"실장의 에너지가 매출로 전환됩니다."*
+
+### 4.4 Features (화이트, 기본 6개 카드)
+
+실제 서비스 기능에 맞춰 조정:
+
+1. 📊 **일일 업무 보고서** — 상담·선물·해피콜·리콜 자동 집계
+2. ⏱ **출퇴근 · 근태** — QR 체크인, 팀 현황, 스케쥴
+3. 📝 **근로계약서 관리** — 템플릿 기반 계약서 생성·보관 *(기존 "전자서명" 문구 삭제 — 실제 구현과 일치)*
+4. 📅 **연차 자동 계산** — 정책·발생·잔여·승인 워크플로우
+5. 💰 **급여 명세서** — 자동 생성·배포 *(기존 랜딩 누락분 추가)*
+6. 👥 **직원 권한 · 프로토콜** — 역할별 접근 + 업무 표준 문서화
+
+### 4.5 Premium (그라데이션 배경, Features 다음 신규 섹션)
+
+- 헤더: `PREMIUM · 월 ₩499,000`
+- 카피: *"경영자의 시간을 위해 준비된 한 단계 더"*
+- 3카드:
+  1. 🤖 **AI 데이터 분석** — 매출·상담 지표에서 인사이트 자동 추출
+  2. 📈 **경영현황 대시보드** — 재무·매출·KPI 한 화면
+  3. ✍ **마케팅 자동화** — 네이버 블로그 자동 기획·발행·KPI 추적
+
+### 4.6 Trust (라이트 블루)
+
+- 타이틀: *"현직 치과 원장이 직접 개발 · 본인 병원에서 매일 사용 중"*
+- 3가지 증언:
+  - 현장의 불편함을 직접 경험하고 해결한 솔루션
+  - 본인 병원에서 매일 사용하며 지속 개선
+  - 치과 업무 흐름을 정확히 이해한 맞춤형 설계
+- 인용: *"직접 쓰면서 불편한 건 바로바로 고칩니다. 제가 매일 쓰니까요."*
+
+### 4.7 CTA (블루→인디고→퍼플 그라데이션)
+
+- 타이틀: *"실장의 시간을 매출로 전환할 때입니다"*
+- 서브: 복잡한 설치 없이 웹 브라우저로 즉시 시작
+- 버튼: `무료로 시작하기` + `로그인`
+
+### 4.8 FAQ (5개)
+
+1. 설치가 필요한가요?
+2. 데이터는 안전한가요?
+3. 직원 권한 설정이 가능한가요?
+4. 기존 데이터 이전이 가능한가요?
+5. **프리미엄 패키지는 무엇이 다른가요?** *(신규)*
+
+## 5. 실장 · 직원 랜딩(`/staff`)
+
+**톤**: 밝은 캐주얼, 파스텔, "~하세요~" 친근한 말투
+**플로우**: Hero → 공감 → 해결 → Features → CTA → FAQ → Footer
+
+### 5.1 Hero (파스텔 그라데이션: amber-50 → rose-100 → violet-100)
+
+- 라벨: `FOR STAFF · 실장님, 팀원님`
+- 헤드라인 (3줄, 중간줄 핑크→바이올렛 그라데이션):
+  > "출퇴근부터 연차까지
+  > **간단하게 끝내고**
+  > 정시 퇴근하세요 ~"
+- 서브카피: *"반복 업무는 앱이 대신합니다. 손 덜 쓰는 하루 루틴."*
+- CTA: `지금 시작하기` + `기능 살펴보기`
+- 플로팅 이모지 데코 (☕ ✨ 🎈)
+
+### 5.2 공감 (파스텔 배경, 짧은 한 줄)
+
+- *"혹시 오늘도… 퇴근하고 엑셀 켜셨나요?"*
+- 서브: 연차 계산, 스케쥴 조율, 업무 집계… 이제 그만 하셔도 됩니다.
+
+### 5.3 해결 (화이트)
+
+- 타이틀: *"클릭 몇 번이면 끝."*
+- 3스텝 플로우:
+  1. QR로 출근
+  2. 하루 업무를 앱에서 관리
+  3. QR로 퇴근 · 정시 귀가
+
+### 5.4 Features (실장/직원 관점 6개)
+
+1. ⏱ **QR 출퇴근** — 스마트폰으로 1초 체크인
+2. 📅 **스케쥴 · 연차** — 신청·승인까지 앱에서
+3. 📊 **일일 업무 보고** — 상담·해피콜·리콜 탭 한 번
+4. ✅ **업무 체크리스트** — 오늘 할 일·완료 현황
+5. 🎁 **선물 재고** — 실시간 수량 확인
+6. 💬 **팀 커뮤니티 · 텔레그램** — 공지·질문·빠른 소통
+
+### 5.5 CTA (시안 → 티얼 그라데이션, 따뜻한 톤)
+
+- 타이틀: *"오늘 퇴근은 정시에"*
+- 버튼: `지금 바로 시작` + `로그인`
+
+### 5.6 FAQ (4개)
+
+1. 개인정보가 안전한가요?
+2. 휴대폰으로도 잘 되나요?
+3. 연차 잔여일은 어떻게 확인하나요?
+4. 실수로 출근 체크 빼먹으면요?
+
+## 6. 공통 디자인 토큰
+
+| 용도 | `/owner` | `/staff` |
+|---|---|---|
+| 히어로 배경 | `slate-950` 다크 | 파스텔 그라데이션(amber-50 → rose-100 → violet-100) |
+| 주 액센트 | 블루(#3b82f6) → 인디고(#6366f1) | 핑크(#ec4899) → 바이올렛(#8b5cf6) |
+| CTA 버튼 | 그라데이션 솔리드 | 슬레이트-900 + 화이트 보조 |
+| 헤더 variant | `dark` | `light` |
+| 톤 | 신뢰·경영·무게감 | 가볍고 따뜻함·"~요~" 말투 |
+
+**선택 페이지(`/`)**: 카드별로 위 액센트를 각각 사용해 두 경로를 시각적으로 예고
+
+**타이포 (공통)**
+- 헤드라인: `text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold leading-[1.15] tracking-tight`
+- 서브카피: `text-lg sm:text-xl leading-relaxed`
+- 기존 Tailwind 토큰(`at-text`, `at-accent`, `at-border` 등) 유지
+
+## 7. 공유 컴포넌트 계약
+
+### `LandingHeader.tsx`
+```ts
+interface LandingHeaderProps {
+  variant: 'dark' | 'light'
+  onShowLogin: () => void
+  onShowSignup: () => void
+}
+```
+
+### `AuthFlow.tsx`
+- 기존 `AuthApp.tsx`의 상태 관리 로직(`'landing' | 'login' | 'signup' | 'forgotPassword'`)을 재사용 래퍼로 분리
+- `children`이 아닌 **렌더 프롭** 방식으로 랜딩 컴포넌트에 콜백 주입:
+  ```tsx
+  <AuthFlow>
+    {({ onShowLogin, onShowSignup }) => (
+      <OwnerLanding onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
+    )}
+  </AuthFlow>
+  ```
+- `LoginForm`·`SignupForm`·`ForgotPasswordForm` 전환, `?show=login|signup` 쿼리 파라미터 지원
+- 인증된 사용자 → `/dashboard` 리디렉션 (기존 AuthApp 로직 그대로 이식)
+
+### `useVisitorRole.ts`
+```ts
+type VisitorRole = 'owner' | 'staff'
+function useVisitorRole(): {
+  role: VisitorRole | null
+  setRole: (role: VisitorRole) => void
+  clearRole: () => void
+}
+```
+- localStorage 키: `clinicmgr.visitor_role`
+- SSR 환경 대응 (hydration mismatch 방지 — 초기값 null 후 useEffect로 읽기)
+
+## 8. 구현 순서
+
+1. `shared/` 공용 유틸 추출 — `useVisitorRole`, `ScrollAnimation`, `TypeWriter`, `CountUp`
+2. `AuthFlow.tsx` 작성 (기존 `AuthApp` 로직 이식)
+3. `LandingHeader.tsx` 작성
+4. `RoleSelector.tsx` + `app/page.tsx` 교체 (자동 리디렉션 포함)
+5. `OwnerLanding.tsx` + `app/owner/page.tsx`
+6. `StaffLanding.tsx` + `app/staff/page.tsx`
+7. 기존 `AuthApp.tsx`, `LandingPage.tsx` 제거
+8. `npm run build` — 빌드·타입 에러 확인 및 수정 반복
+9. 브라우저 수동 확인:
+   - `/` 자동 리디렉션 동작 (localStorage 있음/없음 두 케이스)
+   - `/owner`, `/staff` 렌더링 확인
+   - 로그인/회원가입 전환(`?show=login`, `?show=signup`)
+   - 테스트 계정(`whitedc0902@gmail.com`)으로 로그인 → `/dashboard` 리디렉션
+   - 선택 기억 해제 버튼
+10. Git commit → `develop` 브랜치 push
+
+## 9. 실제 서비스 대비 보완 사항 (요약)
+
+기존 랜딩에서 수정·보완된 항목:
+
+| 항목 | 변경 |
+|---|---|
+| 근로계약서 | "전자서명으로 간편하게" → "템플릿 기반 계약서 관리" (구현 상태와 일치) |
+| 급여 명세서 | 기존 랜딩 누락 → Features에 추가 |
+| 환자 리콜 관리 | 기존 랜딩 미표기 → Problem 리스트·일일보고 설명에 반영 |
+| 업무 체크리스트 | 기존 랜딩 미표기 → `/staff` Features에 추가 |
+| 선물 재고 관리 | 기존 랜딩 미표기 → Problem·`/staff` Features에 반영 |
+| 팀 커뮤니티/텔레그램 | 기존 랜딩 미표기 → `/staff` Features에 추가 |
+| 프리미엄 패키지(₩499,000) | 기존 랜딩 미표기 → `/owner` Premium 섹션 신규 |
+| AI 분석 / 경영현황 / 마케팅 자동화 | 기존 랜딩 미표기 → `/owner` Premium 섹션 3카드 |
+
+## 10. 범위 외 (YAGNI)
+
+- 로그인/회원가입 UI 자체의 재설계 (기존 그대로 재사용)
+- 회원가입 시 역할(owner/staff) prefill — 랜딩은 마케팅 분기일 뿐, 실제 가입 폼은 공통 유지
+- `/dashboard` 이후 화면 변경
+- `AuthContext`, `middleware.ts` 수정
+- 다국어 대응
+- 동료 후기 섹션 (실제 후기 확보 후 별도 작업)

--- a/dental-clinic-manager/docs/superpowers/specs/2026-04-19-subscription-headcount-gating-design.md
+++ b/dental-clinic-manager/docs/superpowers/specs/2026-04-19-subscription-headcount-gating-design.md
@@ -1,0 +1,452 @@
+# 구독 플랜 개편: 직원 수 기반 게이팅 + 통합 플랜 화면
+
+- **작성일**: 2026-04-19
+- **작성자**: huisu-hwang (brainstorming by Claude)
+- **대상 브랜치**: `develop`
+- **관련 커밋**: `415ee1c9 feat(premium): AI분석+경영현황+마케팅을 프리미엄 패키지(499,000원)로 통합`
+
+## 1. 배경 및 문제
+
+현재 구독 체계는 아래 두 가지 문제가 있다.
+
+1. **요금제가 직원 수와 연동되지 않음**: 기본 기능(근태/직원관리/게시판 등)이 모든 병원에 동일 가격(또는 무료)으로 제공되고 있어, 인원이 많은 병원도 과금되지 않는다.
+2. **플랜 선택 UX 분절**: `PlanSelectModal`이 "인원별 플랜"과 "기능별 추가" 두 탭으로 나뉘어 있어 전체 체계가 한눈에 들어오지 않는다.
+3. **주식 자동매매 가격 오표기**: 실제로는 "수익의 5%"인데 메뉴/홍보 카드 곳곳에서 "무료"처럼 노출되는 지점이 남아 있다.
+
+본 스펙은 위 세 문제를 한 번에 해결한다.
+
+## 2. 목표 (Goals)
+
+1. **기본 기능을 직원 수 구간별로 차등 과금**: 5인 미만 무료, 이상은 구간별 정액.
+2. **원장이 결제 전에 직원을 추가로 승인할 수 없도록 홀드**하고, 결제 알람을 다층으로 확실히 전달.
+3. **플랜 선택 화면을 한 화면으로 통합**하고 카테고리별 색상으로 구분.
+4. **프리미엄 패키지 DB 마이그레이션**을 추가하여 UI(`premium-bundle`)와 DB 불일치를 해소.
+5. **주식 자동매매의 "수익의 5%"를 명확히 표시**하고, 월별 수익 스냅샷 기반으로 예정 정산액을 원장이 인지할 수 있게 한다.
+
+## 3. 비목표 (Non-Goals)
+
+- 주식 자동매매 5%의 실제 자동 청구 / 인보이스 발행 / 증권사 연동 (별도 프로젝트).
+- 기존 개별 feature 플랜(`feature-ai-analysis`, `feature-financial`, `feature-marketing`) 구독자의 강제 이관. 기존 구독은 유지되며 `PremiumGate`가 호환 처리한다.
+- 다국어, 달러 결제, 환율 대응.
+
+## 4. 확정 요구사항 요약
+
+### 4.1 인원 구간별 과금 (기본 플랜)
+| 플랜 | 인원 | 월 가격 |
+|---|---|---|
+| Free | 1~4명 | 0원 |
+| Starter | 5~10명 | 39,000원 |
+| Growth | 11~20명 | 79,000원 |
+| Pro | 21~50명 | 149,000원 |
+| Enterprise | 51명+ | 맞춤 문의 |
+
+### 4.2 프리미엄 패키지
+- AI 분석 + 경영 현황 + 마케팅 자동화 통합
+- 월 **499,000원** (DB `premium-bundle` 신규)
+
+### 4.3 주식 자동매매
+- 구독료 0원, **수익의 5%** (성과 연동)
+- 이번 스펙에서는 UI 명확화 + 월별 수익 스냅샷까지
+
+### 4.4 홀드 로직
+- 스태프 가입 요청은 기존처럼 `pending`으로 저장.
+- **원장이 승인할 때** 인원 상한 초과 여부를 검사.
+- 초과 시 승인 차단 + `UpgradeRequiredModal` 표시.
+- 결제 완료 시 "전체 자동 승인 / 개별 승인" 토글을 원장에게 제공.
+
+### 4.5 알림 (다층)
+1. 승인 시점 차단 모달
+2. `user_notifications`에 인앱 알림 생성
+3. 대시보드 상단 고정 배너 ("직원 N명 승인 대기 중")
+
+### 4.6 다운그레이드
+- 직원 퇴사 / 원장 수동 다운그레이드 시 **일할 기준 즉시 부분 환불** (포트원 부분 환불 API).
+
+### 4.7 통합 UI
+- `PlanSelectModal`의 탭 구조 제거.
+- 단일 스크롤 화면에 3개 섹션:
+  - 🟦 파랑: 기본 플랜
+  - 🟪 보라: 프리미엄 패키지
+  - 🟩 초록: 성과 연동 (주식 자동매매)
+
+## 5. 시스템 아키텍처
+
+### 5.1 컴포넌트 변경 맵
+| 영역 | 파일 | 변경 |
+|---|---|---|
+| DB 마이그레이션 | `supabase/migrations/20260419_subscription_headcount_gating.sql` | 신규 |
+| 플랜 유틸 | `src/lib/subscriptionPlans.ts` | 신규 (`findPlanByHeadcount`, `formatPlanPrice`) |
+| 구독 조회 유틸 | `src/lib/subscriptionService.ts` (기존 확장) | `getCurrentPlan`, `countActiveEmployees` |
+| 승인 API | `src/app/api/admin/users/approve/route.ts` | 인원 상한 가드 추가 |
+| 벌크 자동 승인 API | `src/app/api/admin/users/approve-bulk-auto/route.ts` | 신규 |
+| 다운그레이드 API | `src/app/api/subscription/downgrade/route.ts` | 신규 |
+| 포트원 클라이언트 | `src/lib/portone.ts` | `partialRefund` 추가 |
+| 포트원 웹훅 | `src/app/api/webhooks/portone/route.ts` | 결제 성공 시 `subscription_payment_succeeded` 알림 생성 |
+| 크론 API | `src/app/api/investment/profit-snapshot/route.ts` | 신규 (말일 가드) |
+| 수동 재집계 API | `src/app/api/investment/profit-snapshot/refresh/route.ts` | 신규 |
+| 수익 계산 유틸 | `src/lib/investmentProfit.ts` | 신규 |
+| 플랜 선택 모달 | `src/components/Subscription/PlanSelectModal.tsx` | 리팩터 (탭 제거, 3섹션) |
+| 업그레이드 필요 모달 | `src/components/Subscription/UpgradeRequiredModal.tsx` | 신규 |
+| 결제 후 승인 모달 | `src/components/Subscription/PostPaymentApprovalModal.tsx` | 신규 |
+| 대기 배너 | `src/components/Dashboard/PendingApprovalBanner.tsx` | 신규 |
+| 성과 섹션 | `src/components/Subscription/PerformanceSection.tsx` | 신규 |
+| 직원 관리 | `src/components/Management/StaffManagement.tsx` | 승인 실패 시 모달 트리거 분기 |
+| 알림 타입 | `src/types/notification.ts` | enum 확장 |
+| 메뉴/홍보 카드 | `src/config/menuConfig.ts` 외 | "수익의 5%" 문구 전수 검수 및 `formatPlanPrice` 적용 |
+| Vercel Cron | `vercel.json` | `profit-snapshot` 스케줄 추가 |
+
+### 5.2 데이터 흐름
+1. 스태프 가입 요청 → `users.status='pending'`
+2. 원장 승인 → `/api/admin/users/approve` 호출 → 인원 상한 가드
+   - 상한 내 → 즉시 `approved`
+   - 초과 → 403 + `UPGRADE_REQUIRED` + 권장 플랜
+3. `UpgradeRequiredModal`에서 "지금 결제" → `PlanSelectModal` → 포트원 결제
+4. 포트원 웹훅 → `subscriptions.status='active'` + 원장 알림 생성
+5. 원장 대시보드 자동 감지 → `PostPaymentApprovalModal` 노출
+   - 전체 자동 승인 → 신규 상한까지 `created_at` 오름차순 일괄 승인
+   - 개별 승인 → 인원 관리 페이지로 이동
+
+## 6. 데이터베이스 스키마 변경
+
+### 6.1 `subscription_plans` 업데이트 및 신규
+```sql
+-- Free 상단 4명, Starter 하단 5명으로 조정
+UPDATE subscription_plans SET max_users = 4 WHERE name = 'free';
+UPDATE subscription_plans SET min_users = 5 WHERE name = 'starter';
+
+-- 프리미엄 패키지 신규
+INSERT INTO subscription_plans
+  (name, display_name, type, feature_id, price, description, features, sort_order)
+VALUES
+  ('premium-bundle', '프리미엄 패키지', 'feature', 'premium-bundle', 499000,
+   'AI 분석 + 경영 현황 + 마케팅 자동화 통합',
+   '["AI 데이터 분석","경영 현황 관리","마케팅 자동화"]', 9)
+ON CONFLICT (name) DO UPDATE
+  SET price = EXCLUDED.price,
+      feature_id = EXCLUDED.feature_id,
+      description = EXCLUDED.description,
+      features = EXCLUDED.features;
+
+-- 주식 자동매매 명시
+INSERT INTO subscription_plans
+  (name, display_name, type, feature_id, price, description, features, sort_order)
+VALUES
+  ('feature-investment', '주식 자동매매', 'feature', 'investment', 0,
+   '수익의 5% 성과 연동 과금',
+   '["AI 자동매매 전략","실시간 포트폴리오","백테스트"]', 13)
+ON CONFLICT (name) DO UPDATE
+  SET description = EXCLUDED.description;
+```
+
+`price = 0`이지만 UI는 `priceLabel: '수익의 5%'` + `formatPlanPrice` 유틸로 "수익의 5%"로 렌더.
+
+### 6.2 `investment_profit_snapshots` (신규)
+```sql
+CREATE TABLE investment_profit_snapshots (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  year INT NOT NULL,
+  month INT NOT NULL CHECK (month BETWEEN 1 AND 12),
+  realized_profit NUMERIC(15,2) NOT NULL DEFAULT 0,
+  unrealized_profit NUMERIC(15,2) NOT NULL DEFAULT 0,
+  expected_fee NUMERIC(15,2) GENERATED ALWAYS AS
+    (GREATEST(realized_profit, 0) * 0.05) STORED,
+  snapshot_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (clinic_id, year, month)
+);
+
+CREATE INDEX idx_investment_profit_clinic_ym
+  ON investment_profit_snapshots (clinic_id, year DESC, month DESC);
+
+ALTER TABLE investment_profit_snapshots ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "클리닉 멤버만 조회"
+  ON investment_profit_snapshots FOR SELECT
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+```
+
+### 6.3 `subscription_payments` 환불 컬럼
+```sql
+ALTER TABLE subscription_payments
+  ADD COLUMN IF NOT EXISTS refunded_amount NUMERIC(15,2) DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS refund_reason TEXT,
+  ADD COLUMN IF NOT EXISTS refunded_at TIMESTAMPTZ;
+```
+
+### 6.4 `user_notifications` 타입 enum 확장
+코드에서만 확장 (DB는 TEXT 컬럼 가정):
+- `subscription_upgrade_required`
+- `subscription_payment_succeeded`
+
+### 6.5 `clinics.current_plan_id` 확인/추가
+실제 스키마에 이미 있는지 마이그레이션 작성 시 점검. 없으면:
+```sql
+ALTER TABLE clinics
+  ADD COLUMN IF NOT EXISTS current_plan_id UUID REFERENCES subscription_plans(id);
+```
+
+## 7. 홀드·결제 게이트 로직 상세
+
+### 7.1 인원 상한 가드 (서버)
+`POST /api/admin/users/approve`가 승인 대상 `userIds`를 받은 뒤 기존 로직 앞에 삽입:
+
+```ts
+const activeCount = await countActiveEmployees(clinicId);
+const projected = activeCount + userIds.length;
+const currentPlan = await getCurrentPlan(clinicId) ?? FREE_PLAN;
+if (projected > currentPlan.max_users) {
+  const recommendedPlan = await findPlanByHeadcount(projected);
+  return NextResponse.json({
+    error: 'UPGRADE_REQUIRED',
+    currentPlan: currentPlan.name,
+    currentLimit: currentPlan.max_users,
+    currentActive: activeCount,
+    pendingToApprove: userIds.length,
+    recommendedPlan,
+  }, { status: 403 });
+}
+```
+
+### 7.2 플랜 매핑 유틸
+```ts
+// src/lib/subscriptionPlans.ts
+export function findPlanByHeadcount(total: number): PlanName {
+  if (total <= 4) return 'free';
+  if (total <= 10) return 'starter';
+  if (total <= 20) return 'growth';
+  if (total <= 50) return 'pro';
+  return 'enterprise';
+}
+
+export function formatPlanPrice(plan: SubscriptionPlan): string {
+  if (plan.feature_id === 'investment') return '수익의 5%';
+  if (plan.name === 'enterprise') return '맞춤 문의';
+  if (plan.price === 0) return '무료';
+  return `월 ${plan.price.toLocaleString()}원`;
+}
+```
+
+### 7.3 `UpgradeRequiredModal`
+- 상단: "현재 X명 / 상한 Y명 · Z명이 대기 중"
+- 추천 플랜 카드(가격/구간) + "다른 플랜 보기" → `PlanSelectModal` 오픈
+- CTA: `지금 결제하기` / `나중에 결제`
+- "나중에 결제" 클릭 시 `subscription_upgrade_required` 알림 생성
+
+### 7.4 결제 완료 후 자동 승인
+웹훅 `payment.completed`:
+```ts
+await updateSubscriptionActive(clinicId, planId);
+const pending = await listPending(clinicId);
+if (pending.length > 0) {
+  await userNotificationService.createNotification({
+    userId: ownerId,
+    type: 'subscription_payment_succeeded',
+    payload: { pendingCount: pending.length, newLimit: newPlan.max_users },
+  });
+}
+```
+
+`PostPaymentApprovalModal`:
+- 트리거: 대시보드 `useEffect`에서 `subscription_payment_succeeded` 미읽음 알림 감지
+- 두 CTA:
+  - **전체 자동 승인** → `/api/admin/users/approve-bulk-auto`
+  - **개별 승인** → `/management?tab=requests` 이동
+- 대기자 수 > 신규 상한 여유일 때 경고 표시
+
+### 7.5 `PendingApprovalBanner`
+- 위치: `src/app/dashboard/page.tsx` 상단
+- 조건: `user.role === 'owner'` && `pendingCount > 0`
+- 문구: "직원 N명이 승인 대기 중 · **지금 확인**"
+
+## 8. 통합 플랜 화면 UI
+
+### 8.1 구조
+```
+┌─ 구독 플랜 (현재: Starter · 8/10명) ─────────┐
+│ 🟦 기본 플랜                                  │
+│  [Free][Starter*][Growth][Pro][Enterprise]   │
+│                                               │
+│ 🟪 프리미엄 패키지                            │
+│  [ AI분석+경영현황+마케팅 · 월 499,000원 ]    │
+│                                               │
+│ 🟩 성과 연동                                  │
+│  [ 주식 자동매매 · 구독료 0 + 수익 5% ]       │
+│  이번 달 예정 정산: 62,500원 🔄               │
+└───────────────────────────────────────────────┘
+```
+
+### 8.2 색상 토큰
+| 섹션 | 헤더 | 카드 배경 | 액센트 | 아이콘 |
+|---|---|---|---|---|
+| 기본 | `bg-blue-500` | `bg-blue-50 dark:bg-blue-950/30` | `ring-blue-500` | Users |
+| 프리미엄 | `bg-purple-500` | `bg-purple-50 dark:bg-purple-950/30` | `ring-purple-500` | Sparkles |
+| 성과 | `bg-emerald-500` | `bg-emerald-50 dark:bg-emerald-950/30` | `ring-emerald-500` | TrendingUp |
+
+### 8.3 카드 상태
+| 상태 | 시각 |
+|---|---|
+| current | "현재 이용 중" 배지 + `ring-2` |
+| available | 기본 외관 + "구독하기"/"업그레이드" |
+| downgrade | 회색톤 + "다운그레이드" |
+| disabled | grayout + tooltip ("현재 N명 재직") |
+
+### 8.4 반응형·접근성
+- 모바일(`<640px`): 기본 플랜 5카드 세로 스택
+- 태블릿: 기본 플랜 2~3열 그리드
+- 섹션 헤더 `<h2>` + `aria-labelledby`
+- 포커스: `focus-visible:ring-2 ring-offset-2`
+- 색 외에 배지 텍스트로도 상태 구분
+
+### 8.5 `menuConfig.ts` 및 기타 가격 표시 일관화
+- `formatPlanPrice` 유틸을 모든 가격 렌더 지점에 적용
+- "무료" 문구가 주식 자동매매 컨텍스트에 남아 있는지 전수 검수
+
+## 9. 다운그레이드 및 환불
+
+### 9.1 트리거
+- `users.employment_status: active → resigned/terminated`
+- `users.deleted_at` 설정 (hard/soft delete)
+- 원장이 `PlanSelectModal`에서 낮은 카드 선택
+
+### 9.2 계산 공식
+```
+refund = floor((currentPlan.price - newPlan.price) × remainDays / totalDays)
+```
+- `totalDays`: `current_period_start ~ current_period_end` 일수
+- `remainDays`: `today ~ current_period_end` 일수
+- 같은 구간 내 감소는 `no_change`로 0원
+
+### 9.3 트랜잭션
+```sql
+BEGIN;
+  UPDATE subscription_payments
+     SET refunded_amount = refunded_amount + :amount,
+         refund_reason   = :reason,
+         refunded_at     = NOW()
+   WHERE id = :paymentId;
+
+  UPDATE subscriptions
+     SET plan_id = :newPlanId,
+         updated_at = NOW()
+   WHERE clinic_id = :clinicId AND status = 'active';
+COMMIT;
+```
+
+### 9.4 포트원 호출
+```ts
+export async function partialRefund(p: {
+  portone_payment_id: string;
+  amount: number;
+  reason: string;
+}): Promise<void>
+```
+- 실패 시 DB 트랜잭션 롤백 + 에러 모달 + `master_admin` 알림
+- 포트원 취소 정책(7일 등) 만료 시 "다음 결제 주기부터 자동 하향" 폴백
+
+### 9.5 재조정 헬퍼
+```ts
+// src/lib/subscriptionReconciler.ts
+export async function reconcileSubscriptionOnHeadcountChange(clinicId: string) {
+  const activeCount = await countActiveEmployees(clinicId);
+  const target = findPlanByHeadcount(activeCount);
+  const current = await getActiveSubscription(clinicId);
+  if (current.plan.name !== target) {
+    await requestDowngrade({ clinicId, newPlanName: target });
+  }
+}
+```
+
+## 10. 주식 수익 스냅샷
+
+### 10.1 크론
+`vercel.json`에 매일 스케줄 추가 후 API가 "말일" 가드:
+```json
+{ "crons": [
+  { "path": "/api/investment/profit-snapshot", "schedule": "5 15 * * *" }
+] }
+```
+(UTC 15:05 = KST 00:05)
+
+### 10.2 API
+```ts
+// /api/investment/profit-snapshot
+// - Authorization: Bearer CRON_SECRET 검증
+// - 말일 아니면 skipped 반환
+// - 주식 자동매매 활성 클리닉 대상 calculateMonthlyProfit 실행 후 upsert
+
+// /api/investment/profit-snapshot/refresh
+// - owner 권한, throttle 5분/회
+// - 당월/지정월 즉시 재집계
+```
+
+### 10.3 수익 계산
+```ts
+export async function calculateMonthlyProfit(
+  clinicId: string, year: number, month: number
+): Promise<{ realized: number; unrealized: number }>
+```
+- `investment_transactions`의 `side='sell'` + `executed_at` 월 범위에서 `realized_pnl - fee - tax` 합
+- `investment_positions`에서 `(current_price - avg_price) × quantity` 합
+- 실제 컬럼명은 구현 시 `src/types/investment.ts`와 매칭
+
+### 10.4 UI
+`PerformanceSection`에 이번 달 실현/평가/예정 정산 5% + 지난 3개월 히스토리. 수동 재집계 🔄 버튼은 5분 throttle.
+
+## 11. 에러 처리 / 엣지 케이스
+
+| 상황 | 처리 |
+|---|---|
+| 결제 실패 웹훅 | `subscription.status='past_due'` + 재결제 유도 알림 |
+| 포트원 환불 실패 | 트랜잭션 롤백 + 재시도 모달 + 마스터 알림 |
+| 중복 승인 시도 | 동일 403 재노출 (모달 다시 열림) |
+| 원장 없는 클리닉 | 알림을 `master_admin`에게 병행 전송 |
+| Enterprise | 결제 대신 "문의하기" CTA |
+| 기존 feature 플랜 구독자 | 기존 구독 유지, `PremiumGate`에서 OR 조건으로 호환 |
+| 재직자 수 > 새 플랜 상한 다운그레이드 시도 | 차단 + "재직자 먼저 조정" 안내 |
+| 크론 중복 실행 | `ON CONFLICT (clinic_id,year,month)` upsert로 idempotent |
+
+## 12. 테스트 계획 요약
+
+### 12.1 수동 E2E (Chrome DevTools MCP)
+- 시나리오 A~I (Section 7 참조): 홀드·결제·자동 승인·다운그레이드·환불·색 구분 UI·주식 스냅샷
+- 테스트 계정: `whitedc0902@gmail.com` (원장) / `sani81@gmail.com` (마스터)
+
+### 12.2 DB 검증
+- 마이그레이션 후 `subscription_plans` 경계값, `premium-bundle` 존재, RLS 정책, GENERATED 컬럼 동작
+
+### 12.3 회귀
+- Free 병원 일상 기능 (출퇴근/게시판/스케줄)
+- 기존 feature 플랜 구독자의 프리미엄 기능 접근 유지
+
+### 12.4 빌드/배포
+- `npm run build` 0 에러
+- `npm run lint` 무경고 목표
+- Vercel Preview에서 E2E 재수행 후 `develop` 푸시
+
+## 13. 구현 순서 (하이레벨)
+
+1. DB 마이그레이션 + 플랜 유틸 + `formatPlanPrice` 적용
+2. 승인 API 가드 + `UpgradeRequiredModal`
+3. 포트원 웹훅 확장 + `PostPaymentApprovalModal` + 벌크 자동 승인 API
+4. `PendingApprovalBanner` + 알림 타입 확장
+5. 다운그레이드 API + 포트원 부분 환불 + UI 확인 모달
+6. `PlanSelectModal` 리팩터 (탭 제거 → 3섹션 색 구분)
+7. 주식 수익 스냅샷 테이블 + 크론 + `PerformanceSection`
+8. 전체 E2E 시나리오 수행 → 회귀 검사 → develop 푸시
+
+세부 스텝/파일 단위 작업은 구현 플랜(Implementation Plan)에서 분해한다.
+
+## 14. 미해결 항목
+
+- `clinics.current_plan_id`가 실제 스키마에 존재하는지 (마이그레이션 시 확인)
+- `investment_transactions` / `investment_positions` 테이블의 실제 컬럼명 (구현 시 확정)
+- Vercel Cron `L` 미지원 확정 여부 — 현재 설계는 매일 실행 + 말일 가드로 대응
+
+## 15. 참고 자료
+
+- 경쟁사 조사:
+  - 시프티 (per-seat 2,000~4,000원/인월, 일할 계산)
+  - Notion/Slack (free tier + per-seat 유료)
+  - Dentrix/Curve ($150~500/provider/월)
+- 프로젝트 컨벤션: 상위 `CLAUDE.md` 및 `.claude/CLAUDE.md`
+- 기존 구현: `supabase/migrations/20260418_subscription_system.sql`, `src/lib/portone.ts`, `src/components/Subscription/PlanSelectModal.tsx`, `src/config/menuConfig.ts`, `src/hooks/usePremiumFeatures.ts`

--- a/dental-clinic-manager/docs/superpowers/specs/2026-04-19-worker-guard-modal-design.md
+++ b/dental-clinic-manager/docs/superpowers/specs/2026-04-19-worker-guard-modal-design.md
@@ -1,0 +1,340 @@
+# 통합 워커 가드 모달 강화 설계
+
+- 작성일: 2026-04-19
+- 작업 유형: 기능 개선 (UX 강화)
+- 상태: 설계 완료 / 구현 대기
+
+## 개요
+
+통합 워커가 필요한 기능을 사용자가 실행할 때, 워커가 **미설치** 또는 **오프라인** 상태이면 현재는 단순 `appAlert`로 "관리자에게 요청해주세요"라고만 안내한다. 이 안내에는 설치 링크도, 재시작/재설치 가이드도 없어 사용자가 스스로 문제를 해결할 수 없다.
+
+본 작업은 기존 `useWorkerGuard` / `requireWorker` API 시그니처를 유지하면서 가드 내부의 안내 팝업만 강화한다.
+
+- 미설치: **다운로드 버튼 + 5단계 설치 가이드**가 포함된 모달
+- 오프라인: **자동 재시도(5초×3회) + 재시작 가이드 + 재설치 버튼**이 포함된 모달
+
+## 배경 및 현황
+
+### 기존 인프라 (재사용)
+
+| 파일 | 역할 |
+|---|---|
+| [src/hooks/useWorkerStatus.ts](../../../src/hooks/useWorkerStatus.ts) | 상태 확인 hook (DB heartbeat + 로컬 ping) |
+| [src/hooks/useWorkerGuard.ts](../../../src/hooks/useWorkerGuard.ts) | 가드 hook + 모듈 함수 `requireWorker` |
+| [src/components/WorkerStatusBanner.tsx](../../../src/components/WorkerStatusBanner.tsx) | 상태 배너 (변경 없음) |
+| [src/app/api/workers/status/route.ts](../../../src/app/api/workers/status/route.ts) | 5종 워커 상태 통합 조회 API |
+| [src/app/api/marketing/worker-api/download/route.ts](../../../src/app/api/marketing/worker-api/download/route.ts) | OS 분기 다운로드 URL API (Windows `.exe` / Mac `.dmg`+스크립트) |
+
+### 통합 워커 가정
+
+5종 워커(`marketing`, `scraping`, `seo`, `dentweb`, `email`)는 **하나의 통합 워커 프로그램**에 속한다. 따라서:
+
+- 다운로드 링크는 1개 (기존 `/api/marketing/worker-api/download` 재사용)
+- 가드 메시지/UI는 워커 타입과 무관하게 동일
+- 단, 호출 시 전달되는 `featureName`(예: "AI 글 발행", "홈택스 동기화")은 그대로 모달에 노출
+
+### 가드 호출처 (기존)
+
+| 파일 | 호출 |
+|---|---|
+| [src/app/dashboard/marketing/posts/new/page.tsx](../../../src/app/dashboard/marketing/posts/new/page.tsx) | `requireWorker('marketing', 'AI 글 발행')` |
+| [src/components/SEO/KeywordAnalysis.tsx](../../../src/components/SEO/KeywordAnalysis.tsx) | `requireWorker('seo', 'SEO 키워드 분석')` |
+| [src/components/Financial/HometaxSyncPanel.tsx](../../../src/components/Financial/HometaxSyncPanel.tsx) | `requireWorker('scraping', '홈택스 동기화')` |
+| [src/hooks/useWorkerGuard.ts](../../../src/hooks/useWorkerGuard.ts) | `useWorkerGuard({ type, featureName })` 훅 정의 |
+
+이 4곳의 호출 시그니처는 **변경하지 않는다**.
+
+## 목표 / 비목표
+
+### 목표
+
+- 미설치 사용자가 **다운로드 → 설치 → 재확인**을 모달 안에서 완결할 수 있다
+- 오프라인 사용자가 **자동 재시도 + 재시작 가이드**로 자체 해결할 수 있다
+- 5종 워커(`marketing`/`scraping`/`seo`/`dentweb`/`email`) 모두 동일한 모달 경험을 받는다
+- 기존 4곳 호출처는 코드 수정 없이 강화된 동작을 받는다
+
+### 비목표
+
+- 워커 프로세스 자동 시작 (브라우저는 로컬 프로세스 제어 불가)
+- 자동 업데이트 알림 (별도 기능)
+- `dentweb` / `email` 진입 지점에 신규 가드 호출 추가 (별도 PR 권장)
+- 워커 자동 진단(로그 수집 등) — 가시적 상태(설치/온라인)만 판정
+
+## 아키텍처
+
+### 흐름
+
+```
+[사용자가 기능 클릭]
+        ↓
+requireWorker(type, featureName)
+        ↓
+GET /api/workers/status?type=...
+        ↓
+   ┌────┼─────────────┐
+   ↓    ↓             ↓
+[OK]  [미설치]      [오프라인]
+return openWorkerGuardModal({ state: 'not_installed' | 'offline' })
+true              ↓
+            ┌─────┴──────┐
+            ↓            ↓
+         true          false
+       (재확인 성공)  (취소)
+```
+
+### 신규/수정 파일
+
+| 파일 | 종류 | 역할 |
+|---|---|---|
+| `src/components/WorkerGuardModal.tsx` | 신규 | Promise 기반 모달 컴포넌트 + `openWorkerGuardModal()` 헬퍼 |
+| `src/lib/workers/installer.ts` | 신규 | OS 감지 (`detectOS`) + 다운로드 트리거 (`triggerWorkerDownload`) |
+| `src/hooks/useWorkerGuard.ts` | 수정 | `appAlert` 대신 `openWorkerGuardModal` 호출. `guardAction` / `requireWorker`가 모달 결과 반환 |
+| `src/app/api/marketing/worker-api/download/route.ts` | 변경 없음 | OS 분기 그대로 재사용 |
+| `src/components/WorkerStatusBanner.tsx` | 변경 없음 | |
+| 호출처 4개 파일 | 변경 없음 | 시그니처 동일 |
+
+## 컴포넌트 명세
+
+### `WorkerGuardModal` (Promise 기반)
+
+```ts
+type GuardState = 'not_installed' | 'offline'
+type WorkerType = 'marketing' | 'scraping' | 'seo' | 'dentweb' | 'email'
+
+interface OpenOptions {
+  type: WorkerType
+  featureName: string         // 모달 본문에 노출 (예: "AI 글 발행")
+  state: GuardState
+}
+
+export function openWorkerGuardModal(opts: OpenOptions): Promise<boolean>
+// resolve(true)  - 가드 통과 (모달 안에서 [다시 확인] 후 온라인 확인됨)
+// resolve(false) - 사용자 취소 또는 닫기
+```
+
+#### 마운트 방식
+
+- `appAlert`와 동일하게 `createRoot()`로 동적 마운트
+- 모듈 레벨 싱글톤: 이미 열려있으면 기존 Promise를 반환 (중복 호출 방지)
+- 닫힐 때 `root.unmount()` + 컨테이너 DOM 제거
+
+#### 공통 레이아웃
+
+```
+┌──────────────────────────────────────────┐
+│ 통합 워커 [상태 라벨]                  ✕ │
+├──────────────────────────────────────────┤
+│ {featureName} 기능을 사용하려면 통합     │
+│ 워커가 [필요/실행 중이어야] 합니다.      │
+│                                          │
+│ [상태별 가이드 박스]                     │
+│ [상태별 보조 영역]                       │
+├──────────────────────────────────────────┤
+│        [상태별 액션 버튼들]              │
+└──────────────────────────────────────────┘
+```
+
+### 케이스 A: `state="not_installed"`
+
+- **헤더**: `통합 워커 미설치`
+- **본문 첫 줄**: `{featureName} 기능을 사용하려면 통합 워커가 설치되어 있어야 합니다.`
+- **가이드 박스 (5단계)**:
+  1. 아래 [통합 워커 다운로드] 버튼 클릭
+  2. 다운로드된 `clinic-manager-worker-x.x.x-setup.exe` 실행
+  3. 설치 마법사 안내에 따라 진행
+  4. 설치 완료 후 자동 실행됨 (트레이 아이콘 확인)
+  5. 1분 후 [다시 확인] 클릭
+- **버튼**: `[취소]` `[다시 확인]` `[통합 워커 다운로드]` (primary)
+- **자동 재시도**: **없음** (사용자 액션 필요)
+
+### 케이스 B: `state="offline"`
+
+- **헤더**: `통합 워커 응답 없음`
+- **본문 첫 줄**: `{featureName} 기능을 사용하려면 통합 워커가 실행 중이어야 합니다.`
+- **가이드 박스 (4단계)**:
+  1. 작업 표시줄 우측 트레이 영역 확인
+  2. 통합 워커 아이콘 우클릭 → "종료"
+  3. 시작 메뉴에서 통합 워커 재실행
+  4. 1분 후 [다시 확인] 클릭
+- **자동 재시도 영역**:
+  - 모달 열림 시 자동 시작
+  - 5초 간격, 최대 3회 (총 15초)
+  - 표시: `[자동 재시도] ●●○ (2/3) — 5초 후 다시 확인...` (점 인디케이터 + 카운트다운)
+  - 성공 시: 모달 닫고 즉시 `true` 반환
+  - 3회 모두 실패: `자동 확인 종료. 워커를 재시작 후 [다시 확인]을 눌러주세요.` 표시
+  - 수동 [다시 확인] 클릭 시: 자동 카운터 리셋 후 즉시 1회 ping → 실패하면 다시 자동 5초×3회 반복
+- **버튼**: `[취소]` `[재설치]` `[다시 확인]` (primary)
+  - `[재설치]`는 다운로드 동작과 동일 (`triggerWorkerDownload`)
+- **cleanup**: 모달 닫기/취소/언마운트 시 진행 중 타이머 정리
+
+## 다운로드 + OS 감지
+
+### `src/lib/workers/installer.ts`
+
+```ts
+export type DetectedOS = 'windows' | 'mac' | 'unknown'
+
+export function detectOS(): DetectedOS {
+  if (typeof navigator === 'undefined') return 'unknown'
+  const ua = navigator.userAgent
+  if (/Windows/i.test(ua)) return 'windows'
+  if (/Mac OS X|Macintosh/i.test(ua)) return 'mac'
+  return 'unknown'
+}
+
+export async function triggerWorkerDownload(): Promise<
+  | { ok: true }
+  | { ok: false; reason: 'unsupported_os' | 'api_error' }
+> {
+  const os = detectOS()
+  if (os === 'unknown') return { ok: false, reason: 'unsupported_os' }
+
+  try {
+    const res = await fetch(`/api/marketing/worker-api/download?os=${os}`)
+    const contentType = res.headers.get('content-type') || ''
+
+    if (contentType.includes('application/json')) {
+      const data = await res.json() as { downloadUrl?: string }
+      if (!data.downloadUrl) return { ok: false, reason: 'api_error' }
+      window.location.assign(data.downloadUrl)
+      return { ok: true }
+    }
+
+    // Mac shell script (binary): blob 다운로드
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = os === 'mac' ? 'marketing-worker-setup.command' : 'marketing-worker-setup.sh'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+    return { ok: true }
+  } catch {
+    return { ok: false, reason: 'api_error' }
+  }
+}
+```
+
+- Windows: GitHub Release `.exe` URL → `window.location.assign()`로 자동 다운로드
+- Mac DMG: 동일하게 URL → `window.location.assign()`
+- Mac shell: blob → anchor 다운로드
+- Linux/모바일/기타: `unsupported_os` 반환 → 모달에서 토스트 표시
+
+## `useWorkerGuard.ts` 변경
+
+### `WorkerType` 확장 + `WORKER_LABELS` 보완
+
+기존 `WorkerType`은 `'marketing' | 'scraping' | 'seo'`만 정의되어 있다. 통합 워커 가드의 일관성을 위해 `dentweb` / `email`을 추가한다 (호출 자체는 별도 PR이지만 타입은 미리 확장).
+
+```ts
+type WorkerType = 'marketing' | 'scraping' | 'seo' | 'dentweb' | 'email'
+
+const WORKER_LABELS: Record<WorkerType, { defaultFeature: string }> = {
+  marketing: { defaultFeature: '마케팅 기능' },
+  scraping:  { defaultFeature: '데이터 연동' },
+  seo:       { defaultFeature: 'SEO 키워드 분석' },
+  dentweb:   { defaultFeature: '덴트웹 매출 동기화' },
+  email:     { defaultFeature: '이메일 알림' },
+}
+```
+
+`name` 필드(예: "마케팅 워커")는 모달 헤더가 "통합 워커 [상태]"로 고정되므로 더 이상 사용하지 않는다 (제거).
+
+### `showGuardDialog` 변경
+
+```ts
+// Before
+async function showGuardDialog(type, feature, state) {
+  await appAlert({ ... 단순 메시지 ... })
+}
+
+// After
+async function showGuardDialog(
+  type: WorkerType,
+  feature: string,
+  state: WorkerState
+): Promise<boolean> {
+  const guardState: GuardState = !state.installed ? 'not_installed' : 'offline'
+  return openWorkerGuardModal({ type, featureName: feature, state: guardState })
+}
+
+const guardAction = useCallback(async (): Promise<boolean> => {
+  const state = await checkWorkerState(type)
+  if (state.installed && state.online) return true
+  return await showGuardDialog(type, feature, state)
+}, [type, feature])
+
+export async function requireWorker(type, featureName): Promise<boolean> {
+  const state = await checkWorkerState(type)
+  if (state.installed && state.online) return true
+  const label = WORKER_LABELS[type]
+  const feature = featureName || label.defaultFeature
+  return await showGuardDialog(type, feature, state)
+}
+```
+
+### `checkWorkerState` 분기 보완
+
+`/api/workers/status?type=...`는 이미 `dentweb`/`email` 응답 키를 반환하므로 `checkWorkerState` switch에 두 케이스만 추가:
+
+```ts
+if (type === 'dentweb') return { installed: data.dentweb?.installed ?? false, online: data.dentweb?.online ?? false }
+if (type === 'email')   return { installed: data.email?.installed   ?? false, online: data.email?.online   ?? false }
+```
+
+호출처 측면에서 동작 차이:
+
+- **Before**: 가드 실패 시 알럿만 표시하고 `false` 반환. 사용자가 알럿 닫고 다시 버튼 눌러야 함
+- **After**: 가드 실패 시 모달이 자동 재시도/재확인 → 성공하면 `true` 반환. **호출처는 분기 코드를 바꿀 필요 없음** (이미 `if (!await guardAction()) return` 패턴이라 `true` 받으면 자연스럽게 다음 코드 진행)
+
+## 테스트 케이스
+
+### 수동 테스트 (Chrome DevTools MCP)
+
+1. **미설치 케이스**
+   - DB의 `marketing_worker_control` 레코드 임시 삭제
+   - `/dashboard/marketing/posts/new`에서 발행 시도
+   - 모달 열림 → `[통합 워커 다운로드]` 클릭 → `.exe` 다운로드 시작 확인
+   - `[다시 확인]` 클릭 → 여전히 미설치면 모달 유지
+
+2. **오프라인 케이스 (자동 재시도)**
+   - 워커 종료 (heartbeat 60초 경과 대기)
+   - 발행 시도 → 모달 열림 + 자동 재시도 5초×3회 진행 표시
+   - 3회 종료 후 안내 문구 노출
+   - 워커 재실행 → `[다시 확인]` 클릭 → 모달 닫히고 발행 진행
+
+3. **자동 재시도 중 워커 복구**
+   - 모달 열린 상태에서 워커 재실행
+   - 다음 자동 재시도 사이클에 온라인 감지 → 모달 자동 닫힘 → `true` 반환
+
+4. **취소**
+   - `[취소]` 클릭 → 자동 재시도 타이머 정리 → `false` 반환 → 호출처에서 기능 차단
+
+5. **OS 미지원**
+   - DevTools에서 User-Agent를 Linux로 변경 → `[다운로드]` 클릭 → 토스트 안내
+
+### 엣지 케이스
+
+- 모달 열린 채 페이지 이동: cleanup으로 타이머/마운트 정리
+- 연속 호출 (중복 모달): 모듈 레벨 싱글톤으로 1개만 유지
+- API 5초 타임아웃: 자동 재시도 1회로 카운트
+- 네트워크 오류: 자동 재시도 그대로 진행, 마지막 실패 시 안내
+
+## 영향 범위 요약
+
+| 영역 | 변경 |
+|---|---|
+| 신규 파일 | `WorkerGuardModal.tsx`, `lib/workers/installer.ts` |
+| 수정 파일 | `useWorkerGuard.ts` (내부만) |
+| 호출처 4곳 | **수정 없음** |
+| 백엔드 API | **수정 없음** (기존 status / download API 재사용) |
+| DB 스키마 | **변경 없음** |
+
+## 위험 요소
+
+- **자동 재시도 타이머 누수**: cleanup 누락 시 메모리 누수 → 컴포넌트 unmount 훅에서 명시적 clearTimeout 필수
+- **싱글톤 충돌**: 동일 페이지에서 여러 가드가 동시에 실행되는 경우 → 두 번째 호출은 첫 번째 Promise 재사용
+- **OS 감지 부정확**: User-Agent 위조/모바일 데스크톱 모드 → fallback으로 Windows를 기본 추천하는 옵션 고려 가능 (현재 설계는 unsupported로 처리)
+- **다운로드 API 인증**: `/api/marketing/worker-api/download`는 인증 필요. 비로그인 상태에서 가드 발동은 발생하지 않으므로 문제 없음

--- a/dental-clinic-manager/marketing-worker/api-client.ts
+++ b/dental-clinic-manager/marketing-worker/api-client.ts
@@ -117,6 +117,22 @@ export class WorkerApiClient {
     return result.config;
   }
 
+  /** 측정 대상 큐 조회 (마지막 측정 ≥ 6h 또는 미측정) */
+  async listMetricsQueue(limit: number = 20): Promise<MetricsQueueItem[]> {
+    const result = await this.request<{ queue: MetricsQueueItem[] }>(
+      `/post-metrics?limit=${limit}`
+    );
+    return result.queue || [];
+  }
+
+  /** 스크래핑 결과 push */
+  async pushPostMetrics(items: PostMetricsInput[]): Promise<{ inserted: number }> {
+    return this.request('/post-metrics', {
+      method: 'POST',
+      body: JSON.stringify({ items }),
+    });
+  }
+
   /** 발행 로그 기록 + 키워드 이력 */
   async logPublish(params: {
     item_id: string;
@@ -133,4 +149,24 @@ export class WorkerApiClient {
       body: JSON.stringify(params),
     });
   }
+}
+
+export interface MetricsQueueItem {
+  id: string;
+  title: string;
+  publish_date: string;
+  published_urls: Record<string, string> | null;
+  platforms: Record<string, boolean> | null;
+  last_measured_at: string | null;
+}
+
+export interface PostMetricsInput {
+  item_id: string;
+  platform: string;
+  views?: number;
+  comments?: number;
+  likes?: number;
+  scraps?: number;
+  shares?: number;
+  raw_payload?: Record<string, unknown>;
 }

--- a/dental-clinic-manager/marketing-worker/scheduler.ts
+++ b/dental-clinic-manager/marketing-worker/scheduler.ts
@@ -4,7 +4,8 @@ import path from 'path';
 import os from 'os';
 import { CONFIG, isApiMode } from './config.js';
 import { NaverBlogPublisher } from './publisher/naver-blog-publisher.js';
-import { WorkerApiClient, type ScheduledItem } from './api-client.js';
+import { NaverBlogMetricsScraper } from './scraper/naver-blog-metrics.js';
+import { WorkerApiClient, type ScheduledItem, type PostMetricsInput } from './api-client.js';
 
 // ============================================
 // 자동 발행 스케줄러
@@ -131,6 +132,18 @@ export function startScheduler(): void {
       console.error('[Scheduler] 처리 오류:', error);
     }
   });
+
+  // KPI 수집 사이클 — 매 4시간마다 (API 모드에서만)
+  if (isApiMode()) {
+    cron.schedule('0 */4 * * *', async () => {
+      try {
+        await collectPostMetricsCycle();
+      } catch (error) {
+        console.error('[Scheduler] KPI 수집 오류:', error);
+      }
+    });
+    console.log('[Scheduler] KPI 수집 cron 등록 (4시간 간격)');
+  }
 }
 
 /**
@@ -456,5 +469,74 @@ export async function stopScheduler(): Promise<void> {
     await publisher.close();
     publisher = null;
   }
+  if (metricsScraper) {
+    await metricsScraper.close();
+    metricsScraper = null;
+  }
   console.log('[Scheduler] 종료');
+}
+
+// ─── KPI 수집 사이클 ───
+
+let metricsScraper: NaverBlogMetricsScraper | null = null;
+
+/**
+ * 측정 큐를 받아 네이버 블로그 메트릭 일괄 스크래핑 → push
+ * - 한 사이클 최대 10건 (Vercel 응답 시간 고려)
+ * - 항목별 5초 간격 (네이버 차단 회피)
+ */
+export async function collectPostMetricsCycle(): Promise<{ scraped: number; failed: number }> {
+  const client = getApiClient();
+  const queue = await client.listMetricsQueue(10);
+
+  if (queue.length === 0) {
+    console.log('[Metrics] 측정 대상 없음');
+    return { scraped: 0, failed: 0 };
+  }
+
+  console.log(`[Metrics] 측정 시작: ${queue.length}건`);
+
+  if (!metricsScraper) {
+    metricsScraper = new NaverBlogMetricsScraper();
+    await metricsScraper.init(true);
+  }
+
+  const results: PostMetricsInput[] = [];
+  let failed = 0;
+
+  for (const it of queue) {
+    const url = it.published_urls?.naverBlog;
+    if (!url || !it.platforms?.naverBlog) {
+      continue;
+    }
+    try {
+      const m = await metricsScraper.scrape(url);
+      results.push({
+        item_id: it.id,
+        platform: 'naver_blog',
+        views: m.views ?? undefined,
+        comments: m.comments ?? undefined,
+        likes: m.likes ?? undefined,
+        scraps: m.scraps ?? undefined,
+        raw_payload: m.raw_payload,
+      });
+      console.log(`[Metrics] ✓ "${it.title}" views=${m.views} likes=${m.likes} comments=${m.comments}`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`[Metrics] ✗ "${it.title}":`, msg);
+      failed++;
+    }
+    await new Promise((r) => setTimeout(r, 5000)); // 5초 간격
+  }
+
+  if (results.length > 0) {
+    try {
+      const r = await client.pushPostMetrics(results);
+      console.log(`[Metrics] push 완료: ${r.inserted}건`);
+    } catch (e) {
+      console.error('[Metrics] push 실패:', e);
+    }
+  }
+
+  return { scraped: results.length, failed };
 }

--- a/dental-clinic-manager/marketing-worker/scraper/naver-blog-metrics.ts
+++ b/dental-clinic-manager/marketing-worker/scraper/naver-blog-metrics.ts
@@ -1,0 +1,130 @@
+import { chromium, type Browser, type Page } from 'playwright';
+
+// ============================================
+// 네이버 블로그 KPI 스크래퍼
+// - 게시글 URL 방문 → 조회수·공감·댓글·스크랩 추출
+// - 익명 접근 (로그인 불필요) — 조회수 공개 영역만 사용
+// - 페이지 구조 변경에 대비해 여러 selector 시도
+// ============================================
+
+export interface NaverBlogMetrics {
+  views: number | null;
+  comments: number | null;
+  likes: number | null;     // 공감수
+  scraps: number | null;    // 스크랩수
+  raw_payload?: Record<string, unknown>;
+}
+
+export class NaverBlogMetricsScraper {
+  private browser: Browser | null = null;
+
+  async init(headless: boolean = true): Promise<void> {
+    this.browser = await chromium.launch({
+      headless,
+      args: ['--disable-blink-features=AutomationControlled', '--no-sandbox'],
+    });
+  }
+
+  /**
+   * 단건 스크래핑
+   * @param blogUrl 네이버 블로그 게시글 URL
+   *   예: https://blog.naver.com/whitedc0902/223234567890
+   */
+  async scrape(blogUrl: string): Promise<NaverBlogMetrics> {
+    if (!this.browser) throw new Error('init() 호출 필요');
+
+    const context = await this.browser.newContext({
+      viewport: { width: 1280, height: 900 },
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+    });
+
+    const page = await context.newPage();
+
+    try {
+      await page.goto(blogUrl, { waitUntil: 'networkidle', timeout: 30000 });
+
+      // 네이버 블로그는 iframe 내부에 본문이 들어가 있는 경우가 많음
+      const frame =
+        page.frame({ name: 'mainFrame' }) ||
+        page.frames().find((f) => f.url().includes('PostView'));
+      const target = frame || page;
+
+      const metrics: NaverBlogMetrics = {
+        views: null,
+        comments: null,
+        likes: null,
+        scraps: null,
+      };
+
+      // 조회수 — 여러 selector 시도
+      metrics.views = await firstNumber(target, [
+        '.area_visitor .num',                    // 모바일/일부 PC
+        '.blog_count .num',                      // 변종
+        '.post_view_count em, .post_view_count', // 신 에디터
+        'em.post_count',                         // 신 에디터 변종
+        'span.btn_visit_count em',
+      ]);
+
+      // 댓글
+      metrics.comments = await firstNumber(target, [
+        '#commentCount',
+        '.btn_comment em',
+        'em.u_cnt',
+        '.area_comment .num',
+      ]);
+
+      // 공감
+      metrics.likes = await firstNumber(target, [
+        '.u_likeit_text._count',
+        '#viewCntLayer .num',
+        'em.u_likeit_list_module__count',
+        '.like .num',
+      ]);
+
+      // 스크랩
+      metrics.scraps = await firstNumber(target, [
+        '.area_subscribe .num',
+        'em.scrap_count',
+        '.btn_scrap em',
+      ]);
+
+      // 디버깅용 raw payload (제목·URL)
+      const title = await target.title().catch(() => '');
+      metrics.raw_payload = { url: blogUrl, page_title: title };
+
+      return metrics;
+    } finally {
+      await context.close();
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.browser) {
+      await this.browser.close();
+      this.browser = null;
+    }
+  }
+}
+
+/**
+ * 여러 selector를 순회하며 처음으로 매칭되는 숫자를 반환
+ * - 텍스트에서 콤마/공백 제거 후 정수 변환
+ */
+async function firstNumber(
+  ctx: import('playwright').Page | import('playwright').Frame,
+  selectors: string[]
+): Promise<number | null> {
+  for (const sel of selectors) {
+    try {
+      const el = ctx.locator(sel).first();
+      if ((await el.count()) === 0) continue;
+      const txt = (await el.innerText({ timeout: 2000 })).trim();
+      const num = parseInt(txt.replace(/[,\s]/g, ''), 10);
+      if (!Number.isNaN(num)) return num;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}

--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,15 +1,16 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1774521573479'
+const SW_VERSION = 'v1776604688827'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`
 
 self.addEventListener('install', () => {
   console.log(`[SW] Installing version: ${SW_VERSION}`)
-  // 새 SW 설치 즉시 활성화 (대기하지 않음)
-  self.skipWaiting()
+  // skipWaiting은 클라이언트의 SKIP_WAITING 메시지 수신 시에만 호출
+  // (UpdatePrompt에서 사용자가 확인 버튼을 누르거나 자동 카운트다운이 끝난 시점)
+  // 이렇게 해야 사용자 작업 도중 예고 없이 페이지가 reload되지 않음
 })
 
 self.addEventListener('activate', (event) => {

--- a/dental-clinic-manager/scripts/stamp-sw-version.js
+++ b/dental-clinic-manager/scripts/stamp-sw-version.js
@@ -14,7 +14,22 @@ const version = `v${Date.now()}`
 
 try {
   let content = fs.readFileSync(SW_PATH, 'utf-8')
+  const before = content
+
+  // 1) 초기 템플릿 상태: __SW_VERSION__ 플레이스홀더 치환
   content = content.replace(/__SW_VERSION__/g, version)
+
+  // 2) 이미 스탬프된 상태: const SW_VERSION = '...' 라인을 새 타임스탬프로 교체
+  //    (빌드 산출물이 git에 커밋되어 플레이스홀더가 사라진 상태에서도 항상 갱신되도록)
+  content = content.replace(
+    /const\s+SW_VERSION\s*=\s*['"][^'"]*['"]/,
+    `const SW_VERSION = '${version}'`
+  )
+
+  if (content === before) {
+    throw new Error('SW_VERSION 패턴을 찾지 못했습니다. public/sw.js를 확인하세요.')
+  }
+
   fs.writeFileSync(SW_PATH, content, 'utf-8')
   console.log(`[stamp-sw-version] sw.js stamped with version: ${version}`)
 } catch (err) {

--- a/dental-clinic-manager/src/app/api/admin/users/approve/route.ts
+++ b/dental-clinic-manager/src/app/api/admin/users/approve/route.ts
@@ -59,9 +59,9 @@ export async function POST(request: Request) {
     // 요청 바디에서 데이터 추출
     const { userId, clinicId, permissions } = await request.json()
 
-    if (!userId || !clinicId) {
+    if (!userId) {
       return NextResponse.json(
-        { success: false, error: 'userId and clinicId are required' },
+        { success: false, error: 'userId is required' },
         { status: 400 }
       )
     }
@@ -74,15 +74,18 @@ export async function POST(request: Request) {
       }
     })
 
-    console.log('[Admin API - Approve User] Approving user:', userId)
+    console.log('[Admin API - Approve User] Approving user:', userId, 'clinicId:', clinicId ?? 'null')
 
     // 1. 사용자 정보 조회 (이메일 발송용)
-    const { data: userData, error: fetchError } = await supabase
+    // clinic_id가 null인 사용자(예: 시스템 관리자 후보)도 처리한다.
+    const fetchQuery = supabase
       .from('users')
       .select('email, name, clinics(name)')
       .eq('id', userId)
-      .eq('clinic_id', clinicId)
-      .single()
+
+    const { data: userData, error: fetchError } = await (
+      clinicId ? fetchQuery.eq('clinic_id', clinicId) : fetchQuery.is('clinic_id', null)
+    ).single()
 
     if (fetchError || !userData) {
       console.error('[Admin API - Approve User] Error fetching user:', fetchError)
@@ -103,11 +106,14 @@ export async function POST(request: Request) {
       updateData.permissions = permissions
     }
 
-    const { error } = await supabase
+    const updateQuery = supabase
       .from('users')
       .update(updateData)
       .eq('id', userId)
-      .eq('clinic_id', clinicId)
+
+    const { error } = await (
+      clinicId ? updateQuery.eq('clinic_id', clinicId) : updateQuery.is('clinic_id', null)
+    )
 
     if (error) {
       console.error('[Admin API - Approve User] Database error:', error)

--- a/dental-clinic-manager/src/app/api/admin/users/reject/route.ts
+++ b/dental-clinic-manager/src/app/api/admin/users/reject/route.ts
@@ -46,9 +46,9 @@ export async function POST(request: Request) {
     // 요청 바디에서 데이터 추출
     const { userId, clinicId, reason } = await request.json()
 
-    if (!userId || !clinicId || !reason) {
+    if (!userId || !reason) {
       return NextResponse.json(
-        { success: false, error: 'userId, clinicId, and reason are required' },
+        { success: false, error: 'userId and reason are required' },
         { status: 400 }
       )
     }
@@ -61,18 +61,22 @@ export async function POST(request: Request) {
       }
     })
 
-    console.log('[Admin API - Reject User] Rejecting user:', userId)
+    console.log('[Admin API - Reject User] Rejecting user:', userId, 'clinicId:', clinicId ?? 'null')
     console.log('[Admin API - Reject User] Reason:', reason)
 
     // 사용자 상태 업데이트 (users 테이블에는 review_note 컬럼이 없음)
-    const { error } = await supabase
+    // clinic_id가 null인 사용자도 처리할 수 있도록 조건을 분기한다.
+    const updateQuery = supabase
       .from('users')
       .update({
         status: 'rejected',
         approved_at: new Date().toISOString(),
       })
       .eq('id', userId)
-      .eq('clinic_id', clinicId)
+
+    const { error } = await (
+      clinicId ? updateQuery.eq('clinic_id', clinicId) : updateQuery.is('clinic_id', null)
+    )
 
     if (error) {
       console.error('[Admin API - Reject User] Database error:', error)

--- a/dental-clinic-manager/src/app/api/marketing/calendar/items/regenerate/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/calendar/items/regenerate/route.ts
@@ -6,6 +6,9 @@ import { checkMedicalLaw } from '@/lib/marketing/medical-law-checker';
 import { titleSimilarity } from '@/lib/marketing/keyword-researcher';
 import type { TopicProposal } from '@/types/marketing';
 
+// Vercel 서버리스 함수 타임아웃 확장 (Anthropic API 응답 대기 대응)
+export const maxDuration = 120;
+
 // 개별 캘린더 항목 AI 재생성
 // - 같은 journey_stage / topic_category 유지
 // - 기존 제목·키워드와는 다른 주제 제안

--- a/dental-clinic-manager/src/app/api/marketing/calendar/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/calendar/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { generateCalendar, type CalendarRequest } from '@/lib/marketing/calendar-generator';
 
+// Vercel 서버리스 함수 타임아웃 확장
+// 월간 캘린더 생성은 Anthropic Claude(6144 tokens) + 네이버 SearchAd/DataLab + Gemini 임베딩을
+// 직렬로 호출하므로 기본 60초로는 부족하여 504(Gateway Timeout) 발생
+export const maxDuration = 120;
+
 // 캘린더 목록 조회
 export async function GET(request: NextRequest) {
   try {

--- a/dental-clinic-manager/src/app/api/marketing/calendar/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/calendar/route.ts
@@ -39,7 +39,49 @@ export async function GET(request: NextRequest) {
     const { data, error } = await query;
     if (error) throw error;
 
-    return NextResponse.json({ data });
+    // 발행됨 상태 항목의 최신 metrics 일괄 조회 → 카드별 매핑
+    type CalendarRow = { id: string; content_calendar_items?: { id: string; status: string }[] };
+    const calendarRows = (data as unknown as CalendarRow[] | null) || [];
+    const allItemIds = calendarRows
+      .flatMap((c) => c.content_calendar_items || [])
+      .filter((i) => i.status === 'published')
+      .map((i) => i.id);
+
+    let metricsMap: Record<string, {
+      platform: string; views: number | null; comments: number | null;
+      likes: number | null; scraps: number | null; measured_at: string;
+    }[]> = {};
+    if (allItemIds.length > 0) {
+      const { data: metricsRows } = await supabase
+        .from('content_post_metrics_latest')
+        .select('*')
+        .in('item_id', allItemIds);
+
+      metricsMap = (metricsRows || []).reduce((acc, m) => {
+        const id = m.item_id as string;
+        if (!acc[id]) acc[id] = [];
+        acc[id].push({
+          platform: m.platform as string,
+          views: m.views as number | null,
+          comments: m.comments as number | null,
+          likes: m.likes as number | null,
+          scraps: m.scraps as number | null,
+          measured_at: m.measured_at as string,
+        });
+        return acc;
+      }, {} as typeof metricsMap);
+    }
+
+    // 각 캘린더의 항목에 metrics 부착
+    const enriched = calendarRows.map((cal) => ({
+      ...cal,
+      content_calendar_items: (cal.content_calendar_items || []).map((it) => ({
+        ...it,
+        metrics: metricsMap[it.id] || [],
+      })),
+    }));
+
+    return NextResponse.json({ data: enriched });
   } catch (error) {
     console.error('[API] calendar GET:', error);
     return NextResponse.json({ error: '캘린더 조회 실패' }, { status: 500 });

--- a/dental-clinic-manager/src/app/api/marketing/worker-api/post-metrics/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/worker-api/post-metrics/route.ts
@@ -1,0 +1,126 @@
+// 발행 후 KPI 수집 — Worker가 스크래핑한 결과를 push
+// POST: 단건 또는 배치 기록
+// GET:  발행됨(published) + 7일 내 마지막 측정이 6시간 이상 지난 항목 목록
+//       (Worker가 다음 측정 대상을 식별하기 위함)
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyWorkerApiKey } from '@/lib/marketing/workerApiAuth';
+
+interface MetricsPayload {
+  item_id: string;
+  platform: string;            // 'naver_blog' 등
+  views?: number;
+  comments?: number;
+  likes?: number;
+  scraps?: number;
+  shares?: number;
+  raw_payload?: Record<string, unknown>;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const admin = await verifyWorkerApiKey(request);
+    if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const body = await request.json();
+    const items: MetricsPayload[] = Array.isArray(body) ? body : (body.items || [body]);
+
+    if (items.length === 0) {
+      return NextResponse.json({ error: 'metrics 항목 없음' }, { status: 400 });
+    }
+
+    // 기본 검증
+    for (const m of items) {
+      if (!m.item_id || !m.platform) {
+        return NextResponse.json(
+          { error: 'item_id, platform 필수' },
+          { status: 400 }
+        );
+      }
+    }
+
+    const rows = items.map((m) => ({
+      item_id: m.item_id,
+      platform: m.platform,
+      views: m.views ?? null,
+      comments: m.comments ?? null,
+      likes: m.likes ?? null,
+      scraps: m.scraps ?? null,
+      shares: m.shares ?? null,
+      raw_payload: m.raw_payload || null,
+    }));
+
+    const { error } = await admin.from('content_post_metrics').insert(rows);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true, inserted: rows.length });
+  } catch (error) {
+    console.error('[worker-api/post-metrics POST]', error);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}
+
+// 측정 대상 큐: published + (7일 내 발행 OR 마지막 측정 ≥ 6시간 전)
+export async function GET(request: NextRequest) {
+  try {
+    const admin = await verifyWorkerApiKey(request);
+    if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const url = new URL(request.url);
+    const limit = Math.min(parseInt(url.searchParams.get('limit') || '20', 10), 100);
+
+    // 기준일: 14일 내 발행된 글까지 측정
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - 14);
+
+    const { data: items, error } = await admin
+      .from('content_calendar_items')
+      .select('id, title, publish_date, published_urls, platforms, calendar_id')
+      .eq('status', 'published')
+      .gte('publish_date', cutoff.toISOString().split('T')[0])
+      .order('publish_date', { ascending: false })
+      .limit(limit * 2); // 후처리 필터를 위한 여유
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    // 각 항목의 마지막 측정 시각 조회 → 6시간 이상 지난 것만 필터
+    const itemIds = (items || []).map((i) => i.id as string);
+    const { data: latestRows } = await admin
+      .from('content_post_metrics')
+      .select('item_id, measured_at')
+      .in('item_id', itemIds)
+      .order('measured_at', { ascending: false });
+
+    const lastMeasured = new Map<string, Date>();
+    for (const r of latestRows || []) {
+      const id = r.item_id as string;
+      if (!lastMeasured.has(id)) {
+        lastMeasured.set(id, new Date(r.measured_at as string));
+      }
+    }
+
+    const sixHoursAgo = new Date(Date.now() - 6 * 60 * 60 * 1000);
+    const queue = (items || [])
+      .filter((it) => {
+        const last = lastMeasured.get(it.id as string);
+        return !last || last < sixHoursAgo;
+      })
+      .slice(0, limit)
+      .map((it) => ({
+        id: it.id as string,
+        title: it.title as string,
+        publish_date: it.publish_date as string,
+        published_urls: it.published_urls as Record<string, string> | null,
+        platforms: it.platforms as Record<string, boolean> | null,
+        last_measured_at: lastMeasured.get(it.id as string)?.toISOString() || null,
+      }));
+
+    return NextResponse.json({ queue, total: queue.length });
+  } catch (error) {
+    console.error('[worker-api/post-metrics GET]', error);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/dental-clinic-manager/src/app/api/staff/approve/route.ts
+++ b/dental-clinic-manager/src/app/api/staff/approve/route.ts
@@ -1,0 +1,93 @@
+// 원장용 직원 승인 API — 인원 상한 가드 포함
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import {
+  countActiveEmployees,
+  getSubscription,
+  getPlanById,
+} from '@/lib/subscriptionService'
+import { findPlanByHeadcount, requiresUpgrade } from '@/lib/subscriptionPlans'
+
+const FREE_LIMIT = 4
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}))
+  const ids: string[] = Array.isArray(body.userIds)
+    ? body.userIds.filter((x: unknown): x is string => typeof x === 'string')
+    : body.userId
+      ? [body.userId as string]
+      : []
+  const permissions: string[] | undefined = Array.isArray(body.permissions) ? body.permissions : undefined
+
+  if (ids.length === 0) {
+    return NextResponse.json({ error: 'NO_USER_IDS' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+
+  const { data: me, error: meErr } = await supabase
+    .from('users')
+    .select('id, clinic_id, role')
+    .eq('id', user.id)
+    .single()
+  if (meErr || !me?.clinic_id) {
+    return NextResponse.json({ error: 'NO_CLINIC' }, { status: 403 })
+  }
+  if (!['owner', 'master_admin'].includes(me.role as string)) {
+    return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 })
+  }
+
+  // 인원 상한 가드
+  const [activeCount, subscription] = await Promise.all([
+    countActiveEmployees(me.clinic_id),
+    getSubscription(me.clinic_id),
+  ])
+  const currentPlan = subscription?.plan_id ? await getPlanById(subscription.plan_id) : null
+  const currentLimit = currentPlan?.max_users ?? FREE_LIMIT
+
+  if (
+    requiresUpgrade({
+      currentActive: activeCount,
+      pendingToApprove: ids.length,
+      currentLimit,
+    })
+  ) {
+    const projected = activeCount + ids.length
+    return NextResponse.json(
+      {
+        error: 'UPGRADE_REQUIRED',
+        currentPlan: currentPlan?.name ?? 'free',
+        currentLimit,
+        currentActive: activeCount,
+        pendingToApprove: ids.length,
+        recommendedPlan: findPlanByHeadcount(projected),
+      },
+      { status: 403 },
+    )
+  }
+
+  // 승인 실행 (pending → active)
+  const updatePayload: Record<string, unknown> = {
+    status: 'active',
+    approved_at: new Date().toISOString(),
+  }
+  if (permissions && permissions.length > 0) {
+    updatePayload.permissions = permissions
+  }
+
+  const { error: upErr } = await supabase
+    .from('users')
+    .update(updatePayload)
+    .in('id', ids)
+    .eq('clinic_id', me.clinic_id)
+
+  if (upErr) {
+    return NextResponse.json({ error: upErr.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true, approvedCount: ids.length })
+}

--- a/dental-clinic-manager/src/app/api/workers/status/route.ts
+++ b/dental-clinic-manager/src/app/api/workers/status/route.ts
@@ -111,7 +111,14 @@ export async function GET(request: NextRequest) {
           .single();
 
         if (controlData) {
-          installed = true;
+          // 주의: marketing_worker_control 테이블은 마이그레이션 시점에 id='main' seed row가
+          // 자동 삽입되므로 "row 존재 여부"만으로는 설치 여부를 판정할 수 없다.
+          // 실제 워커가 한 번이라도 실행되면 worker_version이 기록되거나
+          // watchdog_online=true 로 heartbeat가 올라오므로 이를 설치의 증거로 사용한다.
+          const hasVersion = !!controlData.worker_version;
+          const hasHeartbeat = !!controlData.watchdog_online;
+          installed = hasVersion || hasHeartbeat;
+
           const lastUpdated = controlData.last_updated ? new Date(controlData.last_updated) : null;
           const isRecent = lastUpdated && (Date.now() - lastUpdated.getTime() < 60_000);
           online = !!(controlData.watchdog_online && isRecent);
@@ -190,11 +197,15 @@ export async function GET(request: NextRequest) {
         if (admin) {
           const { data: controlData } = await admin
             .from('marketing_worker_control')
-            .select('watchdog_online, last_updated')
+            .select('watchdog_online, last_updated, worker_version')
             .eq('id', 'main')
             .single();
           if (controlData) {
-            marketingInstalled = true;
+            // seed row로 인한 오탐 방지: worker_version 또는 watchdog_online 으로 설치 판정
+            const hasVersion = !!controlData.worker_version;
+            const hasHeartbeat = !!controlData.watchdog_online;
+            marketingInstalled = hasVersion || hasHeartbeat;
+
             const lastUpdated = controlData.last_updated ? new Date(controlData.last_updated) : null;
             const isRecent = lastUpdated && (Date.now() - lastUpdated.getTime() < 60_000);
             marketingOnline = !!(controlData.watchdog_online && isRecent);

--- a/dental-clinic-manager/src/app/manifest.ts
+++ b/dental-clinic-manager/src/app/manifest.ts
@@ -1,5 +1,7 @@
 import type { MetadataRoute } from 'next'
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://hi-clinic.co.kr'
+
 export default function manifest(): MetadataRoute.Manifest {
   return {
     name: '클리닉 매니저 - 치과 업무 관리 시스템',
@@ -14,11 +16,13 @@ export default function manifest(): MetadataRoute.Manifest {
     },
     background_color: '#f1f5f9',
     theme_color: '#3b82f6',
+    // 이미 설치된 같은 도메인 PWA를 getInstalledRelatedApps()로 감지하려면
+    // 현재 사이트의 manifest URL을 정확히 가리켜야 함.
     prefer_related_applications: false,
     related_applications: [
       {
         platform: 'webapp',
-        url: 'https://dental-clinic-manager.vercel.app/manifest.webmanifest',
+        url: `${SITE_URL}/manifest.webmanifest`,
       },
     ],
     categories: ['medical', 'productivity', 'business'],

--- a/dental-clinic-manager/src/app/master/page.tsx
+++ b/dental-clinic-manager/src/app/master/page.tsx
@@ -304,7 +304,7 @@ export default function MasterAdminPage() {
     }
   }
 
-  const handleApproveUser = async (userId: string, clinicId: string) => {
+  const handleApproveUser = async (userId: string, clinicId: string | null) => {
     try {
       const result = await dataService.approveUser(userId, clinicId)
       if (result.success) {
@@ -319,7 +319,7 @@ export default function MasterAdminPage() {
     }
   }
 
-  const handleRejectUser = async (userId: string, clinicId: string) => {
+  const handleRejectUser = async (userId: string, clinicId: string | null) => {
     const reason = await appPrompt('거절 사유를 입력하세요:')
     if (!reason) return
 

--- a/dental-clinic-manager/src/app/owner/page.tsx
+++ b/dental-clinic-manager/src/app/owner/page.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useEffect } from 'react'
+import AuthFlow from '@/components/Landing/shared/AuthFlow'
+import OwnerLanding from '@/components/Landing/OwnerLanding'
+import { useVisitorRole } from '@/components/Landing/shared/useVisitorRole'
+
+export default function OwnerPage() {
+  const { setRole, hydrated, role } = useVisitorRole()
+
+  // 첫 방문 시 localStorage에 저장
+  useEffect(() => {
+    if (!hydrated) return
+    if (role !== 'owner') {
+      setRole('owner')
+    }
+  }, [hydrated, role, setRole])
+
+  return (
+    <AuthFlow>
+      {({ onShowLogin, onShowSignup }) => (
+        <OwnerLanding onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
+      )}
+    </AuthFlow>
+  )
+}

--- a/dental-clinic-manager/src/app/page.tsx
+++ b/dental-clinic-manager/src/app/page.tsx
@@ -1,7 +1,14 @@
-import AuthApp from './AuthApp'
+import AuthFlow from '@/components/Landing/shared/AuthFlow'
+import RoleSelector from '@/components/Landing/RoleSelector'
 
 export const dynamic = 'force-dynamic'
 
 export default function RootPage() {
-  return <AuthApp />
+  return (
+    <AuthFlow>
+      {({ onShowLogin, onShowSignup }) => (
+        <RoleSelector onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
+      )}
+    </AuthFlow>
+  )
 }

--- a/dental-clinic-manager/src/components/Landing/OwnerLanding.tsx
+++ b/dental-clinic-manager/src/components/Landing/OwnerLanding.tsx
@@ -11,6 +11,7 @@ import {
   CalendarDaysIcon,
   UserGroupIcon,
   CurrencyDollarIcon,
+  GiftIcon,
   HeartIcon,
   SparklesIcon,
   CheckCircleIcon,
@@ -46,6 +47,7 @@ const problemItems = [
   { icon: UserGroupIcon, label: '스케쥴 수동 조율' },
   { icon: CurrencyDollarIcon, label: '급여 명세서 취합' },
   { icon: HeartIcon, label: '환자 리콜 추적' },
+  { icon: GiftIcon, label: '선물 재고 확인' },
   { icon: DocumentTextIcon, label: '상담 기록 정리' },
 ]
 
@@ -438,24 +440,35 @@ export default function OwnerLanding({ onShowLogin, onShowSignup }: OwnerLanding
           </div>
 
           <div className="space-y-4">
-            {ownerFaqs.map((faq, i) => (
-              <div key={i} className="bg-white rounded-2xl overflow-hidden shadow-at-card border border-at-border">
-                <button
-                  onClick={() => setOpenFaq(openFaq === i ? null : i)}
-                  className="w-full px-6 py-5 flex items-center justify-between text-left hover:bg-at-surface-alt transition-colors"
-                >
-                  <span className="font-semibold text-at-text pr-4">{faq.q}</span>
-                  <ChevronDownIcon
-                    className={`w-5 h-5 text-at-text-weak transition-transform duration-300 flex-shrink-0 ${openFaq === i ? 'rotate-180' : ''}`}
-                  />
-                </button>
-                <div className={`overflow-hidden transition-all duration-300 ${openFaq === i ? 'max-h-48' : 'max-h-0'}`}>
-                  <div className="px-6 pb-5">
-                    <p className="text-at-text-secondary leading-relaxed">{faq.a}</p>
+            {ownerFaqs.map((faq, i) => {
+              const isOpen = openFaq === i
+              const answerId = `owner-faq-answer-${i}`
+              return (
+                <div key={i} className="bg-white rounded-2xl overflow-hidden shadow-at-card border border-at-border">
+                  <button
+                    type="button"
+                    aria-expanded={isOpen}
+                    aria-controls={answerId}
+                    onClick={() => setOpenFaq(isOpen ? null : i)}
+                    className="w-full px-6 py-5 flex items-center justify-between text-left hover:bg-at-surface-alt transition-colors"
+                  >
+                    <span className="font-semibold text-at-text pr-4">{faq.q}</span>
+                    <ChevronDownIcon
+                      className={`w-5 h-5 text-at-text-weak transition-transform duration-300 flex-shrink-0 ${isOpen ? 'rotate-180' : ''}`}
+                    />
+                  </button>
+                  <div
+                    id={answerId}
+                    role="region"
+                    className={`overflow-hidden transition-all duration-300 ${isOpen ? 'max-h-96' : 'max-h-0'}`}
+                  >
+                    <div className="px-6 pb-5">
+                      <p className="text-at-text-secondary leading-relaxed">{faq.a}</p>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
         </div>
       </section>

--- a/dental-clinic-manager/src/components/Landing/OwnerLanding.tsx
+++ b/dental-clinic-manager/src/components/Landing/OwnerLanding.tsx
@@ -106,6 +106,14 @@ const premiumItems = [
   },
 ]
 
+const ownerFaqs = [
+  { q: '설치가 필요한가요?', a: '아니요. 웹 브라우저에서 바로 사용 가능합니다. PC·태블릿·스마트폰 어디서든 접속됩니다.' },
+  { q: '데이터는 안전한가요?', a: '글로벌 클라우드 인프라에서 암호화되어 저장되며, 자동 백업으로 손실 없이 보관됩니다.' },
+  { q: '직원 권한 설정이 가능한가요?', a: '원장·부원장·실장·팀장·일반 직원 등 역할별 권한을 세분화해 설정할 수 있습니다.' },
+  { q: '기존 데이터 이전이 가능한가요?', a: 'Excel 파일 등을 통한 기존 데이터 이전을 지원합니다.' },
+  { q: '프리미엄 패키지는 무엇이 다른가요?', a: '기본 기능은 그대로 사용 가능하며, 월 ₩499,000에 AI 데이터 분석·경영현황 대시보드·마케팅 자동화(네이버 블로그)가 포함됩니다.' },
+]
+
 export default function OwnerLanding({ onShowLogin, onShowSignup }: OwnerLandingProps) {
   const [openFaq, setOpenFaq] = useState<number | null>(null)
 
@@ -331,7 +339,126 @@ export default function OwnerLanding({ onShowLogin, onShowSignup }: OwnerLanding
         </div>
       </section>
 
-      {/* 나머지 섹션은 다음 Task에서 추가 */}
+      {/* TRUST */}
+      <section className="relative py-32 bg-gradient-to-br from-slate-50 to-blue-50">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <StoryBlock>
+            <div className="text-center mb-12">
+              <span className="inline-flex items-center gap-2 px-4 py-2 bg-at-tag text-at-accent rounded-full text-sm font-semibold mb-6">
+                <SparklesIcon className="w-4 h-4" />
+                Why Clinic Manager?
+              </span>
+              <h2 className="text-3xl sm:text-4xl font-bold text-at-text leading-tight">
+                현장의 필요를 느낀{' '}
+                <span className="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
+                  치과 원장이 직접 개발
+                </span>
+                했습니다
+              </h2>
+            </div>
+
+            <div className="bg-white rounded-3xl p-8 sm:p-10 shadow-xl border border-at-border">
+              <div className="flex flex-col sm:flex-row items-center gap-6 mb-8">
+                <div className="w-20 h-20 bg-gradient-to-br from-slate-700 to-slate-900 rounded-2xl flex items-center justify-center shadow-lg">
+                  <span className="text-3xl">👨‍⚕️</span>
+                </div>
+                <div className="text-center sm:text-left">
+                  <p className="text-at-text-weak text-sm mb-1">개발자이자 사용자</p>
+                  <p className="text-2xl font-bold text-at-text">현직 치과 원장</p>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div className="flex items-start gap-3">
+                  <CheckCircleIcon className="w-6 h-6 text-green-500 flex-shrink-0 mt-0.5" />
+                  <p className="text-lg text-at-text-secondary">
+                    <span className="font-semibold">현장의 불편함</span>을 직접 경험하고 해결한 솔루션
+                  </p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <CheckCircleIcon className="w-6 h-6 text-green-500 flex-shrink-0 mt-0.5" />
+                  <p className="text-lg text-at-text-secondary">
+                    <span className="font-semibold">본인 병원에서 매일 사용</span>하며 지속 개선 중
+                  </p>
+                </div>
+                <div className="flex items-start gap-3">
+                  <CheckCircleIcon className="w-6 h-6 text-green-500 flex-shrink-0 mt-0.5" />
+                  <p className="text-lg text-at-text-secondary">
+                    치과 업무 흐름을 <span className="font-semibold">정확히 이해</span>한 맞춤형 설계
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-8 pt-8 border-t border-at-border">
+                <p className="text-at-text-secondary italic text-center">
+                  &quot;직접 쓰면서 불편한 건 바로바로 고칩니다.<br />제가 매일 쓰니까요.&quot;
+                </p>
+              </div>
+            </div>
+          </StoryBlock>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-32 bg-gradient-to-br from-blue-600 via-indigo-600 to-purple-600 relative overflow-hidden">
+        <div className="absolute top-0 left-0 w-96 h-96 bg-white/10 rounded-full filter blur-3xl -translate-x-1/2 -translate-y-1/2" />
+        <div className="absolute bottom-0 right-0 w-96 h-96 bg-white/10 rounded-full filter blur-3xl translate-x-1/2 translate-y-1/2" />
+
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-6">
+            실장의 시간을 매출로 전환할 때입니다
+          </h2>
+          <p className="text-xl text-white/80 mb-10 max-w-2xl mx-auto">
+            복잡한 설치 없이, 웹 브라우저로 바로 시작하세요.
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <button
+              onClick={onShowSignup}
+              className="group px-10 py-4 bg-white text-at-text font-bold text-lg rounded-2xl transition-all shadow-xl hover:shadow-2xl hover:-translate-y-1 flex items-center gap-2 justify-center"
+            >
+              무료로 시작하기
+              <ArrowRightIcon className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
+            </button>
+            <button
+              onClick={onShowLogin}
+              className="px-10 py-4 border-2 border-white/30 text-white hover:bg-white/10 font-semibold text-lg rounded-2xl transition-all backdrop-blur-sm"
+            >
+              로그인
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section id="owner-faq" className="py-24 bg-at-surface-alt">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-16">
+            <h2 className="text-3xl font-bold text-at-text mb-4">자주 묻는 질문</h2>
+          </div>
+
+          <div className="space-y-4">
+            {ownerFaqs.map((faq, i) => (
+              <div key={i} className="bg-white rounded-2xl overflow-hidden shadow-at-card border border-at-border">
+                <button
+                  onClick={() => setOpenFaq(openFaq === i ? null : i)}
+                  className="w-full px-6 py-5 flex items-center justify-between text-left hover:bg-at-surface-alt transition-colors"
+                >
+                  <span className="font-semibold text-at-text pr-4">{faq.q}</span>
+                  <ChevronDownIcon
+                    className={`w-5 h-5 text-at-text-weak transition-transform duration-300 flex-shrink-0 ${openFaq === i ? 'rotate-180' : ''}`}
+                  />
+                </button>
+                <div className={`overflow-hidden transition-all duration-300 ${openFaq === i ? 'max-h-48' : 'max-h-0'}`}>
+                  <div className="px-6 pb-5">
+                    <p className="text-at-text-secondary leading-relaxed">{faq.a}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
     </div>
   )
 }

--- a/dental-clinic-manager/src/components/Landing/OwnerLanding.tsx
+++ b/dental-clinic-manager/src/components/Landing/OwnerLanding.tsx
@@ -49,6 +49,63 @@ const problemItems = [
   { icon: DocumentTextIcon, label: '상담 기록 정리' },
 ]
 
+const ownerFeatures = [
+  {
+    icon: ChartBarIcon,
+    title: '일일 업무 보고서',
+    description: '상담·선물·해피콜·리콜 자동 집계와 통계 분석',
+    color: 'from-blue-500 to-cyan-500',
+  },
+  {
+    icon: ClockIcon,
+    title: '출퇴근 · 근태',
+    description: 'QR 체크인, 팀 현황, 스케쥴을 한 화면에서',
+    color: 'from-green-500 to-emerald-500',
+  },
+  {
+    icon: DocumentTextIcon,
+    title: '근로계약서 관리',
+    description: '템플릿 기반 계약서 생성과 체계적 보관',
+    color: 'from-purple-500 to-pink-500',
+  },
+  {
+    icon: CalendarDaysIcon,
+    title: '연차 자동 계산',
+    description: '정책·발생·잔여·승인 워크플로우까지',
+    color: 'from-orange-500 to-amber-500',
+  },
+  {
+    icon: CurrencyDollarIcon,
+    title: '급여 명세서',
+    description: '월별 급여 자동 생성과 직원 배포',
+    color: 'from-rose-500 to-pink-500',
+  },
+  {
+    icon: UserGroupIcon,
+    title: '직원 권한 · 프로토콜',
+    description: '역할별 접근 통제와 업무 표준 문서화',
+    color: 'from-indigo-500 to-violet-500',
+  },
+]
+
+const premiumItems = [
+  {
+    icon: CpuChipIcon,
+    title: 'AI 데이터 분석',
+    description: '매출·상담 지표에서 인사이트를 자동 추출',
+  },
+  {
+    icon: PresentationChartLineIcon,
+    title: '경영현황 대시보드',
+    description: '재무·매출·KPI를 한 화면에서 실시간 확인',
+  },
+  {
+    icon: PencilSquareIcon,
+    title: '마케팅 자동화',
+    description: '네이버 블로그 자동 기획·발행·KPI 추적',
+  },
+]
+
 export default function OwnerLanding({ onShowLogin, onShowSignup }: OwnerLandingProps) {
   const [openFaq, setOpenFaq] = useState<number | null>(null)
 
@@ -155,6 +212,122 @@ export default function OwnerLanding({ onShowLogin, onShowSignup }: OwnerLanding
               </p>
             </div>
           </StoryBlock>
+        </div>
+      </section>
+
+      {/* SOLUTION */}
+      <section className="relative py-32 bg-white">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <StoryBlock>
+            <div className="flex items-center gap-4 mb-10">
+              <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-2xl flex items-center justify-center shadow-lg">
+                <HeartIcon className="w-8 h-8 text-white" />
+              </div>
+              <div>
+                <span className="text-at-accent font-semibold text-sm tracking-wider uppercase">The Solution</span>
+                <h2 className="text-2xl font-bold text-at-text">잡무는 시스템에게, 실장은 매출에게</h2>
+              </div>
+            </div>
+
+            <div className="grid sm:grid-cols-2 gap-6 mb-8">
+              <div className="bg-at-surface-alt rounded-2xl p-6 border border-at-border shadow-at-card">
+                <div className="text-4xl mb-4">🔁</div>
+                <h3 className="font-bold text-at-text mb-2">Before</h3>
+                <p className="text-at-text-secondary">
+                  반복 업무에 <span className="text-red-500 font-semibold">70%</span>의 집중력 소진,
+                  상담·매출에는 30%만 남습니다.
+                </p>
+              </div>
+              <div className="bg-gradient-to-br from-blue-50 to-indigo-50 rounded-2xl p-6 border border-at-border shadow-at-card">
+                <div className="text-4xl mb-4">✨</div>
+                <h3 className="font-bold text-at-text mb-2">After</h3>
+                <p className="text-at-text-secondary">
+                  잡무는 시스템이 처리하고, 실장은{' '}
+                  <span className="text-at-accent font-semibold">상담·해피콜·매출 관리</span>에 집중합니다.
+                </p>
+              </div>
+            </div>
+
+            <div className="text-center">
+              <p className="text-xl text-at-text-secondary font-medium">
+                실장의 에너지가{' '}
+                <span className="text-at-accent font-bold">매출로 전환</span>됩니다.
+              </p>
+            </div>
+          </StoryBlock>
+        </div>
+      </section>
+
+      {/* FEATURES */}
+      <section id="owner-features" className="py-32 bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-16">
+            <span className="inline-block px-4 py-1.5 bg-at-surface-alt text-at-text-secondary font-semibold text-sm rounded-full mb-4">
+              FEATURES
+            </span>
+            <h2 className="text-3xl sm:text-4xl font-bold text-at-text mb-4">
+              병원 운영에 필요한 모든 것
+            </h2>
+            <p className="text-lg text-at-text-secondary max-w-2xl mx-auto">
+              반복 업무를 시스템이 처리하는 6가지 핵심 기능
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {ownerFeatures.map((feature) => {
+              const Icon = feature.icon
+              return (
+                <div
+                  key={feature.title}
+                  className="group bg-at-surface-alt hover:bg-white rounded-2xl p-8 transition-all duration-500 hover:shadow-2xl hover:-translate-y-1 border border-at-border"
+                >
+                  <div className={`w-14 h-14 rounded-2xl bg-gradient-to-br ${feature.color} flex items-center justify-center mb-6 shadow-lg`}>
+                    <Icon className="w-7 h-7 text-white" />
+                  </div>
+                  <h3 className="text-xl font-bold text-at-text mb-3">{feature.title}</h3>
+                  <p className="text-at-text-secondary leading-relaxed">{feature.description}</p>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* PREMIUM */}
+      <section className="py-32 bg-gradient-to-br from-indigo-950 via-slate-900 to-slate-950 relative overflow-hidden">
+        <div className="absolute top-0 left-1/3 w-96 h-96 bg-purple-500/10 rounded-full filter blur-3xl" />
+        <div className="absolute bottom-0 right-1/3 w-96 h-96 bg-blue-500/10 rounded-full filter blur-3xl" />
+
+        <div className="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-16">
+            <span className="inline-flex items-center gap-2 px-4 py-1.5 bg-gradient-to-r from-amber-400/20 to-orange-400/20 border border-amber-400/30 text-amber-300 font-bold text-xs tracking-wider uppercase rounded-full mb-4">
+              <SparklesIcon className="w-4 h-4" /> PREMIUM · 월 ₩499,000
+            </span>
+            <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+              경영자의 시간을 위해 준비된 한 단계 더
+            </h2>
+            <p className="text-lg text-slate-300 max-w-2xl mx-auto">
+              기본 기능에 더해, 매출 성장을 직접 끌어올리는 도구
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-3 gap-6">
+            {premiumItems.map((item) => {
+              const Icon = item.icon
+              return (
+                <div
+                  key={item.title}
+                  className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-8 hover:bg-white/10 transition-all"
+                >
+                  <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-amber-400 to-orange-500 flex items-center justify-center mb-6 shadow-lg">
+                    <Icon className="w-7 h-7 text-white" />
+                  </div>
+                  <h3 className="text-xl font-bold text-white mb-3">{item.title}</h3>
+                  <p className="text-slate-300 leading-relaxed">{item.description}</p>
+                </div>
+              )
+            })}
+          </div>
         </div>
       </section>
 

--- a/dental-clinic-manager/src/components/Landing/OwnerLanding.tsx
+++ b/dental-clinic-manager/src/components/Landing/OwnerLanding.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  ArrowRightIcon,
+  BoltIcon,
+  ChartBarIcon,
+  ChevronDownIcon,
+  ClockIcon,
+  DocumentTextIcon,
+  CalendarDaysIcon,
+  UserGroupIcon,
+  CurrencyDollarIcon,
+  HeartIcon,
+  SparklesIcon,
+  CheckCircleIcon,
+  CpuChipIcon,
+  PresentationChartLineIcon,
+  PencilSquareIcon,
+} from '@heroicons/react/24/outline'
+import LandingHeader from './shared/LandingHeader'
+import { useScrollAnimation } from './shared/useScrollAnimation'
+
+interface OwnerLandingProps {
+  onShowLogin: () => void
+  onShowSignup: () => void
+}
+
+function StoryBlock({ children }: { children: React.ReactNode }) {
+  const { ref, isVisible } = useScrollAnimation()
+  return (
+    <div
+      ref={ref}
+      className={`transition-all duration-1000 ${
+        isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
+      }`}
+    >
+      {children}
+    </div>
+  )
+}
+
+const problemItems = [
+  { icon: CalendarDaysIcon, label: '엑셀 연차 계산' },
+  { icon: ClockIcon, label: '출퇴근 수기 집계' },
+  { icon: UserGroupIcon, label: '스케쥴 수동 조율' },
+  { icon: CurrencyDollarIcon, label: '급여 명세서 취합' },
+  { icon: HeartIcon, label: '환자 리콜 추적' },
+  { icon: DocumentTextIcon, label: '상담 기록 정리' },
+]
+
+export default function OwnerLanding({ onShowLogin, onShowSignup }: OwnerLandingProps) {
+  const [openFaq, setOpenFaq] = useState<number | null>(null)
+
+  return (
+    <div className="min-h-screen bg-white overflow-x-hidden">
+      <LandingHeader variant="dark" onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
+
+      {/* HERO */}
+      <section className="relative min-h-screen flex items-center justify-center pt-16 overflow-hidden bg-slate-950">
+        <div className="absolute inset-0 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950" />
+        <div className="absolute top-1/4 -left-32 w-96 h-96 bg-blue-500/20 rounded-full filter blur-[120px] opacity-40" />
+        <div className="absolute bottom-1/4 -right-32 w-96 h-96 bg-indigo-500/20 rounded-full filter blur-[120px] opacity-40" />
+
+        <div className="relative max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center z-10">
+          <div className="mb-10">
+            <span className="inline-flex items-center gap-2 px-5 py-2.5 bg-white/5 backdrop-blur-sm border border-white/10 text-blue-300 rounded-full text-sm font-medium">
+              <SparklesIcon className="w-4 h-4" />
+              FOR CLINIC OWNERS
+            </span>
+          </div>
+
+          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-white leading-[1.15] tracking-tight mb-8">
+            <span className="block mb-2 sm:mb-4">능력있는 실장을</span>
+            <span className="block bg-gradient-to-r from-blue-400 via-indigo-400 to-purple-400 bg-clip-text text-transparent pb-2">
+              엑셀과 연차 계산에
+            </span>
+            <span className="block">낭비하지 마세요</span>
+          </h1>
+
+          <p className="text-slate-300 text-lg sm:text-xl max-w-2xl mx-auto mb-12 leading-relaxed">
+            잡무는 시스템에 맡기고,{' '}
+            <span className="text-white font-medium">실장은 매출에만 집중</span>하게 하세요.
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-16">
+            <button
+              onClick={onShowSignup}
+              className="group px-8 py-4 bg-gradient-to-r from-blue-500 to-indigo-500 hover:from-blue-600 hover:to-indigo-600 text-white font-bold text-lg rounded-2xl transition-all shadow-lg shadow-blue-500/25 hover:shadow-blue-500/40 hover:-translate-y-1 flex items-center gap-2"
+            >
+              무료로 시작하기
+              <ArrowRightIcon className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
+            </button>
+            <button
+              onClick={() => document.getElementById('owner-problem')?.scrollIntoView({ behavior: 'smooth' })}
+              className="px-8 py-4 text-slate-300 hover:text-white font-medium transition-colors flex items-center gap-2"
+            >
+              기능 살펴보기
+              <ChevronDownIcon className="w-5 h-5" />
+            </button>
+          </div>
+
+          <div className="flex justify-center items-center gap-6 sm:gap-10">
+            <div className="flex items-center gap-2.5 px-4 py-2 bg-white/5 backdrop-blur-sm rounded-full border border-white/10">
+              <div className="w-2.5 h-2.5 rounded-full bg-green-400 shadow-lg shadow-green-400/50" />
+              <span className="text-sm text-slate-300 font-medium">현직 원장 개발</span>
+            </div>
+            <div className="flex items-center gap-2.5 px-4 py-2 bg-white/5 backdrop-blur-sm rounded-full border border-white/10">
+              <div className="w-2.5 h-2.5 rounded-full bg-blue-400 shadow-lg shadow-blue-400/50" />
+              <span className="text-sm text-slate-300 font-medium">실제 병원 운영 중</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
+          <ChevronDownIcon className="w-5 h-5 text-slate-400" />
+        </div>
+      </section>
+
+      {/* PROBLEM */}
+      <section id="owner-problem" className="relative py-32 bg-slate-900">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <StoryBlock>
+            <div className="flex items-center gap-4 mb-10">
+              <div className="w-16 h-16 bg-gradient-to-br from-amber-400 to-orange-500 rounded-2xl flex items-center justify-center shadow-lg">
+                <BoltIcon className="w-8 h-8 text-white" />
+              </div>
+              <div>
+                <span className="text-amber-400 font-semibold text-sm tracking-wider uppercase">The Problem</span>
+                <h2 className="text-2xl font-bold text-white">실장이 하루에 버리는 시간</h2>
+              </div>
+            </div>
+
+            <p className="text-2xl sm:text-3xl lg:text-4xl font-medium text-white leading-relaxed mb-10">
+              능력있는 실장이 매일 처리하는{' '}
+              <span className="text-amber-400">반복 잡무</span>들.
+            </p>
+
+            <div className="grid sm:grid-cols-2 gap-3 mb-10">
+              {problemItems.map(({ icon: Icon, label }) => (
+                <div
+                  key={label}
+                  className="flex items-center gap-3 bg-slate-800/50 backdrop-blur-sm rounded-xl p-4 border border-slate-700/50"
+                >
+                  <Icon className="w-5 h-5 text-amber-400 flex-shrink-0" />
+                  <span className="text-slate-200">{label}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="bg-slate-800/50 backdrop-blur-sm rounded-2xl p-6 sm:p-8 border border-slate-700/50 shadow-xl">
+              <p className="text-xl text-slate-200 leading-relaxed text-center">
+                이 시간에 실장은{' '}
+                <span className="text-amber-400 font-semibold">상담 한 건을 더</span> 받을 수 있었습니다.
+              </p>
+            </div>
+          </StoryBlock>
+        </div>
+      </section>
+
+      {/* 나머지 섹션은 다음 Task에서 추가 */}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Landing/RoleSelector.tsx
+++ b/dental-clinic-manager/src/components/Landing/RoleSelector.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useVisitorRole, type VisitorRole } from './shared/useVisitorRole'
+import LandingHeader from './shared/LandingHeader'
+
+interface RoleSelectorProps {
+  onShowLogin: () => void
+  onShowSignup: () => void
+}
+
+interface RoleCardProps {
+  role: VisitorRole
+  emoji: string
+  title: string
+  tagline: string
+  accent: 'owner' | 'staff'
+  onSelect: (role: VisitorRole) => void
+}
+
+function RoleCard({ role, emoji, title, tagline, accent, onSelect }: RoleCardProps) {
+  const accentClasses = accent === 'owner'
+    ? 'from-indigo-50 to-white border-indigo-200 hover:border-indigo-400 hover:shadow-indigo-200/50'
+    : 'from-cyan-50 to-white border-cyan-200 hover:border-cyan-400 hover:shadow-cyan-200/50'
+  const labelClasses = accent === 'owner'
+    ? 'text-indigo-600'
+    : 'text-cyan-700'
+
+  return (
+    <button
+      onClick={() => onSelect(role)}
+      className={`group text-left bg-gradient-to-b ${accentClasses} border-2 rounded-3xl p-8 sm:p-10 transition-all hover:-translate-y-1 hover:shadow-2xl`}
+    >
+      <div className="text-5xl mb-4">{emoji}</div>
+      <div className={`text-xs font-bold tracking-wider uppercase mb-2 ${labelClasses}`}>
+        {accent === 'owner' ? 'FOR OWNERS' : 'FOR STAFF'}
+      </div>
+      <div className="text-2xl sm:text-3xl font-bold text-at-text mb-3">{title}</div>
+      <div className="text-at-text-secondary leading-relaxed">{tagline}</div>
+      <div className={`mt-6 inline-flex items-center gap-2 font-semibold ${labelClasses} group-hover:gap-3 transition-all`}>
+        페이지 보기 <span>→</span>
+      </div>
+    </button>
+  )
+}
+
+export default function RoleSelector({ onShowLogin, onShowSignup }: RoleSelectorProps) {
+  const router = useRouter()
+  const { role, setRole, clearRole, hydrated } = useVisitorRole()
+
+  // 저장된 역할이 있으면 자동 리디렉션
+  useEffect(() => {
+    if (!hydrated) return
+    if (role === 'owner') {
+      router.replace('/owner')
+    } else if (role === 'staff') {
+      router.replace('/staff')
+    }
+  }, [hydrated, role, router])
+
+  const handleSelect = (selected: VisitorRole) => {
+    setRole(selected)
+    router.push(selected === 'owner' ? '/owner' : '/staff')
+  }
+
+  // 하이드레이션 완료 전이거나 리디렉션 중일 때 플래시 방지
+  if (!hydrated || role) {
+    return (
+      <div className="min-h-screen bg-white flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-at-accent" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-white">
+      <LandingHeader variant="light" onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
+
+      <main className="pt-32 pb-24 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="text-center mb-14">
+            <h1 className="text-3xl sm:text-5xl font-bold text-at-text leading-tight mb-4">
+              먼저 알려주세요 —{' '}
+              <span className="bg-gradient-to-r from-indigo-600 to-cyan-600 bg-clip-text text-transparent">
+                누구신가요?
+              </span>
+            </h1>
+            <p className="text-lg text-at-text-secondary">
+              역할에 맞는 페이지로 안내해드립니다
+            </p>
+          </div>
+
+          <div className="grid sm:grid-cols-2 gap-6">
+            <RoleCard
+              role="owner"
+              emoji="👨‍⚕️"
+              title="대표원장"
+              tagline="병원 경영·매출 중심 뷰. 실장을 매출에만 집중하게 하는 시스템."
+              accent="owner"
+              onSelect={handleSelect}
+            />
+            <RoleCard
+              role="staff"
+              emoji="🧑‍💼"
+              title="실장 · 직원"
+              tagline="출퇴근·스케쥴·연차까지 간단하게 끝내고 정시 퇴근하는 업무 앱."
+              accent="staff"
+              onSelect={handleSelect}
+            />
+          </div>
+
+          <div className="text-center mt-10 text-sm text-at-text-weak">
+            선택한 페이지는 다음 방문 시 자동으로 열립니다 ·{' '}
+            <button
+              onClick={clearRole}
+              className="underline hover:text-at-text-secondary"
+            >
+              선택 기억 해제
+            </button>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Landing/shared/AuthFlow.tsx
+++ b/dental-clinic-manager/src/components/Landing/shared/AuthFlow.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useEffect, useState, type ReactNode } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useAuth } from '@/contexts/AuthContext'
+import LoginForm from '@/components/Auth/LoginForm'
+import SignupForm from '@/components/Auth/SignupForm'
+import ForgotPasswordForm from '@/components/Auth/ForgotPasswordForm'
+import Footer from '@/components/Layout/Footer'
+
+type AppState = 'landing' | 'login' | 'signup' | 'forgotPassword'
+
+export interface AuthFlowRenderProps {
+  onShowLogin: () => void
+  onShowSignup: () => void
+}
+
+interface AuthFlowProps {
+  children: (props: AuthFlowRenderProps) => ReactNode
+}
+
+export default function AuthFlow({ children }: AuthFlowProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { isAuthenticated, user, loading } = useAuth()
+  const [appState, setAppState] = useState<AppState>('landing')
+
+  useEffect(() => {
+    const show = searchParams.get('show')
+    if (show === 'login') {
+      setAppState('login')
+    } else if (show === 'signup') {
+      setAppState('signup')
+    }
+  }, [searchParams])
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      if (user?.status === 'pending' || user?.status === 'rejected') {
+        router.push('/pending-approval')
+        return
+      }
+      const redirect = searchParams.get('redirect')
+      router.push(redirect || '/dashboard')
+    }
+  }, [isAuthenticated, user, router, searchParams])
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-at-surface-alt flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-at-accent mx-auto mb-4"></div>
+          <p className="text-at-text-secondary">로딩 중...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (isAuthenticated) {
+    return null
+  }
+
+  const showLogin = () => setAppState('login')
+  const showSignup = () => setAppState('signup')
+  const showLanding = () => setAppState('landing')
+  const showForgot = () => setAppState('forgotPassword')
+
+  let content: ReactNode
+  switch (appState) {
+    case 'login':
+      content = (
+        <LoginForm
+          onBackToLanding={showLanding}
+          onShowSignup={showSignup}
+          onShowForgotPassword={showForgot}
+          onLoginSuccess={() => {
+            setTimeout(() => { window.location.reload() }, 150)
+          }}
+        />
+      )
+      break
+    case 'signup':
+      content = (
+        <SignupForm
+          onBackToLanding={showLanding}
+          onShowLogin={showLogin}
+          onSignupSuccess={() => { setAppState('login') }}
+        />
+      )
+      break
+    case 'forgotPassword':
+      content = <ForgotPasswordForm onBackToLogin={showLogin} />
+      break
+    default:
+      content = children({ onShowLogin: showLogin, onShowSignup: showSignup })
+  }
+
+  return (
+    <>
+      {content}
+      <Footer />
+    </>
+  )
+}

--- a/dental-clinic-manager/src/components/Landing/shared/CountUp.tsx
+++ b/dental-clinic-manager/src/components/Landing/shared/CountUp.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useScrollAnimation } from './useScrollAnimation'
+
+interface CountUpProps {
+  end: number
+  suffix?: string
+  duration?: number
+}
+
+export default function CountUp({ end, suffix = '', duration = 2000 }: CountUpProps) {
+  const [count, setCount] = useState(0)
+  const { ref, isVisible } = useScrollAnimation()
+
+  useEffect(() => {
+    if (!isVisible) return
+
+    let startTime: number
+    const animate = (currentTime: number) => {
+      if (!startTime) startTime = currentTime
+      const progress = Math.min((currentTime - startTime) / duration, 1)
+      setCount(Math.floor(progress * end))
+      if (progress < 1) {
+        requestAnimationFrame(animate)
+      }
+    }
+    requestAnimationFrame(animate)
+  }, [isVisible, end, duration])
+
+  return <span ref={ref}>{count}{suffix}</span>
+}

--- a/dental-clinic-manager/src/components/Landing/shared/CountUp.tsx
+++ b/dental-clinic-manager/src/components/Landing/shared/CountUp.tsx
@@ -17,15 +17,18 @@ export default function CountUp({ end, suffix = '', duration = 2000 }: CountUpPr
     if (!isVisible) return
 
     let startTime: number
+    let animationId = 0
     const animate = (currentTime: number) => {
       if (!startTime) startTime = currentTime
       const progress = Math.min((currentTime - startTime) / duration, 1)
       setCount(Math.floor(progress * end))
       if (progress < 1) {
-        requestAnimationFrame(animate)
+        animationId = requestAnimationFrame(animate)
       }
     }
-    requestAnimationFrame(animate)
+    animationId = requestAnimationFrame(animate)
+
+    return () => cancelAnimationFrame(animationId)
   }, [isVisible, end, duration])
 
   return <span ref={ref}>{count}{suffix}</span>

--- a/dental-clinic-manager/src/components/Landing/shared/LandingHeader.tsx
+++ b/dental-clinic-manager/src/components/Landing/shared/LandingHeader.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import Image from 'next/image'
+
+export type LandingHeaderVariant = 'dark' | 'light'
+
+interface LandingHeaderProps {
+  variant: LandingHeaderVariant
+  onShowLogin: () => void
+  onShowSignup: () => void
+}
+
+export default function LandingHeader({ variant, onShowLogin, onShowSignup }: LandingHeaderProps) {
+  const isDark = variant === 'dark'
+  const wrapperClass = isDark
+    ? 'bg-slate-950/80 border-b border-white/10'
+    : 'bg-white/80 border-b border-at-border/50 shadow-at-card'
+  const logoTextClass = isDark ? 'text-white' : 'text-at-text'
+  const loginClass = isDark
+    ? 'text-slate-300 hover:text-white'
+    : 'text-at-text-secondary hover:text-at-text'
+  const signupClass = isDark
+    ? 'bg-gradient-to-r from-blue-500 to-indigo-500 hover:from-blue-600 hover:to-indigo-600 text-white'
+    : 'bg-slate-900 hover:bg-slate-800 text-white'
+
+  return (
+    <header className={`fixed top-0 left-0 right-0 backdrop-blur-xl z-50 ${wrapperClass}`}>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          <div className="flex items-center gap-3">
+            <Image
+              src="/icons/icon-192x192.png"
+              alt="클리닉 매니저 로고"
+              width={40}
+              height={40}
+              className="w-10 h-10 rounded-xl shadow-at-card"
+            />
+            <span className={`text-xl font-bold ${logoTextClass}`}>클리닉 매니저</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={onShowLogin}
+              className={`px-4 py-2 font-medium transition-colors ${loginClass}`}
+            >
+              로그인
+            </button>
+            <button
+              onClick={onShowSignup}
+              className={`px-5 py-2.5 font-semibold rounded-xl transition-all shadow-at-card hover:shadow-lg ${signupClass}`}
+            >
+              시작하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/dental-clinic-manager/src/components/Landing/shared/TypeWriter.tsx
+++ b/dental-clinic-manager/src/components/Landing/shared/TypeWriter.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useScrollAnimation } from './useScrollAnimation'
+
+export default function TypeWriter({ text, delay = 50 }: { text: string; delay?: number }) {
+  const [displayText, setDisplayText] = useState('')
+  const [isStarted, setIsStarted] = useState(false)
+  const { ref, isVisible } = useScrollAnimation()
+
+  useEffect(() => {
+    if (isVisible && !isStarted) {
+      setIsStarted(true)
+      let i = 0
+      const timer = setInterval(() => {
+        if (i < text.length) {
+          setDisplayText(text.slice(0, i + 1))
+          i++
+        } else {
+          clearInterval(timer)
+        }
+      }, delay)
+      return () => clearInterval(timer)
+    }
+  }, [isVisible, isStarted, text, delay])
+
+  return (
+    <span ref={ref}>
+      {displayText}
+      {displayText.length < text.length && isStarted && (
+        <span className="animate-pulse">|</span>
+      )}
+    </span>
+  )
+}

--- a/dental-clinic-manager/src/components/Landing/shared/useScrollAnimation.ts
+++ b/dental-clinic-manager/src/components/Landing/shared/useScrollAnimation.ts
@@ -1,0 +1,27 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+export function useScrollAnimation() {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+        }
+      },
+      { threshold: 0.1, rootMargin: '0px 0px -50px 0px' }
+    )
+
+    if (ref.current) {
+      observer.observe(ref.current)
+    }
+
+    return () => observer.disconnect()
+  }, [])
+
+  return { ref, isVisible }
+}

--- a/dental-clinic-manager/src/components/Landing/shared/useVisitorRole.ts
+++ b/dental-clinic-manager/src/components/Landing/shared/useVisitorRole.ts
@@ -1,0 +1,47 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+export type VisitorRole = 'owner' | 'staff'
+const STORAGE_KEY = 'clinicmgr.visitor_role'
+
+function isVisitorRole(value: unknown): value is VisitorRole {
+  return value === 'owner' || value === 'staff'
+}
+
+export function useVisitorRole() {
+  const [role, setRoleState] = useState<VisitorRole | null>(null)
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY)
+      if (isVisitorRole(stored)) {
+        setRoleState(stored)
+      }
+    } catch {
+      // localStorage 접근 실패 시 무시
+    }
+    setHydrated(true)
+  }, [])
+
+  const setRole = useCallback((next: VisitorRole) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next)
+    } catch {
+      // 무시
+    }
+    setRoleState(next)
+  }, [])
+
+  const clearRole = useCallback(() => {
+    try {
+      window.localStorage.removeItem(STORAGE_KEY)
+    } catch {
+      // 무시
+    }
+    setRoleState(null)
+  }, [])
+
+  return { role, setRole, clearRole, hydrated }
+}

--- a/dental-clinic-manager/src/components/Layout/UserNotificationDropdown.tsx
+++ b/dental-clinic-manager/src/components/Layout/UserNotificationDropdown.tsx
@@ -49,6 +49,8 @@ const NotificationTypeIcons: Record<UserNotificationType, React.ComponentType<{ 
   protocol_review_requested: ClipboardDocumentCheckIcon,
   protocol_review_approved: CheckCircleIcon,
   protocol_review_rejected: XCircleIcon,
+  subscription_upgrade_required: ExclamationCircleIcon,
+  subscription_payment_succeeded: CheckCircleIcon,
 }
 
 // 알림 타입별 기본 링크 매핑 (link가 없는 경우 fallback)

--- a/dental-clinic-manager/src/components/PWA/ServiceWorkerRegistrar.tsx
+++ b/dental-clinic-manager/src/components/PWA/ServiceWorkerRegistrar.tsx
@@ -69,9 +69,8 @@ export default function ServiceWorkerRegistrar() {
         console.log(`[SW] 업데이트 확인 (${source})`)
         await registration.update()
 
-        // 업데이트 확인 후 대기 중인 SW가 있으면 활성화
+        // 대기 중인 SW가 있으면 배너 표시 (즉시 활성화하지 않음)
         if (registration.waiting) {
-          activateWaitingSW(registration)
           notifyUpdate()
         }
       } catch (err) {
@@ -133,9 +132,8 @@ export default function ServiceWorkerRegistrar() {
           newSW.addEventListener('statechange', () => {
             if (newSW.state === 'installed') {
               if (navigator.serviceWorker.controller) {
-                // 기존 SW가 있는 상태에서 새 SW 설치됨
-                console.log('[SW] 새 버전 설치 완료, 활성화 요청')
-                activateWaitingSW(reg)
+                // 기존 SW가 있는 상태에서 새 SW 설치됨 → 배너 표시 (즉시 활성화 X)
+                console.log('[SW] 새 버전 설치 완료, 배너 표시')
                 notifyUpdate()
               } else {
                 // 최초 설치 (기존 SW 없음)
@@ -145,10 +143,9 @@ export default function ServiceWorkerRegistrar() {
           })
         })
 
-        // 초기 로드 시 이미 대기 중인 SW가 있으면 즉시 활성화
+        // 초기 로드 시 이미 대기 중인 SW가 있으면 배너만 표시 (즉시 활성화 X)
         if (reg.waiting) {
-          console.log('[SW] 이미 대기 중인 새 버전 발견, 활성화')
-          activateWaitingSW(reg)
+          console.log('[SW] 이미 대기 중인 새 버전 발견, 배너 표시')
           notifyUpdate()
         }
 
@@ -176,6 +173,30 @@ export default function ServiceWorkerRegistrar() {
       window.location.reload()
     }
     navigator.serviceWorker.addEventListener('controllerchange', handleControllerChange)
+
+    // ─── UpdatePrompt로부터 업데이트 적용 요청 수신 ───
+    // 사용자가 '지금 새로고침' 버튼을 눌렀거나 자동 카운트다운이 끝난 시점에 호출됨.
+    // waiting SW가 있으면 SKIP_WAITING을 보내 controllerchange로 자연스럽게 reload 되고,
+    // 없으면(SW 변경은 없고 빌드 ID만 변경된 케이스) 직접 reload 한다.
+    const handleApplyUpdate = () => {
+      if (refreshing) return
+      if (registration?.waiting) {
+        console.log('[SW] 사용자 요청으로 업데이트 적용')
+        activateWaitingSW(registration)
+        // controllerchange가 발생하지 않는 경우 대비 폴백 (3초 후 강제 reload)
+        setTimeout(() => {
+          if (!refreshing) {
+            refreshing = true
+            window.location.reload()
+          }
+        }, 3000)
+      } else {
+        console.log('[SW] 대기 중인 SW 없음 → 바로 reload')
+        refreshing = true
+        window.location.reload()
+      }
+    }
+    window.addEventListener('pwa-apply-update', handleApplyUpdate)
 
     // ─── 이벤트 핸들러들 ───
 
@@ -253,6 +274,7 @@ export default function ServiceWorkerRegistrar() {
       window.removeEventListener('pageshow', handlePageShow)
       window.removeEventListener('online', handleOnline)
       window.removeEventListener('focus', handleFocus)
+      window.removeEventListener('pwa-apply-update', handleApplyUpdate)
       navigator.serviceWorker.removeEventListener('controllerchange', handleControllerChange)
       if (displayModeQuery) {
         displayModeQuery.removeEventListener('change', () => {})

--- a/dental-clinic-manager/src/components/PWA/UpdatePrompt.tsx
+++ b/dental-clinic-manager/src/components/PWA/UpdatePrompt.tsx
@@ -29,6 +29,12 @@ export default function UpdatePrompt({ autoReloadDelay = 0 }: UpdatePromptProps)
     return () => window.removeEventListener('pwa-update-available', handleUpdateAvailable)
   }, [autoReloadDelay])
 
+  const handleReload = useCallback(() => {
+    // ServiceWorkerRegistrar에 위임: waiting SW가 있으면 SKIP_WAITING → controllerchange → reload,
+    // 없으면 즉시 reload. (사용자가 카운트다운 도중에도 직접 눌러 즉시 적용 가능)
+    window.dispatchEvent(new CustomEvent('pwa-apply-update'))
+  }, [])
+
   // 자동 새로고침 카운트다운
   useEffect(() => {
     if (!showUpdate || autoReloadDelay <= 0) return
@@ -37,7 +43,7 @@ export default function UpdatePrompt({ autoReloadDelay = 0 }: UpdatePromptProps)
       setCountdown((prev) => {
         if (prev <= 1) {
           clearInterval(timer)
-          window.location.reload()
+          handleReload()
           return 0
         }
         return prev - 1
@@ -45,11 +51,7 @@ export default function UpdatePrompt({ autoReloadDelay = 0 }: UpdatePromptProps)
     }, 1000)
 
     return () => clearInterval(timer)
-  }, [showUpdate, autoReloadDelay])
-
-  const handleReload = useCallback(() => {
-    window.location.reload()
-  }, [])
+  }, [showUpdate, autoReloadDelay, handleReload])
 
   const handleDismiss = useCallback(() => {
     setShowUpdate(false)

--- a/dental-clinic-manager/src/components/WorkerGuardModal.tsx
+++ b/dental-clinic-manager/src/components/WorkerGuardModal.tsx
@@ -1,0 +1,244 @@
+// src/components/WorkerGuardModal.tsx
+'use client'
+
+import { useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { AlertTriangle, Download, RefreshCw, X, Loader2 } from 'lucide-react'
+import { triggerWorkerDownload } from '@/lib/workers/installer'
+
+export type GuardState = 'not_installed' | 'offline'
+export type WorkerType = 'marketing' | 'scraping' | 'seo' | 'dentweb' | 'email'
+
+interface OpenOptions {
+  type: WorkerType
+  featureName: string
+  state: GuardState
+}
+
+interface ModalProps extends OpenOptions {
+  onResolve: (result: boolean) => void
+}
+
+// =====================================================
+// Singleton mount (중복 호출 방지)
+// =====================================================
+
+let activePromise: Promise<boolean> | null = null
+let activeRoot: Root | null = null
+let activeContainer: HTMLDivElement | null = null
+
+function unmountModal() {
+  if (activeRoot) {
+    activeRoot.unmount()
+    activeRoot = null
+  }
+  if (activeContainer && activeContainer.parentNode) {
+    activeContainer.parentNode.removeChild(activeContainer)
+    activeContainer = null
+  }
+  activePromise = null
+}
+
+export function openWorkerGuardModal(opts: OpenOptions): Promise<boolean> {
+  if (activePromise) return activePromise
+
+  activePromise = new Promise<boolean>((resolve) => {
+    activeContainer = document.createElement('div')
+    document.body.appendChild(activeContainer)
+    activeRoot = createRoot(activeContainer)
+
+    const handleResolve = (result: boolean) => {
+      resolve(result)
+      // 다음 tick에 unmount (React state 정리 시간 확보)
+      setTimeout(unmountModal, 0)
+    }
+
+    activeRoot.render(<WorkerGuardModal {...opts} onResolve={handleResolve} />)
+  })
+
+  return activePromise
+}
+
+// =====================================================
+// 워커 상태 재핑 (모달 내부 사용)
+// =====================================================
+
+async function pingWorkerStatus(type: WorkerType): Promise<{ installed: boolean; online: boolean }> {
+  try {
+    const res = await fetch(`/api/workers/status?type=${type}`, {
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) return { installed: false, online: false }
+    const data = await res.json()
+    const slot = data[type]
+    return {
+      installed: slot?.installed ?? false,
+      online: slot?.online ?? false,
+    }
+  } catch {
+    return { installed: false, online: false }
+  }
+}
+
+// =====================================================
+// Modal Component
+// =====================================================
+
+function WorkerGuardModal({ type, featureName, state, onResolve }: ModalProps) {
+  const [downloading, setDownloading] = useState(false)
+  const [rechecking, setRechecking] = useState(false)
+  const [downloadError, setDownloadError] = useState<string | null>(null)
+
+  const isNotInstalled = state === 'not_installed'
+
+  const handleDownload = async () => {
+    setDownloading(true)
+    setDownloadError(null)
+    const result = await triggerWorkerDownload()
+    setDownloading(false)
+    if (!result.ok) {
+      setDownloadError(
+        result.reason === 'unsupported_os'
+          ? 'Windows 또는 macOS에서만 지원됩니다.'
+          : '다운로드 URL을 가져올 수 없습니다. 잠시 후 다시 시도해주세요.'
+      )
+    }
+  }
+
+  const handleRecheck = async () => {
+    setRechecking(true)
+    const status = await pingWorkerStatus(type)
+    setRechecking(false)
+    if (status.installed && status.online) {
+      onResolve(true)
+    }
+    // else: 모달 유지 — 미설치/오프라인 상태 그대로
+  }
+
+  const handleCancel = () => onResolve(false)
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4"
+      onClick={handleCancel}
+    >
+      <div
+        className="w-full max-w-lg rounded-2xl bg-white shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-100">
+              <AlertTriangle className="h-5 w-5 text-amber-600" />
+            </div>
+            <h2 className="text-lg font-semibold text-gray-900">
+              {isNotInstalled ? '통합 워커 미설치' : '통합 워커 응답 없음'}
+            </h2>
+          </div>
+          <button
+            onClick={handleCancel}
+            className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+            aria-label="닫기"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="space-y-4 px-6 py-5">
+          <p className="text-sm text-gray-700">
+            <strong>{featureName}</strong> 기능을 사용하려면 통합 워커가{' '}
+            {isNotInstalled ? '설치되어 있어야' : '실행 중이어야'} 합니다.
+          </p>
+
+          {isNotInstalled ? (
+            <NotInstalledGuide />
+          ) : (
+            <OfflineGuide />
+          )}
+
+          {downloadError && (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {downloadError}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 border-t border-gray-200 px-6 py-4">
+          <button
+            onClick={handleCancel}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+          >
+            취소
+          </button>
+          {!isNotInstalled && (
+            <button
+              onClick={handleDownload}
+              disabled={downloading}
+              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              {downloading ? '다운로드 중...' : '재설치'}
+            </button>
+          )}
+          <button
+            onClick={handleRecheck}
+            disabled={rechecking}
+            className="flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {rechecking ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            다시 확인
+          </button>
+          {isNotInstalled && (
+            <button
+              onClick={handleDownload}
+              disabled={downloading}
+              className="flex items-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-white hover:bg-amber-600 disabled:opacity-50"
+            >
+              {downloading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Download className="h-4 w-4" />
+              )}
+              통합 워커 다운로드
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// =====================================================
+// 가이드 컴포넌트
+// =====================================================
+
+function NotInstalledGuide() {
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm">
+      <p className="mb-2 font-medium text-amber-900">설치 방법</p>
+      <ol className="list-decimal space-y-1 pl-5 text-amber-800">
+        <li>아래 [통합 워커 다운로드] 버튼을 클릭합니다.</li>
+        <li>다운로드된 <code className="rounded bg-amber-100 px-1">clinic-manager-worker-x.x.x-setup.exe</code>를 실행합니다.</li>
+        <li>설치 마법사 안내에 따라 진행합니다.</li>
+        <li>설치 완료 후 자동 실행됩니다 (작업 표시줄 트레이 아이콘 확인).</li>
+        <li>1분 후 [다시 확인]을 눌러주세요.</li>
+      </ol>
+    </div>
+  )
+}
+
+function OfflineGuide() {
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm">
+      <p className="mb-2 font-medium text-amber-900">해결 방법</p>
+      <ol className="list-decimal space-y-1 pl-5 text-amber-800">
+        <li>작업 표시줄 우측 트레이 영역을 확인합니다.</li>
+        <li>통합 워커 아이콘을 우클릭하여 &ldquo;종료&rdquo;합니다.</li>
+        <li>시작 메뉴에서 통합 워커를 다시 실행합니다.</li>
+        <li>1분 후 [다시 확인]을 눌러주세요.</li>
+      </ol>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/WorkerGuardModal.tsx
+++ b/dental-clinic-manager/src/components/WorkerGuardModal.tsx
@@ -1,7 +1,7 @@
 // src/components/WorkerGuardModal.tsx
 'use client'
 
-import { useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { AlertTriangle, Download, RefreshCw, X, Loader2 } from 'lucide-react'
 import { triggerWorkerDownload } from '@/lib/workers/installer'
@@ -88,8 +88,13 @@ function WorkerGuardModal({ type, featureName, state, onResolve }: ModalProps) {
   const [downloading, setDownloading] = useState(false)
   const [rechecking, setRechecking] = useState(false)
   const [downloadError, setDownloadError] = useState<string | null>(null)
+  const [offlineCycleKey, setOfflineCycleKey] = useState(0)
 
   const isNotInstalled = state === 'not_installed'
+
+  const handleAutoRecovered = useCallback(() => {
+    onResolve(true)
+  }, [onResolve])
 
   const handleDownload = async () => {
     setDownloading(true)
@@ -111,8 +116,12 @@ function WorkerGuardModal({ type, featureName, state, onResolve }: ModalProps) {
     setRechecking(false)
     if (status.installed && status.online) {
       onResolve(true)
+      return
     }
-    // else: 모달 유지 — 미설치/오프라인 상태 그대로
+    // 실패 시 OfflineSection 재마운트 (자동 재시도 카운터 리셋)
+    if (!isNotInstalled) {
+      setOfflineCycleKey((k) => k + 1)
+    }
   }
 
   const handleCancel = () => onResolve(false)
@@ -155,7 +164,11 @@ function WorkerGuardModal({ type, featureName, state, onResolve }: ModalProps) {
           {isNotInstalled ? (
             <NotInstalledGuide />
           ) : (
-            <OfflineGuide />
+            <OfflineSection
+              key={offlineCycleKey}
+              type={type}
+              onAutoRecovered={handleAutoRecovered}
+            />
           )}
 
           {downloadError && (
@@ -229,16 +242,94 @@ function NotInstalledGuide() {
   )
 }
 
-function OfflineGuide() {
+interface OfflineSectionProps {
+  type: WorkerType
+  onAutoRecovered: () => void
+}
+
+function OfflineSection({ type, onAutoRecovered }: OfflineSectionProps) {
+  const MAX_ATTEMPTS = 3
+  const INTERVAL_MS = 5000
+
+  const [attempt, setAttempt] = useState(0) // 0..MAX_ATTEMPTS (완료 횟수)
+  const [secondsLeft, setSecondsLeft] = useState(INTERVAL_MS / 1000)
+  const [exhausted, setExhausted] = useState(false)
+
+  useEffect(() => {
+    if (exhausted) return
+    if (attempt >= MAX_ATTEMPTS) {
+      setExhausted(true)
+      return
+    }
+
+    let cancelled = false
+    let countdownTimer: ReturnType<typeof setInterval> | null = null
+    let tickRemaining = INTERVAL_MS / 1000
+
+    setSecondsLeft(tickRemaining)
+    countdownTimer = setInterval(() => {
+      tickRemaining -= 1
+      if (cancelled) return
+      setSecondsLeft(Math.max(0, tickRemaining))
+    }, 1000)
+
+    const fireTimer = setTimeout(async () => {
+      if (cancelled) return
+      const status = await pingWorkerStatus(type)
+      if (cancelled) return
+      if (status.installed && status.online) {
+        onAutoRecovered()
+        return
+      }
+      setAttempt((n) => n + 1)
+    }, INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      if (countdownTimer) clearInterval(countdownTimer)
+      clearTimeout(fireTimer)
+    }
+  }, [attempt, exhausted, type, onAutoRecovered])
+
   return (
-    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm">
-      <p className="mb-2 font-medium text-amber-900">해결 방법</p>
-      <ol className="list-decimal space-y-1 pl-5 text-amber-800">
-        <li>작업 표시줄 우측 트레이 영역을 확인합니다.</li>
-        <li>통합 워커 아이콘을 우클릭하여 &ldquo;종료&rdquo;합니다.</li>
-        <li>시작 메뉴에서 통합 워커를 다시 실행합니다.</li>
-        <li>1분 후 [다시 확인]을 눌러주세요.</li>
-      </ol>
+    <div className="space-y-3">
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm">
+        <p className="mb-2 font-medium text-amber-900">해결 방법</p>
+        <ol className="list-decimal space-y-1 pl-5 text-amber-800">
+          <li>작업 표시줄 우측 트레이 영역을 확인합니다.</li>
+          <li>통합 워커 아이콘을 우클릭하여 &ldquo;종료&rdquo;합니다.</li>
+          <li>시작 메뉴에서 통합 워커를 다시 실행합니다.</li>
+          <li>1분 후 [다시 확인]을 눌러주세요.</li>
+        </ol>
+      </div>
+
+      <div className="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
+        <RefreshCw className={`h-3.5 w-3.5 ${exhausted ? '' : 'animate-spin'}`} />
+        {exhausted ? (
+          <span>자동 확인 종료. 워커를 재시작 후 [다시 확인]을 눌러주세요.</span>
+        ) : (
+          <span>
+            자동 재시도{' '}
+            <DotIndicator current={attempt} total={MAX_ATTEMPTS} />{' '}
+            ({attempt + 1}/{MAX_ATTEMPTS}) — {secondsLeft}초 후 다시 확인...
+          </span>
+        )}
+      </div>
     </div>
+  )
+}
+
+function DotIndicator({ current, total }: { current: number; total: number }) {
+  return (
+    <span aria-hidden className="inline-flex gap-0.5">
+      {Array.from({ length: total }).map((_, i) => (
+        <span
+          key={i}
+          className={`inline-block h-1.5 w-1.5 rounded-full ${
+            i < current ? 'bg-amber-600' : 'bg-amber-300'
+          }`}
+        />
+      ))}
+    </span>
   )
 }

--- a/dental-clinic-manager/src/components/marketing/CalendarItemCard.tsx
+++ b/dental-clinic-manager/src/components/marketing/CalendarItemCard.tsx
@@ -8,6 +8,10 @@ import {
   PencilIcon,
   ExclamationTriangleIcon,
   ChartBarIcon,
+  EyeIcon,
+  HeartIcon,
+  ChatBubbleLeftIcon,
+  BookmarkIcon,
 } from '@heroicons/react/24/outline'
 import {
   TOPIC_CATEGORY_LABELS,
@@ -230,6 +234,66 @@ export default function CalendarItemCard({
           ⚠️ {item.fail_reason}
         </p>
       )}
+
+      {item.status === 'published' && item.metrics && item.metrics.length > 0 && (
+        <div className="mt-2 pt-2 border-t border-gray-100 space-y-1">
+          {item.metrics.map((m) => {
+            const measured = new Date(m.measured_at)
+            const ago = formatTimeAgo(measured)
+            return (
+              <div key={m.platform} className="flex items-center gap-2 flex-wrap text-[11px]">
+                <span className="text-gray-400 font-medium">{platformLabel(m.platform)}</span>
+                {m.views !== null && (
+                  <span className="inline-flex items-center gap-0.5 text-blue-600">
+                    <EyeIcon className="h-3 w-3" />
+                    {m.views.toLocaleString()}
+                  </span>
+                )}
+                {m.likes !== null && (
+                  <span className="inline-flex items-center gap-0.5 text-rose-500">
+                    <HeartIcon className="h-3 w-3" />
+                    {m.likes.toLocaleString()}
+                  </span>
+                )}
+                {m.comments !== null && (
+                  <span className="inline-flex items-center gap-0.5 text-emerald-600">
+                    <ChatBubbleLeftIcon className="h-3 w-3" />
+                    {m.comments.toLocaleString()}
+                  </span>
+                )}
+                {m.scraps !== null && m.scraps > 0 && (
+                  <span className="inline-flex items-center gap-0.5 text-violet-600">
+                    <BookmarkIcon className="h-3 w-3" />
+                    {m.scraps.toLocaleString()}
+                  </span>
+                )}
+                <span className="text-gray-400 ml-auto">{ago}</span>
+              </div>
+            )
+          })}
+        </div>
+      )}
     </div>
   )
+}
+
+function platformLabel(p: string): string {
+  switch (p) {
+    case 'naver_blog': return '네이버'
+    case 'instagram': return '인스타'
+    case 'facebook': return '페북'
+    case 'threads': return '쓰레드'
+    default: return p
+  }
+}
+
+function formatTimeAgo(d: Date): string {
+  const ms = Date.now() - d.getTime()
+  const min = Math.floor(ms / 60000)
+  if (min < 1) return '방금'
+  if (min < 60) return `${min}분 전`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}시간 전`
+  const day = Math.floor(hr / 24)
+  return `${day}일 전`
 }

--- a/dental-clinic-manager/src/config/menuConfig.ts
+++ b/dental-clinic-manager/src/config/menuConfig.ts
@@ -32,23 +32,23 @@ export const PREMIUM_FEATURE_INFO: Record<PremiumFeatureId, {
   priceLabel: string
 }> = {
   'ai-analysis': {
-    title: 'AI 데이터 분석',
-    description: 'AI가 병원 데이터를 분석하여 경영 인사이트를 제공합니다.',
-    highlights: ['매출/환자 추이 자동 분석', '맞춤형 경영 인사이트', 'AI 채팅으로 질문하기'],
+    title: '프리미엄 패키지',
+    description: 'AI 분석, 경영 현황, 마케팅 자동화를 하나의 패키지로 이용하세요.',
+    highlights: ['AI 데이터 분석 — 매출/환자 추이 자동 분석, AI 채팅', '경영 현황 — 수입/지출 관리, 손익 분석, 세금 계산', '마케팅 자동화 — AI 임상글 생성, SEO 분석, 게시물 관리'],
     planName: '프리미엄',
     priceLabel: '월 499,000원',
   },
   'financial': {
-    title: '경영 현황',
-    description: '수입/지출을 체계적으로 관리하고 손익을 분석합니다.',
-    highlights: ['수입/지출 관리', '손익 분석 리포트', '세금 계산 자동화'],
+    title: '프리미엄 패키지',
+    description: 'AI 분석, 경영 현황, 마케팅 자동화를 하나의 패키지로 이용하세요.',
+    highlights: ['AI 데이터 분석 — 매출/환자 추이 자동 분석, AI 채팅', '경영 현황 — 수입/지출 관리, 손익 분석, 세금 계산', '마케팅 자동화 — AI 임상글 생성, SEO 분석, 게시물 관리'],
     planName: '프리미엄',
     priceLabel: '월 499,000원',
   },
   'marketing': {
-    title: '마케팅 자동화',
-    description: '네이버 블로그 임상글을 AI로 자동 생성하고 관리합니다.',
-    highlights: ['AI 임상글 자동 생성', 'SEO 최적화 분석', '게시물 일괄 관리'],
+    title: '프리미엄 패키지',
+    description: 'AI 분석, 경영 현황, 마케팅 자동화를 하나의 패키지로 이용하세요.',
+    highlights: ['AI 데이터 분석 — 매출/환자 추이 자동 분석, AI 채팅', '경영 현황 — 수입/지출 관리, 손익 분석, 세금 계산', '마케팅 자동화 — AI 임상글 생성, SEO 분석, 게시물 관리'],
     planName: '프리미엄',
     priceLabel: '월 499,000원',
   },

--- a/dental-clinic-manager/src/hooks/useInstallPrompt.ts
+++ b/dental-clinic-manager/src/hooks/useInstallPrompt.ts
@@ -64,9 +64,34 @@ if (typeof window !== 'undefined') {
   // → Uninstall detection only works reliably on Android.
   const _isAndroid = /Android/i.test(navigator.userAgent)
 
+  // getInstalledRelatedApps()로 이미 설치된 same-origin PWA 감지 (async)
+  const detectInstalledViaRelatedApps = async (): Promise<boolean> => {
+    if (!('getInstalledRelatedApps' in navigator)) return false
+    try {
+      const apps = await (
+        navigator as unknown as { getInstalledRelatedApps(): Promise<{ platform: string }[]> }
+      ).getInstalledRelatedApps()
+      return apps.length > 0
+    } catch {
+      return false
+    }
+  }
+
   // Capture beforeinstallprompt event globally (before any component mounts)
-  window.addEventListener('beforeinstallprompt', (e) => {
+  window.addEventListener('beforeinstallprompt', async (e) => {
     e.preventDefault()
+
+    // 데스크톱 Chrome: PWA가 이미 설치되어 있어도 이 이벤트가 발생함.
+    // getInstalledRelatedApps()로 실제 설치 상태를 재확인하여 배너를 숨긴다.
+    const alreadyInstalled = await detectInstalledViaRelatedApps()
+    if (alreadyInstalled) {
+      _isInstalled = true
+      _deferredPrompt = null
+      localStorage.setItem(INSTALLED_KEY, 'true')
+      notifyListeners()
+      return
+    }
+
     _deferredPrompt = e as BeforeInstallPromptEvent
 
     // Detect uninstall on Android only:

--- a/dental-clinic-manager/src/hooks/usePremiumFeatures.ts
+++ b/dental-clinic-manager/src/hooks/usePremiumFeatures.ts
@@ -4,6 +4,10 @@ import { useState, useEffect, useCallback } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { dataService } from '@/lib/dataService'
 import { PREMIUM_FEATURE_IDS } from '@/config/menuConfig'
+import { getSupabase } from '@/lib/supabase'
+
+// premium-bundle 구독 시 포함되는 기능 ID들
+const PREMIUM_BUNDLE_FEATURES = ['ai-analysis', 'financial', 'marketing'] as const
 
 export function usePremiumFeatures() {
   const { user } = useAuth()
@@ -26,14 +30,44 @@ export function usePremiumFeatures() {
 
     const fetchPremiumFeatures = async () => {
       try {
-        const { data, error } = await dataService.getClinicPremiumFeatures(user.clinic_id!)
-        if (error) {
-          console.error('[usePremiumFeatures] Error:', error)
-          setPremiumFeatures(new Set())
-        } else {
-          const featureIds = new Set<string>((data || []).map((f: { feature_id: string }) => f.feature_id))
-          setPremiumFeatures(featureIds)
+        const featureIds = new Set<string>()
+
+        // 1. 기존: clinic_premium_features 테이블 체크 (마스터가 수동 활성화)
+        const { data } = await dataService.getClinicPremiumFeatures(user.clinic_id!)
+        if (data) {
+          for (const f of data) {
+            featureIds.add(f.feature_id)
+          }
         }
+
+        // 2. 신규: subscriptions 테이블 체크 (구독 결제)
+        const supabase = getSupabase()
+        if (supabase) {
+          const { data: subs } = await supabase
+            .from('subscriptions')
+            .select('plan_id, status, subscription_plans(feature_id)')
+            .eq('clinic_id', user.clinic_id!)
+            .in('status', ['active', 'trialing'])
+
+          if (subs) {
+            for (const sub of subs) {
+              const plan = sub.subscription_plans as unknown as { feature_id: string | null } | null
+              if (!plan?.feature_id) continue
+
+              if (plan.feature_id === 'premium-bundle') {
+                // premium-bundle → 3개 기능 모두 활성화
+                for (const fid of PREMIUM_BUNDLE_FEATURES) {
+                  featureIds.add(fid)
+                }
+              } else {
+                // 개별 feature 플랜 (investment 등)
+                featureIds.add(plan.feature_id)
+              }
+            }
+          }
+        }
+
+        setPremiumFeatures(featureIds)
       } catch (err) {
         console.error('[usePremiumFeatures] Unexpected error:', err)
         setPremiumFeatures(new Set())

--- a/dental-clinic-manager/src/lib/dataService.ts
+++ b/dental-clinic-manager/src/lib/dataService.ts
@@ -1733,11 +1733,12 @@ export const dataService = {
 
   // 사용자 승인 (직원 관리)
   // Database Trigger가 자동으로 승인 이메일을 발송합니다.
-  async approveUser(userId: string, clinicId: string, permissions?: string[]) {
+  // clinic_id가 null인 사용자(예: 시스템 관리자 후보)도 처리한다.
+  async approveUser(userId: string, clinicId: string | null, permissions?: string[]) {
     try {
       const supabase = await ensureConnection()
 
-      console.log('[approveUser] Approving user:', userId)
+      console.log('[approveUser] Approving user:', userId, 'clinicId:', clinicId ?? 'null')
 
       // 업데이트 데이터 준비
       const updateData: any = {
@@ -1753,11 +1754,14 @@ export const dataService = {
       // 사용자 상태를 'active'로 업데이트
       // Database Trigger (users_approval_notification_trigger)가
       // 자동으로 Edge Function을 호출하여 승인 이메일을 발송합니다.
-      const { error } = await supabase
+      const updateQuery = supabase
         .from('users')
         .update(updateData)
         .eq('id', userId)
-        .eq('clinic_id', clinicId)
+
+      const { error } = await (
+        clinicId ? updateQuery.eq('clinic_id', clinicId) : updateQuery.is('clinic_id', null)
+      )
 
       if (error) {
         console.error('[approveUser] Database error:', error)
@@ -1774,7 +1778,8 @@ export const dataService = {
   },
 
   // 사용자 거절 (직원 관리)
-  async rejectUser(userId: string, clinicId: string, reason: string) {
+  // clinic_id가 null인 사용자도 처리할 수 있도록 옵셔널로 받는다.
+  async rejectUser(userId: string, clinicId: string | null, reason: string) {
     try {
       console.log('[rejectUser] Calling Admin API to reject user:', userId)
 

--- a/dental-clinic-manager/src/lib/dataService.ts
+++ b/dental-clinic-manager/src/lib/dataService.ts
@@ -1735,43 +1735,52 @@ export const dataService = {
   // Database Trigger가 자동으로 승인 이메일을 발송합니다.
   // clinic_id가 null인 사용자(예: 시스템 관리자 후보)도 처리한다.
   async approveUser(userId: string, clinicId: string | null, permissions?: string[]) {
+    // clinic_id가 null인 경우(시스템 관리자 후보)는 기존 클라이언트 직접 업데이트 유지
+    // clinic_id가 있는 경우는 인원 상한 가드를 위해 서버 API 경유
+    if (!clinicId) {
+      try {
+        const supabase = await ensureConnection()
+        const updateData: Record<string, unknown> = {
+          status: 'active',
+          approved_at: new Date().toISOString(),
+        }
+        if (permissions && permissions.length > 0) updateData.permissions = permissions
+        const { error } = await supabase
+          .from('users')
+          .update(updateData)
+          .eq('id', userId)
+          .is('clinic_id', null)
+        if (error) return { error: error.message }
+        return { success: true as const }
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : JSON.stringify(error)
+        return { error: errorMessage }
+      }
+    }
+
     try {
-      const supabase = await ensureConnection()
+      const res = await fetch('/api/staff/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userIds: [userId], permissions }),
+      })
+      const data = await res.json().catch(() => ({}))
 
-      console.log('[approveUser] Approving user:', userId, 'clinicId:', clinicId ?? 'null')
-
-      // 업데이트 데이터 준비
-      const updateData: any = {
-        status: 'active',
-        approved_at: new Date().toISOString()
+      if (res.status === 403 && data?.error === 'UPGRADE_REQUIRED') {
+        return {
+          upgradeRequired: true as const,
+          currentPlan: data.currentPlan as string,
+          currentLimit: data.currentLimit as number,
+          currentActive: data.currentActive as number,
+          pendingToApprove: data.pendingToApprove as number,
+          recommendedPlan: data.recommendedPlan as string,
+        }
       }
-
-      // 권한이 지정된 경우 저장
-      if (permissions && permissions.length > 0) {
-        updateData.permissions = permissions
+      if (!res.ok) {
+        return { error: (data?.error as string) ?? '승인 처리에 실패했습니다.' }
       }
-
-      // 사용자 상태를 'active'로 업데이트
-      // Database Trigger (users_approval_notification_trigger)가
-      // 자동으로 Edge Function을 호출하여 승인 이메일을 발송합니다.
-      const updateQuery = supabase
-        .from('users')
-        .update(updateData)
-        .eq('id', userId)
-
-      const { error } = await (
-        clinicId ? updateQuery.eq('clinic_id', clinicId) : updateQuery.is('clinic_id', null)
-      )
-
-      if (error) {
-        console.error('[approveUser] Database error:', error)
-        return { error: error.message }
-      }
-
-      console.log('[approveUser] User approved successfully (email will be sent by trigger)')
-      return { success: true }
+      return { success: true as const }
     } catch (error: unknown) {
-      console.error('[approveUser] Unexpected error:', error)
       const errorMessage = error instanceof Error ? error.message : JSON.stringify(error)
       return { error: errorMessage }
     }

--- a/dental-clinic-manager/src/lib/dataService.ts
+++ b/dental-clinic-manager/src/lib/dataService.ts
@@ -1736,42 +1736,33 @@ export const dataService = {
   // clinic_id가 null인 사용자(예: 시스템 관리자 후보)도 처리한다.
   async approveUser(userId: string, clinicId: string | null, permissions?: string[]) {
     try {
-      const supabase = await ensureConnection()
+      const res = await fetch('/api/staff/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId,
+          userIds: [userId],
+          permissions,
+        }),
+      })
+      const data = await res.json().catch(() => ({}))
 
-      console.log('[approveUser] Approving user:', userId, 'clinicId:', clinicId ?? 'null')
-
-      // 업데이트 데이터 준비
-      const updateData: any = {
-        status: 'active',
-        approved_at: new Date().toISOString()
+      if (res.status === 403 && data?.error === 'UPGRADE_REQUIRED') {
+        return {
+          upgradeRequired: true,
+          currentPlan: data.currentPlan,
+          currentLimit: data.currentLimit,
+          currentActive: data.currentActive,
+          pendingToApprove: data.pendingToApprove,
+          recommendedPlan: data.recommendedPlan,
+        } as const
       }
 
-      // 권한이 지정된 경우 저장
-      if (permissions && permissions.length > 0) {
-        updateData.permissions = permissions
+      if (!res.ok) {
+        return { error: data?.error ?? '승인 처리에 실패했습니다.' }
       }
-
-      // 사용자 상태를 'active'로 업데이트
-      // Database Trigger (users_approval_notification_trigger)가
-      // 자동으로 Edge Function을 호출하여 승인 이메일을 발송합니다.
-      const updateQuery = supabase
-        .from('users')
-        .update(updateData)
-        .eq('id', userId)
-
-      const { error } = await (
-        clinicId ? updateQuery.eq('clinic_id', clinicId) : updateQuery.is('clinic_id', null)
-      )
-
-      if (error) {
-        console.error('[approveUser] Database error:', error)
-        return { error: error.message }
-      }
-
-      console.log('[approveUser] User approved successfully (email will be sent by trigger)')
-      return { success: true }
+      return { success: true as const }
     } catch (error: unknown) {
-      console.error('[approveUser] Unexpected error:', error)
       const errorMessage = error instanceof Error ? error.message : JSON.stringify(error)
       return { error: errorMessage }
     }

--- a/dental-clinic-manager/src/lib/dataService.ts
+++ b/dental-clinic-manager/src/lib/dataService.ts
@@ -1735,52 +1735,43 @@ export const dataService = {
   // Database Trigger가 자동으로 승인 이메일을 발송합니다.
   // clinic_id가 null인 사용자(예: 시스템 관리자 후보)도 처리한다.
   async approveUser(userId: string, clinicId: string | null, permissions?: string[]) {
-    // clinic_id가 null인 경우(시스템 관리자 후보)는 기존 클라이언트 직접 업데이트 유지
-    // clinic_id가 있는 경우는 인원 상한 가드를 위해 서버 API 경유
-    if (!clinicId) {
-      try {
-        const supabase = await ensureConnection()
-        const updateData: Record<string, unknown> = {
-          status: 'active',
-          approved_at: new Date().toISOString(),
-        }
-        if (permissions && permissions.length > 0) updateData.permissions = permissions
-        const { error } = await supabase
-          .from('users')
-          .update(updateData)
-          .eq('id', userId)
-          .is('clinic_id', null)
-        if (error) return { error: error.message }
-        return { success: true as const }
-      } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : JSON.stringify(error)
-        return { error: errorMessage }
-      }
-    }
-
     try {
-      const res = await fetch('/api/staff/approve', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userIds: [userId], permissions }),
-      })
-      const data = await res.json().catch(() => ({}))
+      const supabase = await ensureConnection()
 
-      if (res.status === 403 && data?.error === 'UPGRADE_REQUIRED') {
-        return {
-          upgradeRequired: true as const,
-          currentPlan: data.currentPlan as string,
-          currentLimit: data.currentLimit as number,
-          currentActive: data.currentActive as number,
-          pendingToApprove: data.pendingToApprove as number,
-          recommendedPlan: data.recommendedPlan as string,
-        }
+      console.log('[approveUser] Approving user:', userId, 'clinicId:', clinicId ?? 'null')
+
+      // 업데이트 데이터 준비
+      const updateData: any = {
+        status: 'active',
+        approved_at: new Date().toISOString()
       }
-      if (!res.ok) {
-        return { error: (data?.error as string) ?? '승인 처리에 실패했습니다.' }
+
+      // 권한이 지정된 경우 저장
+      if (permissions && permissions.length > 0) {
+        updateData.permissions = permissions
       }
-      return { success: true as const }
+
+      // 사용자 상태를 'active'로 업데이트
+      // Database Trigger (users_approval_notification_trigger)가
+      // 자동으로 Edge Function을 호출하여 승인 이메일을 발송합니다.
+      const updateQuery = supabase
+        .from('users')
+        .update(updateData)
+        .eq('id', userId)
+
+      const { error } = await (
+        clinicId ? updateQuery.eq('clinic_id', clinicId) : updateQuery.is('clinic_id', null)
+      )
+
+      if (error) {
+        console.error('[approveUser] Database error:', error)
+        return { error: error.message }
+      }
+
+      console.log('[approveUser] User approved successfully (email will be sent by trigger)')
+      return { success: true }
     } catch (error: unknown) {
+      console.error('[approveUser] Unexpected error:', error)
       const errorMessage = error instanceof Error ? error.message : JSON.stringify(error)
       return { error: errorMessage }
     }

--- a/dental-clinic-manager/src/lib/dataService.ts
+++ b/dental-clinic-manager/src/lib/dataService.ts
@@ -1501,17 +1501,37 @@ export const dataService = {
   },
 
   // 모든 병원 목록 가져오기 (마스터 전용)
+  // 대표원장(owner)이 'active' 상태로 승인된 병원만 반환한다.
+  // pending(승인 대기) 또는 rejected(거절)된 owner의 병원은 목록에서 제외된다.
   async getAllClinics() {
     const supabase = await ensureConnection()
     if (!supabase) throw new Error('Supabase client not available')
 
     try {
+      const { data: activeOwners, error: ownersError } = await supabase
+        .from('users')
+        .select('clinic_id')
+        .eq('role', 'owner')
+        .eq('status', 'active')
+        .not('clinic_id', 'is', null)
+
+      if (ownersError) throw ownersError
+
+      const activeClinicIds = (activeOwners ?? [])
+        .map((u: { clinic_id: string | null }) => u.clinic_id)
+        .filter((id: string | null): id is string => !!id)
+
+      if (activeClinicIds.length === 0) {
+        return { data: [] }
+      }
+
       const { data, error } = await supabase
         .from('clinics')
         .select(`
           *,
           users!users_clinic_id_fkey(count)
         `)
+        .in('id', activeClinicIds)
         .order('created_at', { ascending: false })
 
       if (error) throw error

--- a/dental-clinic-manager/src/lib/marketing/calendar-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/calendar-generator.ts
@@ -5,6 +5,13 @@ import { getKeywordInsights, totalMonthlyQc, isSearchAdConfigured } from '@/lib/
 import { getSeasonalScores, isDataLabConfigured } from '@/lib/marketing/naver-datalab-client';
 import { checkMedicalLaw } from '@/lib/marketing/medical-law-checker';
 import {
+  embedTextsBatch,
+  cosineSimilarity,
+  serializeEmbedding,
+  deserializeEmbedding,
+  isEmbeddingsConfigured,
+} from '@/lib/marketing/embeddings';
+import {
   DEFAULT_PLATFORM_PRESETS,
   DEFAULT_JOURNEY_DISTRIBUTION,
   JOURNEY_CATEGORY_MAP,
@@ -81,15 +88,38 @@ export async function generateCalendar(
 
   const recentKeywords = (historyRows || []).map((r) => r.keyword as string);
 
-  // 최근 발행 제목도 로드 (유사도 체크용)
+  // 최근 발행 제목 + 임베딩도 함께 로드 (유사도 체크용)
   const { data: recentItems } = await supabase
     .from('content_calendar_items')
-    .select('title')
+    .select('title, title_embedding')
     .in('status', ['scheduled', 'publishing', 'published'])
     .gte('created_at', cutoff.toISOString())
     .order('created_at', { ascending: false })
     .limit(100);
   const recentTitles = (recentItems || []).map((i) => i.title as string);
+  const recentEmbeddingsRaw = (recentItems || []).map((i) =>
+    deserializeEmbedding((i as unknown as { title_embedding: string | null }).title_embedding)
+  );
+  const recentTitlesNeedingEmbedding = recentTitles
+    .map((t, i) => ({ t, i }))
+    .filter((x) => recentEmbeddingsRaw[x.i] === null)
+    .map((x) => x.t);
+
+  // 임베딩 미생성 분량을 일괄 임베딩 → 메모리 보강
+  let recentEmbeddings = recentEmbeddingsRaw;
+  if (isEmbeddingsConfigured() && recentTitlesNeedingEmbedding.length > 0) {
+    try {
+      const generated = await embedTextsBatch(recentTitlesNeedingEmbedding);
+      let g = 0;
+      recentEmbeddings = recentEmbeddingsRaw.map((existing) => {
+        if (existing) return existing;
+        const next = generated[g++];
+        return next ?? null;
+      });
+    } catch (e) {
+      console.error('[CalendarGen v2] 기존 제목 임베딩 백필 실패:', e);
+    }
+  }
 
   const excludeList = [...(request.excludeKeywords || []), ...recentKeywords];
 
@@ -165,6 +195,43 @@ export async function generateCalendar(
     year,
   });
 
+  // 5-1. 의미적 중복 검사 (Gemini 임베딩 — 토큰 유사도가 못 잡는 표현 변종 차단)
+  let proposalEmbeddings: (number[] | null)[] = proposals.map(() => null);
+  if (isEmbeddingsConfigured()) {
+    try {
+      proposalEmbeddings = await embedTextsBatch(proposals.map((p) => p.title));
+      const SIM_THRESHOLD = 0.85;
+      for (let i = 0; i < proposals.length; i++) {
+        const propEmb = proposalEmbeddings[i];
+        if (!propEmb) continue;
+
+        // 기존 발행분과 비교
+        for (const existing of recentEmbeddings) {
+          if (!existing) continue;
+          if (cosineSimilarity(propEmb, existing) >= SIM_THRESHOLD) {
+            console.warn(`[CalendarGen v2] 임베딩 중복 감지(과거): ${proposals[i].title}`);
+            proposals[i] = fallbackProposal(i, journeySlots[i]);
+            proposalEmbeddings[i] = null;
+            break;
+          }
+        }
+
+        // 같은 회차 내 중복도 검사
+        for (let j = 0; j < i; j++) {
+          if (!proposalEmbeddings[j]) continue;
+          if (cosineSimilarity(propEmb, proposalEmbeddings[j]!) >= SIM_THRESHOLD) {
+            console.warn(`[CalendarGen v2] 임베딩 중복 감지(회차내): ${proposals[i].title}`);
+            proposals[i] = fallbackProposal(i, journeySlots[i]);
+            proposalEmbeddings[i] = null;
+            break;
+          }
+        }
+      }
+    } catch (e) {
+      console.error('[CalendarGen v2] 임베딩 중복 검사 실패 — 토큰 유사도로만 진행:', e);
+    }
+  }
+
   // 6. 의료법 사전 검증 (제목 수준)
   const verifiedProposals = proposals.map((p) => verifyMedicalLaw(p));
 
@@ -209,7 +276,7 @@ export async function generateCalendar(
     throw new Error(`캘린더 생성 실패: ${calError?.message || '알 수 없는 오류'}`);
   }
 
-  const itemsToInsert = items.map((item) => ({
+  const itemsToInsert = items.map((item, i) => ({
     calendar_id: calendar.id as string,
     publish_date: item.publishDate,
     publish_time: item.publishTime,
@@ -227,6 +294,7 @@ export async function generateCalendar(
     needs_medical_review: item.needsMedicalReview,
     planning_rationale: item.planningRationale,
     estimated_search_volume: item.estimatedSearchVolume,
+    title_embedding: serializeEmbedding(proposalEmbeddings[i]),
   }));
 
   const { error: itemsError } = await supabase

--- a/dental-clinic-manager/src/lib/marketing/embeddings.ts
+++ b/dental-clinic-manager/src/lib/marketing/embeddings.ts
@@ -1,0 +1,119 @@
+import { GoogleGenAI } from '@google/genai';
+
+// ============================================
+// 텍스트 임베딩 클라이언트 (Gemini embedding-001)
+// 제목 의미 유사도 기반 중복 검사용
+// - outputDimensionality=768 로 축소 (저장 절감, 정확도 유지)
+// - 코사인 유사도 ≥ 0.85 → 의미적 중복으로 판단
+// - 미설정 시 null 반환 (호출 측에서 토큰 유사도로 폴백)
+// ============================================
+
+const EMBED_MODEL = 'gemini-embedding-001';
+const OUTPUT_DIM = 768;
+
+let cachedClient: GoogleGenAI | null = null;
+
+function getClient(): GoogleGenAI | null {
+  if (!process.env.GEMINI_API_KEY) return null;
+  if (!cachedClient) {
+    cachedClient = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+  }
+  return cachedClient;
+}
+
+export function isEmbeddingsConfigured(): boolean {
+  return Boolean(process.env.GEMINI_API_KEY);
+}
+
+/**
+ * 단일 텍스트 임베딩
+ * - 실패 시 null (조용히 폴백 가능하도록)
+ */
+export async function embedText(text: string): Promise<number[] | null> {
+  const client = getClient();
+  if (!client || !text) return null;
+
+  try {
+    const res = await client.models.embedContent({
+      model: EMBED_MODEL,
+      contents: [text],
+      config: { outputDimensionality: OUTPUT_DIM },
+    });
+    const embeddings = res.embeddings;
+    if (!embeddings || embeddings.length === 0) return null;
+    const values = embeddings[0]?.values;
+    return Array.isArray(values) ? values : null;
+  } catch (error) {
+    console.error('[Embeddings] embedText 실패:', error);
+    return null;
+  }
+}
+
+/**
+ * 일괄 임베딩 (Gemini는 batch 요청도 단일 호출로 가능)
+ * - 100개씩 청크
+ */
+export async function embedTextsBatch(texts: string[]): Promise<(number[] | null)[]> {
+  if (texts.length === 0) return [];
+  const client = getClient();
+  if (!client) return texts.map(() => null);
+
+  const out: (number[] | null)[] = [];
+  for (let i = 0; i < texts.length; i += 100) {
+    const chunk = texts.slice(i, i + 100);
+    try {
+      const res = await client.models.embedContent({
+        model: EMBED_MODEL,
+        contents: chunk,
+        config: { outputDimensionality: OUTPUT_DIM },
+      });
+      const embeddings = res.embeddings || [];
+      for (let j = 0; j < chunk.length; j++) {
+        const vals = embeddings[j]?.values;
+        out.push(Array.isArray(vals) ? vals : null);
+      }
+    } catch (error) {
+      console.error('[Embeddings] embedTextsBatch chunk 실패:', error);
+      for (let j = 0; j < chunk.length; j++) out.push(null);
+    }
+  }
+  return out;
+}
+
+/**
+ * 코사인 유사도 (-1.0 ~ 1.0)
+ * 두 벡터 길이가 다르면 0
+ */
+export function cosineSimilarity(a: number[] | null, b: number[] | null): number {
+  if (!a || !b || a.length !== b.length || a.length === 0) return 0;
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  const denom = Math.sqrt(na) * Math.sqrt(nb);
+  if (denom === 0) return 0;
+  return dot / denom;
+}
+
+/**
+ * JSON ↔ float[] 변환 (DB text 컬럼 직렬화)
+ */
+export function serializeEmbedding(v: number[] | null): string | null {
+  if (!v || v.length === 0) return null;
+  // 6자리 소수로 반올림 → 저장 크기 절반 (768 × 8B → 768 × 4B)
+  return JSON.stringify(v.map((x) => Math.round(x * 1e6) / 1e6));
+}
+
+export function deserializeEmbedding(s: string | null): number[] | null {
+  if (!s) return null;
+  try {
+    const arr = JSON.parse(s);
+    return Array.isArray(arr) ? arr : null;
+  } catch {
+    return null;
+  }
+}

--- a/dental-clinic-manager/src/lib/subscriptionPlans.ts
+++ b/dental-clinic-manager/src/lib/subscriptionPlans.ts
@@ -1,0 +1,41 @@
+// src/lib/subscriptionPlans.ts
+import type { SubscriptionPlan } from '@/types/subscription'
+
+export type HeadcountPlanName = 'free' | 'starter' | 'growth' | 'pro' | 'enterprise'
+
+/**
+ * 총 재직자 수에 맞는 헤드카운트 플랜 이름을 반환한다.
+ * 경계: Free 1~4, Starter 5~10, Growth 11~20, Pro 21~50, Enterprise 51+
+ */
+export function findPlanByHeadcount(total: number): HeadcountPlanName {
+  if (total <= 4) return 'free'
+  if (total <= 10) return 'starter'
+  if (total <= 20) return 'growth'
+  if (total <= 50) return 'pro'
+  return 'enterprise'
+}
+
+/**
+ * 플랜 가격을 일관된 문구로 포맷한다.
+ * - 주식 자동매매(feature_id='investment'): "수익의 5%"
+ * - Enterprise: "맞춤 문의"
+ * - price=0: "무료"
+ * - 그 외: "월 N,NNN원"
+ */
+export function formatPlanPrice(plan: Pick<SubscriptionPlan, 'name' | 'price' | 'feature_id'>): string {
+  if (plan.feature_id === 'investment') return '수익의 5%'
+  if (plan.name === 'enterprise') return '맞춤 문의'
+  if (plan.price === 0) return '무료'
+  return `월 ${plan.price.toLocaleString()}원`
+}
+
+/**
+ * 현재 재직자 수와 승인 대기 중인 인원을 합산해 신규 플랜이 필요한지 판정한다.
+ */
+export function requiresUpgrade(params: {
+  currentActive: number
+  pendingToApprove: number
+  currentLimit: number
+}): boolean {
+  return params.currentActive + params.pendingToApprove > params.currentLimit
+}

--- a/dental-clinic-manager/src/lib/subscriptionService.ts
+++ b/dental-clinic-manager/src/lib/subscriptionService.ts
@@ -496,3 +496,30 @@ export async function getSubscriptionStatus(clinicId: string): Promise<Subscript
     daysUntilExpiry,
   }
 }
+
+// 해당 병원의 승인된(active) 직원 수 조회 — 인원 상한 체크용
+export async function countActiveEmployees(clinicId: string): Promise<number> {
+  const supabase = await createClient()
+  const { count, error } = await supabase
+    .from('users')
+    .select('id', { count: 'exact', head: true })
+    .eq('clinic_id', clinicId)
+    .eq('status', 'active')
+  if (error) throw new Error(`countActiveEmployees: ${error.message}`)
+  return count ?? 0
+}
+
+// 현재 구독의 가장 최근 성공 결제 조회 (부분 환불 기준 계산용)
+export async function getLatestPaidPayment(clinicId: string) {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('subscription_payments')
+    .select('*')
+    .eq('clinic_id', clinicId)
+    .eq('status', 'paid')
+    .order('paid_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (error) throw new Error(`getLatestPaidPayment: ${error.message}`)
+  return data
+}

--- a/dental-clinic-manager/src/lib/workers/installer.ts
+++ b/dental-clinic-manager/src/lib/workers/installer.ts
@@ -1,0 +1,60 @@
+// src/lib/workers/installer.ts
+
+export type DetectedOS = 'windows' | 'mac' | 'unknown'
+
+/**
+ * navigator.userAgent로 OS 감지.
+ * SSR 환경에서는 'unknown' 반환.
+ */
+export function detectOS(): DetectedOS {
+  if (typeof navigator === 'undefined') return 'unknown'
+  const ua = navigator.userAgent
+  if (/Windows/i.test(ua)) return 'windows'
+  if (/Mac OS X|Macintosh/i.test(ua)) return 'mac'
+  return 'unknown'
+}
+
+export type DownloadResult =
+  | { ok: true }
+  | { ok: false; reason: 'unsupported_os' | 'api_error' }
+
+/**
+ * 통합 워커 인스톨러 다운로드를 트리거한다.
+ * - Windows: GitHub Release `.exe` URL → window.location.assign() 자동 다운로드
+ * - Mac (DMG 있음): GitHub Release `.dmg` URL → window.location.assign()
+ * - Mac (DMG 없음): /api 응답이 shell script binary → blob anchor 다운로드
+ * - Linux/모바일: unsupported_os
+ */
+export async function triggerWorkerDownload(): Promise<DownloadResult> {
+  const os = detectOS()
+  if (os === 'unknown') return { ok: false, reason: 'unsupported_os' }
+
+  try {
+    const res = await fetch(`/api/marketing/worker-api/download?os=${os}`)
+    if (!res.ok) return { ok: false, reason: 'api_error' }
+
+    const contentType = res.headers.get('content-type') || ''
+
+    // JSON 응답: { downloadUrl } → 직접 이동
+    if (contentType.includes('application/json')) {
+      const data = (await res.json()) as { downloadUrl?: string }
+      if (!data.downloadUrl) return { ok: false, reason: 'api_error' }
+      window.location.assign(data.downloadUrl)
+      return { ok: true }
+    }
+
+    // 바이너리 응답 (Mac shell script): blob 다운로드
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = os === 'mac' ? 'marketing-worker-setup.command' : 'marketing-worker-setup.sh'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+    return { ok: true }
+  } catch {
+    return { ok: false, reason: 'api_error' }
+  }
+}

--- a/dental-clinic-manager/src/types/marketing.ts
+++ b/dental-clinic-manager/src/types/marketing.ts
@@ -164,8 +164,19 @@ export interface ContentCalendarItem {
   needs_medical_review: boolean;
   planning_rationale: string | null;
   estimated_search_volume: number | null;
+  // 발행 후 KPI (calendar API GET 시 enrich됨)
+  metrics?: PostMetricsSnapshot[];
   created_at: string;
   updated_at: string;
+}
+
+export interface PostMetricsSnapshot {
+  platform: string;
+  views: number | null;
+  comments: number | null;
+  likes: number | null;
+  scraps: number | null;
+  measured_at: string;
 }
 
 export type ClinicalPhotoType = 'before' | 'during' | 'after';

--- a/dental-clinic-manager/src/types/notification.ts
+++ b/dental-clinic-manager/src/types/notification.ts
@@ -313,6 +313,8 @@ export type UserNotificationType =
   | 'protocol_review_rejected'    // 프로토콜 검토 반려 (요청자에게)
   | 'important'                   // 중요 알림
   | 'system'                      // 시스템 알림
+  | 'subscription_upgrade_required'  // 구독 업그레이드 필요 (원장에게)
+  | 'subscription_payment_succeeded' // 결제 성공 후 대기자 승인 안내 (원장에게)
 
 // 사용자 알림 타입 라벨
 export const USER_NOTIFICATION_TYPE_LABELS: Record<UserNotificationType, string> = {
@@ -337,7 +339,9 @@ export const USER_NOTIFICATION_TYPE_LABELS: Record<UserNotificationType, string>
   protocol_review_approved: '프로토콜 검토 승인',
   protocol_review_rejected: '프로토콜 검토 반려',
   important: '중요 알림',
-  system: '시스템 알림'
+  system: '시스템 알림',
+  subscription_upgrade_required: '구독 업그레이드 필요',
+  subscription_payment_succeeded: '결제 완료 · 승인 대기'
 }
 
 // 사용자 알림 아이콘 매핑
@@ -363,7 +367,9 @@ export const USER_NOTIFICATION_TYPE_ICONS: Record<UserNotificationType, string> 
   protocol_review_approved: 'check-circle',
   protocol_review_rejected: 'x-circle',
   important: 'exclamation-circle',
-  system: 'bell'
+  system: 'bell',
+  subscription_upgrade_required: 'alert-circle',
+  subscription_payment_succeeded: 'credit-card'
 }
 
 // 사용자 알림 색상 매핑
@@ -389,7 +395,9 @@ export const USER_NOTIFICATION_TYPE_COLORS: Record<UserNotificationType, { icon:
   protocol_review_approved: { icon: 'text-green-500', bg: 'bg-green-50', text: 'text-green-700' },
   protocol_review_rejected: { icon: 'text-red-500', bg: 'bg-red-50', text: 'text-red-700' },
   important: { icon: 'text-red-500', bg: 'bg-red-50', text: 'text-red-700' },
-  system: { icon: 'text-blue-500', bg: 'bg-blue-50', text: 'text-blue-700' }
+  system: { icon: 'text-blue-500', bg: 'bg-blue-50', text: 'text-blue-700' },
+  subscription_upgrade_required: { icon: 'text-amber-500', bg: 'bg-amber-50', text: 'text-amber-700' },
+  subscription_payment_succeeded: { icon: 'text-emerald-500', bg: 'bg-emerald-50', text: 'text-emerald-700' }
 }
 
 // 사용자 알림 인터페이스

--- a/dental-clinic-manager/supabase/migrations/20260419_investment_profit_snapshots.sql
+++ b/dental-clinic-manager/supabase/migrations/20260419_investment_profit_snapshots.sql
@@ -1,0 +1,35 @@
+-- supabase/migrations/20260419_investment_profit_snapshots.sql
+-- 주식 자동매매 월별 수익 스냅샷 (예정 정산 5% 표시용)
+
+CREATE TABLE IF NOT EXISTS investment_profit_snapshots (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  year INT NOT NULL,
+  month INT NOT NULL CHECK (month BETWEEN 1 AND 12),
+  realized_profit NUMERIC(15,2) NOT NULL DEFAULT 0,
+  unrealized_profit NUMERIC(15,2) NOT NULL DEFAULT 0,
+  expected_fee NUMERIC(15,2) GENERATED ALWAYS AS
+    (GREATEST(realized_profit, 0) * 0.05) STORED,
+  snapshot_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (clinic_id, year, month)
+);
+
+CREATE INDEX IF NOT EXISTS idx_investment_profit_clinic_ym
+  ON investment_profit_snapshots (clinic_id, year DESC, month DESC);
+
+ALTER TABLE investment_profit_snapshots ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "클리닉 멤버만 조회" ON investment_profit_snapshots;
+CREATE POLICY "클리닉 멤버만 조회"
+  ON investment_profit_snapshots FOR SELECT
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+
+DROP POLICY IF EXISTS "서비스 롤만 기록" ON investment_profit_snapshots;
+CREATE POLICY "서비스 롤만 기록"
+  ON investment_profit_snapshots FOR INSERT
+  WITH CHECK (auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS "서비스 롤만 갱신" ON investment_profit_snapshots;
+CREATE POLICY "서비스 롤만 갱신"
+  ON investment_profit_snapshots FOR UPDATE
+  USING (auth.role() = 'service_role');

--- a/dental-clinic-manager/supabase/migrations/20260419_subscription_headcount_gating.sql
+++ b/dental-clinic-manager/supabase/migrations/20260419_subscription_headcount_gating.sql
@@ -1,0 +1,47 @@
+-- supabase/migrations/20260419_subscription_headcount_gating.sql
+-- 구독 플랜 개편: 직원 수 게이팅 + 프리미엄/주식매매 플랜 정비 + 환불 컬럼
+
+BEGIN;
+
+-- 1. Free 상한 4명, Starter 하한 5명으로 조정
+UPDATE subscription_plans
+   SET max_users = 4, description = '4인 이하 사업장 무료'
+ WHERE name = 'free';
+
+UPDATE subscription_plans
+   SET min_users = 5, description = '5~10인 사업장'
+ WHERE name = 'starter';
+
+-- 2. 프리미엄 패키지 (UI는 이미 premium-bundle 가정)
+INSERT INTO subscription_plans
+  (name, display_name, type, feature_id, price, description, features, sort_order)
+VALUES
+  ('premium-bundle', '프리미엄 패키지', 'feature', 'premium-bundle', 499000,
+   'AI 분석 + 경영 현황 + 마케팅 자동화 통합',
+   '["AI 데이터 분석","경영 현황 관리","마케팅 자동화"]'::jsonb, 9)
+ON CONFLICT (name) DO UPDATE
+   SET price = EXCLUDED.price,
+       feature_id = EXCLUDED.feature_id,
+       description = EXCLUDED.description,
+       features = EXCLUDED.features,
+       display_name = EXCLUDED.display_name,
+       sort_order = EXCLUDED.sort_order;
+
+-- 3. 주식 자동매매 플랜 (UI priceLabel: '수익의 5%' 유지)
+INSERT INTO subscription_plans
+  (name, display_name, type, feature_id, price, description, features, sort_order)
+VALUES
+  ('feature-investment', '주식 자동매매', 'feature', 'investment', 0,
+   '수익의 5% 성과 연동 과금',
+   '["AI 자동매매 전략","실시간 포트폴리오","백테스트"]'::jsonb, 13)
+ON CONFLICT (name) DO UPDATE
+   SET description = EXCLUDED.description,
+       features = EXCLUDED.features;
+
+-- 4. 환불 컬럼 (subscription_payments)
+ALTER TABLE subscription_payments
+  ADD COLUMN IF NOT EXISTS refunded_amount NUMERIC(15,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS refund_reason   TEXT,
+  ADD COLUMN IF NOT EXISTS refunded_at     TIMESTAMPTZ;
+
+COMMIT;

--- a/dental-clinic-manager/supabase/migrations/20260420_post_metrics.sql
+++ b/dental-clinic-manager/supabase/migrations/20260420_post_metrics.sql
@@ -1,0 +1,51 @@
+-- ============================================
+-- 발행 후 KPI 수집 — content_post_metrics 테이블
+-- Migration: 20260420_post_metrics
+-- Created: 2026-04-20
+--
+-- 목적:
+-- 발행된 글(네이버 블로그 등)의 조회수·댓글·공감·스크랩을 시계열로 누적.
+-- 워커가 주기적으로 스크래핑한 결과를 push.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS content_post_metrics (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  item_id UUID NOT NULL REFERENCES content_calendar_items(id) ON DELETE CASCADE,
+  platform VARCHAR(20) NOT NULL,        -- 'naver_blog', 'instagram', ...
+  views INTEGER,
+  comments INTEGER,
+  likes INTEGER,                         -- 네이버 블로그: 공감수 / IG: 좋아요
+  scraps INTEGER,                        -- 네이버 블로그 스크랩수
+  shares INTEGER,                        -- SNS 공유수
+  measured_at TIMESTAMPTZ DEFAULT NOW(),
+  raw_payload JSONB                      -- 원본 응답 (디버깅·향후 추출)
+);
+
+COMMENT ON TABLE content_post_metrics IS '발행 후 KPI 시계열 (스크래핑 누적)';
+
+CREATE INDEX IF NOT EXISTS idx_post_metrics_item
+  ON content_post_metrics(item_id, measured_at DESC);
+CREATE INDEX IF NOT EXISTS idx_post_metrics_recent
+  ON content_post_metrics(measured_at DESC);
+
+ALTER TABLE content_post_metrics ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "post_metrics_clinic_access" ON content_post_metrics
+  FOR ALL USING (
+    item_id IN (
+      SELECT id FROM content_calendar_items
+      WHERE calendar_id IN (
+        SELECT id FROM content_calendars
+        WHERE clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())
+      )
+    )
+  );
+
+-- 항목별 최신 metrics 조회용 뷰 (UI 카드 한 번에 fetch)
+CREATE OR REPLACE VIEW content_post_metrics_latest AS
+SELECT DISTINCT ON (item_id, platform)
+  item_id, platform, views, comments, likes, scraps, shares, measured_at
+FROM content_post_metrics
+ORDER BY item_id, platform, measured_at DESC;
+
+COMMENT ON VIEW content_post_metrics_latest IS '항목·플랫폼별 최신 metrics (UI 카드용)';

--- a/dental-clinic-manager/supabase/migrations/20260420_title_embedding.sql
+++ b/dental-clinic-manager/supabase/migrations/20260420_title_embedding.sql
@@ -1,0 +1,21 @@
+-- ============================================
+-- 제목 임베딩 컬럼 추가 (의미 유사도 중복 검사용)
+-- Migration: 20260420_title_embedding
+-- Created: 2026-04-20
+--
+-- 목적:
+-- 토큰 Jaccard 유사도는 "임플란트 비용" vs "임플란트 가격"을 잡지 못함.
+-- Gemini text-embedding-004 (768차원) JSON 배열로 저장하고,
+-- 코사인 유사도로 의미적 중복을 차단.
+-- ============================================
+
+ALTER TABLE content_calendar_items
+  ADD COLUMN IF NOT EXISTS title_embedding TEXT;
+
+COMMENT ON COLUMN content_calendar_items.title_embedding IS
+  'Gemini text-embedding-004 (768d) JSON-encoded float array. NULL = 미생성';
+
+-- 빈 임베딩 제외 부분 인덱스 (조회 시 NULL 스캔 회피)
+CREATE INDEX IF NOT EXISTS idx_calendar_items_has_embedding
+  ON content_calendar_items(created_at DESC)
+  WHERE title_embedding IS NOT NULL;


### PR DESCRIPTION
## Summary

develop 브랜치에 누적된 변경사항을 main으로 릴리스합니다. (39 commits)

### 이번 세션 핵심 변경 (PWA)
- **fix(pwa)**: 데스크톱 PWA 자동 업데이트가 동작하지 않던 버그 수정
  - `stamp-sw-version.js`가 매 빌드마다 `SW_VERSION`을 갱신하도록 regex 강화
  - `install` 단계의 즉시 `skipWaiting()` 제거 → 작업 중 예고 없는 reload 방지
  - `ServiceWorkerRegistrar`: 업데이트 감지 시 배너만 표시 후 `pwa-apply-update` 이벤트로 활성화 위임
  - `UpdatePrompt`: 카운트다운/클릭 시 커스텀 이벤트 dispatch → SKIP_WAITING → controllerchange → reload
- **fix(pwa)**: 이미 설치된 PWA에서 "앱으로 설치하기" 배너 노출되는 문제 수정
  - `manifest.ts`의 `related_applications.url`을 `NEXT_PUBLIC_SITE_URL` 기반 동적 생성
  - `beforeinstallprompt` 핸들러에서 `getInstalledRelatedApps()`로 설치 여부 재확인

### 기타 주요 변경 (이전 작업 누적분)
- **feat(landing)**: OwnerLanding 페이지 Hero / Problem / Solution / Features / Premium / Trust / CTA / FAQ 섹션 구축
- **feat(landing)**: RoleSelector 역할 선택 컴포넌트, AuthFlow 래퍼, LandingHeader 공통 컴포넌트
- **feat(subscription)**: 구독 플랜 개편 (subscription_plans 경계 조정, premium-bundle / feature-investment, findPlanByHeadcount / formatPlanPrice 유틸, countActiveEmployees / getLatestPaidPayment)
- **feat(worker)**: WorkerGuardModal 기본 구조 + 미설치 케이스, OS 감지 + 통합 워커 다운로드 트리거 유틸
- **feat(api)**: 원장용 승인 API + 인원 상한 가드
- **feat(db)**: investment_profit_snapshots 테이블, subscription_plans 플랜 추가
- **feat(notifications)**: subscription_upgrade_required / payment_succeeded 타입 추가
- **fix(workers/status)**: 마케팅/이메일 워커 installed 판정 오류 수정

## Test plan

- [ ] Vercel Preview 배포에서 PWA 자동 업데이트 동작 확인 (새 버전 감지 → 배너 → 새로고침)
- [ ] 이미 설치된 데스크톱 PWA가 있는 Chrome에서 사이트 열 때 설치 배너가 뜨지 않는지 확인
- [ ] OwnerLanding 주요 섹션 및 CTA 동작 확인
- [ ] RoleSelector 및 AuthFlow 진입 경로 확인
- [ ] 구독 플랜 계산 및 인원 상한 가드 동작 확인
- [ ] WorkerGuardModal 플로우 확인 (미설치 → 다운로드 유도)

🤖 Generated with [Claude Code](https://claude.com/claude-code)