### PR TITLE
fix(landing): 루트 페이지를 대표원장 랜딩으로 변경

### DIFF
--- a/dental-clinic-manager/src/app/page.tsx
+++ b/dental-clinic-manager/src/app/page.tsx
@@ -1,12 +1,23 @@
 'use client'
 
+import { useEffect } from 'react'
 import AuthFlow from '@/components/Landing/shared/AuthFlow'
-import RoleSelector from '@/components/Landing/RoleSelector'
+import OwnerLanding from '@/components/Landing/OwnerLanding'
+import { useVisitorRole } from '@/components/Landing/shared/useVisitorRole'
 
 export default function RootPage() {
+  const { setRole, hydrated, role } = useVisitorRole()
+
+  useEffect(() => {
+    if (!hydrated) return
+    if (role !== 'owner') {
+      setRole('owner')
+    }
+  }, [hydrated, role, setRole])
+
   return (
     <AuthFlow>
-      <RoleSelector />
+      <OwnerLanding />
     </AuthFlow>
   )
 }

--- a/dental-clinic-manager/src/components/Landing/RoleSelector.tsx
+++ b/dental-clinic-manager/src/components/Landing/RoleSelector.tsx
@@ -313,7 +313,7 @@ export default function RoleSelector() {
               Welcome
             </div>
             <h1 className="fade-up-2 text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-tight text-slate-900 leading-[1.1] mb-5">
-              먼저, 어느 쪽이신가요?
+              본인의 직급을 선택해 주세요~
             </h1>
             <p className="fade-up-3 text-lg text-slate-600 max-w-xl mx-auto leading-relaxed">
               클리닉 매니저는 역할에 맞춰{' '}


### PR DESCRIPTION
## Summary
- 루트(`/`) 페이지를 RoleSelector 대신 대표원장 랜딩(OwnerLanding)으로 변경하여 첫 방문 이탈 방지
- RoleSelector 헤드라인 문구를 "본인의 직급을 선택해 주세요~"로 수정

## Test plan
- [ ] `/` 접속 시 대표원장 랜딩페이지가 표시되는지 확인
- [ ] `/staff` 접속 시 실장·직원 랜딩페이지가 정상 표시되는지 확인
- [ ] 로그인/회원가입 플로우가 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)