### PR TITLE
feat(investment): 대시보드 실시간 KIS 계좌 잔고 표시

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/balance/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/balance/route.ts
@@ -1,0 +1,95 @@
+/**
+ * KIS 잔고 조회 API
+ *
+ * GET /api/investment/balance
+ * 활성 credential의 KIS 계좌 잔고를 조회합니다.
+ *
+ * 응답:
+ * - totalEvaluation: 총 평가금액
+ * - totalPnl: 총 손익 (실현 포함)
+ * - items: 보유 종목 목록
+ * - isPaperTrading: 모의투자 여부
+ */
+
+import { NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { getKRBalance } from '@/lib/kisApiService'
+import { investmentDecrypt } from '@/lib/investmentCrypto'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const auth = await requireAuth()
+  if (auth.error) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const userId = auth.user!.id
+
+  const supabase = getSupabaseAdmin()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+
+  // 1. 활성 credential 조회
+  const { data: credential, error: credError } = await supabase
+    .from('user_broker_credentials')
+    .select('id, app_key_encrypted, app_secret_encrypted, account_number_encrypted, is_paper_trading')
+    .eq('user_id', userId)
+    .eq('is_active', true)
+    .maybeSingle()
+
+  if (credError || !credential) {
+    return NextResponse.json({ error: '연결된 계좌가 없습니다', hasCredential: false }, { status: 404 })
+  }
+
+  try {
+    // 2. 암호화된 정보 복호화
+    const appKey = investmentDecrypt(credential.app_key_encrypted)
+    const appSecret = investmentDecrypt(credential.app_secret_encrypted)
+    const accountNumber = investmentDecrypt(credential.account_number_encrypted)
+
+    // 3. 감사 로그 (credential 접근)
+    await supabase.from('credential_access_log').insert({
+      credential_id: credential.id,
+      user_id: userId,
+      action: 'decrypt_for_balance',
+    })
+
+    // 4. KIS API로 잔고 조회 (국내 기준)
+    const balance = await getKRBalance(
+      credential.id,
+      {
+        appKey,
+        appSecret,
+        isPaperTrading: credential.is_paper_trading,
+      },
+      accountNumber
+    )
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        totalEvaluation: balance.totalEvaluation,
+        totalPnl: balance.totalPnl,
+        items: balance.items,
+        isPaperTrading: credential.is_paper_trading,
+      },
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '잔고 조회 실패'
+    console.error('[balance] 조회 실패:', message)
+
+    // 감사 로그 (실패)
+    await supabase.from('credential_access_log').insert({
+      credential_id: credential.id,
+      user_id: userId,
+      action: 'balance_fetch_failed',
+    })
+
+    return NextResponse.json({
+      error: message,
+      hasCredential: true,
+    }, { status: 500 })
+  }
+}

--- a/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { createClient } from '@/lib/supabase/client'
 import {
-  LayoutDashboard, Link2, Target, TrendingUp, Briefcase,
+  LayoutDashboard, Link2, Target, TrendingUp, TrendingDown, Briefcase,
   Wallet, Activity, AlertCircle, OctagonX, Loader2,
   ArrowRight, Plus, Play, Pause, Trash2, BarChart3,
 } from 'lucide-react'
