### PR TITLE
feat(investment): 자동매매 프로세스 명확화 (감시 종목 + 활성화 가이드)

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/strategies/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/strategies/route.ts
@@ -179,7 +179,7 @@ export async function PATCH(request: NextRequest) {
   // 소유권 확인
   const { data: existing } = await supabase
     .from('investment_strategies')
-    .select('id, user_id, is_active')
+    .select('id, user_id, is_active, automation_level')
     .eq('id', id)
     .eq('user_id', userId)
     .single()
@@ -250,7 +250,40 @@ export async function PATCH(request: NextRequest) {
     updateData.automation_level = updates.automationLevel
   }
   if (updates.isActive !== undefined) {
-    updateData.is_active = Boolean(updates.isActive)
+    const activating = Boolean(updates.isActive)
+
+    // 활성화 시 사전 조건 체크
+    if (activating && !existing.is_active) {
+      // 1. 감시 종목 존재 여부
+      const { count: watchCount } = await supabase
+        .from('strategy_watchlist')
+        .select('id', { count: 'exact', head: true })
+        .eq('strategy_id', id)
+        .eq('is_active', true)
+      if ((watchCount ?? 0) === 0) {
+        return NextResponse.json({
+          error: '감시 종목이 없습니다. 자동매매할 종목을 먼저 추가해주세요.',
+          code: 'NO_WATCHLIST',
+        }, { status: 400 })
+      }
+
+      // 2. 활성 계좌 존재 여부 (Level 2 자동매매만)
+      if (existing.automation_level === 2) {
+        const { count: credCount } = await supabase
+          .from('user_broker_credentials')
+          .select('id', { count: 'exact', head: true })
+          .eq('user_id', userId)
+          .eq('is_active', true)
+        if ((credCount ?? 0) === 0) {
+          return NextResponse.json({
+            error: 'Level 2 자동매매는 증권 계좌 연결이 필요합니다.',
+            code: 'NO_CREDENTIAL',
+          }, { status: 400 })
+        }
+      }
+    }
+
+    updateData.is_active = activating
   }
 
   if (Object.keys(updateData).length === 0) {

--- a/dental-clinic-manager/src/app/api/investment/watchlist/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/watchlist/route.ts
@@ -1,0 +1,152 @@
+/**
+ * 전략 감시 종목 (Watchlist) CRUD API
+ *
+ * GET    /api/investment/watchlist?strategyId=xxx - 전략별 감시 종목 목록
+ * POST   /api/investment/watchlist - 감시 종목 추가
+ * DELETE /api/investment/watchlist?id=xxx - 감시 종목 제거
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+const KR_TICKER = /^\d{6}$/
+const US_TICKER = /^[A-Z]{1,5}[.]?[A-Z]?$/
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const userId = auth.user!.id
+
+  const supabase = getSupabaseAdmin()
+  if (!supabase) return NextResponse.json({ error: 'Server error' }, { status: 500 })
+
+  const strategyId = new URL(request.url).searchParams.get('strategyId')
+  if (!strategyId) return NextResponse.json({ error: 'strategyId가 필요합니다' }, { status: 400 })
+
+  // 전략 소유권 확인
+  const { data: strategy } = await supabase
+    .from('investment_strategies')
+    .select('id')
+    .eq('id', strategyId)
+    .eq('user_id', userId)
+    .maybeSingle()
+  if (!strategy) return NextResponse.json({ error: '전략을 찾을 수 없습니다' }, { status: 404 })
+
+  const { data, error } = await supabase
+    .from('strategy_watchlist')
+    .select('*')
+    .eq('strategy_id', strategyId)
+    .order('created_at', { ascending: true })
+
+  if (error) return NextResponse.json({ error: '조회 실패' }, { status: 500 })
+  return NextResponse.json({ data })
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const userId = auth.user!.id
+
+  const supabase = getSupabaseAdmin()
+  if (!supabase) return NextResponse.json({ error: 'Server error' }, { status: 500 })
+
+  let body: Record<string, unknown>
+  try { body = await request.json() } catch {
+    return NextResponse.json({ error: '잘못된 요청' }, { status: 400 })
+  }
+
+  const { strategyId, ticker, tickerName, market } = body
+  if (!strategyId || typeof strategyId !== 'string') {
+    return NextResponse.json({ error: 'strategyId가 필요합니다' }, { status: 400 })
+  }
+  if (!ticker || typeof ticker !== 'string') {
+    return NextResponse.json({ error: 'ticker가 필요합니다' }, { status: 400 })
+  }
+  if (market !== 'KR' && market !== 'US') {
+    return NextResponse.json({ error: '올바른 시장을 선택해주세요' }, { status: 400 })
+  }
+
+  const tickerUpper = ticker.trim().toUpperCase()
+  if (market === 'KR' && !KR_TICKER.test(tickerUpper)) {
+    return NextResponse.json({ error: '국내 종목 코드는 6자리 숫자여야 합니다' }, { status: 400 })
+  }
+  if (market === 'US' && !US_TICKER.test(tickerUpper)) {
+    return NextResponse.json({ error: '미국 종목 코드가 올바르지 않습니다' }, { status: 400 })
+  }
+
+  // 전략 소유권 확인
+  const { data: strategy } = await supabase
+    .from('investment_strategies')
+    .select('id')
+    .eq('id', strategyId)
+    .eq('user_id', userId)
+    .maybeSingle()
+  if (!strategy) return NextResponse.json({ error: '전략을 찾을 수 없습니다' }, { status: 404 })
+
+  // 중복 체크
+  const { data: existing } = await supabase
+    .from('strategy_watchlist')
+    .select('id')
+    .eq('strategy_id', strategyId)
+    .eq('ticker', tickerUpper)
+    .eq('market', market)
+    .maybeSingle()
+  if (existing) return NextResponse.json({ error: '이미 추가된 종목입니다' }, { status: 400 })
+
+  // 최대 20개 제한
+  const { count } = await supabase
+    .from('strategy_watchlist')
+    .select('id', { count: 'exact', head: true })
+    .eq('strategy_id', strategyId)
+  if ((count ?? 0) >= 20) {
+    return NextResponse.json({ error: '감시 종목은 최대 20개까지 추가 가능합니다' }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from('strategy_watchlist')
+    .insert({
+      strategy_id: strategyId,
+      ticker: tickerUpper,
+      ticker_name: typeof tickerName === 'string' ? tickerName : null,
+      market,
+      is_active: true,
+    })
+    .select()
+    .single()
+
+  if (error) return NextResponse.json({ error: '추가 실패' }, { status: 500 })
+  return NextResponse.json({ data }, { status: 201 })
+}
+
+export async function DELETE(request: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const userId = auth.user!.id
+
+  const supabase = getSupabaseAdmin()
+  if (!supabase) return NextResponse.json({ error: 'Server error' }, { status: 500 })
+
+  const id = new URL(request.url).searchParams.get('id')
+  if (!id) return NextResponse.json({ error: 'id가 필요합니다' }, { status: 400 })
+
+  // 소유권 확인 (전략 → 사용자)
+  const { data: item } = await supabase
+    .from('strategy_watchlist')
+    .select('id, strategy_id, investment_strategies!inner(user_id)')
+    .eq('id', id)
+    .maybeSingle()
+
+  const strategy = item?.investment_strategies as unknown as { user_id: string } | null
+  if (!item || strategy?.user_id !== userId) {
+    return NextResponse.json({ error: '권한이 없습니다' }, { status: 403 })
+  }
+
+  const { error } = await supabase
+    .from('strategy_watchlist')
+    .delete()
+    .eq('id', id)
+
+  if (error) return NextResponse.json({ error: '삭제 실패' }, { status: 500 })
+  return NextResponse.json({ success: true })
+}

--- a/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link'
 import ConnectContent from './ConnectContent'
 import TradingContent from './TradingContent'
 import BacktestPanel from './BacktestPanel'
+import StrategyCard from './StrategyCard'
 import type { InvestmentStrategy } from '@/types/investment'
 
 type SubTab = 'dashboard' | 'connect' | 'strategy' | 'trading' | 'portfolio'
@@ -172,7 +173,7 @@ export default function InvestmentTab() {
           <ConnectContent onCredentialChange={loadData} />
         )}
         {subTab === 'strategy' && (
-          <StrategySubTab strategies={strategies} onRefresh={loadData} onBacktest={setBacktestStrategyId} />
+          <StrategySubTab strategies={strategies} onRefresh={loadData} onBacktest={setBacktestStrategyId} hasCredential={!!hasCredential} />
         )}
         {subTab === 'trading' && (
           <TradingContent />
@@ -291,6 +292,50 @@ function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergenc
         </button>
       )}
 
+      {/* 자동매매 시작 가이드 (활성 전략 없을 때만) */}
+      {activeStrategies.length === 0 && (
+        <div className="bg-white rounded-2xl shadow-sm border border-at-border p-5">
+          <h3 className="font-semibold text-at-text mb-3">🚀 자동매매 시작하기</h3>
+          <ol className="space-y-2 text-sm">
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-at-accent-light text-at-accent text-xs font-bold flex items-center justify-center">1</span>
+              <div>
+                <button onClick={() => onNavigate('connect')} className="text-at-accent font-medium hover:underline">계좌 연결</button>
+                <span className="text-at-text-secondary"> - KIS 증권 계좌를 연결 (모의투자부터 권장)</span>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-at-accent-light text-at-accent text-xs font-bold flex items-center justify-center">2</span>
+              <div>
+                <button onClick={() => onNavigate('strategy')} className="text-at-accent font-medium hover:underline">전략 만들기</button>
+                <span className="text-at-text-secondary"> - 지표/조건/리스크 설정 (프리셋 활용 가능)</span>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-at-accent-light text-at-accent text-xs font-bold flex items-center justify-center">3</span>
+              <div>
+                <span className="text-at-text font-medium">감시 종목 추가</span>
+                <span className="text-at-text-secondary"> - 전략 카드를 펼쳐서 자동매매할 종목 추가</span>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-at-accent-light text-at-accent text-xs font-bold flex items-center justify-center">4</span>
+              <div>
+                <span className="text-at-text font-medium">백테스트</span>
+                <span className="text-at-text-secondary"> - 과거 데이터로 전략의 성과 검증</span>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-green-100 text-green-700 text-xs font-bold flex items-center justify-center">5</span>
+              <div>
+                <span className="text-at-text font-medium">▶ 자동매매 시작</span>
+                <span className="text-at-text-secondary"> - 전략 카드의 [▶] 버튼으로 활성화</span>
+              </div>
+            </li>
+          </ol>
+        </div>
+      )}
+
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* 활성 전략 */}
         <div className="bg-white rounded-3xl shadow-sm border border-at-border overflow-hidden">
