### PR TITLE
랜딩 페이지 UX 개선 + AI 캘린더 회귀 수정

### DIFF
--- a/dental-clinic-manager/src/components/Landing/OwnerLanding.tsx
+++ b/dental-clinic-manager/src/components/Landing/OwnerLanding.tsx
@@ -469,6 +469,21 @@ export default function OwnerLanding() {
           </div>
         </div>
       </section>
+
+      {/* 역할 다시 선택 — 실수로 이 페이지로 온 경우 */}
+      <section className="py-10 bg-white border-t border-at-border">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <p className="text-sm text-at-text-secondary">
+            실장·직원이신가요?{' '}
+            <a
+              href="/?clear=1"
+              className="font-semibold text-at-accent underline decoration-at-accent/40 underline-offset-4 hover:decoration-at-accent transition-colors"
+            >
+              역할 다시 선택
+            </a>
+          </p>
+        </div>
+      </section>
     </div>
   )
 }

--- a/dental-clinic-manager/src/components/Landing/RoleSelector.tsx
+++ b/dental-clinic-manager/src/components/Landing/RoleSelector.tsx
@@ -32,16 +32,23 @@ interface RoleCardProps {
 function RoleCard({ role, emoji, label, title, tagline, tags, accent, onSelect }: RoleCardProps) {
   const cardRef = useRef<HTMLButtonElement>(null)
   const [tilt, setTilt] = useState({ x: 0, y: 0 })
+  const [spot, setSpot] = useState({ x: 50, y: 50 })
+  const [hovering, setHovering] = useState(false)
 
-  // 3D 틸트 호버 (커서가 카드 위에 있을 때만 적용)
+  // 3D 틸트 + spotlight 좌표
   const handleMouseMove = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (!cardRef.current) return
     const rect = cardRef.current.getBoundingClientRect()
-    const x = (e.clientX - rect.left) / rect.width - 0.5
-    const y = (e.clientY - rect.top) / rect.height - 0.5
-    setTilt({ x: -y * 6, y: x * 6 })
+    const xPct = ((e.clientX - rect.left) / rect.width) * 100
+    const yPct = ((e.clientY - rect.top) / rect.height) * 100
+    setSpot({ x: xPct, y: yPct })
+    setTilt({ x: -((yPct / 100) - 0.5) * 4, y: ((xPct / 100) - 0.5) * 4 })
   }
-  const handleMouseLeave = () => setTilt({ x: 0, y: 0 })
+  const handleMouseEnter = () => setHovering(true)
+  const handleMouseLeave = () => {
+    setHovering(false)
+    setTilt({ x: 0, y: 0 })
+  }
 
   const accentGradient = accent === 'owner'
     ? 'from-indigo-500 via-violet-500 to-purple-600'
@@ -49,37 +56,57 @@ function RoleCard({ role, emoji, label, title, tagline, tags, accent, onSelect }
   const accentSoftBg = accent === 'owner'
     ? 'from-indigo-50/90 via-white to-violet-50/60'
     : 'from-rose-50/90 via-white to-cyan-50/60'
-  const accentRing = accent === 'owner' ? 'ring-indigo-200/60' : 'ring-rose-200/60'
-  const accentGlow = accent === 'owner'
-    ? 'from-indigo-400/30 via-violet-400/30 to-transparent'
-    : 'from-rose-400/30 via-pink-400/30 to-transparent'
+  const accentRing = accent === 'owner'
+    ? 'ring-indigo-200/60 hover:ring-indigo-300/80'
+    : 'ring-rose-200/60 hover:ring-rose-300/80'
   const labelColor = accent === 'owner' ? 'text-indigo-600' : 'text-rose-600'
   const ctaGradient = accent === 'owner'
     ? 'from-indigo-600 to-violet-600'
     : 'from-rose-500 to-cyan-500'
+  const spotlightColor = accent === 'owner'
+    ? 'rgba(165, 180, 252, 0.35)' // indigo-300
+    : 'rgba(253, 164, 175, 0.35)' // rose-300
+  const borderGlowColor = accent === 'owner'
+    ? 'rgba(99, 102, 241, 0.5)' // indigo-500
+    : 'rgba(244, 63, 94, 0.5)' // rose-500
 
   return (
     <button
       ref={cardRef}
       onClick={() => onSelect(role)}
       onMouseMove={handleMouseMove}
+      onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       style={{
-        transform: `perspective(1000px) rotateX(${tilt.x}deg) rotateY(${tilt.y}deg)`,
-        transition: 'transform 200ms ease-out',
+        transform: `perspective(1200px) rotateX(${tilt.x}deg) rotateY(${tilt.y}deg)`,
+        transition: 'transform 220ms ease-out, box-shadow 400ms ease-out',
       }}
       className={`group relative text-left rounded-[2rem] p-8 sm:p-10 ring-1 ${accentRing}
         bg-gradient-to-br ${accentSoftBg}
         backdrop-blur-xl shadow-xl shadow-slate-200/40
-        hover:shadow-2xl hover:shadow-slate-900/10 hover:-translate-y-1
-        transition-[box-shadow,transform] duration-500 overflow-hidden`}
+        hover:shadow-2xl hover:-translate-y-1
+        transition-[transform] duration-500 overflow-hidden`}
     >
-      {/* 은은한 그라데이션 glow — 호버 시 확장 */}
+      {/* 마우스 따라다니는 밝은 spotlight (어두워지지 않음) */}
       <div
-        className={`pointer-events-none absolute -inset-24 bg-gradient-radial ${accentGlow}
-          opacity-0 group-hover:opacity-100 blur-3xl transition-opacity duration-700`}
+        aria-hidden
+        className="pointer-events-none absolute inset-0 rounded-[2rem] transition-opacity duration-500"
         style={{
-          backgroundImage: `radial-gradient(circle at 50% 30%, currentColor 0%, transparent 60%)`,
+          opacity: hovering ? 1 : 0,
+          background: `radial-gradient(420px circle at ${spot.x}% ${spot.y}%, ${spotlightColor}, transparent 55%)`,
+        }}
+      />
+
+      {/* 외곽 border glow — 호버 시 은은한 accent 링 (마우스 위치 방향으로 포커스) */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -inset-px rounded-[2rem] transition-opacity duration-500"
+        style={{
+          opacity: hovering ? 1 : 0,
+          background: `radial-gradient(600px circle at ${spot.x}% ${spot.y}%, ${borderGlowColor}, transparent 40%)`,
+          WebkitMaskImage: 'linear-gradient(black, black)',
+          maskImage: 'linear-gradient(black, black)',
+          filter: 'blur(18px)',
         }}
       />
 

--- a/dental-clinic-manager/src/components/Landing/RoleSelector.tsx
+++ b/dental-clinic-manager/src/components/Landing/RoleSelector.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import {
   ArrowRightIcon,
   SparklesIcon,
@@ -11,6 +11,8 @@ import {
   QrCodeIcon,
   CalendarDaysIcon,
   ClockIcon,
+  CheckCircleIcon,
+  XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { useVisitorRole, type VisitorRole } from './shared/useVisitorRole'
 import { useAuthFlow } from './shared/AuthFlow'
@@ -173,26 +175,71 @@ function RoleCard({ role, emoji, label, title, tagline, tags, accent, onSelect }
 
 export default function RoleSelector() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { onShowLogin, onShowSignup } = useAuthFlow()
   const { role, setRole, clearRole, hydrated } = useVisitorRole()
+  const [toast, setToast] = useState<string | null>(null)
+  // 이번 세션에서 이미 '해제' 요청을 처리했는지 — 처리 후 role이 다시 저장되지 않도록 자동 리디렉션을 한 번 억제
+  const [clearedThisMount, setClearedThisMount] = useState(false)
 
-  // 저장된 역할이 있으면 자동 리디렉션
+  // ?clear=1로 들어온 경우(다른 랜딩에서 "역할 다시 선택" 클릭): 저장된 역할 해제 + 토스트 + URL 정리
   useEffect(() => {
     if (!hydrated) return
+    if (searchParams.get('clear') !== '1') return
+    if (role) {
+      clearRole()
+    }
+    setClearedThisMount(true)
+    setToast('역할 선택이 초기화되었어요. 다시 선택해 주세요.')
+    router.replace('/', { scroll: false })
+  }, [hydrated, searchParams, role, clearRole, router])
+
+  // 저장된 역할이 있으면 자동 리디렉션
+  // (단, 방금 해제한 세션이거나 ?clear=1 요청 중에는 억제 — 같은 render cycle 경쟁 방지)
+  useEffect(() => {
+    if (!hydrated) return
+    if (clearedThisMount) return
+    if (searchParams.get('clear') === '1') return
     if (role === 'owner') {
       router.replace('/owner')
     } else if (role === 'staff') {
       router.replace('/staff')
     }
-  }, [hydrated, role, router])
+  }, [hydrated, role, router, clearedThisMount, searchParams])
+
+  // 토스트 자동 닫힘 (4초)
+  useEffect(() => {
+    if (!toast) return
+    const id = setTimeout(() => setToast(null), 4000)
+    return () => clearTimeout(id)
+  }, [toast])
 
   const handleSelect = (selected: VisitorRole) => {
     setRole(selected)
-    router.push(selected === 'owner' ? '/owner' : '/staff')
+    // 사용자가 명시적으로 선택 → ?clear=1로 유발된 억제 모드를 해제하고
+    // 자동 리디렉션 useEffect가 fallback으로 동작할 수 있게 한다.
+    setClearedThisMount(false)
+    const target = selected === 'owner' ? '/owner' : '/staff'
+    router.push(target)
+    // router.push가 어떤 이유로 실패한 경우를 대비한 안전망 — 400ms 후에도
+    // 경로가 그대로면 하드 네비게이션으로 전환
+    window.setTimeout(() => {
+      if (typeof window !== 'undefined' && window.location.pathname !== target) {
+        window.location.href = target
+      }
+    }, 400)
   }
 
-  // 하이드레이션 완료 전이거나 리디렉션 중일 때 플래시 방지
-  if (!hydrated || role) {
+  const handleClearInline = () => {
+    const hadRole = Boolean(role)
+    clearRole()
+    setClearedThisMount(true)
+    setToast(hadRole ? '저장된 역할을 해제했어요.' : '저장된 역할이 없었어요.')
+  }
+
+  // 하이드레이션 완료 전이거나 자동 리디렉션 중일 때 플래시 방지
+  // (clearedThisMount=true면 리디렉션 억제 — role이 잠깐 남아있어도 RoleSelector를 그대로 표시)
+  if (!hydrated || (role && !clearedThisMount)) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-50 flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-slate-400" />
@@ -237,6 +284,25 @@ export default function RoleSelector() {
       `}</style>
 
       <LandingHeader variant="light" onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
+
+      {/* 상단 토스트 (해제 완료 / clear=1 처리 등 피드백) */}
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed top-20 left-1/2 -translate-x-1/2 z-[60] flex items-center gap-3 rounded-full bg-emerald-600 text-white px-5 py-2.5 shadow-lg shadow-emerald-600/20 text-sm font-medium"
+        >
+          <CheckCircleIcon className="h-5 w-5" />
+          <span>{toast}</span>
+          <button
+            onClick={() => setToast(null)}
+            aria-label="알림 닫기"
+            className="-mr-1 p-1 rounded-full hover:bg-white/15 transition-colors"
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        </div>
+      )}
 
       <main className="relative pt-32 pb-24 px-4 sm:px-6 lg:px-8">
         <div className="max-w-6xl mx-auto">
