### PR TITLE
feat: develop → main 통합 (구독 결제 시스템 + 프리미엄 패키지)

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
@@ -661,13 +661,110 @@ async function getMonthlyRevenue(dbPool: sql.ConnectionPool, year: number, month
   };
 }
 
-/** 앱 시작 후 첫 수입 동기화에서 전체 backfill 완료 여부 */
-let revenueBackfillDone = false;
+/**
+ * 단일 월 수입 데이터를 서버에 전송하고 성공 여부 반환
+ */
+async function syncSingleMonthRevenue(
+  dbPool: sql.ConnectionPool,
+  year: number,
+  month: number,
+  clinicId: string,
+  apiKey: string,
+  dashboardUrl: string,
+): Promise<boolean> {
+  try {
+    const revenue = await getMonthlyRevenue(dbPool, year, month);
+    const total = revenue.insurance_revenue + revenue.non_insurance_revenue + revenue.other_revenue;
+
+    // 수입이 0이면 전송 생략 (성공으로 처리)
+    if (total === 0) return true;
+
+    const url = `${dashboardUrl}/api/dentweb/sync-revenue`;
+    const response = await fetchWithRetry(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        clinic_id: clinicId,
+        api_key: apiKey,
+        year: revenue.year,
+        month: revenue.month,
+        insurance_revenue: revenue.insurance_revenue,
+        non_insurance_revenue: revenue.non_insurance_revenue,
+        other_revenue: revenue.other_revenue,
+      }),
+    });
+
+    const result = await response.json();
+    if (result.success) {
+      log('info', `[DentWeb] ${year}-${String(month).padStart(2, '0')} 수입 동기화 완료: 보험=${revenue.insurance_revenue}, 비보험=${revenue.non_insurance_revenue}, 기타=${revenue.other_revenue}`);
+      return true;
+    } else {
+      log('warn', `[DentWeb] ${year}-${String(month).padStart(2, '0')} 수입 동기화 실패: ${result.error}`);
+      return false;
+    }
+  } catch (err) {
+    log('warn', `[DentWeb] ${year}-${String(month).padStart(2, '0')} 수입 동기화 오류: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}
+
+/**
+ * pending_revenue_months에서 요청된 월 동기화 + 처리 완료된 항목 제거
+ */
+async function processPendingRevenueMonths(dbPool: sql.ConnectionPool): Promise<void> {
+  const cfg = getDentwebConfig();
+  const { dashboardUrl } = getConfig();
+  if (!cfg.clinicId || !cfg.apiKey) return;
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://beahjntkmkfhpcbhfnrr.supabase.co';
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+  if (!supabaseAnonKey) return;
+
+  try {
+    const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+    // pending_revenue_months 조회
+    const { data: config } = await supabase
+      .from('dentweb_sync_config')
+      .select('pending_revenue_months')
+      .eq('clinic_id', cfg.clinicId)
+      .single();
+
+    const pending = (config?.pending_revenue_months || []) as Array<{ year: number; month: number }>;
+    if (pending.length === 0) return;
+
+    log('info', `[DentWeb] on-demand 수입 동기화 요청 ${pending.length}건 처리 시작`);
+
+    const completed: Array<{ year: number; month: number }> = [];
+
+    for (const { year, month } of pending) {
+      const success = await syncSingleMonthRevenue(dbPool, year, month, cfg.clinicId, cfg.apiKey, dashboardUrl);
+      if (success) {
+        completed.push({ year, month });
+      }
+    }
+
+    // 완료된 항목 제거
+    if (completed.length > 0) {
+      const remaining = pending.filter(
+        p => !completed.some(c => c.year === p.year && c.month === p.month)
+      );
+      await supabase
+        .from('dentweb_sync_config')
+        .update({ pending_revenue_months: remaining })
+        .eq('clinic_id', cfg.clinicId);
+
+      log('info', `[DentWeb] on-demand 수입 동기화 완료: ${completed.length}건 처리, ${remaining.length}건 잔여`);
+    }
+  } catch (err) {
+    log('warn', `[DentWeb] on-demand 수입 동기화 오류: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
 
 /**
  * 수입 데이터를 서버에 전송.
- * - 앱 시작 후 첫 호출: 올해 전체(1~당월) + 전년도 10~12월 backfill
- * - 이후 호출: 당월 + 전월만 동기화 (효율적)
+ * - 당월 + 전월 기본 동기화
+ * - pending_revenue_months에 요청된 월이 있으면 on-demand 동기화
  */
 async function syncRevenueToServer(dbPool: sql.ConnectionPool): Promise<void> {
   const cfg = getDentwebConfig();
@@ -679,66 +776,22 @@ async function syncRevenueToServer(dbPool: sql.ConnectionPool): Promise<void> {
   const currentYear = now.getFullYear();
   const currentMonth = now.getMonth() + 1;
 
-  let months: Array<{ year: number; month: number }>;
-
-  if (!revenueBackfillDone) {
-    // 첫 동기화: 올해 1월~당월 전체 + 전년도 최근 3개월
-    months = [];
-    for (let m = 1; m <= currentMonth; m++) {
-      months.push({ year: currentYear, month: m });
-    }
-    for (let m = 10; m <= 12; m++) {
-      months.push({ year: currentYear - 1, month: m });
-    }
-    log('info', `[DentWeb] 수입 전체 backfill 시작 (${months.length}개월)`);
+  // 기본: 당월 + 전월 동기화
+  const months: Array<{ year: number; month: number }> = [
+    { year: currentYear, month: currentMonth },
+  ];
+  if (currentMonth === 1) {
+    months.push({ year: currentYear - 1, month: 12 });
   } else {
-    // 정기 동기화: 당월 + 전월
-    months = [{ year: currentYear, month: currentMonth }];
-    if (currentMonth === 1) {
-      months.push({ year: currentYear - 1, month: 12 });
-    } else {
-      months.push({ year: currentYear, month: currentMonth - 1 });
-    }
+    months.push({ year: currentYear, month: currentMonth - 1 });
   }
 
   for (const { year, month } of months) {
-    try {
-      const revenue = await getMonthlyRevenue(dbPool, year, month);
-      const total = revenue.insurance_revenue + revenue.non_insurance_revenue + revenue.other_revenue;
-
-      // 수입이 0이면 전송 생략
-      if (total === 0) continue;
-
-      const url = `${dashboardUrl}/api/dentweb/sync-revenue`;
-      const response = await fetchWithRetry(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          clinic_id: cfg.clinicId,
-          api_key: cfg.apiKey,
-          year: revenue.year,
-          month: revenue.month,
-          insurance_revenue: revenue.insurance_revenue,
-          non_insurance_revenue: revenue.non_insurance_revenue,
-          other_revenue: revenue.other_revenue,
-        }),
-      });
-
-      const result = await response.json();
-      if (result.success) {
-        log('info', `[DentWeb] ${year}-${String(month).padStart(2, '0')} 수입 동기화 완료: 보험=${revenue.insurance_revenue}, 비보험=${revenue.non_insurance_revenue}, 기타=${revenue.other_revenue}`);
-      } else {
-        log('warn', `[DentWeb] ${year}-${String(month).padStart(2, '0')} 수입 동기화 실패: ${result.error}`);
-      }
-    } catch (err) {
-      log('warn', `[DentWeb] ${year}-${String(month).padStart(2, '0')} 수입 동기화 오류: ${err instanceof Error ? err.message : String(err)}`);
-    }
+    await syncSingleMonthRevenue(dbPool, year, month, cfg.clinicId, cfg.apiKey, dashboardUrl);
   }
 
-  if (!revenueBackfillDone) {
-    revenueBackfillDone = true;
-    log('info', '[DentWeb] 수입 전체 backfill 완료, 이후 당월+전월만 동기화');
-  }
+  // on-demand: pending_revenue_months 처리
+  await processPendingRevenueMonths(dbPool);
 }
 
 /* ------------------------------------------------------------------ */

--- a/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
@@ -661,7 +661,14 @@ async function getMonthlyRevenue(dbPool: sql.ConnectionPool, year: number, month
   };
 }
 