@@ -32,6 +32,33 @@ export default function InvestmentTab() {
   const [loading, setLoading] = useState(true)
   const [emergencyStopping, setEmergencyStopping] = useState(false)
   const [backtestStrategyId, setBacktestStrategyId] = useState<string | null>(null)
+  const [balance, setBalance] = useState<{ totalEvaluation: number; totalPnl: number; holdingsCount: number } | null>(null)
+  const [balanceLoading, setBalanceLoading] = useState(false)
+  const [balanceError, setBalanceError] = useState<string | null>(null)
+
+  const loadBalance = useCallback(async () => {
+    setBalanceLoading(true)
+    setBalanceError(null)
+    try {
+      const res = await fetch('/api/investment/balance')
+      const json = await res.json()
+      if (res.ok && json.success && json.data) {
+        setBalance({
+          totalEvaluation: json.data.totalEvaluation || 0,
+          totalPnl: json.data.totalPnl || 0,
+          holdingsCount: (json.data.items || []).length,
+        })
+      } else {
+        setBalance(null)
+        if (res.status !== 404) setBalanceError(json.error || '잔고 조회 실패')
+      }
+    } catch {
+      setBalance(null)
+      setBalanceError('네트워크 오류')
+    } finally {
+      setBalanceLoading(false)
+    }
+  }, [])
 
   const loadData = useCallback(async () => {
     try {
@@ -41,17 +68,23 @@ export default function InvestmentTab() {
         .select('id, is_paper_trading')
         .eq('is_active', true)
         .maybeSingle()
-      setHasCredential(!!data)
+      const connected = !!data
+      setHasCredential(connected)
 
       const res = await fetch('/api/investment/strategies')
       const json = await res.json()
       if (json.data) setStrategies(json.data)
+
+      // 계좌 연결된 경우 잔고도 로드
+      if (connected) {
+        loadBalance()
+      }
     } catch {
       setHasCredential(false)
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [loadBalance])
 
   useEffect(() => {
     if (user) loadData()
@@ -129,6 +162,10 @@ export default function InvestmentTab() {
             emergencyStopping={emergencyStopping}
             onEmergencyStop={handleEmergencyStop}
             onNavigate={setSubTab}
+            balance={balance}
+            balanceLoading={balanceLoading}
+            balanceError={balanceError}
+            onRefreshBalance={loadBalance}
           />
         )}
         {subTab === 'connect' && (
@@ -158,13 +195,17 @@ export default function InvestmentTab() {
 // 서브탭 컴포넌트들
 // ============================================
 
-function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergencyStopping, onEmergencyStop, onNavigate }: {
+function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergencyStopping, onEmergencyStop, onNavigate, balance, balanceLoading, balanceError, onRefreshBalance }: {
   hasCredential: boolean | null
   strategies: InvestmentStrategy[]
   activeStrategies: InvestmentStrategy[]
   emergencyStopping: boolean
   onEmergencyStop: () => void
   onNavigate: (tab: SubTab) => void
+  balance: { totalEvaluation: number; totalPnl: number; holdingsCount: number } | null
+  balanceLoading: boolean
+  balanceError: string | null
+  onRefreshBalance: () => void
 }) {
   if (!hasCredential) {
     return (
@@ -189,19 +230,53 @@ function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergenc
     )
   }
 
+  const formatCurrency = (n: number) => {
+    if (!Number.isFinite(n)) return '--'
+    return Math.round(n).toLocaleString('ko-KR')
+  }
+  const totalEvalDisplay = balanceLoading ? '...' : (balance ? formatCurrency(balance.totalEvaluation) : '--')
+  const totalPnlDisplay = balanceLoading ? '...' : (balance ? formatCurrency(balance.totalPnl) : '--')
+  const pnlPositive = balance ? balance.totalPnl >= 0 : null
+
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-xl font-bold text-at-text">투자 대시보드</h2>
-        <p className="text-sm text-at-text-secondary mt-1">포트폴리오 현황과 활성 전략을 확인하세요</p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-bold text-at-text">투자 대시보드</h2>
+          <p className="text-sm text-at-text-secondary mt-1">포트폴리오 현황과 활성 전략을 확인하세요</p>
+        </div>
+        {hasCredential && (
+          <button
+            onClick={onRefreshBalance}
+            disabled={balanceLoading}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-at-text-secondary hover:bg-at-surface-alt transition-colors disabled:opacity-50"
+            title="잔고 새로고침"
+          >
+            <Loader2 className={`w-4 h-4 ${balanceLoading ? 'animate-spin' : ''}`} />
+            잔고 새로고침
+          </button>
+        )}
       </div>
+
+      {balanceError && (
+        <div className="flex items-center gap-2 p-3 rounded-xl bg-red-50 border border-red-200 text-red-700 text-sm">
+          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+          잔고 조회 실패: {balanceError}
+        </div>
+      )}
 
       {/* 요약 카드 */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        <SummaryCard title="총 평가금액" value="--" unit="원" icon={Wallet} />
-        <SummaryCard title="오늘 손익" value="--" unit="원" icon={TrendingUp} />
+        <SummaryCard title="총 평가금액" value={totalEvalDisplay} unit="원" icon={Wallet} />
+        <SummaryCard
+          title="총 손익"
+          value={pnlPositive === null ? totalPnlDisplay : `${balance!.totalPnl >= 0 ? '+' : ''}${totalPnlDisplay}`}
+          unit="원"
+          icon={pnlPositive === false ? TrendingDown : TrendingUp}
+          valueColor={pnlPositive === true ? 'text-red-500' : pnlPositive === false ? 'text-blue-500' : undefined}
+        />
+        <SummaryCard title="보유 종목" value={balance ? String(balance.holdingsCount) : '--'} unit="개" icon={Briefcase} />
         <SummaryCard title="활성 전략" value={String(activeStrategies.length)} unit="개" icon={Target} />
-        <SummaryCard title="전체 전략" value={String(strategies.length)} unit="개" icon={Activity} />
       </div>
 
       {/* 긴급 정지 */}
@@ -352,7 +427,7 @@ function StrategySubTab({ strategies, onRefresh, onBacktest }: { strategies: Inv
   )
 }
 
-function SummaryCard({ title, value, unit, icon: Icon }: { title: string; value: string; unit: string; icon: React.ElementType }) {
+function SummaryCard({ title, value, unit, icon: Icon, valueColor }: { title: string; value: string; unit: string; icon: React.ElementType; valueColor?: string }) {
   return (
     <div className="bg-at-surface-alt rounded-2xl p-4 border border-at-border">
       <div className="flex items-center justify-between mb-2">
@@ -360,7 +435,7 @@ function SummaryCard({ title, value, unit, icon: Icon }: { title: string; value:
         <Icon className="w-4 h-4 text-at-text-weak" />
       </div>
       <div className="flex items-baseline gap-1">
-        <span className="text-xl font-bold text-at-text">{value}</span>
+        <span className={`text-xl font-bold ${valueColor || 'text-at-text'}`}>{value}</span>
         <span className="text-xs text-at-text-weak">{unit}</span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

투자 대시보드에서 KIS 계좌의 실시간 잔고(총 평가금액, 총 손익, 보유 종목 수)가 표시되도록 수정했습니다. 기존에는 \`--\` 로 하드코딩되어 있어 실제 잔고가 보이지 않던 문제를 해결했습니다.

## 변경

- ✅ \`/api/investment/balance\` API 라우트 추가 — KIS API \`getKRBalance\` 호출, credential 복호화 + 감사 로그 기록
- ✅ 대시보드 서브탭에 실시간 잔고 카드 연동
- ✅ 손익 색상 (한국식: 양수=빨강, 음수=파랑)
- ✅ "잔고 새로고침" 버튼 추가
- ✅ 에러 배너 (잔고 조회 실패 시)
- ✅ 보유 종목 수 카드 추가

## Test plan
- [x] 빌드 통과 (\`npm run build\`)
- [x] 브라우저 테스트: 대시보드에서 \`총 평가금액: 307,723원\` 정상 표시 확인
- [x] 콘솔 에러 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)