@@ -287,17 +353,23 @@ export default function RoleSelector() {
             />
           </div>
 
-          {/* 선택 기억 해제 */}
+          {/* 선택 기억 해제 — 저장된 role이 있을 때만 의미 있음 */}
           <div className="text-center mt-14">
-            <p className="text-sm text-slate-500">
-              선택한 페이지는 다음 방문 시 자동으로 열려요 ·{' '}
-              <button
-                onClick={clearRole}
-                className="font-medium text-slate-600 underline decoration-slate-300 underline-offset-4 hover:text-slate-900 hover:decoration-slate-600 transition-colors"
-              >
-                선택 기억 해제
-              </button>
-            </p>
+            {role ? (
+              <p className="text-sm text-slate-600">
+                현재 <span className="font-semibold text-slate-900">{role === 'owner' ? '대표원장' : '실장·직원'}</span> 페이지가 저장돼 있어요 ·{' '}
+                <button
+                  onClick={handleClearInline}
+                  className="font-semibold text-indigo-600 underline decoration-indigo-300 underline-offset-4 hover:text-indigo-700 hover:decoration-indigo-500 transition-colors"
+                >
+                  선택 기억 해제
+                </button>
+              </p>
+            ) : (
+              <p className="text-sm text-slate-500">
+                선택한 페이지는 다음 방문 시 자동으로 열려요.
+              </p>
+            )}
           </div>
         </div>
       </main>

--- a/dental-clinic-manager/src/components/Landing/RoleSelector.tsx
+++ b/dental-clinic-manager/src/components/Landing/RoleSelector.tsx
@@ -1,41 +1,144 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import {
+  ArrowRightIcon,
+  SparklesIcon,
+  ChartBarIcon,
+  Cog6ToothIcon,
+  CurrencyDollarIcon,
+  QrCodeIcon,
+  CalendarDaysIcon,
+  ClockIcon,
+} from '@heroicons/react/24/outline'
 import { useVisitorRole, type VisitorRole } from './shared/useVisitorRole'
 import { useAuthFlow } from './shared/AuthFlow'
 import LandingHeader from './shared/LandingHeader'
 
+type Accent = 'owner' | 'staff'
+
 interface RoleCardProps {
   role: VisitorRole
   emoji: string
+  label: string
   title: string
   tagline: string
-  accent: 'owner' | 'staff'
+  tags: { icon: React.ComponentType<{ className?: string }>; text: string }[]
+  accent: Accent
   onSelect: (role: VisitorRole) => void
 }
 
-function RoleCard({ role, emoji, title, tagline, accent, onSelect }: RoleCardProps) {
-  const accentClasses = accent === 'owner'
-    ? 'from-indigo-50 to-white border-indigo-200 hover:border-indigo-400 hover:shadow-indigo-200/50'
-    : 'from-cyan-50 to-white border-cyan-200 hover:border-cyan-400 hover:shadow-cyan-200/50'
-  const labelClasses = accent === 'owner'
-    ? 'text-indigo-600'
-    : 'text-cyan-700'
+function RoleCard({ role, emoji, label, title, tagline, tags, accent, onSelect }: RoleCardProps) {
+  const cardRef = useRef<HTMLButtonElement>(null)
+  const [tilt, setTilt] = useState({ x: 0, y: 0 })
+
+  // 3D 틸트 호버 (커서가 카드 위에 있을 때만 적용)
+  const handleMouseMove = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (!cardRef.current) return
+    const rect = cardRef.current.getBoundingClientRect()
+    const x = (e.clientX - rect.left) / rect.width - 0.5
+    const y = (e.clientY - rect.top) / rect.height - 0.5
+    setTilt({ x: -y * 6, y: x * 6 })
+  }
+  const handleMouseLeave = () => setTilt({ x: 0, y: 0 })
+
+  const accentGradient = accent === 'owner'
+    ? 'from-indigo-500 via-violet-500 to-purple-600'
+    : 'from-rose-500 via-pink-500 to-cyan-500'
+  const accentSoftBg = accent === 'owner'
+    ? 'from-indigo-50/90 via-white to-violet-50/60'
+    : 'from-rose-50/90 via-white to-cyan-50/60'
+  const accentRing = accent === 'owner' ? 'ring-indigo-200/60' : 'ring-rose-200/60'
+  const accentGlow = accent === 'owner'
+    ? 'from-indigo-400/30 via-violet-400/30 to-transparent'
+    : 'from-rose-400/30 via-pink-400/30 to-transparent'
+  const labelColor = accent === 'owner' ? 'text-indigo-600' : 'text-rose-600'
+  const ctaGradient = accent === 'owner'
+    ? 'from-indigo-600 to-violet-600'
+    : 'from-rose-500 to-cyan-500'
 
   return (
     <button
+      ref={cardRef}
       onClick={() => onSelect(role)}
-      className={`group text-left bg-gradient-to-b ${accentClasses} border-2 rounded-3xl p-8 sm:p-10 transition-all hover:-translate-y-1 hover:shadow-2xl`}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      style={{
+        transform: `perspective(1000px) rotateX(${tilt.x}deg) rotateY(${tilt.y}deg)`,
+        transition: 'transform 200ms ease-out',
+      }}
+      className={`group relative text-left rounded-[2rem] p-8 sm:p-10 ring-1 ${accentRing}
+        bg-gradient-to-br ${accentSoftBg}
+        backdrop-blur-xl shadow-xl shadow-slate-200/40
+        hover:shadow-2xl hover:shadow-slate-900/10 hover:-translate-y-1
+        transition-[box-shadow,transform] duration-500 overflow-hidden`}
     >
-      <div className="text-5xl mb-4">{emoji}</div>
-      <div className={`text-xs font-bold tracking-wider uppercase mb-2 ${labelClasses}`}>
-        {accent === 'owner' ? 'FOR OWNERS' : 'FOR STAFF'}
+      {/* 은은한 그라데이션 glow — 호버 시 확장 */}
+      <div
+        className={`pointer-events-none absolute -inset-24 bg-gradient-radial ${accentGlow}
+          opacity-0 group-hover:opacity-100 blur-3xl transition-opacity duration-700`}
+        style={{
+          backgroundImage: `radial-gradient(circle at 50% 30%, currentColor 0%, transparent 60%)`,
+        }}
+      />
+
+      {/* Eyebrow 라벨 */}
+      <div className="relative flex items-center gap-2 mb-6">
+        <span className={`h-1.5 w-1.5 rounded-full bg-gradient-to-r ${accentGradient}`} />
+        <span className={`text-[11px] font-bold tracking-[0.18em] uppercase ${labelColor}`}>{label}</span>
       </div>
-      <div className="text-2xl sm:text-3xl font-bold text-at-text mb-3">{title}</div>
-      <div className="text-at-text-secondary leading-relaxed">{tagline}</div>
-      <div className={`mt-6 inline-flex items-center gap-2 font-semibold ${labelClasses} group-hover:gap-3 transition-all`}>
-        페이지 보기 <span>→</span>
+
+      {/* 이모지 + 아이콘 버블 */}
+      <div className="relative mb-6 flex items-end gap-3">
+        <div className={`relative flex h-20 w-20 items-center justify-center rounded-2xl
+          bg-gradient-to-br ${accentGradient} shadow-lg shadow-slate-900/10
+          transition-transform duration-500 group-hover:scale-105 group-hover:rotate-[-3deg]`}>
+          <span className="text-4xl">{emoji}</span>
+          {/* 반짝이 */}
+          <span className="pointer-events-none absolute -top-1 -right-1 text-white/80 text-xs animate-pulse">
+            <SparklesIcon className="h-4 w-4" />
+          </span>
+        </div>
+      </div>
+
+      {/* 타이틀 + 태그라인 */}
+      <div className="relative mb-7">
+        <div className="text-3xl sm:text-4xl font-extrabold tracking-tight text-slate-900 leading-tight mb-3">
+          {title}
+        </div>
+        <p className="text-[15px] sm:text-base text-slate-600 leading-relaxed">{tagline}</p>
+      </div>
+
+      {/* 기능 태그 */}
+      <div className="relative flex flex-wrap gap-1.5 mb-8">
+        {tags.map(({ icon: Icon, text }) => (
+          <span
+            key={text}
+            className="inline-flex items-center gap-1.5 rounded-full border border-slate-200/80
+              bg-white/70 backdrop-blur px-3 py-1 text-xs font-medium text-slate-700"
+          >
+            <Icon className="h-3.5 w-3.5 text-slate-500" />
+            {text}
+          </span>
+        ))}
+      </div>
+
+      {/* CTA bar — 호버 시 텍스트 슬라이드 */}
+      <div
+        className={`relative rounded-2xl bg-gradient-to-r ${ctaGradient}
+          px-5 py-3.5 flex items-center justify-between text-white font-semibold
+          shadow-md shadow-slate-900/10 overflow-hidden`}
+      >
+        <span className="relative z-10">페이지로 이동</span>
+        <span className="relative z-10 inline-flex items-center gap-2 text-sm opacity-90 group-hover:gap-3 transition-all">
+          <ArrowRightIcon className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
+        </span>
+        {/* 내부 shimmer */}
+        <span
+          className="absolute inset-y-0 -left-full w-1/3 bg-white/30 skew-x-[-20deg]
+            group-hover:left-[120%] transition-all duration-700"
+        />
       </div>
     </button>
   )
@@ -64,57 +167,110 @@ export default function RoleSelector() {
   // 하이드레이션 완료 전이거나 리디렉션 중일 때 플래시 방지
   if (!hydrated || role) {
     return (
-      <div className="min-h-screen bg-white flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-at-accent" />
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-50 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-slate-400" />
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="relative min-h-screen overflow-hidden bg-slate-50">
+      {/* 메쉬 그라데이션 배경 */}
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-indigo-50/80 via-white to-rose-50/60" />
+      <div className="pointer-events-none absolute -top-32 -left-32 h-[32rem] w-[32rem] rounded-full bg-indigo-300/30 blur-3xl animate-pulse-slow" />
+      <div className="pointer-events-none absolute top-1/3 -right-40 h-[28rem] w-[28rem] rounded-full bg-rose-300/30 blur-3xl animate-pulse-slow" style={{ animationDelay: '2s' }} />
+      <div className="pointer-events-none absolute bottom-0 left-1/4 h-[24rem] w-[24rem] rounded-full bg-cyan-200/30 blur-3xl animate-pulse-slow" style={{ animationDelay: '4s' }} />
+
+      {/* 그리드 패턴 */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.025]"
+        style={{
+          backgroundImage: `linear-gradient(rgba(15,23,42,0.6) 1px, transparent 1px),
+                           linear-gradient(90deg, rgba(15,23,42,0.6) 1px, transparent 1px)`,
+          backgroundSize: '48px 48px',
+        }}
+      />
+
+      {/* 로컬 CSS: pulse-slow 애니메이션 + 진입 fade-in */}
+      <style>{`
+        @keyframes pulseSlow {
+          0%, 100% { opacity: 0.35; transform: scale(1); }
+          50% { opacity: 0.6; transform: scale(1.05); }
+        }
+        .animate-pulse-slow { animation: pulseSlow 8s ease-in-out infinite; }
+
+        @keyframes fadeUp {
+          from { opacity: 0; transform: translateY(16px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        .fade-up-1 { animation: fadeUp 0.7s ease-out 0.1s both; }
+        .fade-up-2 { animation: fadeUp 0.7s ease-out 0.25s both; }
+        .fade-up-3 { animation: fadeUp 0.7s ease-out 0.4s both; }
+        .fade-up-4 { animation: fadeUp 0.7s ease-out 0.55s both; }
+      `}</style>
+
       <LandingHeader variant="light" onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
 
-      <main className="pt-32 pb-24 px-4 sm:px-6 lg:px-8">
-        <div className="max-w-5xl mx-auto">
-          <div className="text-center mb-14">
-            <h1 className="text-3xl sm:text-5xl font-bold text-at-text leading-tight mb-4">
-              먼저 알려주세요 —{' '}
-              <span className="bg-gradient-to-r from-indigo-600 to-cyan-600 bg-clip-text text-transparent">
-                누구신가요?
-              </span>
+      <main className="relative pt-32 pb-24 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-6xl mx-auto">
+          {/* Eyebrow + 헤드라인 */}
+          <div className="text-center mb-14 sm:mb-20">
+            <div className="fade-up-1 inline-flex items-center gap-2 rounded-full border border-slate-200/80 bg-white/70 backdrop-blur px-4 py-1.5 text-xs font-semibold tracking-wider uppercase text-slate-600 mb-6">
+              <SparklesIcon className="h-3.5 w-3.5 text-indigo-500" />
+              Welcome
+            </div>
+            <h1 className="fade-up-2 text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-tight text-slate-900 leading-[1.1] mb-5">
+              먼저, 어느 쪽이신가요?
             </h1>
-            <p className="text-lg text-at-text-secondary">
-              역할에 맞는 페이지로 안내해드립니다
+            <p className="fade-up-3 text-lg text-slate-600 max-w-xl mx-auto leading-relaxed">
+              클리닉 매니저는 역할에 맞춰{' '}
+              <span className="font-semibold text-slate-900">다른 화면</span>을 보여드려요.
             </p>
           </div>
 
-          <div className="grid sm:grid-cols-2 gap-6">
+          {/* 카드 그리드 */}
+          <div className="fade-up-4 grid sm:grid-cols-2 gap-5 sm:gap-7">
             <RoleCard
               role="owner"
               emoji="👨‍⚕️"
-              title="대표원장"
-              tagline="병원 경영·매출 중심 뷰. 실장을 매출에만 집중하게 하는 시스템."
+              label="FOR OWNERS"
+              title={"대표원장"}
+              tagline="실장을 매출에 집중하게. 경영 지표와 프리미엄 기능까지 한눈에."
+              tags={[
+                { icon: ChartBarIcon, text: '매출·경영 지표' },
+                { icon: Cog6ToothIcon, text: '잡무 자동화' },
+                { icon: CurrencyDollarIcon, text: 'ROI·프리미엄' },
+              ]}
               accent="owner"
               onSelect={handleSelect}
             />
             <RoleCard
               role="staff"
               emoji="🧑‍💼"
-              title="실장 · 직원"
-              tagline="출퇴근·스케쥴·연차까지 간단하게 끝내고 정시 퇴근하는 업무 앱."
+              label="FOR STAFF"
+              title={"실장 · 직원"}
+              tagline="출퇴근부터 연차·스케쥴까지 몇 번 탭으로 끝. 정시 퇴근 루틴."
+              tags={[
+                { icon: QrCodeIcon, text: 'QR 출퇴근' },
+                { icon: CalendarDaysIcon, text: '스케쥴 · 연차' },
+                { icon: ClockIcon, text: '정시 퇴근' },
+              ]}
               accent="staff"
               onSelect={handleSelect}
             />
           </div>
 
-          <div className="text-center mt-10 text-sm text-at-text-weak">
-            선택한 페이지는 다음 방문 시 자동으로 열립니다 ·{' '}
-            <button
-              onClick={clearRole}
-              className="underline hover:text-at-text-secondary"
-            >
-              선택 기억 해제
-            </button>
+          {/* 선택 기억 해제 */}
+          <div className="text-center mt-14">
+            <p className="text-sm text-slate-500">
+              선택한 페이지는 다음 방문 시 자동으로 열려요 ·{' '}
+              <button
+                onClick={clearRole}
+                className="font-medium text-slate-600 underline decoration-slate-300 underline-offset-4 hover:text-slate-900 hover:decoration-slate-600 transition-colors"
+              >
+                선택 기억 해제
+              </button>
+            </p>
           </div>
         </div>
       </main>

--- a/dental-clinic-manager/src/components/Landing/StaffLanding.tsx
+++ b/dental-clinic-manager/src/components/Landing/StaffLanding.tsx
@@ -12,6 +12,8 @@ import {
   ChatBubbleLeftRightIcon,
   SparklesIcon,
   QrCodeIcon,
+  PaperAirplaneIcon,
+  XMarkIcon,
 } from '@heroicons/react/24/outline'
 import LandingHeader from './shared/LandingHeader'
 import { useScrollAnimation } from './shared/useScrollAnimation'
@@ -92,10 +94,67 @@ const staffFaqs = [
 export default function StaffLanding() {
   const { onShowLogin, onShowSignup } = useAuthFlow()
   const [openFaq, setOpenFaq] = useState<number | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
+
+  // 토스트 자동 닫힘
+  const showToast = (msg: string) => {
+    setToast(msg)
+    window.setTimeout(() => setToast(null), 3500)
+  }
+
+  // 원장에게 추천하기 — Web Share API 우선, 미지원 환경은 클립보드 복사
+  const handleRecommendToOwner = async () => {
+    const origin = typeof window !== 'undefined' ? window.location.origin : ''
+    const url = `${origin}/owner`
+    const shareData = {
+      title: '클리닉 매니저 · 원장용 소개',
+      text: '원장님, 실장·직원 업무를 자동화해주는 치과 관리 서비스예요. 한번 보시겠어요?',
+      url,
+    }
+    try {
+      const nav = typeof navigator !== 'undefined' ? navigator : null
+      if (nav && typeof nav.share === 'function') {
+        await nav.share(shareData)
+        return
+      }
+    } catch {
+      // 사용자 취소 등은 조용히 무시하고 복사 fallback으로 넘어감
+    }
+    try {
+      if (navigator.clipboard && url) {
+        await navigator.clipboard.writeText(url)
+        showToast('원장님께 공유할 링크가 복사되었어요 ✨')
+        return
+      }
+    } catch {
+      // clipboard 접근 실패
+    }
+    showToast('이 환경에서는 공유를 지원하지 않아요. 직접 주소를 알려주세요.')
+  }
 
   return (
     <div className="min-h-screen bg-white overflow-x-hidden">
       <LandingHeader variant="light" onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
+
+      {/* 상단 토스트 (원장에게 추천 링크 복사 등 피드백) */}
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed top-20 left-1/2 -translate-x-1/2 z-[60] flex items-center gap-3 rounded-full bg-slate-900 text-white px-5 py-2.5 shadow-lg shadow-slate-900/20 text-sm font-medium"
+        >
+          <CheckCircleIcon className="h-5 w-5 text-emerald-400" />
+          <span>{toast}</span>
+          <button
+            type="button"
+            onClick={() => setToast(null)}
+            aria-label="알림 닫기"
+            className="-mr-1 p-1 rounded-full hover:bg-white/10 transition-colors"
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        </div>
+      )}
 
       {/* HERO */}
       <section className="relative min-h-screen flex items-center justify-center pt-16 overflow-hidden">
@@ -247,24 +306,29 @@ export default function StaffLanding() {
             오늘 퇴근은 정시에 🕕
           </h2>
           <p className="text-xl text-white/90 mb-10">
-            앱 하나로 오늘 업무를 깔끔하게 끝내세요.
+            혼자서는 못 바꿔요. 원장님께도 같이 보여드려요.
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <button
-              onClick={onShowSignup}
+              type="button"
+              onClick={handleRecommendToOwner}
               className="group px-10 py-4 bg-white text-slate-900 font-bold text-lg rounded-2xl transition-all shadow-xl hover:shadow-2xl hover:-translate-y-1 flex items-center gap-2 justify-center"
             >
-              지금 바로 시작
-              <ArrowRightIcon className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
+              <PaperAirplaneIcon className="w-5 h-5 -rotate-45" />
+              원장에게 추천하기
             </button>
             <button
+              type="button"
               onClick={onShowLogin}
               className="px-10 py-4 border-2 border-white/40 text-white hover:bg-white/10 font-semibold text-lg rounded-2xl transition-all backdrop-blur-sm"
             >
               로그인
             </button>
           </div>
+          <p className="mt-5 text-sm text-white/70">
+            버튼을 누르면 원장님용 소개 링크를 공유(또는 복사)할 수 있어요.
+          </p>
         </div>
       </section>
 
@@ -306,6 +370,21 @@ export default function StaffLanding() {
               )
             })}
           </div>
+        </div>
+      </section>
+
+      {/* 역할 다시 선택 — 실수로 이 페이지로 온 경우 */}
+      <section className="py-10 bg-white border-t border-slate-100">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <p className="text-sm text-slate-600">
+            대표원장이신가요?{' '}
+            <a
+              href="/?clear=1"
+              className="font-semibold text-rose-600 underline decoration-rose-300 underline-offset-4 hover:decoration-rose-500 transition-colors"
+            >
+              역할 다시 선택
+            </a>
+          </p>
         </div>
       </section>
     </div>

--- a/dental-clinic-manager/src/components/marketing/ContentCalendarView.tsx
+++ b/dental-clinic-manager/src/components/marketing/ContentCalendarView.tsx
@@ -58,8 +58,12 @@ export default function ContentCalendarView() {
     setGenerating(true)
     setError(null)
     try {
+      // offsetMonths=0(이번 달): 오늘부터 1달, offsetMonths>0: 그 달 1일부터
       const today = new Date()
-      const target = new Date(today.getFullYear(), today.getMonth() + offsetMonths, 1)
+      const target =
+        offsetMonths === 0
+          ? today
+          : new Date(today.getFullYear(), today.getMonth() + offsetMonths, 1)
       const startDate = target.toISOString().split('T')[0]
 
       const res = await fetch('/api/marketing/calendar', {
@@ -171,20 +175,37 @@ export default function ContentCalendarView() {
   }, [selected])
 
   // ─── 월간 그리드 (날짜별 항목) ───
+  // 선택된 캘린더 항목 + 같은 기간에 걸친 다른 캘린더의 항목(이미 생성/발행된 글)도 함께 표시
   const grid = useMemo(() => {
     if (!selected) return null
-    const items = (selected.content_calendar_items || []).slice().sort((a, b) =>
+
+    const start = new Date(selected.period_start)
+    const end = new Date(selected.period_end)
+    const startStr = selected.period_start
+    const endStr = selected.period_end
+
+    type GridItem = ContentCalendarItem & { _foreign?: boolean }
+    const collected: GridItem[] = []
+    const seenIds = new Set<string>()
+    for (const cal of calendars) {
+      const isSelf = cal.id === selected.id
+      for (const it of cal.content_calendar_items || []) {
+        if (it.publish_date < startStr || it.publish_date > endStr) continue
+        if (seenIds.has(it.id)) continue
+        seenIds.add(it.id)
+        collected.push(isSelf ? it : { ...it, _foreign: true })
+      }
+    }
+    collected.sort((a, b) =>
       a.publish_date.localeCompare(b.publish_date) || a.publish_time.localeCompare(b.publish_time)
     )
-    const byDate = new Map<string, ContentCalendarItem[]>()
-    for (const it of items) {
+
+    const byDate = new Map<string, GridItem[]>()
+    for (const it of collected) {
       const list = byDate.get(it.publish_date) || []
       list.push(it)
       byDate.set(it.publish_date, list)
     }
-
-    const start = new Date(selected.period_start)
-    const end = new Date(selected.period_end)
     // 시작주 일요일로 보정
     const firstSunday = new Date(start)
     firstSunday.setDate(firstSunday.getDate() - firstSunday.getDay())
@@ -192,7 +213,7 @@ export default function ContentCalendarView() {
     const lastSaturday = new Date(end)
     lastSaturday.setDate(lastSaturday.getDate() + (6 - lastSaturday.getDay()))
 
-    const cells: { date: string; inMonth: boolean; items: ContentCalendarItem[] }[] = []
+    const cells: { date: string; inMonth: boolean; items: GridItem[] }[] = []
     const cur = new Date(firstSunday)
     while (cur <= lastSaturday) {
       const ds = cur.toISOString().split('T')[0]
@@ -204,7 +225,7 @@ export default function ContentCalendarView() {
       cur.setDate(cur.getDate() + 1)
     }
     return cells
-  }, [selected])
+  }, [selected, calendars])
 
   return (
     <div className="space-y-4">
@@ -372,16 +393,25 @@ export default function ContentCalendarView() {
                     {day}
                   </div>
                   <div className="space-y-1">
-                    {cell.items.map((item) => (
-                      <CalendarItemCard
-                        key={item.id}
-                        item={item}
-                        onApprove={() => handleApprove(item.id)}
-                        onReject={() => handleReject(item.id)}
-                        onUpdate={(patch) => handleItemUpdate(item.id, patch)}
-                        onRegenerate={() => handleRegenerate(item.id)}
-                      />
-                    ))}
+                    {cell.items.map((item) => {
+                      const isForeign = (item as ContentCalendarItem & { _foreign?: boolean })._foreign
+                      const noop = () => {}
+                      return (
+                        <div
+                          key={item.id}
+                          className={isForeign ? 'opacity-60' : ''}
+                          title={isForeign ? '다른 캘린더의 항목 (읽기 전용)' : undefined}
+                        >
+                          <CalendarItemCard
+                            item={item}
+                            onApprove={isForeign ? noop : () => handleApprove(item.id)}
+                            onReject={isForeign ? noop : () => handleReject(item.id)}
+                            onUpdate={isForeign ? noop : (patch) => handleItemUpdate(item.id, patch)}
+                            onRegenerate={isForeign ? noop : () => handleRegenerate(item.id)}
+                          />
+                        </div>
+                      )
+                    })}
                   </div>
                 </div>
               )

--- a/dental-clinic-manager/src/lib/marketing/calendar-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/calendar-generator.ts
@@ -464,21 +464,36 @@ ${focusKeywords.length ? `\n## 집중 키워드 (있으면 최소 1개 포함)\n
 - 후기(review)·결과 보장 언급 시 needsMedicalReview=true 설정
 - estimatedSearchVolume은 시드 검색량에서 추정`;
 
+  // 슬롯 수 × 한글 JSON 토큰 ≈ 22 × ~400 = ~8800 — 6144로는 잘림(stop_reason=max_tokens)이 발생해
+  // 모든 슬롯이 fallback으로 채워지는 회귀가 있었음. 16384로 확장.
   const aiResponse = await anthropic.messages.create({
     model: 'claude-sonnet-4-6',
-    max_tokens: 6144,
+    max_tokens: 16384,
     messages: [{ role: 'user', content: prompt }],
   });
 
-  const text = aiResponse.content[0].type === 'text' ? aiResponse.content[0].text : '[]';
+  const text = aiResponse.content[0].type === 'text' ? aiResponse.content[0].text : '';
+  const stopReason = aiResponse.stop_reason;
+  console.log(
+    `[CalendarGen v2] AI 응답: len=${text.length} stop=${stopReason} usage=${JSON.stringify(aiResponse.usage)}`
+  );
 
   let parsed: TopicProposal[] = [];
   try {
-    const match = text.match(/\[[\s\S]*\]/);
-    if (match) parsed = JSON.parse(match[0]) as TopicProposal[];
+    parsed = parseTopicProposals(text);
   } catch (e) {
-    console.error('[CalendarGen v2] AI 응답 파싱 실패:', e);
+    console.error('[CalendarGen v2] AI 응답 파싱 실패:', e, '— 응답 앞 200자:', text.slice(0, 200));
     parsed = [];
+  }
+  if (parsed.length === 0) {
+    console.warn(
+      `[CalendarGen v2] 파싱 결과 0건 — totalSlots=${totalSlots} stop=${stopReason} 응답 끝 200자:`,
+      text.slice(-200)
+    );
+  } else if (parsed.length < totalSlots) {
+    console.warn(
+      `[CalendarGen v2] 부분 파싱 — parsed=${parsed.length}/${totalSlots} stop=${stopReason}`
+    );
   }
 
   // 길이 보정 (부족/초과 모두 대응)
@@ -508,6 +523,50 @@ ${focusKeywords.length ? `\n## 집중 키워드 (있으면 최소 1개 포함)\n
   }
 
   return parsed;
+}
+
+// 응답 텍스트가 잘리거나 코드블록으로 감싸져도 가능한 만큼 객체를 추출.
+// 1) 정상: '[' … ']' 전체 JSON.parse
+// 2) 잘림: 마지막 완결된 '}' 위치까지 잘라 ']'로 닫고 파싱
+// 3) 그래도 실패: 객체 단위 정규식으로 한 개씩 시도
+function parseTopicProposals(text: string): TopicProposal[] {
+  if (!text) return [];
+
+  const start = text.indexOf('[');
+  if (start < 0) return [];
+
+  const end = text.lastIndexOf(']');
+  if (end > start) {
+    try {
+      return JSON.parse(text.slice(start, end + 1)) as TopicProposal[];
+    } catch {
+      // 다음 단계로
+    }
+  }
+
+  // 잘린 응답 복구: 마지막 완결 객체 '}'까지만 사용해 배열 닫음
+  const lastBrace = text.lastIndexOf('}');
+  if (lastBrace > start) {
+    const candidate = text.slice(start, lastBrace + 1) + ']';
+    try {
+      return JSON.parse(candidate) as TopicProposal[];
+    } catch {
+      // 다음 단계로
+    }
+  }
+
+  // 마지막 수단: 객체 하나씩 추출 (필드 충실도가 떨어질 수 있음)
+  const objects: TopicProposal[] = [];
+  const objectRe = /\{[^{}]*"title"[\s\S]*?\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = objectRe.exec(text)) !== null) {
+    try {
+      objects.push(JSON.parse(m[0]) as TopicProposal);
+    } catch {
+      // 개별 객체 파싱 실패는 무시
+    }
+  }
+  return objects;
 }
 
 function fallbackProposal(index: number, slot: JourneySlot | undefined): TopicProposal {


### PR DESCRIPTION
## Summary

- **랜딩 페이지 UX 개선** — 대표원장/실장 분리 랜딩의 역할 선택 흐름 다듬기
  - RoleSelector: Bento 카드 · 메쉬 배경 · 3D 틸트 · 마우스 따라가는 accent spotlight 등 최신 UI 트렌드 반영
  - 호버 시 카드가 어두워 보이던 버그 수정 (currentColor 기반 radial gradient 제거, accent glow로 교체)
  - "선택 기억 해제" 버튼이 실제로 동작 + 인라인 토스트 피드백
  - \`/owner\`, \`/staff\` Footer 직전에 "역할 다시 선택" 링크 추가 (\`/?clear=1\`로 이동)
  - \`?clear=1\` 감지 시 localStorage 해제 + 상단 토스트 + URL 정리
  - StaffLanding CTA를 "원장에게 추천하기" 버튼으로 교체 (Web Share API + 클립보드 fallback)
- **AI 캘린더 회귀 수정** (다른 작업자 커밋 포함) — AI 응답 누락 + 시작 날짜/기존 글 표시 개선

## Commits

- \`82b44f35\` feat(landing): 선택 기억 해제·역할 다시 선택·원장에게 추천 기능 추가
- \`5bfabe06\` fix(landing): RoleSelector 호버 시 카드가 어두워지던 버그 수정
- \`996abd69\` feat(landing): RoleSelector UI/UX 전면 개선
- \`8aed7272\` fix(calendar): AI 응답 누락 회귀 + 시작날짜·기존 글 표시 개선

## Test plan

- [ ] \`/\`: 처음 방문 시 RoleSelector 카드 2개 렌더링
- [ ] 대표원장 카드 클릭 → \`/owner\` 이동, localStorage에 \`owner\` 저장, 이후 \`/\` 재방문 시 자동 \`/owner\` 리디렉션
- [ ] 실장 카드 클릭 → \`/staff\` 이동 (이전 버그: 원장 랜딩으로 가던 현상 재발 없음)
- [ ] \`/staff\` CTA의 "원장에게 추천하기" 클릭 → Web Share(모바일) 또는 링크 클립보드 복사(데스크톱) + 성공 토스트
- [ ] \`/owner\` 또는 \`/staff\` Footer 직전 "역할 다시 선택" 클릭 → \`/?clear=1\` → 상단 토스트 "역할 선택이 초기화되었어요" + URL \`/\`로 정리 + RoleSelector 표시
- [ ] 카드 호버 시 카드 중앙이 어두워지지 않고 accent spotlight + 외곽 glow만 나타나는지
- [ ] AI 콘텐츠 캘린더 생성 흐름 정상 동작 (기존 글 포함, 시작 날짜 반영, 504 회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)