-/** 당월 + 전월 수입 데이터를 서버에 전송 */
+/** 앱 시작 후 첫 수입 동기화에서 전체 backfill 완료 여부 */
+let revenueBackfillDone = false;
+
+/**
+ * 수입 데이터를 서버에 전송.
+ * - 앱 시작 후 첫 호출: 올해 전체(1~당월) + 전년도 10~12월 backfill
+ * - 이후 호출: 당월 + 전월만 동기화 (효율적)
+ */
 async function syncRevenueToServer(dbPool: sql.ConnectionPool): Promise<void> {
   const cfg = getDentwebConfig();
   const { dashboardUrl } = getConfig();
@@ -672,14 +679,26 @@ async function syncRevenueToServer(dbPool: sql.ConnectionPool): Promise<void> {
   const currentYear = now.getFullYear();
   const currentMonth = now.getMonth() + 1;
 
-  // 당월과 전월 동기화 (전월 데이터가 늦게 입력될 수 있으므로)
-  const months: Array<{ year: number; month: number }> = [
-    { year: currentYear, month: currentMonth },
-  ];
-  if (currentMonth === 1) {
-    months.push({ year: currentYear - 1, month: 12 });
+  let months: Array<{ year: number; month: number }>;
+
+  if (!revenueBackfillDone) {
+    // 첫 동기화: 올해 1월~당월 전체 + 전년도 최근 3개월
+    months = [];
+    for (let m = 1; m <= currentMonth; m++) {
+      months.push({ year: currentYear, month: m });
+    }
+    for (let m = 10; m <= 12; m++) {
+      months.push({ year: currentYear - 1, month: m });
+    }
+    log('info', `[DentWeb] 수입 전체 backfill 시작 (${months.length}개월)`);
   } else {
-    months.push({ year: currentYear, month: currentMonth - 1 });
+    // 정기 동기화: 당월 + 전월
+    months = [{ year: currentYear, month: currentMonth }];
+    if (currentMonth === 1) {
+      months.push({ year: currentYear - 1, month: 12 });
+    } else {
+      months.push({ year: currentYear, month: currentMonth - 1 });
+    }
   }
 
   for (const { year, month } of months) {
@@ -714,6 +733,11 @@ async function syncRevenueToServer(dbPool: sql.ConnectionPool): Promise<void> {
     } catch (err) {
       log('warn', `[DentWeb] ${year}-${String(month).padStart(2, '0')} 수입 동기화 오류: ${err instanceof Error ? err.message : String(err)}`);
     }
+  }
+
+  if (!revenueBackfillDone) {
+    revenueBackfillDone = true;
+    log('info', '[DentWeb] 수입 전체 backfill 완료, 이후 당월+전월만 동기화');
   }
 }
 

--- a/dental-clinic-manager/src/app/api/dentweb/request-revenue-sync/route.ts
+++ b/dental-clinic-manager/src/app/api/dentweb/request-revenue-sync/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+/**
+ * POST: 특정 월 또는 전체 과거 데이터 수입 동기화 요청
+ * - mode: 'single' (단일 월) 또는 'backfill' (올해 전체 + 전년도 최근 3개월)
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { clinic_id, mode, year, month } = body
+
+    if (!clinic_id) {
+      return NextResponse.json({ success: false, error: 'clinic_id가 필요합니다.' }, { status: 400 })
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    // dentweb_sync_config 확인
+    const { data: syncConfig } = await supabase
+      .from('dentweb_sync_config')
+      .select('id, pending_revenue_months, is_active')
+      .eq('clinic_id', clinic_id)
+      .eq('is_active', true)
+      .maybeSingle()
+
+    if (!syncConfig) {
+      return NextResponse.json({ success: false, error: '덴트웹 연동이 활성화되지 않았습니다.' }, { status: 404 })
+    }
+
+    const existing = (syncConfig.pending_revenue_months || []) as Array<{ year: number; month: number }>
+
+    let newMonths: Array<{ year: number; month: number }> = []
+
+    if (mode === 'backfill') {
+      // 올해 1월~현재월 + 전년도 10~12월
+      const now = new Date()
+      const currentYear = now.getFullYear()
+      const currentMonth = now.getMonth() + 1
+
+      for (let m = 1; m <= currentMonth; m++) {
+        newMonths.push({ year: currentYear, month: m })
+      }
+      for (let m = 10; m <= 12; m++) {
+        newMonths.push({ year: currentYear - 1, month: m })
+      }
+    } else {
+      // 단일 월
+      if (!year || !month) {
+        return NextResponse.json({ success: false, error: 'year와 month가 필요합니다.' }, { status: 400 })
+      }
+      newMonths = [{ year: parseInt(year), month: parseInt(month) }]
+    }
+
+    // 이미 revenue_records에 있는 월은 제외
+    const { data: existingRevenues } = await supabase
+      .from('revenue_records')
+      .select('year, month')
+      .eq('clinic_id', clinic_id)
+
+    const existingSet = new Set(
+      (existingRevenues || []).map((r: { year: number; month: number }) => `${r.year}-${r.month}`)
+    )
+
+    // 기존 pending + 새 요청 합치기 (중복 제거)
+    const allPending = [...existing]
+    for (const m of newMonths) {
+      const key = `${m.year}-${m.month}`
+      if (existingSet.has(key)) continue // 이미 데이터 있음
+      if (allPending.some(p => p.year === m.year && p.month === m.month)) continue // 이미 pending
+      allPending.push(m)
+    }
+
+    await supabase
+      .from('dentweb_sync_config')
+      .update({ pending_revenue_months: allPending })
+      .eq('id', syncConfig.id)
+
+    const addedCount = allPending.length - existing.length
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        added_count: addedCount,
+        total_pending: allPending.length,
+        pending_months: allPending,
+      },
+    })
+  } catch (error) {
+    console.error('[dentweb/request-revenue-sync] Error:', error)
+    return NextResponse.json({ success: false, error: '서버 오류가 발생했습니다.' }, { status: 500 })
+  }
+}

--- a/dental-clinic-manager/src/app/api/financial/summary/route.ts
+++ b/dental-clinic-manager/src/app/api/financial/summary/route.ts
@@ -44,6 +44,50 @@ async function loadYtdMonths(
   return (data ?? []) as Array<{ month: number; total_revenue: number | null; total_expense: number | null; pre_tax_profit: number | null }>;
 }
 
+// dentweb 연동 클리닉에서 해당 월 revenue가 없으면 pending 요청 추가
+async function requestRevenueSyncIfNeeded(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  clinicId: string,
+  year: number,
+  month: number,
+): Promise<boolean> {
+  // dentweb_sync_config가 있는지 (= dentweb 연동 클리닉인지) 확인
+  const { data: syncConfig } = await supabase
+    .from('dentweb_sync_config')
+    .select('id, pending_revenue_months, is_active')
+    .eq('clinic_id', clinicId)
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (!syncConfig) return false;
+
+  // 해당 월 revenue_records가 있는지 확인
+  const { data: existingRevenue } = await supabase
+    .from('revenue_records')
+    .select('id')
+    .eq('clinic_id', clinicId)
+    .eq('year', year)
+    .eq('month', month)
+    .maybeSingle();
+
+  if (existingRevenue) return false; // 이미 데이터 있음
+
+  // pending 목록에 이미 있는지 확인
+  const pending = (syncConfig.pending_revenue_months || []) as Array<{ year: number; month: number }>;
+  const alreadyPending = pending.some((p: { year: number; month: number }) => p.year === year && p.month === month);
+  if (alreadyPending) return true; // 이미 요청됨
+
+  // pending 목록에 추가
+  const updated = [...pending, { year, month }];
+  await supabase
+    .from('dentweb_sync_config')
+    .update({ pending_revenue_months: updated })
+    .eq('id', syncConfig.id);
+
+  return true; // 새로 요청함
+}
+
 // GET: 재무 요약 조회
 export async function GET(request: NextRequest) {
   try {
@@ -86,6 +130,9 @@ export async function GET(request: NextRequest) {
         .eq('month', monthNum)
         .single();
 
+      // 2-1. dentweb 연동인데 해당 월 revenue가 없으면 on-demand 동기화 요청
+      const syncPending = await requestRevenueSyncIfNeeded(supabase, clinicId, yearNum, monthNum);
+
       // 3. 올해 누적 순이익 + 예상 세금 계산
       const ytdMonths = await loadYtdMonths(supabase, clinicId, yearNum, monthNum);
       const ytdNetIncome = ytdMonths.reduce(
@@ -100,6 +147,7 @@ export async function GET(request: NextRequest) {
 
       return NextResponse.json({
         success: true,
+        sync_pending: syncPending,
         data: {
           ...(data || {}),
           revenue_source_type: revenueRecord?.source_type || null,

--- a/dental-clinic-manager/src/app/dashboard/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/page.tsx
@@ -825,7 +825,9 @@ export default function DashboardPage() {
 
           {/* 환자 리콜 관리 */}
           {activeTab === 'recall' && (
-            <RecallManagement />
+            <PremiumGate featureId="recall">
+              <RecallManagement />
+            </PremiumGate>
           )}
 
           {/* 업무 체크리스트 */}

--- a/dental-clinic-manager/src/components/Financial/FinancialDashboard.tsx
+++ b/dental-clinic-manager/src/components/Financial/FinancialDashboard.tsx
@@ -35,6 +35,8 @@ import {
   ChevronDown,
   ChevronUp,
   Settings,
+  RefreshCw,
+  Download,
 } from 'lucide-react'
 import dynamic from 'next/dynamic'
 
@@ -54,6 +56,11 @@ export default function FinancialDashboard() {
   const [summary, setSummary] = useState<FinancialSummary | null>(null)
   const [expenses, setExpenses] = useState<ExpenseRecord[]>([])
   const [loading, setLoading] = useState(true)
+
+  // 수입 동기화 상태
+  const [syncPending, setSyncPending] = useState(false)
+  const [syncRetryCount, setSyncRetryCount] = useState(0)
+  const [backfillLoading, setBackfillLoading] = useState(false)
 
   // 모달 상태
   const [showRevenueForm, setShowRevenueForm] = useState(false)
@@ -78,6 +85,7 @@ export default function FinancialDashboard() {
       const summaryData = await summaryRes.json()
       if (summaryData.success) {
         setSummary(summaryData.data)
+        setSyncPending(!!summaryData.sync_pending)
       }
 
       // 지출 내역 로드
@@ -96,8 +104,44 @@ export default function FinancialDashboard() {
   }
 
   useEffect(() => {
+    setSyncRetryCount(0)
     loadData()
   }, [clinicId, selectedYear, selectedMonth])
+
+  // sync_pending일 때 자동 재조회 (최대 6회, 5초 간격 = 30초)
+  useEffect(() => {
+    if (!syncPending || syncRetryCount >= 6) return
+    const timer = setTimeout(() => {
+      setSyncRetryCount(prev => prev + 1)
+      loadData()
+    }, 5000)
+    return () => clearTimeout(timer)
+  }, [syncPending, syncRetryCount])
+
+  // 과거 데이터 전체 불러오기
+  const handleBackfillRequest = async () => {
+    if (!clinicId) return
+    setBackfillLoading(true)
+    try {
+      const res = await fetch('/api/dentweb/request-revenue-sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clinic_id: clinicId, mode: 'backfill' }),
+      })
+      const result = await res.json()
+      if (result.success) {
+        await appAlert(`${result.data.added_count}개월 수입 데이터 동기화를 요청했습니다. 워커에서 처리 후 자동으로 반영됩니다.`)
+        setSyncPending(true)
+        setSyncRetryCount(0)
+      } else {
+        await appAlert(result.error || '요청 실패')
+      }
+    } catch {
+      await appAlert('요청 중 오류가 발생했습니다.')
+    } finally {
+      setBackfillLoading(false)
+    }
+  }
 
   // 월 이동
   const goToPreviousMonth = () => {
@@ -210,6 +254,33 @@ export default function FinancialDashboard() {
         </div>
       ) : activeTab === 'status' ? (
         <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700">
+
+          {/* 수입 동기화 안내 배너 */}
+          {syncPending && (
+            <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4 flex items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <RefreshCw className="w-5 h-5 text-amber-600 animate-spin" />
+                <div>
+                  <p className="text-sm font-semibold text-amber-800">
+                    {selectedYear}년 {selectedMonth}월 수입 데이터를 덴트웹에서 불러오는 중...
+                  </p>
+                  <p className="text-xs text-amber-600 mt-0.5">
+                    워커에서 처리 후 자동으로 반영됩니다 (최대 30초 소요)
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <button
+                  onClick={handleBackfillRequest}
+                  disabled={backfillLoading}
+                  className="flex items-center gap-1.5 px-3 py-1.5 bg-amber-600 text-white text-xs font-medium rounded-xl hover:bg-amber-700 transition disabled:opacity-50"
+                >
+                  <Download className="w-3.5 h-3.5" />
+                  {backfillLoading ? '요청 중...' : '과거 전체 불러오기'}
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* Executive Summary Cards */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">

--- a/dental-clinic-manager/src/components/Master/PremiumFeatureModal.tsx
+++ b/dental-clinic-manager/src/components/Master/PremiumFeatureModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import { dataService } from '@/lib/dataService'
 import { PREMIUM_FEATURE_IDS, PREMIUM_FEATURE_LABELS } from '@/config/menuConfig'
 import type { PremiumFeatureId } from '@/config/menuConfig'
-import { X, Sparkles, BarChart3, Megaphone } from 'lucide-react'
+import { X, Sparkles, BarChart3, Megaphone, PhoneCall } from 'lucide-react'
 
 interface PremiumFeatureModalProps {
   clinic: { id: string; name: string }
@@ -14,6 +14,7 @@ interface PremiumFeatureModalProps {
 }
 
 const FEATURE_ICONS: Record<PremiumFeatureId, React.ElementType> = {
+  'recall': PhoneCall,
   'ai-analysis': Sparkles,
   'financial': BarChart3,
   'marketing': Megaphone,

--- a/dental-clinic-manager/src/components/Premium/PremiumGate.tsx
+++ b/dental-clinic-manager/src/components/Premium/PremiumGate.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { usePremiumFeatures } from '@/hooks/usePremiumFeatures'
 import { PREMIUM_FEATURE_INFO } from '@/config/menuConfig'
-import type { PremiumFeatureId } from '@/config/menuConfig'
+import type { PremiumFeatureId, PremiumPlanOption } from '@/config/menuConfig'
 import { Sparkles, Check, CreditCard } from 'lucide-react'
 import CardRegistrationModal from '@/components/Subscription/CardRegistrationModal'
 import type { SubscriptionPlan } from '@/types/subscription'
@@ -32,14 +32,11 @@ export default function PremiumGate({ featureId, children }: PremiumGateProps) {
 
   const info = PREMIUM_FEATURE_INFO[featureId]
 
-  async function handleSubscribe() {
+  async function handleSelectPlan(option: PremiumPlanOption) {
     try {
       const res = await fetch('/api/subscription/plans?type=feature')
       const plans: SubscriptionPlan[] = await res.json()
-      // premium-bundle 또는 해당 feature의 플랜 찾기
-      const plan = featureId === 'investment'
-        ? plans.find(p => p.feature_id === 'investment')
-        : plans.find(p => p.feature_id === 'premium-bundle')
+      const plan = plans.find(p => p.feature_id === option.planFeatureId)
       if (plan) {
         setSelectedPlan(plan)
         setShowPayment(true)
@@ -51,19 +48,18 @@ export default function PremiumGate({ featureId, children }: PremiumGateProps) {
 
   return (
     <div className="relative min-h-screen">
-      {/* 데모 배경: 실제 콘텐츠를 흐리게 표시 */}
+      {/* 데모 배경 */}
       <div className="pointer-events-none select-none" aria-hidden="true">
         <div className="blur-[6px] opacity-40 saturate-50">
           {children}
         </div>
       </div>
 
-      {/* 중앙 오버레이: 기능 설명 + 결제 CTA */}
+      {/* 중앙 오버레이 */}
       <div className="absolute inset-0 flex items-center justify-center p-4 z-10">
-        {/* 배경 그라데이션 */}
         <div className="absolute inset-0 bg-gradient-to-b from-white/60 via-white/80 to-white/60" />
 
-        <div className="relative w-full max-w-lg">
+        <div className="relative w-full max-w-2xl">
           <div className="bg-white rounded-2xl shadow-2xl border border-gray-100 overflow-hidden">
             {/* 헤더 */}
             <div className="bg-gradient-to-r from-amber-400 to-amber-500 px-6 py-4">
@@ -76,44 +72,62 @@ export default function PremiumGate({ featureId, children }: PremiumGateProps) {
                     <h2 className="text-lg font-bold text-white">{info.title}</h2>
                     <span className="text-[10px] font-bold tracking-wider bg-white/25 text-white px-2 py-0.5 rounded-full">PRO</span>
                   </div>
-                  <p className="text-sm text-white/80">{info.planName} 플랜</p>
+                  <p className="text-sm text-white/80">{info.description}</p>
                 </div>
               </div>
             </div>
 
-            {/* 본문 */}
-            <div className="px-6 py-5">
-              <p className="text-sm text-gray-600 mb-4">{info.description}</p>
+            {/* 플랜 카드 */}
+            <div className={`px-6 py-5 ${info.plans.length > 1 ? 'grid grid-cols-1 sm:grid-cols-2 gap-4' : ''}`}>
+              {info.plans.map((option) => (
+                <div
+                  key={option.planFeatureId}
+                  className={`relative rounded-xl border-2 p-5 flex flex-col ${
+                    option.recommended ? 'border-amber-400 bg-amber-50/50' : 'border-gray-200 bg-white'
+                  }`}
+                >
+                  {option.recommended && info.plans.length > 1 && (
+                    <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 rounded-full bg-amber-500 px-3 py-0.5 text-[10px] font-bold text-white whitespace-nowrap">
+                      추천
+                    </span>
+                  )}
 
-              <ul className="space-y-2.5 mb-6">
-                {info.highlights.map((item, i) => (
-                  <li key={i} className="flex items-center gap-2.5 text-sm text-gray-700">
-                    <div className="w-5 h-5 rounded-full bg-green-100 flex items-center justify-center flex-shrink-0">
-                      <Check className="w-3 h-3 text-green-600" />
-                    </div>
-                    {item}
-                  </li>
-                ))}
-              </ul>
+                  <h3 className="font-semibold text-gray-900 text-base">{option.name}</h3>
+                  <div className="mt-2 mb-4">
+                    <span className="text-2xl font-bold text-gray-900">{option.priceLabel}</span>
+                    {option.priceLabel.includes('원') && (
+                      <span className="text-xs text-gray-500 ml-1">(VAT 포함)</span>
+                    )}
+                  </div>
 
-              {/* 가격 */}
-              <div className="flex items-baseline gap-1 mb-5">
-                <span className="text-3xl font-bold text-gray-900">{info.priceLabel}</span>
-                {info.priceLabel.includes('원') && (
-                  <span className="text-sm text-gray-500">(VAT 포함)</span>
-                )}
-              </div>
+                  <ul className="space-y-2 mb-5 flex-1">
+                    {option.includes.map((item, i) => (
+                      <li key={i} className="flex items-center gap-2 text-sm text-gray-700">
+                        <div className="w-4 h-4 rounded-full bg-green-100 flex items-center justify-center flex-shrink-0">
+                          <Check className="w-2.5 h-2.5 text-green-600" />
+                        </div>
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
 
-              {/* 결제 버튼 */}
-              <button
-                onClick={handleSubscribe}
-                className="w-full flex items-center justify-center gap-2 bg-gradient-to-r from-amber-400 to-amber-500 hover:from-amber-500 hover:to-amber-600 text-white font-semibold py-3.5 px-6 rounded-xl transition-all shadow-lg shadow-amber-500/25 hover:shadow-amber-500/40"
-              >
-                <CreditCard className="w-5 h-5" />
-                구독 시작하기
-              </button>
+                  <button
+                    onClick={() => handleSelectPlan(option)}
+                    className={`w-full flex items-center justify-center gap-2 font-semibold py-3 px-4 rounded-xl transition-all text-sm ${
+                      option.recommended
+                        ? 'bg-gradient-to-r from-amber-400 to-amber-500 hover:from-amber-500 hover:to-amber-600 text-white shadow-lg shadow-amber-500/25'
+                        : 'bg-gray-100 hover:bg-gray-200 text-gray-800'
+                    }`}
+                  >
+                    <CreditCard className="w-4 h-4" />
+                    구독 시작하기
+                  </button>
+                </div>
+              ))}
+            </div>
 
-              <p className="text-center text-xs text-gray-400 mt-3">
+            <div className="px-6 pb-4">
+              <p className="text-center text-xs text-gray-400">
                 언제든 구독을 취소할 수 있습니다
               </p>
             </div>

--- a/dental-clinic-manager/src/config/menuConfig.ts
+++ b/dental-clinic-manager/src/config/menuConfig.ts
@@ -12,52 +12,70 @@
 import type { Permission } from '@/types/permissions'
 
 // 프리미엄 기능 ID 상수
-export const PREMIUM_FEATURE_IDS = ['ai-analysis', 'financial', 'marketing', 'investment'] as const
+export const PREMIUM_FEATURE_IDS = ['recall', 'ai-analysis', 'financial', 'marketing', 'investment'] as const
 export type PremiumFeatureId = typeof PREMIUM_FEATURE_IDS[number]
 
 // 프리미엄 기능 라벨 맵
 export const PREMIUM_FEATURE_LABELS: Record<PremiumFeatureId, string> = {
+  'recall': '리콜 관리',
   'ai-analysis': 'AI 데이터 분석',
   'financial': '경영 현황',
   'marketing': '마케팅 자동화',
   'investment': '주식 자동매매',
 }
 
+// 프리미엄 기능별 데모 오버레이에 표시할 두 가지 플랜 옵션
+export interface PremiumPlanOption {
+  planFeatureId: string   // subscription_plans.feature_id
+  name: string
+  priceLabel: string
+  includes: string[]
+  recommended?: boolean
+}
+
 // 프리미엄 기능 상세 설명 (데모 오버레이에서 사용)
 export const PREMIUM_FEATURE_INFO: Record<PremiumFeatureId, {
   title: string
   description: string
-  highlights: string[]
-  planName: string
-  priceLabel: string
+  plans: PremiumPlanOption[]
 }> = {
+  'recall': {
+    title: '리콜 관리',
+    description: '미내원 환자를 자동으로 관리하고 리콜 캠페인을 실행합니다.',
+    plans: [
+      { planFeatureId: 'standard-bundle', name: '스탠다드', priceLabel: '월 99,000원', includes: ['리콜 관리', 'AI 데이터 분석', '경영 현황'], recommended: true },
+      { planFeatureId: 'premium-bundle', name: '프리미엄', priceLabel: '월 499,000원', includes: ['리콜 관리', 'AI 데이터 분석', '경영 현황', '마케팅 자동화'] },
+    ],
+  },
   'ai-analysis': {
-    title: '프리미엄 패키지',
-    description: 'AI 분석, 경영 현황, 마케팅 자동화를 하나의 패키지로 이용하세요.',
-    highlights: ['AI 데이터 분석 — 매출/환자 추이 자동 분석, AI 채팅', '경영 현황 — 수입/지출 관리, 손익 분석, 세금 계산', '마케팅 자동화 — AI 임상글 생성, SEO 분석, 게시물 관리'],
-    planName: '프리미엄',
-    priceLabel: '월 499,000원',
+    title: 'AI 데이터 분석',
+    description: 'AI가 병원 데이터를 분석하여 경영 인사이트를 제공합니다.',
+    plans: [
+      { planFeatureId: 'standard-bundle', name: '스탠다드', priceLabel: '월 99,000원', includes: ['리콜 관리', 'AI 데이터 분석', '경영 현황'], recommended: true },
+      { planFeatureId: 'premium-bundle', name: '프리미엄', priceLabel: '월 499,000원', includes: ['리콜 관리', 'AI 데이터 분석', '경영 현황', '마케팅 자동화'] },
+    ],
   },
   'financial': {
-    title: '프리미엄 패키지',
-    description: 'AI 분석, 경영 현황, 마케팅 자동화를 하나의 패키지로 이용하세요.',
-    highlights: ['AI 데이터 분석 — 매출/환자 추이 자동 분석, AI 채팅', '경영 현황 — 수입/지출 관리, 손익 분석, 세금 계산', '마케팅 자동화 — AI 임상글 생성, SEO 분석, 게시물 관리'],
-    planName: '프리미엄',
-    priceLabel: '월 499,000원',
+    title: '경영 현황',
+    description: '수입/지출을 체계적으로 관리하고 손익을 분석합니다.',
+    plans: [
+      { planFeatureId: 'standard-bundle', name: '스탠다드', priceLabel: '월 99,000원', includes: ['리콜 관리', 'AI 데이터 분석', '경영 현황'], recommended: true },
+      { planFeatureId: 'premium-bundle', name: '프리미엄', priceLabel: '월 499,000원', includes: ['리콜 관리', 'AI 데이터 분석', '경영 현황', '마케팅 자동화'] },
+    ],
   },
   'marketing': {
-    title: '프리미엄 패키지',
-    description: 'AI 분석, 경영 현황, 마케팅 자동화를 하나의 패키지로 이용하세요.',
-    highlights: ['AI 데이터 분석 — 매출/환자 추이 자동 분석, AI 채팅', '경영 현황 — 수입/지출 관리, 손익 분석, 세금 계산', '마케팅 자동화 — AI 임상글 생성, SEO 분석, 게시물 관리'],
-    planName: '프리미엄',
-    priceLabel: '월 499,000원',
+    title: '마케팅 자동화',
+    description: '네이버 블로그 임상글을 AI로 자동 생성하고 관리합니다.',
+    plans: [
+      { planFeatureId: 'premium-bundle', name: '프리미엄', priceLabel: '월 499,000원', includes: ['리콜 관리', 'AI 데이터 분석', '경영 현황', '마케팅 자동화'], recommended: true },
+    ],
   },
   'investment': {
     title: '주식 자동매매',
     description: 'AI 기반 자동매매 전략으로 자산을 운용합니다.',
-    highlights: ['AI 자동매매 전략', '실시간 포트폴리오 관리', '백테스트로 전략 검증'],
-    planName: '주식 자동매매',
-    priceLabel: '수익의 5%',
+    plans: [
+      { planFeatureId: 'investment', name: '주식 자동매매', priceLabel: '수익의 5%', includes: ['AI 자동매매', '전략 백테스트', '실시간 포트폴리오'], recommended: true },
+    ],
   },
 }
 
@@ -274,6 +292,7 @@ export const MENU_CONFIG: MenuConfigItem[] = [
     categoryId: 'operations',
     order: 14,
     visible: true,
+    premiumFeature: true,
   },
   {
     id: 'financial',

--- a/dental-clinic-manager/src/hooks/usePremiumFeatures.ts
+++ b/dental-clinic-manager/src/hooks/usePremiumFeatures.ts
@@ -6,8 +6,11 @@ import { dataService } from '@/lib/dataService'
 import { PREMIUM_FEATURE_IDS } from '@/config/menuConfig'
 import { getSupabase } from '@/lib/supabase'
 
-// premium-bundle 구독 시 포함되는 기능 ID들
-const PREMIUM_BUNDLE_FEATURES = ['ai-analysis', 'financial', 'marketing'] as const
+// 번들 구독 시 포함되는 기능 ID 매핑
+const BUNDLE_FEATURE_MAP: Record<string, readonly string[]> = {
+  'standard-bundle': ['recall', 'ai-analysis', 'financial'],
+  'premium-bundle': ['recall', 'ai-analysis', 'financial', 'marketing'],
+} as const
 
 export function usePremiumFeatures() {
   const { user } = useAuth()
@@ -54,9 +57,10 @@ export function usePremiumFeatures() {
               const plan = sub.subscription_plans as unknown as { feature_id: string | null } | null
               if (!plan?.feature_id) continue
 
-              if (plan.feature_id === 'premium-bundle') {
-                // premium-bundle → 3개 기능 모두 활성화
-                for (const fid of PREMIUM_BUNDLE_FEATURES) {
+              const bundleFeatures = BUNDLE_FEATURE_MAP[plan.feature_id]
+              if (bundleFeatures) {
+                // 번들 구독 → 포함된 기능 모두 활성화
+                for (const fid of bundleFeatures) {
                   featureIds.add(fid)
                 }
               } else {


### PR DESCRIPTION
## Summary
- 포트원 v2 + 토스페이먼츠 구독 결제 시스템 구현
- 프리미엄 2단계 패키지: 스탠다드(99,000원) / 프리미엄(499,000원)
- 유료 기능 PRO 뱃지 + 데모 오버레이 + 결제 CTA
- 리콜 관리 유료 전환
- 주식 자동매매 (수익 5%) 플랜 추가
- 기타 다수 기능 추가 및 버그 수정

## Test plan
- [ ] 사이드바에서 PRO 뱃지 정상 표시 확인
- [ ] 미결제 상태에서 유료 메뉴 클릭 → 데모 오버레이 + 플랜 카드 표시 확인
- [ ] 포트원 테스트 환경에서 카드 등록 → 결제 플로우 확인
- [ ] 구독 후 기능 잠금 해제 확인
- [ ] 빌드 에러 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)