### PR TITLE
fix(investment): 종목 검색 자모 단위 추가 근본 해결 (onSelect 분리)

### DIFF
--- a/dental-clinic-manager/src/components/Investment/BacktestPanel.tsx
+++ b/dental-clinic-manager/src/components/Investment/BacktestPanel.tsx
@@ -186,8 +186,7 @@ export default function BacktestPanel({ strategyId, onBack }: BacktestPanelProps
             <option value="US">미국</option>
           </select>
           <TickerSearch
-            value=""
-            onChange={(ticker, name) => { if (ticker) addTicker(ticker, name) }}
+            onSelect={(ticker, name) => addTicker(ticker, name)}
             market={addingMarket}
             className="flex-1"
           />

--- a/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
@@ -224,8 +224,7 @@ export default function StrategyCard({ strategy, hasCredential, onRefresh, onBac
                 <option value="US">미국</option>
               </select>
               <TickerSearch
-                value=""
-                onChange={(ticker, name) => { if (ticker) addTicker(ticker, name) }}
+                onSelect={(ticker, name) => addTicker(ticker, name)}
                 market={addingMarket}
                 className="flex-1"
               />

--- a/dental-clinic-manager/src/components/Investment/TickerSearch.tsx
+++ b/dental-clinic-manager/src/components/Investment/TickerSearch.tsx
@@ -13,21 +13,24 @@ interface TickerResult {
 }
 
 interface Props {
-  value: string
-  onChange: (ticker: string, name?: string) => void
+  /** 종목 선택 시 호출 (드롭다운 클릭 OR Enter 키) */
+  onSelect: (ticker: string, name?: string) => void
   market: Market
   placeholder?: string
   className?: string
+  /** 선택 후 입력 필드를 비울지 여부 (기본 true) */
+  clearOnSelect?: boolean
 }
 
-export default function TickerSearch({ value, onChange, market, placeholder, className }: Props) {
-  const [query, setQuery] = useState(value)
+export default function TickerSearch({ onSelect, market, placeholder, className, clearOnSelect = true }: Props) {
+  const [query, setQuery] = useState('')
   const [results, setResults] = useState<TickerResult[]>([])
   const [loading, setLoading] = useState(false)
   const [open, setOpen] = useState(false)
+  const [highlightIdx, setHighlightIdx] = useState(-1)
   const debounceRef = useRef<NodeJS.Timeout | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
-  // IME 조합 상태 (한글 입력 시 자모 단위로 onChange 발생 방지)
+  // IME 조합 상태 (한글 입력 시 자모 단위 처리 방지)
   const composingRef = useRef(false)
 
   // 외부 클릭 시 닫기
@@ -41,22 +44,24 @@ export default function TickerSearch({ value, onChange, market, placeholder, cla
     return () => document.removeEventListener('mousedown', handleClick)
   }, [])
 
-  // value prop 변경 시 동기화
+  // 시장 변경 시 결과 초기화
   useEffect(() => {
-    setQuery(value)
-  }, [value])
+    setResults([])
+    setOpen(false)
+  }, [market])
 
   const search = useCallback(async (q: string) => {
-    if (q.length < 1) {
+    if (q.trim().length < 1) {
       setResults([])
       return
     }
     setLoading(true)
     try {
-      const res = await fetch(`/api/investment/ticker-search?q=${encodeURIComponent(q)}&market=${market}`)
+      const res = await fetch(`/api/investment/ticker-search?q=${encodeURIComponent(q.trim())}&market=${market}`)
       const json = await res.json()
       setResults(json.results || [])
       setOpen(true)
+      setHighlightIdx(-1)
     } catch {
       setResults([])
     } finally {
@@ -64,24 +69,21 @@ export default function TickerSearch({ value, onChange, market, placeholder, cla
     }
   }, [market])
 
-  const scheduleSearch = (val: string) => {
+  const scheduleSearch = useCallback((val: string) => {
     if (debounceRef.current) clearTimeout(debounceRef.current)
-    debounceRef.current = setTimeout(() => search(val), 300)
-  }
+    debounceRef.current = setTimeout(() => search(val), 350)
+  }, [search])
 
   const handleInputChange = (val: string) => {
     setQuery(val)
-    onChange(val)
-
-    // IME 조합 중이면 검색 예약 안 함 (compositionend에서 처리)
+    // IME 조합 중이면 검색 안 함 (compositionend에서 처리)
     if (composingRef.current) return
-
     scheduleSearch(val)
   }
 
   const handleCompositionStart = () => {
     composingRef.current = true
-    // 조합 시작 시 기존 디바운스 취소 (불완전한 자모로 검색 방지)
+    // 조합 시작 시 기존 디바운스 취소
     if (debounceRef.current) clearTimeout(debounceRef.current)
   }
 
@@ -89,22 +91,49 @@ export default function TickerSearch({ value, onChange, market, placeholder, cla
     composingRef.current = false
     const val = (e.target as HTMLInputElement).value
     setQuery(val)
-    onChange(val)
     scheduleSearch(val)
   }
 
   const handleSelect = (result: TickerResult) => {
-    setQuery(result.ticker)
-    onChange(result.ticker, result.name)
+    onSelect(result.ticker, result.name)
+    if (clearOnSelect) {
+      setQuery('')
+    } else {
+      setQuery(result.ticker)
+    }
     setOpen(false)
     setResults([])
+    setHighlightIdx(-1)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // IME 조합 중엔 키보드 이벤트 무시 (특히 Enter로 조합 완료되는 경우)
+    if (composingRef.current || e.nativeEvent.isComposing) return
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setHighlightIdx(i => Math.min(i + 1, results.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setHighlightIdx(i => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (highlightIdx >= 0 && results[highlightIdx]) {
+        handleSelect(results[highlightIdx])
+      } else if (results.length > 0) {
+        // 첫 번째 결과 자동 선택
+        handleSelect(results[0])
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false)
+    }
   }
 
   const handleClear = () => {
     setQuery('')
-    onChange('')
     setResults([])
     setOpen(false)
+    setHighlightIdx(-1)
   }
 
   return (
@@ -117,15 +146,18 @@ export default function TickerSearch({ value, onChange, market, placeholder, cla
           onChange={e => handleInputChange(e.target.value)}
           onCompositionStart={handleCompositionStart}
           onCompositionEnd={handleCompositionEnd}
+          onKeyDown={handleKeyDown}
           onFocus={() => results.length > 0 && setOpen(true)}
-          placeholder={placeholder || (market === 'KR' ? '종목명 또는 코드 (예: 삼성전자, 005930)' : '종목명 또는 심볼 (예: Apple, AAPL)')}
-          className="w-full pl-9 pr-8 py-2 rounded-xl border border-at-border bg-at-bg text-at-text text-sm focus:outline-none focus:border-at-accent"
+          placeholder={placeholder || (market === 'KR' ? '종목명 또는 코드 검색 (예: 삼성전자, 005930)' : '종목명 또는 심볼 검색 (예: Apple, AAPL)')}
+          className="w-full pl-9 pr-8 py-2 rounded-xl border border-at-border bg-white text-at-text text-sm focus:outline-none focus:border-at-accent"
         />
         {loading && (
           <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-at-accent animate-spin" />
         )}
         {!loading && query && (
           <button
+            type="button"
+            onMouseDown={e => e.preventDefault()}
             onClick={handleClear}
             className="absolute right-3 top-1/2 -translate-y-1/2 text-at-text-weak hover:text-at-text"
           >
@@ -136,18 +168,22 @@ export default function TickerSearch({ value, onChange, market, placeholder, cla
 
       {/* 검색 결과 드롭다운 */}
       {open && results.length > 0 && (
-        <div className="absolute z-50 mt-1 w-full bg-at-surface rounded-xl shadow-lg border border-at-border max-h-60 overflow-y-auto">
+        <div className="absolute z-50 mt-1 w-full bg-white rounded-xl shadow-lg border border-at-border max-h-60 overflow-y-auto">
           {results.map((r, i) => (
             <button
               key={`${r.ticker}-${i}`}
+              type="button"
+              onMouseDown={e => e.preventDefault()}
               onClick={() => handleSelect(r)}
-              className="w-full text-left px-3 py-2.5 hover:bg-at-bg transition-colors flex items-center gap-3 border-b border-at-border/50 last:border-0"
+              className={`w-full text-left px-3 py-2.5 transition-colors flex items-center gap-3 border-b border-at-border/50 last:border-0 ${
+                highlightIdx === i ? 'bg-at-accent-light' : 'hover:bg-at-surface-alt'
+              }`}
             >
               <span className="font-mono text-sm font-semibold text-at-accent min-w-[60px]">
                 {r.ticker}
               </span>
               <span className="text-sm text-at-text truncate flex-1">{r.name}</span>
-              <span className="text-[10px] text-at-text-weak px-1.5 py-0.5 bg-at-bg rounded">
+              <span className="text-[10px] text-at-text-weak px-1.5 py-0.5 bg-at-surface-alt rounded">
                 {r.type === 'ETF' ? 'ETF' : r.exchange}
               </span>
             </button>
@@ -155,8 +191,8 @@ export default function TickerSearch({ value, onChange, market, placeholder, cla
         </div>
       )}
 
-      {open && !loading && query.length >= 1 && results.length === 0 && (
-        <div className="absolute z-50 mt-1 w-full bg-at-surface rounded-xl shadow-lg border border-at-border p-3 text-center text-sm text-at-text-weak">
+      {open && !loading && query.trim().length >= 1 && results.length === 0 && !composingRef.current && (
+        <div className="absolute z-50 mt-1 w-full bg-white rounded-xl shadow-lg border border-at-border p-3 text-center text-sm text-at-text-weak">
           검색 결과가 없습니다
         </div>
       )}


### PR DESCRIPTION
## 진짜 원인

TickerSearch의 `onChange` 콜백이 **키 입력마다 호출**되고 부모 컴포넌트는 이를 "종목 추가" 이벤트로 해석 → 한글 "삼성전자" 입력 시 `ㅅ,사,삼,삼ㅅ,삼성` 각각이 별도 종목으로 추가되는 문제.

## 해결

- `onChange` prop 완전 제거
- `onSelect` prop 신설 (드롭다운 클릭 또는 Enter로 명시적 선택 시에만 호출)
- 키보드 내비게이션 (↑↓/Enter/Esc)
- IME 조합 중 Enter는 조합 완료로만 처리

이전 커밋(compositionStart/End)은 검색 트리거는 막았지만, **종목 추가 자체**는 여전히 onChange로 모든 키 입력마다 일어나고 있었음.
