### PR TITLE
fix(dentweb): 덴트웹 과거 월 수입 동기화 RLS 문제 해결

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
@@ -674,11 +674,9 @@ async function syncSingleMonthRevenue(
 ): Promise<boolean> {
   try {
     const revenue = await getMonthlyRevenue(dbPool, year, month);
-    const total = revenue.insurance_revenue + revenue.non_insurance_revenue + revenue.other_revenue;
 
-    // 수입이 0이면 전송 생략 (성공으로 처리)
-    if (total === 0) return true;
-
+    // 수입이 0이어도 전송하여 revenue_records에 기록을 남김
+    // (전송 생략 시 대시보드가 매번 pending에 재추가하는 무한 루프 발생)
     const url = `${dashboardUrl}/api/dentweb/sync-revenue`;
     const response = await fetchWithRetry(url, {
       method: 'POST',

--- a/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
@@ -855,6 +855,8 @@ let realtimeChannel: RealtimeChannel | null = null;
 let pollingInterval: ReturnType<typeof setInterval> | null = null;
 let queryApiClient: DentwebApiClient | null = null;
 let cachedWritableTables: string[] = [];
+// 첫 연결 실패 후 재감지로 DB가 붙었을 때 proxy 재시도 여부 판별
+let queryProxyStarted = false;
 
 /** 읽기 쿼리 안전 검증 */
 function validateReadQuery(queryText: string): void {
@@ -940,7 +942,7 @@ async function handleQueryRequest(
 
     // SQL 실행 (30초 타임아웃)
     const sqlRequest = dbPool.request();
-    sqlRequest.timeout = 30000;
+    (sqlRequest as unknown as { timeout: number }).timeout = 30000;
     const result = await sqlRequest.query(request.query_text);
 
     const executionTime = Date.now() - startTime;
@@ -1061,7 +1063,41 @@ function stopQueryProxy(): void {
     pollingInterval = null;
   }
   queryApiClient = null;
+  queryProxyStarted = false;
   log('info', '[DentWeb] Query proxy stopped');
+}
+
+/**
+ * Schema 제출 + 쿼리 프록시를 보장한다.
+ * 첫 연결 실패 후 재감지로 DB가 붙으면 이 함수가 주기 콜백에서 재시도한다.
+ */
+async function ensureQueryProxy(
+  dbPool: sql.ConnectionPool,
+  cfg: ReturnType<typeof getDentwebConfig>
+): Promise<void> {
+  if (queryProxyStarted) return;
+  if (!dbPool.connected || !cfg.clinicId || !cfg.apiKey) return;
+
+  try {
+    queryApiClient = new DentwebApiClient();
+    const { tables, writableTables } = await discoverDentwebSchema(dbPool);
+    cachedWritableTables = writableTables;
+
+    await queryApiClient.submitSchema(
+      cfg.clinicId,
+      cfg.apiKey,
+      { tables },
+      writableTables
+    );
+    log('info', '[DentWeb] Schema submitted to server');
+
+    await startQueryProxy(dbPool, cfg.clinicId, cfg.apiKey, queryApiClient, writableTables);
+    queryProxyStarted = true;
+  } catch (err) {
+    // 실패 시 플래그를 유지하지 않아 다음 주기에 재시도 가능
+    queryProxyStarted = false;
+    throw err;
+  }
 }
 
 /* ------------------------------------------------------------------ */
@@ -1251,27 +1287,12 @@ export async function startDentwebSync(): Promise<void> {
   // Run first sync immediately
   await runSync();
 
-  // Schema discovery + query proxy (DB 연결 성공 시에만)
+  // Schema discovery + query proxy (DB 연결 성공 시에만; 실패해도 기존 동기화는 계속 진행)
   if (pool && pool.connected && cfg.clinicId && cfg.apiKey) {
     try {
-      queryApiClient = new DentwebApiClient();
-      const { tables, writableTables } = await discoverDentwebSchema(pool);
-      cachedWritableTables = writableTables;
-
-      // 스키마 정보를 서버로 전송
-      await queryApiClient.submitSchema(
-        cfg.clinicId,
-        cfg.apiKey,
-        { tables },
-        writableTables
-      );
-      log('info', '[DentWeb] Schema submitted to server');
-
-      // 쿼리 프록시 시작 (Realtime 또는 폴링)
-      await startQueryProxy(pool, cfg.clinicId, cfg.apiKey, queryApiClient, writableTables);
+      await ensureQueryProxy(pool, cfg);
     } catch (err) {
       log('warn', `[DentWeb] Schema discovery / query proxy 시작 실패: ${err instanceof Error ? err.message : String(err)}`);
-      // 스키마/프록시 실패해도 기존 동기화는 계속 진행
     }
   }
 
@@ -1279,9 +1300,19 @@ export async function startDentwebSync(): Promise<void> {
   const interval = (getDentwebConfig().syncInterval || 300) * 1000;
   if (syncTimer) clearInterval(syncTimer);
   syncTimer = setInterval(() => {
-    runSync().catch(err => {
-      log('error', `[DentWeb] 스케줄 동기화 오류: ${err instanceof Error ? err.message : String(err)}`);
-    });
+    runSync()
+      .then(() => {
+        // 첫 시작 때 DB 연결 실패로 proxy skip 된 경우 주기마다 재시도
+        const latestCfg = getDentwebConfig();
+        if (pool && pool.connected && latestCfg.clinicId && latestCfg.apiKey) {
+          ensureQueryProxy(pool, latestCfg).catch(err => {
+            log('warn', `[DentWeb] Query proxy 재시도 실패: ${err instanceof Error ? err.message : String(err)}`);
+          });
+        }
+      })
+      .catch(err => {
+        log('error', `[DentWeb] 스케줄 동기화 오류: ${err instanceof Error ? err.message : String(err)}`);
+      });
   }, interval);
 }
 

--- a/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
@@ -708,27 +708,25 @@ async function syncSingleMonthRevenue(
 
 /**
  * pending_revenue_months에서 요청된 월 동기화 + 처리 완료된 항목 제거
+ * 서버 API를 통해 pending 조회/정리 (RLS 우회)
  */
 async function processPendingRevenueMonths(dbPool: sql.ConnectionPool): Promise<void> {
   const cfg = getDentwebConfig();
   const { dashboardUrl } = getConfig();
   if (!cfg.clinicId || !cfg.apiKey) return;
 
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://beahjntkmkfhpcbhfnrr.supabase.co';
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
-  if (!supabaseAnonKey) return;
-
   try {
-    const supabase = createClient(supabaseUrl, supabaseAnonKey);
+    // 서버 API로 pending 목록 조회 (RLS 우회)
+    const pendingUrl = `${dashboardUrl}/api/dentweb/pending-revenue?clinic_id=${cfg.clinicId}&api_key=${cfg.apiKey}`;
+    const pendingRes = await fetchWithRetry(pendingUrl, undefined, 1);
+    const pendingData = await pendingRes.json();
 
-    // pending_revenue_months 조회
-    const { data: config } = await supabase
-      .from('dentweb_sync_config')
-      .select('pending_revenue_months')
-      .eq('clinic_id', cfg.clinicId)
-      .single();
+    if (!pendingData.success) {
+      log('warn', `[DentWeb] pending 조회 실패: ${pendingData.error}`);
+      return;
+    }
 
-    const pending = (config?.pending_revenue_months || []) as Array<{ year: number; month: number }>;
+    const pending = (pendingData.data?.pending_months || []) as Array<{ year: number; month: number }>;
     if (pending.length === 0) return;
 
     log('info', `[DentWeb] on-demand 수입 동기화 요청 ${pending.length}건 처리 시작`);
@@ -742,17 +740,25 @@ async function processPendingRevenueMonths(dbPool: sql.ConnectionPool): Promise<
       }
     }
 
-    // 완료된 항목 제거
+    // 완료된 항목을 서버 API로 제거 (RLS 우회)
     if (completed.length > 0) {
-      const remaining = pending.filter(
-        p => !completed.some(c => c.year === p.year && c.month === p.month)
-      );
-      await supabase
-        .from('dentweb_sync_config')
-        .update({ pending_revenue_months: remaining })
-        .eq('clinic_id', cfg.clinicId);
+      const removeUrl = `${dashboardUrl}/api/dentweb/pending-revenue`;
+      const removeRes = await fetchWithRetry(removeUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          clinic_id: cfg.clinicId,
+          api_key: cfg.apiKey,
+          completed_months: completed,
+        }),
+      }, 1);
+      const removeData = await removeRes.json();
 
-      log('info', `[DentWeb] on-demand 수입 동기화 완료: ${completed.length}건 처리, ${remaining.length}건 잔여`);
+      if (removeData.success) {
+        log('info', `[DentWeb] on-demand 수입 동기화 완료: ${completed.length}건 처리, ${removeData.data?.remaining_count || 0}건 잔여`);
+      } else {
+        log('warn', `[DentWeb] pending 제거 실패: ${removeData.error}`);
+      }
     }
   } catch (err) {
     log('warn', `[DentWeb] on-demand 수입 동기화 오류: ${err instanceof Error ? err.message : String(err)}`);

--- a/dental-clinic-manager/src/app/api/dentweb/pending-revenue/route.ts
+++ b/dental-clinic-manager/src/app/api/dentweb/pending-revenue/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+function getServiceClient() {
+  return createClient(supabaseUrl, supabaseServiceKey)
+}
+
+/**
+ * GET: 워커가 api_key로 인증하여 pending_revenue_months 목록 조회
+ * 워커는 RLS 때문에 dentweb_sync_config에 직접 접근 불가하므로 이 API를 사용
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const clinicId = searchParams.get('clinic_id')
+    const apiKey = searchParams.get('api_key')
+
+    if (!clinicId || !apiKey) {
+      return NextResponse.json({ success: false, error: 'clinic_id와 api_key가 필요합니다.' }, { status: 400 })
+    }
+
+    const supabase = getServiceClient()
+
+    // API 키 인증
+    const { data: config, error } = await supabase
+      .from('dentweb_sync_config')
+      .select('pending_revenue_months')
+      .eq('clinic_id', clinicId)
+      .eq('api_key', apiKey)
+      .single()
+
+    if (error || !config) {
+      return NextResponse.json({ success: false, error: '인증 실패' }, { status: 401 })
+    }
+
+    const pending = (config.pending_revenue_months || []) as Array<{ year: number; month: number }>
+
+    return NextResponse.json({ success: true, data: { pending_months: pending } })
+  } catch (error) {
+    console.error('[dentweb/pending-revenue] GET error:', error)
+    return NextResponse.json({ success: false, error: '서버 오류' }, { status: 500 })
+  }
+}
+
+/**
+ * POST: 워커가 처리 완료된 월을 pending에서 제거
+ * body: { clinic_id, api_key, completed_months: [{year, month}, ...] }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { clinic_id, api_key, completed_months } = body
+
+    if (!clinic_id || !api_key || !completed_months) {
+      return NextResponse.json({ success: false, error: '필수 파라미터 누락' }, { status: 400 })
+    }
+
+    const supabase = getServiceClient()
+
+    // API 키 인증 + 현재 pending 조회
+    const { data: config, error } = await supabase
+      .from('dentweb_sync_config')
+      .select('id, pending_revenue_months')
+      .eq('clinic_id', clinic_id)
+      .eq('api_key', api_key)
+      .single()
+
+    if (error || !config) {
+      return NextResponse.json({ success: false, error: '인증 실패' }, { status: 401 })
+    }
+
+    const pending = (config.pending_revenue_months || []) as Array<{ year: number; month: number }>
+    const completed = completed_months as Array<{ year: number; month: number }>
+
+    // 완료된 항목 제거
+    const remaining = pending.filter(
+      p => !completed.some(c => c.year === p.year && c.month === p.month)
+    )
+
+    await supabase
+      .from('dentweb_sync_config')
+      .update({ pending_revenue_months: remaining })
+      .eq('id', config.id)
+
+    return NextResponse.json({
+      success: true,
+      data: { removed_count: pending.length - remaining.length, remaining_count: remaining.length },
+    })
+  } catch (error) {
+    console.error('[dentweb/pending-revenue] POST error:', error)
+    return NextResponse.json({ success: false, error: '서버 오류' }, { status: 500 })
+  }
+}

--- a/dental-clinic-manager/src/app/api/dentweb/sync-revenue/route.ts
+++ b/dental-clinic-manager/src/app/api/dentweb/sync-revenue/route.ts
@@ -19,10 +19,10 @@ export async function POST(request: NextRequest) {
 
     const supabase = createClient(supabaseUrl, supabaseServiceKey)
 
-    // API 키 인증
+    // API 키 인증 + pending 조회
     const { data: config, error: configError } = await supabase
       .from('dentweb_sync_config')
-      .select('clinic_id, api_key, is_active')
+      .select('id, clinic_id, api_key, is_active, pending_revenue_months')
       .eq('clinic_id', clinic_id)
       .eq('api_key', api_key)
       .single()
@@ -61,6 +61,18 @@ export async function POST(request: NextRequest) {
 
     const total = Math.round((insurance_revenue || 0) + (non_insurance_revenue || 0) + (other_revenue || 0))
     console.log(`[dentweb/sync-revenue] ${year}-${month} 수입 저장 완료: 보험=${insurance_revenue}, 비보험=${non_insurance_revenue}, 기타=${other_revenue}, 합계=${total}`)
+
+    // 해당 월이 pending에 있으면 자동 제거
+    const pending = (config.pending_revenue_months || []) as Array<{ year: number; month: number }>
+    const yearNum = parseInt(year)
+    const monthNum = parseInt(month)
+    if (pending.some(p => p.year === yearNum && p.month === monthNum)) {
+      const remaining = pending.filter(p => !(p.year === yearNum && p.month === monthNum))
+      await supabase
+        .from('dentweb_sync_config')
+        .update({ pending_revenue_months: remaining })
+        .eq('id', config.id)
+    }
 
     return NextResponse.json({
       success: true,

--- a/dental-clinic-manager/src/app/api/financial/summary/route.ts
+++ b/dental-clinic-manager/src/app/api/financial/summary/route.ts
@@ -76,7 +76,7 @@ async function requestRevenueSyncIfNeeded(
   // pending 목록에 이미 있는지 확인
   const pending = (syncConfig.pending_revenue_months || []) as Array<{ year: number; month: number }>;
   const alreadyPending = pending.some((p: { year: number; month: number }) => p.year === year && p.month === month);
-  if (alreadyPending) return true; // 이미 요청됨
+  if (alreadyPending) return false; // 이미 요청됨 — 워커가 처리할 때까지 배너 미표시
 
   // pending 목록에 추가
   const updated = [...pending, { year, month }];
@@ -85,7 +85,7 @@ async function requestRevenueSyncIfNeeded(
     .update({ pending_revenue_months: updated })
     .eq('id', syncConfig.id);
 
-  return true; // 새로 요청함
+  return true; // 새로 요청함 — 배너 표시 + 폴링 시작
 }
 
 // GET: 재무 요약 조회

--- a/dental-clinic-manager/src/app/api/marketing/calendar/items/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/calendar/items/route.ts
@@ -135,6 +135,32 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ message: '전체 거절 완료' });
     }
 
+    // 선택된 항목들에 대한 일괄 작업
+    const { itemIds } = body;
+    if (action === 'batch_approve' && Array.isArray(itemIds) && itemIds.length > 0) {
+      const { error } = await supabase
+        .from('content_calendar_items')
+        .update({ status: 'approved' })
+        .in('id', itemIds)
+        .in('status', ['proposed', 'modified']);
+      if (error) throw error;
+      return NextResponse.json({ message: `${itemIds.length}개 항목 승인 완료` });
+    }
+
+    if (action === 'batch_reject' && Array.isArray(itemIds) && itemIds.length > 0) {
+      const { error } = await supabase
+        .from('content_calendar_items')
+        .update({ status: 'rejected' })
+        .in('id', itemIds);
+      if (error) throw error;
+      return NextResponse.json({ message: `${itemIds.length}개 항목 반려 완료` });
+    }
+
+    if (action === 'batch_regenerate' && Array.isArray(itemIds) && itemIds.length > 0) {
+      // 재생성은 개별적으로 처리해야 하므로 itemIds만 반환
+      return NextResponse.json({ message: '일괄 재생성은 클라이언트에서 순차 처리합니다.', itemIds });
+    }
+
     return NextResponse.json({ error: '유효하지 않은 action' }, { status: 400 });
   } catch (error) {
     console.error('[API] calendar/items POST:', error);

--- a/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
+++ b/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
@@ -1266,8 +1266,8 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                                 group flex items-center justify-center py-1.5 rounded-lg text-[13px] font-medium transition-all duration-200 w-full
                                 ${isActive
                                     ? 'bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-sm shadow-blue-500/20'
-                                    : tab.isPremiumFeature
-                                      ? 'text-slate-500 hover:bg-amber-50 hover:text-amber-700 cursor-pointer'
+                                    : tab.isPremiumLocked
+                                      ? 'text-slate-300 hover:bg-amber-50 hover:text-amber-700 cursor-pointer'
                                       : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700'
                                 }
                               `}
@@ -1303,7 +1303,7 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                     }
                   `}
                 >
-                  {tab.isPremiumFeature && !isActive ? (
+                  {tab.isPremiumLocked && !isActive ? (
                     <>
                       <Icon className="w-5 h-5 flex-shrink-0 text-gray-300 group-hover:hidden" />
                       <span className="truncate text-gray-400 group-hover:hidden">{tab.label}</span>
@@ -1337,7 +1337,7 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                     }
                   `}
                 >
-                  {tab.isPremiumFeature && !isActive ? (
+                  {tab.isPremiumLocked && !isActive ? (
                     <>
                       <Icon className="w-5 h-5 flex-shrink-0 text-gray-300 group-hover:hidden" />
                       <span className="truncate text-gray-400 group-hover:hidden">{tab.label}</span>
@@ -1415,13 +1415,13 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                               group flex items-center space-x-2.5 py-1.5 px-3 rounded-lg text-[13px] font-medium transition-all duration-200 w-full
                               ${isActive
                                   ? 'bg-at-accent-light text-at-accent'
-                                  : tab.isPremiumFeature
-                                    ? 'text-at-text-secondary hover:bg-amber-50 hover:text-amber-700 cursor-pointer'
+                                  : tab.isPremiumLocked
+                                    ? 'text-gray-400 hover:bg-amber-50 hover:text-amber-700 cursor-pointer'
                                     : 'text-at-text-secondary hover:bg-at-surface-hover hover:text-at-text'
                               }
                             `}
                           >
-                            {tab.isPremiumFeature && !isActive ? (
+                            {tab.isPremiumLocked && !isActive ? (
                               <>
                                 <Icon className="w-4 h-4 flex-shrink-0 text-gray-300 group-hover:hidden" />
                                 <span className="truncate text-gray-400 group-hover:hidden">{tab.label}</span>

--- a/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
+++ b/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
@@ -1305,7 +1305,12 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                 >
                   <Icon className={`w-5 h-5 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
                   <span className="truncate">{tab.label}</span>
-                  {tab.isPremiumFeature && <span className="ml-auto text-[9px] font-bold tracking-wider bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1.5 py-0.5 rounded-full flex-shrink-0 leading-none transition-transform group-hover:scale-110">PRO</span>}
+                  {tab.isPremiumFeature && (
+                    <span className="ml-auto flex-shrink-0">
+                      <span className="inline-block text-[9px] font-bold tracking-wider bg-gray-200 text-gray-500 px-1.5 py-0.5 rounded-full leading-none group-hover:hidden">비활성</span>
+                      <span className="hidden group-hover:inline-block text-[9px] font-bold bg-gradient-to-r from-amber-400 to-amber-500 text-white px-2 py-0.5 rounded-full leading-none">활성화</span>
+                    </span>
+                  )}
                 </button>
               )
             })}
@@ -1329,7 +1334,12 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                 >
                   <Icon className={`w-5 h-5 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
                   <span className="truncate">{tab.label}</span>
-                  {tab.isPremiumFeature && <span className="ml-auto text-[9px] font-bold tracking-wider bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1.5 py-0.5 rounded-full flex-shrink-0 leading-none transition-transform group-hover:scale-110">PRO</span>}
+                  {tab.isPremiumFeature && (
+                    <span className="ml-auto flex-shrink-0">
+                      <span className="inline-block text-[9px] font-bold tracking-wider bg-gray-200 text-gray-500 px-1.5 py-0.5 rounded-full leading-none group-hover:hidden">비활성</span>
+                      <span className="hidden group-hover:inline-block text-[9px] font-bold bg-gradient-to-r from-amber-400 to-amber-500 text-white px-2 py-0.5 rounded-full leading-none">활성화</span>
+                    </span>
+                  )}
                 </button>
               )
             })}
@@ -1403,7 +1413,12 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                           >
                             <Icon className={`w-4 h-4 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
                             <span className="truncate">{tab.label}</span>
-                            {tab.isPremiumFeature && <span className="ml-auto text-[8px] font-bold tracking-wider bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1 py-0.5 rounded-full flex-shrink-0 leading-none transition-transform group-hover:scale-110">PRO</span>}
+                            {tab.isPremiumFeature && (
+                              <span className="ml-auto flex-shrink-0">
+                                <span className="inline-block text-[8px] font-bold tracking-wider bg-gray-200 text-gray-500 px-1 py-0.5 rounded-full leading-none group-hover:hidden">비활성</span>
+                                <span className="hidden group-hover:inline-block text-[8px] font-bold bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1.5 py-0.5 rounded-full leading-none">활성화</span>
+                              </span>
+                            )}
                           </button>
                         )
                       })}

--- a/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
+++ b/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
@@ -1314,6 +1314,7 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                     <>
                       <Icon className={`w-5 h-5 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
                       <span className="truncate">{tab.label}</span>
+                      {tab.isPremiumFeature && <span className="ml-auto text-[9px] font-bold tracking-wider bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1.5 py-0.5 rounded-full flex-shrink-0 leading-none">PRO</span>}
                     </>
                   )}
                 </button>
@@ -1348,6 +1349,7 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                     <>
                       <Icon className={`w-5 h-5 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
                       <span className="truncate">{tab.label}</span>
+                      {tab.isPremiumFeature && <span className="ml-auto text-[9px] font-bold tracking-wider bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1.5 py-0.5 rounded-full flex-shrink-0 leading-none">PRO</span>}
                     </>
                   )}
                 </button>
@@ -1432,6 +1434,7 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                               <>
                                 <Icon className={`w-4 h-4 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
                                 <span className="truncate">{tab.label}</span>
+                                {tab.isPremiumFeature && <span className="ml-auto text-[8px] font-bold tracking-wider bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1 py-0.5 rounded-full flex-shrink-0 leading-none">PRO</span>}
                               </>
                             )}
                           </button>

--- a/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
+++ b/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
@@ -1303,13 +1303,18 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                     }
                   `}
                 >
-                  <Icon className={`w-5 h-5 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
-                  <span className="truncate">{tab.label}</span>
-                  {tab.isPremiumFeature && (
-                    <span className="ml-auto flex-shrink-0">
-                      <span className="inline-block text-[9px] font-bold tracking-wider bg-gray-200 text-gray-500 px-1.5 py-0.5 rounded-full leading-none group-hover:hidden">비활성</span>
-                      <span className="hidden group-hover:inline-block text-[9px] font-bold bg-gradient-to-r from-amber-400 to-amber-500 text-white px-2 py-0.5 rounded-full leading-none">활성화</span>
-                    </span>
+                  {tab.isPremiumFeature && !isActive ? (
+                    <>
+                      <Icon className="w-5 h-5 flex-shrink-0 text-gray-300 group-hover:hidden" />
+                      <span className="truncate text-gray-400 group-hover:hidden">{tab.label}</span>
+                      <span className="ml-auto text-[9px] font-bold tracking-wider bg-gray-200 text-gray-500 px-1.5 py-0.5 rounded-full leading-none group-hover:hidden">PRO</span>
+                      <span className="hidden group-hover:flex items-center justify-center w-full text-sm font-semibold text-amber-600">활성화</span>
+                    </>
+                  ) : (
+                    <>
+                      <Icon className={`w-5 h-5 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
+                      <span className="truncate">{tab.label}</span>
+                    </>
                   )}
                 </button>
               )
@@ -1332,13 +1337,18 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                     }
                   `}
                 >
-                  <Icon className={`w-5 h-5 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
-                  <span className="truncate">{tab.label}</span>
-                  {tab.isPremiumFeature && (
-                    <span className="ml-auto flex-shrink-0">
-                      <span className="inline-block text-[9px] font-bold tracking-wider bg-gray-200 text-gray-500 px-1.5 py-0.5 rounded-full leading-none group-hover:hidden">비활성</span>
-                      <span className="hidden group-hover:inline-block text-[9px] font-bold bg-gradient-to-r from-amber-400 to-amber-500 text-white px-2 py-0.5 rounded-full leading-none">활성화</span>
-                    </span>
+                  {tab.isPremiumFeature && !isActive ? (
+                    <>
+                      <Icon className="w-5 h-5 flex-shrink-0 text-gray-300 group-hover:hidden" />
+                      <span className="truncate text-gray-400 group-hover:hidden">{tab.label}</span>
+                      <span className="ml-auto text-[9px] font-bold tracking-wider bg-gray-200 text-gray-500 px-1.5 py-0.5 rounded-full leading-none group-hover:hidden">PRO</span>
+                      <span className="hidden group-hover:flex items-center justify-center w-full text-sm font-semibold text-amber-600">활성화</span>
+                    </>
+                  ) : (
+                    <>
+                      <Icon className={`w-5 h-5 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
+                      <span className="truncate">{tab.label}</span>
+                    </>
                   )}
                 </button>
               )
@@ -1411,13 +1421,18 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                               }
                             `}
                           >
-                            <Icon className={`w-4 h-4 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
-                            <span className="truncate">{tab.label}</span>
-                            {tab.isPremiumFeature && (
-                              <span className="ml-auto flex-shrink-0">
-                                <span className="inline-block text-[8px] font-bold tracking-wider bg-gray-200 text-gray-500 px-1 py-0.5 rounded-full leading-none group-hover:hidden">비활성</span>
-                                <span className="hidden group-hover:inline-block text-[8px] font-bold bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1.5 py-0.5 rounded-full leading-none">활성화</span>
-                              </span>
+                            {tab.isPremiumFeature && !isActive ? (
+                              <>
+                                <Icon className="w-4 h-4 flex-shrink-0 text-gray-300 group-hover:hidden" />
+                                <span className="truncate text-gray-400 group-hover:hidden">{tab.label}</span>
+                                <span className="ml-auto text-[8px] font-bold tracking-wider bg-gray-200 text-gray-500 px-1 py-0.5 rounded-full leading-none group-hover:hidden">PRO</span>
+                                <span className="hidden group-hover:flex items-center justify-center w-full text-[13px] font-semibold text-amber-600">활성화</span>
+                              </>
+                            ) : (
+                              <>
+                                <Icon className={`w-4 h-4 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
+                                <span className="truncate">{tab.label}</span>
+                              </>
                             )}
                           </button>
                         )

--- a/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
+++ b/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
@@ -1264,11 +1264,11 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                               onClick={() => handleTabClick(tab.id)}
                               className={`
                                 group flex items-center justify-center py-1.5 rounded-lg text-[13px] font-medium transition-all duration-200 w-full
-                                ${tab.isPremiumLocked
-                                  ? 'text-slate-300 cursor-not-allowed opacity-50'
-                                  : isActive
+                                ${isActive
                                     ? 'bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-sm shadow-blue-500/20'
-                                    : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700'
+                                    : tab.isPremiumFeature
+                                      ? 'text-slate-500 hover:bg-amber-50 hover:text-amber-700 cursor-pointer'
+                                      : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700'
                                 }
                               `}
                             >
@@ -1305,7 +1305,7 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                 >
                   <Icon className={`w-5 h-5 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
                   <span className="truncate">{tab.label}</span>
-                  {tab.isPremiumFeature && <span className="ml-auto text-[9px] font-bold tracking-wider bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1.5 py-0.5 rounded-full flex-shrink-0 leading-none">PRO</span>}
+                  {tab.isPremiumFeature && <span className="ml-auto text-[9px] font-bold tracking-wider bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1.5 py-0.5 rounded-full flex-shrink-0 leading-none transition-transform group-hover:scale-110">PRO</span>}
                 </button>
               )
             })}
@@ -1329,7 +1329,7 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                 >
                   <Icon className={`w-5 h-5 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
                   <span className="truncate">{tab.label}</span>
-                  {tab.isPremiumFeature && <span className="ml-auto text-[9px] font-bold tracking-wider bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1.5 py-0.5 rounded-full flex-shrink-0 leading-none">PRO</span>}
+                  {tab.isPremiumFeature && <span className="ml-auto text-[9px] font-bold tracking-wider bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1.5 py-0.5 rounded-full flex-shrink-0 leading-none transition-transform group-hover:scale-110">PRO</span>}
                 </button>
               )
             })}
@@ -1393,17 +1393,17 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
                             onClick={() => handleTabClick(tab.id)}
                             className={`
                               group flex items-center space-x-2.5 py-1.5 px-3 rounded-lg text-[13px] font-medium transition-all duration-200 w-full
-                              ${tab.isPremiumLocked
-                                ? 'text-at-text-weak cursor-not-allowed opacity-50'
-                                : isActive
+                              ${isActive
                                   ? 'bg-at-accent-light text-at-accent'
-                                  : 'text-at-text-secondary hover:bg-at-surface-hover hover:text-at-text'
+                                  : tab.isPremiumFeature
+                                    ? 'text-at-text-secondary hover:bg-amber-50 hover:text-amber-700 cursor-pointer'
+                                    : 'text-at-text-secondary hover:bg-at-surface-hover hover:text-at-text'
                               }
                             `}
                           >
                             <Icon className={`w-4 h-4 flex-shrink-0 ${isActive ? 'text-at-accent' : 'text-at-text-weak group-hover:text-at-text-secondary'}`} />
                             <span className="truncate">{tab.label}</span>
-                            {tab.isPremiumFeature && <span className="ml-auto text-[8px] font-bold tracking-wider bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1 py-0.5 rounded-full flex-shrink-0 leading-none">PRO</span>}
+                            {tab.isPremiumFeature && <span className="ml-auto text-[8px] font-bold tracking-wider bg-gradient-to-r from-amber-400 to-amber-500 text-white px-1 py-0.5 rounded-full flex-shrink-0 leading-none transition-transform group-hover:scale-110">PRO</span>}
                           </button>
                         )
                       })}

--- a/dental-clinic-manager/src/components/Premium/PremiumGate.tsx
+++ b/dental-clinic-manager/src/components/Premium/PremiumGate.tsx
@@ -55,8 +55,8 @@ export default function PremiumGate({ featureId, children }: PremiumGateProps) {
         </div>
       </div>
 
-      {/* 상단 오버레이 */}
-      <div className="absolute inset-0 flex items-start justify-center pt-8 p-4 z-10 overflow-y-auto">
+      {/* 고정 오버레이 */}
+      <div className="fixed inset-0 flex items-center justify-center p-4 z-10">
         <div className="absolute inset-0 bg-gradient-to-b from-white/40 via-white/30 to-transparent" />
 
         <div className="relative w-full max-w-2xl">

--- a/dental-clinic-manager/src/components/marketing/CalendarItemCard.tsx
+++ b/dental-clinic-manager/src/components/marketing/CalendarItemCard.tsx
@@ -25,6 +25,8 @@ interface Props {
   onReject: () => void | Promise<void>
   onUpdate: (patch: Partial<ContentCalendarItem>) => void | Promise<void>
   onRegenerate: () => void | Promise<void>
+  selected?: boolean
+  onToggleSelect?: (id: string) => void
 }
 
 const STATUS_BADGE: Record<string, { label: string; cls: string }> = {
@@ -55,6 +57,8 @@ export default function CalendarItemCard({
   onReject,
   onUpdate,
   onRegenerate,
+  selected,
+  onToggleSelect,
 }: Props) {
   const [editing, setEditing] = useState(false)
   const [draftTitle, setDraftTitle] = useState(item.title)
@@ -88,8 +92,18 @@ export default function CalendarItemCard({
   }
 
   return (
-    <div className="border border-gray-200 rounded-lg p-3 bg-white hover:border-gray-300 transition-all">
-      <div className="flex items-start justify-between gap-2 mb-2">
+    <div className={`group border rounded-lg p-2.5 bg-white transition-all ${
+      selected ? 'border-blue-400 bg-blue-50/30 ring-1 ring-blue-200' : 'border-gray-200 hover:border-gray-300'
+    }`}>
+      <div className="flex items-start gap-1.5 mb-1.5">
+        {onToggleSelect && !isLocked && (
+          <input
+            type="checkbox"
+            checked={selected || false}
+            onChange={() => onToggleSelect(item.id)}
+            className="mt-0.5 h-3.5 w-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 cursor-pointer shrink-0"
+          />
+        )}
         <div className="flex flex-wrap items-center gap-1 min-w-0 flex-1">
           <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${statusBadge.cls}`}>
             {statusBadge.label}
@@ -178,7 +192,7 @@ export default function CalendarItemCard({
       )}
 
       {!isLocked && !editing && (
-        <div className="flex flex-wrap gap-1 pt-2 border-t border-gray-100">
+        <div className="flex flex-wrap gap-1 pt-1.5 border-t border-gray-100 opacity-0 group-hover:opacity-100 transition-opacity duration-150 max-h-0 group-hover:max-h-20 overflow-hidden">
           {canApprove && (
             <button
               onClick={() => handleAction('approve', onApprove)}

--- a/dental-clinic-manager/src/components/marketing/CalendarItemCard.tsx
+++ b/dental-clinic-manager/src/components/marketing/CalendarItemCard.tsx
@@ -30,16 +30,16 @@ interface Props {
 }
 
 const STATUS_BADGE: Record<string, { label: string; cls: string }> = {
-  proposed:   { label: '제안',     cls: 'bg-gray-100 text-gray-700' },
-  modified:   { label: '수정됨',   cls: 'bg-amber-100 text-amber-700' },
-  approved:   { label: '승인',     cls: 'bg-emerald-100 text-emerald-700' },
-  rejected:   { label: '반려',     cls: 'bg-rose-100 text-rose-700' },
+  proposed:   { label: '제안',     cls: 'bg-at-surface-alt text-at-text-secondary' },
+  modified:   { label: '수정됨',   cls: 'bg-at-warning-bg text-at-warning' },
+  approved:   { label: '승인',     cls: 'bg-at-success-bg text-at-success' },
+  rejected:   { label: '반려',     cls: 'bg-at-error-bg text-at-error' },
   generating: { label: '생성 중',  cls: 'bg-sky-100 text-sky-700' },
-  scheduled:  { label: '발행 예정', cls: 'bg-violet-100 text-violet-700' },
+  scheduled:  { label: '발행 예정', cls: 'bg-at-accent-light text-at-accent' },
   publishing: { label: '발행 중',  cls: 'bg-indigo-100 text-indigo-700' },
-  published:  { label: '발행됨',   cls: 'bg-green-100 text-green-700' },
-  failed:     { label: '실패',     cls: 'bg-red-100 text-red-700' },
-  review:     { label: '검토 필요', cls: 'bg-yellow-100 text-yellow-800' },
+  published:  { label: '발행됨',   cls: 'bg-at-success-bg text-at-success' },
+  failed:     { label: '실패',     cls: 'bg-at-error-bg text-at-error' },
+  review:     { label: '검토 필요', cls: 'bg-at-warning-bg text-at-warning' },
 }
 
 const CATEGORY_BADGE_CLASSES: Record<string, string> = {
@@ -92,8 +92,8 @@ export default function CalendarItemCard({
   }
 
   return (
-    <div className={`group border rounded-lg p-2.5 bg-white transition-all ${
-      selected ? 'border-blue-400 bg-blue-50/30 ring-1 ring-blue-200' : 'border-gray-200 hover:border-gray-300'
+    <div className={`border rounded-xl p-3 bg-white transition-all duration-200 ${
+      selected ? 'border-at-accent bg-at-accent-light/30 ring-1 ring-at-accent/30' : 'border-at-border hover:shadow-at-card'
     }`}>
       <div className="flex items-start gap-1.5 mb-1.5">
         {onToggleSelect && !isLocked && (
@@ -101,16 +101,16 @@ export default function CalendarItemCard({
             type="checkbox"
             checked={selected || false}
             onChange={() => onToggleSelect(item.id)}
-            className="mt-0.5 h-3.5 w-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 cursor-pointer shrink-0"
+            className="mt-0.5 h-3.5 w-3.5 rounded border-at-border text-at-accent focus:ring-at-accent cursor-pointer shrink-0"
           />
         )}
         <div className="flex flex-wrap items-center gap-1 min-w-0 flex-1">
-          <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${statusBadge.cls}`}>
+          <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${statusBadge.cls}`}>
             {statusBadge.label}
           </span>
           {cat && (
             <span
-              className={`text-[10px] px-1.5 py-0.5 rounded border font-medium ${
+              className={`text-xs px-1.5 py-0.5 rounded-full border font-medium ${
                 CATEGORY_BADGE_CLASSES[cat.color] || 'bg-gray-50 text-gray-700 border-gray-200'
               }`}
             >
@@ -119,14 +119,14 @@ export default function CalendarItemCard({
           )}
           {journey && (
             <span
-              className="text-[10px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-700 font-medium"
+              className="text-xs px-1.5 py-0.5 rounded-full bg-at-surface-alt text-at-text-secondary font-medium"
               title={journey.description}
             >
               {journey.label}
             </span>
           )}
           {item.needs_medical_review && (
-            <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-100 text-yellow-800 font-medium inline-flex items-center gap-0.5">
+            <span className="text-xs px-1.5 py-0.5 rounded-full bg-at-warning-bg text-at-warning font-medium inline-flex items-center gap-0.5">
               <ExclamationTriangleIcon className="h-3 w-3" />
               심의
             </span>
@@ -140,21 +140,21 @@ export default function CalendarItemCard({
             type="text"
             value={draftTitle}
             onChange={(e) => setDraftTitle(e.target.value)}
-            className="w-full text-sm border border-gray-300 rounded px-2 py-1"
+            className="w-full text-sm border border-at-border rounded-xl px-2 py-1 focus:ring-1 focus:ring-at-accent focus:outline-none"
             placeholder="제목"
           />
           <input
             type="text"
             value={draftKeyword}
             onChange={(e) => setDraftKeyword(e.target.value)}
-            className="w-full text-xs border border-gray-300 rounded px-2 py-1"
+            className="w-full text-xs border border-at-border rounded-xl px-2 py-1 focus:ring-1 focus:ring-at-accent focus:outline-none"
             placeholder="타겟 키워드"
           />
           <div className="flex gap-1">
             <button
               onClick={handleSaveEdit}
               disabled={busy !== null}
-              className="text-xs bg-emerald-600 text-white px-2 py-1 rounded hover:bg-emerald-700 disabled:opacity-50"
+              className="text-xs bg-at-accent text-white px-2 py-1 rounded-lg hover:bg-at-accent-hover disabled:opacity-50"
             >
               저장
             </button>
@@ -164,7 +164,7 @@ export default function CalendarItemCard({
                 setDraftTitle(item.title)
                 setDraftKeyword(item.keyword || '')
               }}
-              className="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded hover:bg-gray-200"
+              className="text-xs bg-at-surface-alt text-at-text-secondary px-2 py-1 rounded-lg hover:bg-at-surface-hover"
             >
               취소
             </button>
@@ -172,19 +172,19 @@ export default function CalendarItemCard({
         </div>
       ) : (
         <>
-          <h4 className="text-sm font-semibold text-gray-900 leading-snug mb-1 line-clamp-2">
+          <h4 className="text-sm font-semibold text-at-text leading-snug mb-1 line-clamp-2">
             {item.title}
           </h4>
           {item.keyword && (
-            <p className="text-xs text-gray-500 mb-1">🔎 {item.keyword}</p>
+            <p className="text-xs text-at-text-secondary mb-1">🔎 {item.keyword}</p>
           )}
           {item.estimated_search_volume !== null && item.estimated_search_volume > 0 && (
-            <p className="text-[11px] text-gray-400 mb-1 inline-flex items-center gap-0.5">
+            <p className="text-xs text-at-text-weak mb-1 inline-flex items-center gap-0.5">
               <ChartBarIcon className="h-3 w-3" />월 ~{item.estimated_search_volume.toLocaleString()}회
             </p>
           )}
           {item.planning_rationale && (
-            <p className="text-[11px] text-gray-500 leading-tight mb-2 italic">
+            <p className="text-xs text-at-text-weak leading-tight mb-2 italic">
               💡 {item.planning_rationale}
             </p>
           )}
@@ -192,71 +192,60 @@ export default function CalendarItemCard({
       )}
 
       {!isLocked && !editing && (
-        <div className="flex flex-wrap gap-1 pt-1.5 border-t border-gray-100 opacity-0 group-hover:opacity-100 transition-opacity duration-150 max-h-0 group-hover:max-h-20 overflow-hidden">
+        <div className="flex items-center gap-1 pt-1.5 border-t border-at-border">
           {canApprove && (
             <button
               onClick={() => handleAction('approve', onApprove)}
               disabled={busy !== null}
-              className="text-[11px] bg-emerald-50 text-emerald-700 hover:bg-emerald-100 px-2 py-1 rounded inline-flex items-center gap-0.5 disabled:opacity-50"
+              className="p-1.5 rounded-lg text-at-success hover:bg-at-success-bg disabled:opacity-50 transition-all duration-200"
               title="승인"
             >
-              <CheckCircleIcon className="h-3 w-3" /> 승인
-            </button>
-          )}
-          {item.status === 'approved' && (
-            <button
-              onClick={() => handleAction('unapprove', () => onUpdate({ status: 'proposed' }))}
-              disabled={busy !== null}
-              className="text-[11px] bg-gray-100 text-gray-700 hover:bg-gray-200 px-2 py-1 rounded inline-flex items-center gap-0.5 disabled:opacity-50"
-              title="승인 취소"
-            >
-              승인 취소
+              <CheckCircleIcon className="h-3.5 w-3.5" />
             </button>
           )}
           <button
             onClick={() => setEditing(true)}
             disabled={busy !== null}
-            className="text-[11px] bg-blue-50 text-blue-700 hover:bg-blue-100 px-2 py-1 rounded inline-flex items-center gap-0.5 disabled:opacity-50"
+            className="p-1.5 rounded-lg text-at-accent hover:bg-at-accent-light disabled:opacity-50 transition-all duration-200"
             title="수정"
           >
-            <PencilIcon className="h-3 w-3" /> 수정
+            <PencilIcon className="h-3.5 w-3.5" />
           </button>
           <button
             onClick={() => handleAction('regen', onRegenerate)}
             disabled={busy !== null}
-            className="text-[11px] bg-violet-50 text-violet-700 hover:bg-violet-100 px-2 py-1 rounded inline-flex items-center gap-0.5 disabled:opacity-50"
+            className="p-1.5 rounded-lg text-purple-600 hover:bg-purple-50 disabled:opacity-50 transition-all duration-200"
             title="AI 재생성"
           >
-            <ArrowPathIcon className={`h-3 w-3 ${busy === 'regen' ? 'animate-spin' : ''}`} />
-            재생성
+            <ArrowPathIcon className={`h-3.5 w-3.5 ${busy === 'regen' ? 'animate-spin' : ''}`} />
           </button>
           {!['rejected'].includes(item.status) && (
             <button
               onClick={() => handleAction('reject', onReject)}
               disabled={busy !== null}
-              className="text-[11px] bg-rose-50 text-rose-700 hover:bg-rose-100 px-2 py-1 rounded inline-flex items-center gap-0.5 disabled:opacity-50"
+              className="p-1.5 rounded-lg text-at-error hover:bg-at-error-bg disabled:opacity-50 transition-all duration-200"
               title="반려"
             >
-              <XCircleIcon className="h-3 w-3" /> 반려
+              <XCircleIcon className="h-3.5 w-3.5" />
             </button>
           )}
         </div>
       )}
 
       {item.status === 'failed' && item.fail_reason && (
-        <p className="text-[11px] text-rose-600 mt-2 leading-tight">
+        <p className="text-xs text-at-error mt-2 leading-tight">
           ⚠️ {item.fail_reason}
         </p>
       )}
 
       {item.status === 'published' && item.metrics && item.metrics.length > 0 && (
-        <div className="mt-2 pt-2 border-t border-gray-100 space-y-1">
+        <div className="mt-2 pt-2 border-t border-at-border space-y-1">
           {item.metrics.map((m) => {
             const measured = new Date(m.measured_at)
             const ago = formatTimeAgo(measured)
             return (
-              <div key={m.platform} className="flex items-center gap-2 flex-wrap text-[11px]">
-                <span className="text-gray-400 font-medium">{platformLabel(m.platform)}</span>
+              <div key={m.platform} className="flex items-center gap-2 flex-wrap text-xs">
+                <span className="text-at-text-secondary font-medium">{platformLabel(m.platform)}</span>
                 {m.views !== null && (
                   <span className="inline-flex items-center gap-0.5 text-blue-600">
                     <EyeIcon className="h-3 w-3" />
@@ -281,7 +270,7 @@ export default function CalendarItemCard({
                     {m.scraps.toLocaleString()}
                   </span>
                 )}
-                <span className="text-gray-400 ml-auto">{ago}</span>
+                <span className="text-at-text-weak ml-auto">{ago}</span>
               </div>
             )
           })}

--- a/dental-clinic-manager/src/components/marketing/ContentCalendarView.tsx
+++ b/dental-clinic-manager/src/components/marketing/ContentCalendarView.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircleIcon,
   CalendarDaysIcon,
   SparklesIcon,
+  XCircleIcon,
 } from '@heroicons/react/24/outline'
 import {
   TOPIC_CATEGORY_LABELS,
@@ -23,6 +24,7 @@ export default function ContentCalendarView() {
   const [error, setError] = useState<string | null>(null)
   const [selectedCalendarId, setSelectedCalendarId] = useState<string | null>(null)
   const [bulkBusy, setBulkBusy] = useState<string | null>(null)
+  const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set())
 
   // ─── 데이터 로드 ───
   const loadCalendars = useCallback(async () => {
@@ -137,6 +139,54 @@ export default function ContentCalendarView() {
     await loadCalendars()
   }
 
+  // ─── 항목 선택 토글 ───
+  const handleToggleSelect = useCallback((itemId: string) => {
+    setSelectedItems((prev) => {
+      const next = new Set(prev)
+      if (next.has(itemId)) next.delete(itemId)
+      else next.add(itemId)
+      return next
+    })
+  }, [])
+
+  const handleClearSelection = useCallback(() => {
+    setSelectedItems(new Set())
+  }, [])
+
+  // ─── 선택된 항목 일괄 작업 ───
+  const handleBatchAction = async (action: 'batch_approve' | 'batch_reject' | 'batch_regenerate') => {
+    if (selectedItems.size === 0 || bulkBusy) return
+    setBulkBusy(action)
+    try {
+      if (action === 'batch_regenerate') {
+        // 재생성은 순차 처리
+        for (const itemId of selectedItems) {
+          await handleRegenerate(itemId)
+        }
+      } else {
+        const res = await fetch('/api/marketing/calendar/items', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            calendarId: selected?.id,
+            action,
+            itemIds: Array.from(selectedItems),
+          }),
+        })
+        if (!res.ok) {
+          const j = await res.json().catch(() => ({}))
+          throw new Error(j.error || '일괄 작업 실패')
+        }
+      }
+      setSelectedItems(new Set())
+      await loadCalendars()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '일괄 작업 실패')
+    } finally {
+      setBulkBusy(null)
+    }
+  }
+
   // ─── 일괄 작업 ───
   const handleBulk = async (action: 'approve_all' | 'approve_non_review' | 'reject_all') => {
     if (!selected || bulkBusy) return
@@ -192,6 +242,8 @@ export default function ContentCalendarView() {
       for (const it of cal.content_calendar_items || []) {
         if (it.publish_date < startStr || it.publish_date > endStr) continue
         if (seenIds.has(it.id)) continue
+        // 반려된 항목은 캘린더에서 숨김
+        if (it.status === 'rejected') continue
         seenIds.add(it.id)
         collected.push(isSelf ? it : { ...it, _foreign: true })
       }
@@ -353,6 +405,45 @@ export default function ContentCalendarView() {
         </div>
       )}
 
+      {/* 선택된 항목 일괄 작업 바 */}
+      {selectedItems.size > 0 && (
+        <div className="sticky top-0 z-10 flex flex-wrap gap-2 items-center bg-blue-50 border border-blue-300 rounded-lg p-3 shadow-sm">
+          <span className="text-sm font-medium text-blue-800">
+            {selectedItems.size}개 선택됨
+          </span>
+          <button
+            onClick={() => handleBatchAction('batch_approve')}
+            disabled={bulkBusy !== null}
+            className="bg-emerald-600 text-white text-xs px-3 py-1.5 rounded hover:bg-emerald-700 disabled:opacity-50 inline-flex items-center gap-1"
+          >
+            <CheckCircleIcon className="h-3.5 w-3.5" />
+            {bulkBusy === 'batch_approve' ? '처리 중...' : '선택 승인'}
+          </button>
+          <button
+            onClick={() => handleBatchAction('batch_regenerate')}
+            disabled={bulkBusy !== null}
+            className="bg-violet-100 text-violet-700 text-xs px-3 py-1.5 rounded hover:bg-violet-200 disabled:opacity-50 inline-flex items-center gap-1"
+          >
+            <ArrowPathIcon className={`h-3.5 w-3.5 ${bulkBusy === 'batch_regenerate' ? 'animate-spin' : ''}`} />
+            {bulkBusy === 'batch_regenerate' ? '재생성 중...' : '선택 재생성'}
+          </button>
+          <button
+            onClick={() => handleBatchAction('batch_reject')}
+            disabled={bulkBusy !== null}
+            className="bg-rose-100 text-rose-700 text-xs px-3 py-1.5 rounded hover:bg-rose-200 disabled:opacity-50 inline-flex items-center gap-1"
+          >
+            <XCircleIcon className="h-3.5 w-3.5" />
+            {bulkBusy === 'batch_reject' ? '처리 중...' : '선택 반려'}
+          </button>
+          <button
+            onClick={handleClearSelection}
+            className="text-xs text-gray-500 hover:text-gray-700 px-2 py-1.5 ml-auto"
+          >
+            선택 해제
+          </button>
+        </div>
+      )}
+
       {/* 빈 상태 */}
       {!loading && calendars.length === 0 && (
         <div className="text-center py-12 text-gray-500">
@@ -408,6 +499,8 @@ export default function ContentCalendarView() {
                             onReject={isForeign ? noop : () => handleReject(item.id)}
                             onUpdate={isForeign ? noop : (patch) => handleItemUpdate(item.id, patch)}
                             onRegenerate={isForeign ? noop : () => handleRegenerate(item.id)}
+                            selected={selectedItems.has(item.id)}
+                            onToggleSelect={isForeign ? undefined : handleToggleSelect}
                           />
                         </div>
                       )

--- a/dental-clinic-manager/src/components/marketing/ContentCalendarView.tsx
+++ b/dental-clinic-manager/src/components/marketing/ContentCalendarView.tsx
@@ -282,17 +282,17 @@ export default function ContentCalendarView() {
   return (
     <div className="space-y-4">
       {/* 헤더 / 액션 */}
-      <div className="flex flex-wrap items-center justify-between gap-2 pb-3 border-b border-gray-200">
+      <div className="flex flex-wrap items-center justify-between gap-2 pb-3 border-b border-at-border">
         <div className="flex items-center gap-2">
-          <CalendarDaysIcon className="h-5 w-5 text-gray-700" />
-          <h2 className="text-base font-bold text-gray-900">콘텐츠 캘린더</h2>
-          <span className="text-xs text-gray-500">— AI가 한 달치 주제를 기획하고, 승인하면 자동 발행됩니다</span>
+          <CalendarDaysIcon className="h-5 w-5 text-at-text-secondary" />
+          <h2 className="text-base font-bold text-at-text">콘텐츠 캘린더</h2>
+          <span className="text-xs text-at-text-weak">— AI가 한 달치 주제를 기획하고, 승인하면 자동 발행됩니다</span>
         </div>
         <div className="flex items-center gap-2">
           <button
             onClick={() => handleGenerate(0)}
             disabled={generating}
-            className="bg-emerald-600 text-white text-sm px-3 py-1.5 rounded-lg hover:bg-emerald-700 disabled:opacity-50 inline-flex items-center gap-1"
+            className="bg-at-accent text-white text-sm px-3 py-1.5 rounded-xl hover:bg-at-accent-hover disabled:opacity-50 inline-flex items-center gap-1 transition-all duration-200"
           >
             <SparklesIcon className={`h-4 w-4 ${generating ? 'animate-pulse' : ''}`} />
             {generating ? '생성 중...' : '이번 달 계획 생성'}
@@ -300,14 +300,14 @@ export default function ContentCalendarView() {
           <button
             onClick={() => handleGenerate(1)}
             disabled={generating}
-            className="bg-gray-100 text-gray-700 text-sm px-3 py-1.5 rounded-lg hover:bg-gray-200 disabled:opacity-50"
+            className="bg-at-surface-alt text-at-text-secondary text-sm px-3 py-1.5 rounded-xl hover:bg-at-surface-hover disabled:opacity-50 transition-all duration-200"
           >
             다음 달 계획
           </button>
           <button
             onClick={loadCalendars}
             disabled={loading}
-            className="text-gray-500 hover:text-gray-700 p-1.5 rounded hover:bg-gray-100 disabled:opacity-50"
+            className="text-at-text-weak hover:text-at-text-secondary p-1.5 rounded-xl hover:bg-at-surface-alt disabled:opacity-50 transition-all duration-200"
             title="새로고침"
           >
             <ArrowPathIcon className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
@@ -316,7 +316,7 @@ export default function ContentCalendarView() {
       </div>
 
       {error && (
-        <div className="bg-rose-50 border border-rose-200 rounded-lg p-3 text-sm text-rose-700">
+        <div className="bg-at-error-bg border border-at-error/20 rounded-xl p-3 text-sm text-at-error">
           ⚠️ {error}
         </div>
       )}
@@ -324,11 +324,11 @@ export default function ContentCalendarView() {
       {/* 캘린더 목록 (드롭다운) */}
       {calendars.length > 0 && (
         <div className="flex items-center gap-2">
-          <label className="text-sm text-gray-600">기간:</label>
+          <label className="text-sm text-at-text-secondary">기간:</label>
           <select
             value={selectedCalendarId || ''}
             onChange={(e) => setSelectedCalendarId(e.target.value)}
-            className="text-sm border border-gray-300 rounded px-2 py-1"
+            className="text-sm border border-at-border rounded-xl px-2 py-1"
           >
             {calendars.map((c) => (
               <option key={c.id} value={c.id}>
@@ -341,22 +341,22 @@ export default function ContentCalendarView() {
 
       {/* 통계 패널 */}
       {selected && stats && (
-        <div className="bg-gray-50 border border-gray-200 rounded-lg p-3 grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="bg-at-surface-alt border border-at-border rounded-2xl shadow-at-card p-3 grid grid-cols-2 sm:grid-cols-4 gap-3">
           <div>
-            <div className="text-[11px] text-gray-500">총 주제</div>
-            <div className="text-lg font-bold text-gray-900">{stats.total}개</div>
+            <div className="text-xs text-at-text-secondary font-medium">총 주제</div>
+            <div className="text-2xl font-bold text-at-text">{stats.total}개</div>
           </div>
           <div>
-            <div className="text-[11px] text-gray-500">승인 완료</div>
-            <div className="text-lg font-bold text-emerald-600">{stats.byStatus.approved || 0}개</div>
+            <div className="text-xs text-at-text-secondary font-medium">승인 완료</div>
+            <div className="text-2xl font-bold text-at-success">{stats.byStatus.approved || 0}개</div>
           </div>
           <div>
-            <div className="text-[11px] text-gray-500">발행 예정</div>
-            <div className="text-lg font-bold text-violet-600">{stats.byStatus.scheduled || 0}개</div>
+            <div className="text-xs text-at-text-secondary font-medium">발행 예정</div>
+            <div className="text-2xl font-bold text-at-accent">{stats.byStatus.scheduled || 0}개</div>
           </div>
           <div>
-            <div className="text-[11px] text-gray-500">심의 필요</div>
-            <div className="text-lg font-bold text-yellow-700">{stats.needsReview}개</div>
+            <div className="text-xs text-at-text-secondary font-medium">심의 필요</div>
+            <div className="text-2xl font-bold text-at-warning">{stats.needsReview}개</div>
           </div>
           <div className="col-span-2 sm:col-span-4 flex flex-wrap gap-1.5 mt-1">
             {Object.entries(stats.byCategory).map(([cat, count]) => {
@@ -365,10 +365,10 @@ export default function ContentCalendarView() {
               return (
                 <span
                   key={cat}
-                  className="text-[11px] bg-white border border-gray-200 px-2 py-0.5 rounded inline-flex items-center gap-1"
+                  className="text-xs bg-at-surface border border-at-border px-2 py-0.5 rounded-full inline-flex items-center gap-1"
                 >
                   <span>{meta.label}</span>
-                  <span className="font-bold text-gray-700">{count}</span>
+                  <span className="font-bold text-at-text-secondary">{count}</span>
                 </span>
               )
             })}
@@ -376,78 +376,82 @@ export default function ContentCalendarView() {
         </div>
       )}
 
-      {/* 일괄 액션 */}
-      {selected && (selected.content_calendar_items || []).some((i) => ['proposed', 'modified'].includes(i.status)) && (
-        <div className="flex flex-wrap gap-2 items-center bg-amber-50 border border-amber-200 rounded-lg p-3">
-          <span className="text-sm text-amber-800">⚡ 일괄 작업:</span>
-          <button
-            onClick={() => handleBulk('approve_all')}
-            disabled={bulkBusy !== null}
-            className="bg-emerald-600 text-white text-xs px-3 py-1 rounded hover:bg-emerald-700 disabled:opacity-50 inline-flex items-center gap-1"
-          >
-            <CheckCircleIcon className="h-3.5 w-3.5" />
-            {bulkBusy === 'approve_all' ? '처리 중...' : '모두 승인'}
-          </button>
-          <button
-            onClick={() => handleBulk('approve_non_review')}
-            disabled={bulkBusy !== null}
-            className="bg-emerald-50 text-emerald-700 text-xs px-3 py-1 rounded hover:bg-emerald-100 disabled:opacity-50"
-          >
-            {bulkBusy === 'approve_non_review' ? '처리 중...' : '심의 필요 제외 모두 승인'}
-          </button>
-          <button
-            onClick={() => handleBulk('reject_all')}
-            disabled={bulkBusy !== null}
-            className="bg-gray-100 text-gray-700 text-xs px-3 py-1 rounded hover:bg-gray-200 disabled:opacity-50"
-          >
-            {bulkBusy === 'reject_all' ? '처리 중...' : '모두 반려'}
-          </button>
-        </div>
-      )}
-
-      {/* 선택된 항목 일괄 작업 바 */}
-      {selectedItems.size > 0 && (
-        <div className="sticky top-0 z-10 flex flex-wrap gap-2 items-center bg-blue-50 border border-blue-300 rounded-lg p-3 shadow-sm">
-          <span className="text-sm font-medium text-blue-800">
-            {selectedItems.size}개 선택됨
-          </span>
-          <button
-            onClick={() => handleBatchAction('batch_approve')}
-            disabled={bulkBusy !== null}
-            className="bg-emerald-600 text-white text-xs px-3 py-1.5 rounded hover:bg-emerald-700 disabled:opacity-50 inline-flex items-center gap-1"
-          >
-            <CheckCircleIcon className="h-3.5 w-3.5" />
-            {bulkBusy === 'batch_approve' ? '처리 중...' : '선택 승인'}
-          </button>
-          <button
-            onClick={() => handleBatchAction('batch_regenerate')}
-            disabled={bulkBusy !== null}
-            className="bg-violet-100 text-violet-700 text-xs px-3 py-1.5 rounded hover:bg-violet-200 disabled:opacity-50 inline-flex items-center gap-1"
-          >
-            <ArrowPathIcon className={`h-3.5 w-3.5 ${bulkBusy === 'batch_regenerate' ? 'animate-spin' : ''}`} />
-            {bulkBusy === 'batch_regenerate' ? '재생성 중...' : '선택 재생성'}
-          </button>
-          <button
-            onClick={() => handleBatchAction('batch_reject')}
-            disabled={bulkBusy !== null}
-            className="bg-rose-100 text-rose-700 text-xs px-3 py-1.5 rounded hover:bg-rose-200 disabled:opacity-50 inline-flex items-center gap-1"
-          >
-            <XCircleIcon className="h-3.5 w-3.5" />
-            {bulkBusy === 'batch_reject' ? '처리 중...' : '선택 반려'}
-          </button>
-          <button
-            onClick={handleClearSelection}
-            className="text-xs text-gray-500 hover:text-gray-700 px-2 py-1.5 ml-auto"
-          >
-            선택 해제
-          </button>
+      {/* 일괄 작업 바 (통합) */}
+      {selected && (
+        selectedItems.size > 0 ||
+        (selected.content_calendar_items || []).some((i) => ['proposed', 'modified'].includes(i.status))
+      ) && (
+        <div className="bg-at-surface-alt border border-at-border rounded-2xl p-3 sticky top-0 z-10 flex flex-wrap gap-2 items-center transition-all duration-200">
+          {selectedItems.size > 0 ? (
+            <>
+              <span className="bg-at-accent text-white text-xs px-2 py-0.5 rounded-full font-medium">
+                {selectedItems.size}개 선택됨
+              </span>
+              <button
+                onClick={() => handleBatchAction('batch_approve')}
+                disabled={bulkBusy !== null}
+                className="bg-at-accent text-white text-xs px-3 py-1.5 rounded-xl hover:bg-at-accent-hover disabled:opacity-50 inline-flex items-center gap-1 transition-all duration-200"
+              >
+                <CheckCircleIcon className="h-3.5 w-3.5" />
+                {bulkBusy === 'batch_approve' ? '처리 중...' : '선택 승인'}
+              </button>
+              <button
+                onClick={() => handleBatchAction('batch_regenerate')}
+                disabled={bulkBusy !== null}
+                className="bg-at-surface text-at-accent border border-at-accent/30 text-xs px-3 py-1.5 rounded-xl hover:bg-at-accent-light disabled:opacity-50 inline-flex items-center gap-1 transition-all duration-200"
+              >
+                <ArrowPathIcon className={`h-3.5 w-3.5 ${bulkBusy === 'batch_regenerate' ? 'animate-spin' : ''}`} />
+                {bulkBusy === 'batch_regenerate' ? '재생성 중...' : '선택 재생성'}
+              </button>
+              <button
+                onClick={() => handleBatchAction('batch_reject')}
+                disabled={bulkBusy !== null}
+                className="bg-at-surface text-at-error border border-at-error/20 text-xs px-3 py-1.5 rounded-xl hover:bg-at-error-bg disabled:opacity-50 inline-flex items-center gap-1 transition-all duration-200"
+              >
+                <XCircleIcon className="h-3.5 w-3.5" />
+                {bulkBusy === 'batch_reject' ? '처리 중...' : '선택 반려'}
+              </button>
+              <button
+                onClick={handleClearSelection}
+                className="text-at-text-weak hover:text-at-text-secondary text-xs px-2 py-1.5 ml-auto transition-all duration-200"
+              >
+                선택 해제
+              </button>
+            </>
+          ) : (
+            <>
+              <span className="text-sm text-at-text-secondary font-medium">전체:</span>
+              <button
+                onClick={() => handleBulk('approve_all')}
+                disabled={bulkBusy !== null}
+                className="bg-at-accent text-white text-xs px-3 py-1.5 rounded-xl hover:bg-at-accent-hover disabled:opacity-50 inline-flex items-center gap-1 transition-all duration-200"
+              >
+                <CheckCircleIcon className="h-3.5 w-3.5" />
+                {bulkBusy === 'approve_all' ? '처리 중...' : '모두 승인'}
+              </button>
+              <button
+                onClick={() => handleBulk('approve_non_review')}
+                disabled={bulkBusy !== null}
+                className="bg-at-accent text-white text-xs px-3 py-1.5 rounded-xl hover:bg-at-accent-hover disabled:opacity-50 transition-all duration-200"
+              >
+                {bulkBusy === 'approve_non_review' ? '처리 중...' : '심의 제외 승인'}
+              </button>
+              <button
+                onClick={() => handleBulk('reject_all')}
+                disabled={bulkBusy !== null}
+                className="bg-at-surface text-at-error border border-at-error/20 text-xs px-3 py-1.5 rounded-xl hover:bg-at-error-bg disabled:opacity-50 transition-all duration-200"
+              >
+                {bulkBusy === 'reject_all' ? '처리 중...' : '모두 반려'}
+              </button>
+            </>
+          )}
         </div>
       )}
 
       {/* 빈 상태 */}
       {!loading && calendars.length === 0 && (
-        <div className="text-center py-12 text-gray-500">
-          <CalendarDaysIcon className="h-12 w-12 mx-auto mb-3 opacity-50" />
+        <div className="text-center py-12 text-at-text-weak">
+          <CalendarDaysIcon className="h-12 w-12 mx-auto mb-3 text-at-text-weak" />
           <p className="text-sm">아직 생성된 캘린더가 없습니다.</p>
           <p className="text-xs mt-1">위의 &quot;이번 달 계획 생성&quot; 버튼을 눌러 시작하세요.</p>
         </div>
@@ -456,12 +460,12 @@ export default function ContentCalendarView() {
       {/* 월간 그리드 */}
       {selected && grid && (
         <div>
-          <div className="grid grid-cols-7 gap-px bg-gray-200 border border-gray-200 rounded overflow-hidden">
+          <div className="grid grid-cols-7 gap-px bg-at-border border border-at-border rounded-2xl overflow-hidden">
             {WEEKDAY_LABELS.map((label, i) => (
               <div
                 key={label}
-                className={`bg-gray-50 text-center text-xs font-medium py-1.5 ${
-                  i === 0 ? 'text-rose-600' : i === 6 ? 'text-blue-600' : 'text-gray-700'
+                className={`bg-at-surface-alt text-center text-xs font-semibold py-1.5 ${
+                  i === 0 ? 'text-at-error' : i === 6 ? 'text-at-accent' : 'text-at-text-secondary'
                 }`}
               >
                 {label}
@@ -474,11 +478,11 @@ export default function ContentCalendarView() {
               return (
                 <div
                   key={cell.date}
-                  className={`bg-white min-h-[110px] p-1.5 ${cell.inMonth ? '' : 'opacity-40 bg-gray-50'}`}
+                  className={`bg-at-surface min-h-[120px] p-1.5 ${cell.inMonth ? '' : 'opacity-40 bg-at-surface-alt'}`}
                 >
                   <div
-                    className={`text-[11px] font-medium mb-1 ${
-                      dow === 0 ? 'text-rose-500' : dow === 6 ? 'text-blue-500' : 'text-gray-700'
+                    className={`text-xs font-semibold mb-1 ${
+                      dow === 0 ? 'text-at-error' : dow === 6 ? 'text-at-accent' : 'text-at-text-secondary'
                     }`}
                   >
                     {day}

--- a/dental-clinic-manager/src/lib/aiAnalysisServiceV2.ts
+++ b/dental-clinic-manager/src/lib/aiAnalysisServiceV2.ts
@@ -791,6 +791,48 @@ interface DentwebSchemaData {
   writable_tables: string[];
 }
 
+// 스키마 캐시 비어있을 때 최소 DentWeb 정보 (브릿지 미초기화 상태에서도 AI 도구 활성화)
+const DENTWEB_FALLBACK_SCHEMA: DentwebSchemaData = {
+  schema_data: {
+    tables: [
+      { name: 'TB_환자정보', columns: [
+        { name: 'n환자ID', type: 'int' }, { name: 'sz차트번호', type: 'varchar' },
+        { name: 'sz이름', type: 'varchar' }, { name: 'sz휴대폰번호', type: 'varchar' },
+        { name: 'sz생년월일', type: 'varchar' }, { name: 'b성별', type: 'bit' },
+        { name: 'sz최종내원일', type: 'varchar' }, { name: 'sz등록시각', type: 'varchar' },
+        { name: 't수정시각', type: 'datetime' },
+      ]},
+      { name: 'TB_진료비내역', columns: [
+        { name: 'nID', type: 'int' }, { name: 'sz진료일', type: 'char' },
+        { name: 'n환자ID', type: 'int' }, { name: 'n총진료비', type: 'int' },
+        { name: 'n공단부담금', type: 'int' }, { name: 'n본인부담금', type: 'int' },
+        { name: 'n비급여진료비', type: 'int' }, { name: 'n카드수납액', type: 'int' },
+        { name: 'n현금수납액', type: 'int' },
+      ]},
+      { name: 'TB_예약목록', columns: [
+        { name: 'nID', type: 'int' }, { name: 'sz예약시각', type: 'char' },
+        { name: 'n환자ID', type: 'int' }, { name: 'sz예약내용', type: 'varchar' },
+        { name: 'n이행현황', type: 'tinyint' },
+      ]},
+      { name: 'TB_세부처치내역', columns: [
+        { name: 'nID', type: 'int' }, { name: 'n환자ID', type: 'int' },
+        { name: 'sz진료일', type: 'char' }, { name: 'sz수가코드', type: 'varchar' },
+        { name: 'n금액', type: 'int' }, { name: 'b취소', type: 'bit' },
+      ]},
+      { name: 'TB_치료수가표', columns: [
+        { name: 'nID', type: 'int' }, { name: 'sz이름', type: 'varchar' },
+        { name: 'n가격', type: 'int' },
+      ]},
+      { name: 'TB_수입지출장부', columns: [
+        { name: 'nID', type: 'int' }, { name: 'sz작성시각', type: 'char' },
+        { name: 'b수입지출', type: 'bit' }, { name: 'n계정항목', type: 'int' },
+        { name: 'n총액', type: 'int' }, { name: 'sz내용', type: 'varchar' },
+      ]},
+    ],
+  },
+  writable_tables: ['TB_포스트잇', 'TB_컴퓨터포스트잇', 'TB_환자메모', 'TB_예약메모'],
+};
+
 // DentWeb 스키마 캐시에서 동적으로 로드
 async function loadDentwebSchema(
   supabase: SupabaseClient,
@@ -902,7 +944,7 @@ async function executeDentwebQuery(
 
     return JSON.stringify({
       source: 'dentweb',
-      error: '브릿지 에이전트 응답 시간 초과 (30초). 원내 PC가 켜져 있는지 확인하세요.',
+      error: '원내 PC 응답 대기 시간(30초)을 초과했습니다. 브릿지 에이전트가 재시작 중이거나 DB 연결이 불안정할 수 있습니다. 잠시 후 다시 시도해주세요.',
     });
   } catch (error) {
     return JSON.stringify({ error: `DentWeb 쿼리 실행 오류: ${String(error)}` });
@@ -1070,8 +1112,16 @@ export async function performAnalysisV2(
   const supabase = createClient(supabaseUrl, supabaseKey);
   const genAI = new GoogleGenAI({ apiKey: geminiApiKey });
 
-  // DentWeb 스키마 로드 (연동이 있으면 시스템 프롬프트에 반영)
-  const dentwebSchema = await loadDentwebSchema(supabase, clinicId);
+  // DentWeb 연동 여부 확인 후 스키마 로드 (캐시 비어있어도 fallback으로 도구 활성화)
+  const { data: syncCfg } = await supabase
+    .from('dentweb_sync_config')
+    .select('is_active')
+    .eq('clinic_id', clinicId)
+    .maybeSingle();
+  const dentwebEnabled = !!syncCfg?.is_active;
+  const dentwebSchema = dentwebEnabled
+    ? (await loadDentwebSchema(supabase, clinicId)) ?? DENTWEB_FALLBACK_SCHEMA
+    : null;
   const systemPrompt = generateSystemPrompt(dentwebSchema);
 
   // DentWeb 연동이 없으면 DentWeb 도구를 제외

--- a/dentweb-bridge-agent/src/test-connection.ts
+++ b/dentweb-bridge-agent/src/test-connection.ts
@@ -61,18 +61,19 @@ async function main() {
   const tableCount = tables.length
   console.log(`  [OK] ${tableCount} tables found in database`)
 
-  // Check for key DentWeb tables
-  const keyTables = ['PATIENT', 'RECEIPT', 'TREAT_DETAIL', 'RESERVATION']
+  // Check for key DentWeb tables (실제 한글 테이블명)
+  const keyTables = ['TB_환자정보', 'TB_접수목록', 'TB_세부처치내역', 'TB_예약목록', 'TB_치료수가표']
   const foundKeyTables = keyTables.filter(t => tables.includes(t))
   if (foundKeyTables.length > 0) {
     console.log(`  [OK] DentWeb tables found: ${foundKeyTables.join(', ')}`)
+  } else {
+    console.log('  [!] DentWeb core tables not found (expected TB_환자정보 etc.)')
   }
 
   tables.forEach(t => logger.info(`  ${t}`))
 
   // Check key table columns
-  const targetTables = ['PATIENT', 'RECEIPT', 'TREAT_DETAIL', 'RESERVATION']
-  for (const tableName of targetTables) {
+  for (const tableName of keyTables) {
     if (tables.includes(tableName)) {
       logger.info(`\n--- ${tableName} columns ---`)
       const columns = await listColumns(tableName)


### PR DESCRIPTION
## Summary
- 워커가 anon key로 \`dentweb_sync_config\` 직접 조회 시 RLS에 막혀 pending이 처리되지 않던 문제 해결
- \`/api/dentweb/pending-revenue\` API 신규 생성 (service key 기반)
- 워커 \`processPendingRevenueMonths()\`를 서버 API 기반으로 전환
- \`sync-revenue\` API에서 수입 저장 시 pending 자동 정리
- Summary API 쿼리 병렬화, 배너/폴링 UX 개선

## Test plan
- [x] 4월 (당월) 정상 로드 확인
- [x] 2월 페이지에서 배너 미표시 + 즉시 렌더 확인
- [x] 빌드 성공
- [ ] 워커 재배포 후 2월/1월 수입 자동 동기화 확인 (본 PR 머지 후 GitHub Actions에서 빌드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)