@@ -342,25 +387,7 @@ function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergenc
   )
 }
 
-function StrategySubTab({ strategies, onRefresh, onBacktest }: { strategies: InvestmentStrategy[]; onRefresh: () => void; onBacktest: (id: string) => void }) {
-  const toggleActive = async (id: string, isActive: boolean) => {
-    await fetch('/api/investment/strategies', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id, isActive: !isActive }),
-    })
-    onRefresh()
-  }
-
-  const deleteStrategy = async (id: string) => {
-    if (!confirm('이 전략을 삭제하시겠습니까?')) return
-    const res = await fetch(`/api/investment/strategies?id=${id}`, { method: 'DELETE' })
-    if (res.ok) onRefresh()
-    else { const json = await res.json(); alert(json.error) }
-  }
-
-  const MARKET_LABELS: Record<string, string> = { KR: '국내', US: '미국' }
-
+function StrategySubTab({ strategies, onRefresh, onBacktest, hasCredential }: { strategies: InvestmentStrategy[]; onRefresh: () => void; onBacktest: (id: string) => void; hasCredential: boolean }) {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -387,39 +414,13 @@ function StrategySubTab({ strategies, onRefresh, onBacktest }: { strategies: Inv
       ) : (
         <div className="space-y-3">
           {strategies.map(s => (
-            <div key={s.id} className="bg-white rounded-2xl shadow-sm border border-at-border p-5">
-              <div className="flex items-start justify-between">
-                <div className="flex-1">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <h3 className="font-semibold text-at-text">{s.name}</h3>
-                    <span className={`px-2 py-0.5 text-xs rounded-full font-medium ${
-                      s.is_active
-                        ? 'bg-green-50 text-at-success border border-green-200'
-                        : 'bg-at-surface-alt text-at-text-weak border border-at-border'
-                    }`}>{s.is_active ? '활성' : '비활성'}</span>
-                    <span className="px-2 py-0.5 text-xs rounded-full bg-at-accent-light text-at-accent font-medium">
-                      {MARKET_LABELS[s.target_market] || s.target_market}
-                    </span>
-                  </div>
-                  {s.description && <p className="text-xs text-at-text-secondary mt-1">{s.description}</p>}
-                  <div className="flex items-center gap-4 mt-2 text-xs text-at-text-weak">
-                    <span>지표 {(s.indicators as unknown[]).length}개</span>
-                    <span>Level {s.automation_level}</span>
-                  </div>
-                </div>
-                <div className="flex items-center gap-1">
-                  <button onClick={() => onBacktest(s.id)} className="p-2 rounded-lg hover:bg-at-surface-alt transition-colors text-at-text-secondary" title="백테스트">
-                    <BarChart3 className="w-4 h-4" />
-                  </button>
-                  <button onClick={() => toggleActive(s.id, s.is_active)} className="p-2 rounded-lg hover:bg-at-surface-alt transition-colors text-at-text-secondary" title={s.is_active ? '비활성화' : '활성화'}>
-                    {s.is_active ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
-                  </button>
-                  <button onClick={() => deleteStrategy(s.id)} className="p-2 rounded-lg hover:bg-red-50 transition-colors text-at-error/60 hover:text-at-error" title="삭제" disabled={s.is_active}>
-                    <Trash2 className="w-4 h-4" />
-                  </button>
-                </div>
-              </div>
-            </div>
+            <StrategyCard
+              key={s.id}
+              strategy={s}
+              hasCredential={hasCredential}
+              onRefresh={onRefresh}
+              onBacktest={onBacktest}
+            />
           ))}
         </div>
       )}

--- a/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
@@ -1,0 +1,268 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import {
+  Play, Pause, Trash2, BarChart3, ChevronDown, ChevronUp,
+  Plus, X, CheckCircle2, AlertCircle, Target, Eye,
+} from 'lucide-react'
+import TickerSearch from './TickerSearch'
+import type { InvestmentStrategy, Market } from '@/types/investment'
+
+interface WatchlistItem {
+  id: string
+  ticker: string
+  ticker_name: string | null
+  market: Market
+  is_active: boolean
+}
+
+interface Props {
+  strategy: InvestmentStrategy
+  hasCredential: boolean
+  onRefresh: () => void
+  onBacktest: (id: string) => void
+}
+
+const MARKET_LABELS: Record<string, string> = { KR: '국내', US: '미국' }
+
+export default function StrategyCard({ strategy, hasCredential, onRefresh, onBacktest }: Props) {
+  const [expanded, setExpanded] = useState(false)
+  const [watchlist, setWatchlist] = useState<WatchlistItem[]>([])
+  const [watchlistLoading, setWatchlistLoading] = useState(false)
+  const [addingMarket, setAddingMarket] = useState<Market>(strategy.target_market)
+  const [toggling, setToggling] = useState(false)
+
+  const loadWatchlist = useCallback(async () => {
+    setWatchlistLoading(true)
+    try {
+      const res = await fetch(`/api/investment/watchlist?strategyId=${strategy.id}`)
+      const json = await res.json()
+      if (res.ok) setWatchlist(json.data || [])
+    } catch { /* ignore */ } finally { setWatchlistLoading(false) }
+  }, [strategy.id])
+
+  useEffect(() => { loadWatchlist() }, [loadWatchlist])
+
+  const addTicker = async (ticker: string, name?: string) => {
+    if (!ticker.trim()) return
+    const res = await fetch('/api/investment/watchlist', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        strategyId: strategy.id,
+        ticker: ticker.trim(),
+        tickerName: name,
+        market: addingMarket,
+      }),
+    })
+    const json = await res.json()
+    if (res.ok) loadWatchlist()
+    else alert(json.error || '추가 실패')
+  }
+
+  const removeTicker = async (id: string) => {
+    const res = await fetch(`/api/investment/watchlist?id=${id}`, { method: 'DELETE' })
+    if (res.ok) loadWatchlist()
+  }
+
+  const toggleActive = async () => {
+    setToggling(true)
+    try {
+      const res = await fetch('/api/investment/strategies', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: strategy.id, isActive: !strategy.is_active }),
+      })
+      const json = await res.json()
+      if (res.ok) {
+        onRefresh()
+      } else {
+        // 활성화 조건 미충족 에러
+        if (json.code === 'NO_WATCHLIST') {
+          alert('⚠️ 감시 종목이 없습니다.\n\n전략 상세를 펼쳐서 자동매매할 종목을 먼저 추가해주세요.')
+          setExpanded(true)
+        } else if (json.code === 'NO_CREDENTIAL') {
+          alert('⚠️ 증권 계좌 연결이 필요합니다.\n\n계좌 연결 탭에서 KIS 계좌를 먼저 연결해주세요.')
+        } else {
+          alert(json.error || '활성화 실패')
+        }
+      }
+    } catch { alert('네트워크 오류') } finally { setToggling(false) }
+  }
+
+  const deleteStrategy = async () => {
+    if (!confirm('이 전략을 삭제하시겠습니까?')) return
+    const res = await fetch(`/api/investment/strategies?id=${strategy.id}`, { method: 'DELETE' })
+    if (res.ok) onRefresh()
+    else { const json = await res.json(); alert(json.error) }
+  }
+
+  // 활성화 준비 체크리스트
+  const hasWatchlist = watchlist.length > 0
+  const needsCredential = strategy.automation_level === 2
+  const canActivate = hasWatchlist && (!needsCredential || hasCredential)
+
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-at-border p-5">
+      {/* 상단 헤더 */}
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="font-semibold text-at-text">{strategy.name}</h3>
+            <span className={`px-2 py-0.5 text-xs rounded-full font-medium ${
+              strategy.is_active
+                ? 'bg-green-50 text-at-success border border-green-200'
+                : 'bg-at-surface-alt text-at-text-weak border border-at-border'
+            }`}>{strategy.is_active ? '● 자동매매 작동 중' : '● 비활성'}</span>
+            <span className="px-2 py-0.5 text-xs rounded-full bg-at-accent-light text-at-accent font-medium">
+              {MARKET_LABELS[strategy.target_market] || strategy.target_market}
+            </span>
+            <span className="px-2 py-0.5 text-xs rounded-full bg-purple-50 text-purple-700 font-medium">
+              Level {strategy.automation_level} ({strategy.automation_level === 1 ? '알림만' : '완전자동'})
+            </span>
+          </div>
+          {strategy.description && <p className="text-xs text-at-text-secondary mt-1">{strategy.description}</p>}
+          <div className="flex items-center gap-4 mt-2 text-xs text-at-text-weak">
+            <span>지표 {(strategy.indicators as unknown[]).length}개</span>
+            <span className="flex items-center gap-1">
+              <Eye className="w-3 h-3" /> 감시 종목 {watchlistLoading ? '...' : `${watchlist.length}개`}
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <button onClick={() => onBacktest(strategy.id)} className="p-2 rounded-lg hover:bg-at-surface-alt transition-colors text-at-text-secondary" title="백테스트">
+            <BarChart3 className="w-4 h-4" />
+          </button>
+          <button
+            onClick={toggleActive}
+            disabled={toggling}
+            className={`p-2 rounded-lg transition-colors ${
+              strategy.is_active
+                ? 'hover:bg-amber-50 text-amber-600'
+                : canActivate
+                  ? 'hover:bg-green-50 text-green-600'
+                  : 'hover:bg-at-surface-alt text-at-text-secondary'
+            }`}
+            title={strategy.is_active ? '자동매매 중지' : '자동매매 시작'}
+          >
+            {strategy.is_active ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+          </button>
+          <button onClick={deleteStrategy} disabled={strategy.is_active} className="p-2 rounded-lg hover:bg-red-50 transition-colors text-at-error/60 hover:text-at-error disabled:opacity-40 disabled:cursor-not-allowed" title="삭제">
+            <Trash2 className="w-4 h-4" />
+          </button>
+          <button onClick={() => setExpanded(e => !e)} className="p-2 rounded-lg hover:bg-at-surface-alt transition-colors text-at-text-secondary ml-1" title={expanded ? '접기' : '펼치기'}>
+            {expanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+          </button>
+        </div>
+      </div>
+
+      {/* 활성화 체크리스트 (비활성 상태일 때만) */}
+      {!strategy.is_active && (
+        <div className="mt-2 p-3 rounded-xl bg-at-surface-alt border border-at-border">
+          <p className="text-xs font-semibold text-at-text mb-2">🚀 자동매매 시작 준비</p>
+          <ul className="text-xs space-y-1">
+            <li className="flex items-center gap-2">
+              {hasWatchlist ? (
+                <CheckCircle2 className="w-3.5 h-3.5 text-green-500 flex-shrink-0" />
+              ) : (
+                <AlertCircle className="w-3.5 h-3.5 text-amber-500 flex-shrink-0" />
+              )}
+              <span className={hasWatchlist ? 'text-at-text-secondary' : 'text-at-text font-medium'}>
+                감시 종목 추가 ({watchlist.length}개)
+                {!hasWatchlist && (
+                  <button onClick={() => setExpanded(true)} className="ml-2 text-at-accent underline text-xs">
+                    지금 추가
+                  </button>
+                )}
+              </span>
+            </li>
+            {needsCredential && (
+              <li className="flex items-center gap-2">
+                {hasCredential ? (
+                  <CheckCircle2 className="w-3.5 h-3.5 text-green-500 flex-shrink-0" />
+                ) : (
+                  <AlertCircle className="w-3.5 h-3.5 text-amber-500 flex-shrink-0" />
+                )}
+                <span className={hasCredential ? 'text-at-text-secondary' : 'text-at-text font-medium'}>
+                  증권 계좌 연결 (Level 2 필수)
+                </span>
+              </li>
+            )}
+          </ul>
+          {canActivate && (
+            <button
+              onClick={toggleActive}
+              disabled={toggling}
+              className="mt-3 w-full py-2 bg-green-500 hover:bg-green-600 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+            >
+              ▶ 자동매매 시작
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* 확장 영역: 감시 종목 관리 */}
+      {expanded && (
+        <div className="mt-4 pt-4 border-t border-at-border space-y-4">
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <h4 className="text-sm font-semibold text-at-text">감시 종목 (자동매매 대상)</h4>
+              <span className="text-xs text-at-text-weak">{watchlist.length}/20개</span>
+            </div>
+            <p className="text-xs text-at-text-secondary mb-3">
+              이 전략이 자동으로 매매할 종목을 추가하세요. 전략 활성화 시 이 종목들의 실시간 가격을 감시합니다.
+            </p>
+
+            {/* 종목 추가 */}
+            <div className="flex items-center gap-2 mb-3">
+              <select
+                value={addingMarket}
+                onChange={e => setAddingMarket(e.target.value as Market)}
+                className="px-3 py-2 rounded-xl border border-at-border bg-white text-at-text text-sm focus:outline-none focus:border-at-accent w-24"
+              >
+                <option value="KR">국내</option>
+                <option value="US">미국</option>
+              </select>
+              <TickerSearch
+                value=""
+                onChange={(ticker, name) => { if (ticker) addTicker(ticker, name) }}
+                market={addingMarket}
+                className="flex-1"
+              />
+            </div>
+
+            {/* 종목 목록 */}
+            {watchlist.length === 0 ? (
+              <div className="text-center py-4 text-xs text-at-text-weak">
+                <Target className="w-6 h-6 mx-auto mb-1 opacity-30" />
+                검색으로 종목을 추가해주세요
+              </div>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {watchlist.map(w => (
+                  <span key={w.id} className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-at-surface-alt border border-at-border text-sm">
+                    <span className={`px-1 py-0.5 rounded text-[10px] font-bold ${
+                      w.market === 'KR' ? 'bg-blue-100 text-blue-700' : 'bg-purple-100 text-purple-700'
+                    }`}>{w.market}</span>
+                    <span className="font-mono font-semibold text-at-text">{w.ticker}</span>
+                    {w.ticker_name && w.ticker_name !== w.ticker && (
+                      <span className="text-at-text-secondary text-xs">{w.ticker_name}</span>
+                    )}
+                    <button
+                      onClick={() => removeTicker(w.id)}
+                      disabled={strategy.is_active}
+                      className="text-at-text-weak hover:text-red-500 disabled:opacity-40 disabled:cursor-not-allowed"
+                      title={strategy.is_active ? '전략이 활성 상태라 삭제 불가' : '삭제'}
+                    >
+                      <X className="w-3.5 h-3.5" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## 문제

자동매매 활성화 위치, 종목 선택 방법이 불명확. 전략만 활성화하면 실제로 감시할 종목이 없어 자동매매가 작동하지 않음.

## 해결

### 1. Watchlist CRUD API (\`/api/investment/watchlist\`)
전략별 감시 종목(최대 20개) 추가/삭제/조회. 소유권 검증.

### 2. 전략 카드 내 감시 종목 관리 UI
- 전략 카드 펼치기 → 종목 검색(TickerSearch) + 태그 리스트
- 국내/미국 시장 토글
- 태그별 X 버튼으로 삭제

### 3. 활성화 준비 체크리스트
전략 카드 내 표시:
- ✅ 감시 종목 추가 (N개)
- ✅ 증권 계좌 연결 (Level 2 필수)
- 조건 충족 시 [▶ 자동매매 시작] 큰 버튼 표시

### 4. 사전 조건 검증 API
- \`NO_WATCHLIST\` / \`NO_CREDENTIAL\` 에러 코드로 친화적 메시지
- 감시 종목 없이 활성화 시도 시 자동으로 카드 확장

### 5. 대시보드 \"🚀 자동매매 시작하기\" 5단계 가이드
1. 계좌 연결 → 2. 전략 생성 → 3. 감시 종목 → 4. 백테스트 → 5. 자동매매 시작

🤖 Generated with [Claude Code](https://claude.com/claude-code)