### PR TITLE
랜딩 문구·상호 이동 버튼 다듬기

### DIFF
--- a/dental-clinic-manager/src/components/Landing/OwnerLanding.tsx
+++ b/dental-clinic-manager/src/components/Landing/OwnerLanding.tsx
@@ -470,16 +470,25 @@ export default function OwnerLanding() {
         </div>
       </section>
 
-      {/* 역할 다시 선택 — 실수로 이 페이지로 온 경우 */}
-      <section className="py-10 bg-white border-t border-at-border">
+      {/* 반대 랜딩 이동 + 역할 선택 초기화 */}
+      <section className="py-14 bg-white border-t border-at-border">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <p className="text-sm text-at-text-secondary">
-            실장·직원이신가요?{' '}
+          <p className="text-sm text-at-text-secondary mb-5">
+            실장·직원이신가요? 직원용 랜딩에서 실제 업무 기능을 둘러보세요.
+          </p>
+          <a
+            href="/staff"
+            className="group inline-flex items-center gap-2 rounded-xl border border-at-border bg-at-surface-alt hover:bg-white hover:border-at-accent/40 px-6 py-3 text-at-text font-semibold shadow-at-card transition-all hover:-translate-y-0.5"
+          >
+            실장·직원 페이지로 이동
+            <ArrowRightIcon className="h-4 w-4 text-at-accent group-hover:translate-x-0.5 transition-transform" />
+          </a>
+          <p className="mt-5 text-xs text-at-text-weak">
             <a
               href="/?clear=1"
-              className="font-semibold text-at-accent underline decoration-at-accent/40 underline-offset-4 hover:decoration-at-accent transition-colors"
+              className="underline decoration-at-text-weak/40 underline-offset-4 hover:decoration-at-text-weak"
             >
-              역할 다시 선택
+              역할 선택 초기화
             </a>
           </p>
         </div>

--- a/dental-clinic-manager/src/components/Landing/StaffLanding.tsx
+++ b/dental-clinic-manager/src/components/Landing/StaffLanding.tsx
@@ -373,16 +373,25 @@ export default function StaffLanding() {
         </div>
       </section>
 
-      {/* 역할 다시 선택 — 실수로 이 페이지로 온 경우 */}
-      <section className="py-10 bg-white border-t border-slate-100">
+      {/* 반대 랜딩 이동 + 역할 선택 초기화 */}
+      <section className="py-14 bg-white border-t border-slate-100">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <p className="text-sm text-slate-600">
-            대표원장이신가요?{' '}
+          <p className="text-sm text-slate-600 mb-5">
+            대표원장이신가요? 경영·매출 중심으로 정리된 원장용 랜딩을 확인해보세요.
+          </p>
+          <a
+            href="/owner"
+            className="group inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white hover:bg-slate-50 hover:border-indigo-300 px-6 py-3 text-slate-900 font-semibold shadow-sm transition-all hover:-translate-y-0.5"
+          >
+            대표원장 페이지로 이동
+            <ArrowRightIcon className="h-4 w-4 text-indigo-600 group-hover:translate-x-0.5 transition-transform" />
+          </a>
+          <p className="mt-5 text-xs text-slate-500">
             <a
               href="/?clear=1"
-              className="font-semibold text-rose-600 underline decoration-rose-300 underline-offset-4 hover:decoration-rose-500 transition-colors"
+              className="underline decoration-slate-300 underline-offset-4 hover:decoration-slate-500"
             >
-              역할 다시 선택
+              역할 선택 초기화
             </a>
           </p>
         </div>

--- a/dental-clinic-manager/src/components/Landing/StaffLanding.tsx
+++ b/dental-clinic-manager/src/components/Landing/StaffLanding.tsx
@@ -102,7 +102,7 @@ export default function StaffLanding() {
     window.setTimeout(() => setToast(null), 3500)
   }
 
-  // 원장에게 추천하기 — Web Share API 우선, 미지원 환경은 클립보드 복사
+  // 원장님께 추천 — Web Share API 우선, 미지원 환경은 클립보드 복사
   const handleRecommendToOwner = async () => {
     const origin = typeof window !== 'undefined' ? window.location.origin : ''
     const url = `${origin}/owner`
@@ -136,7 +136,7 @@ export default function StaffLanding() {
     <div className="min-h-screen bg-white overflow-x-hidden">
       <LandingHeader variant="light" onShowLogin={onShowLogin} onShowSignup={onShowSignup} />
 
-      {/* 상단 토스트 (원장에게 추천 링크 복사 등 피드백) */}
+      {/* 상단 토스트 (원장님께 추천 링크 복사 등 피드백) */}
       {toast && (
         <div
           role="status"
@@ -316,7 +316,7 @@ export default function StaffLanding() {
               className="group px-10 py-4 bg-white text-slate-900 font-bold text-lg rounded-2xl transition-all shadow-xl hover:shadow-2xl hover:-translate-y-1 flex items-center gap-2 justify-center"
             >
               <PaperAirplaneIcon className="w-5 h-5 -rotate-45" />
-              원장에게 추천하기
+              원장님께 추천
             </button>
             <button
               type="button"


### PR DESCRIPTION
## Summary

- **직원용 CTA 문구** "원장에게 추천하기" → **"원장님께 추천"** (존칭 통일)
- **각 랜딩 푸터에 반대 랜딩 이동 버튼 추가**
  - \`/owner\` → "실장·직원 페이지로 이동" 버튼 (→ \`/staff\`)
  - \`/staff\` → "대표원장 페이지로 이동" 버튼 (→ \`/owner\`)
  - 기존 "역할 선택 초기화"(\`/?clear=1\`) 링크는 보조 텍스트로 축소

## Commits

- \`96c270f2\` fix(landing): StaffLanding 추천 버튼 문구를 "원장님께 추천"으로 수정
- \`74805a42\` feat(landing): 각 랜딩 푸터에 반대 랜딩 이동 버튼 추가

## Test plan

- [ ] \`/staff\` CTA 버튼 레이블이 "원장님께 추천"으로 표시
- [ ] \`/owner\` 하단에 "실장·직원 페이지로 이동" 버튼 노출, 클릭 시 \`/staff\`로 이동
- [ ] \`/staff\` 하단에 "대표원장 페이지로 이동" 버튼 노출, 클릭 시 \`/owner\`로 이동
- [ ] 각 페이지 하단 "역할 선택 초기화" 소형 링크 클릭 시 \`/?clear=1\` → localStorage 해제 + 토스트 + RoleSelector 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)