### PR TITLE
fix(investment): 한글 종목 검색 근본 해결 (로컬 딕셔너리)

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/ticker-search/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/ticker-search/route.ts
@@ -3,11 +3,17 @@
  *
  * GET /api/investment/ticker-search?q=삼성&market=KR
  *
- * yahoo-finance2의 search 기능을 활용하여 종목명/코드 자동완성 제공
+ * 국내: 로컬 한글 딕셔너리 (Yahoo Finance 한글 미지원 대응) + yahoo-finance2 fallback
+ * 미국: yahoo-finance2 search
  */
 
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuth } from '@/lib/auth/requireAuth'
+import { searchKRTicker } from '@/lib/krTickerDict'
+
+// 한글 자모 감지 (자모만 있는 쿼리는 빈 결과 반환)
+const HANGUL_JAMO = /[\u3131-\u318E]/
+const HANGUL_COMPLETE = /[\uAC00-\uD7A3]/
 
 export async function GET(request: NextRequest) {
   const auth = await requireAuth()
@@ -23,11 +29,48 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ results: [] })
   }
 
+  // 자모만 있고 완성형 한글/영문/숫자가 없으면 빈 결과
+  if (HANGUL_JAMO.test(query) && !HANGUL_COMPLETE.test(query) && !/[a-zA-Z0-9]/.test(query)) {
+    return NextResponse.json({ results: [] })
+  }
+
+  const isKorean = HANGUL_COMPLETE.test(query)
+
+  // 국내 시장 + 한글 검색 → 로컬 딕셔너리 우선
+  if (market === 'KR' && isKorean) {
+    const entries = searchKRTicker(query, 10)
+    return NextResponse.json({
+      results: entries.map(e => ({
+        ticker: e.ticker,
+        name: e.name,
+        exchange: 'KSC',
+        type: 'EQUITY',
+        market: 'KR',
+      })),
+    })
+  }
+
+  // 국내 + 영문/숫자 → 로컬 먼저 시도 후 yahoo 보강
+  if (market === 'KR') {
+    const localEntries = searchKRTicker(query, 10)
+    if (localEntries.length > 0) {
+      return NextResponse.json({
+        results: localEntries.map(e => ({
+          ticker: e.ticker,
+          name: e.name,
+          exchange: 'KSC',
+          type: 'EQUITY',
+          market: 'KR',
+        })),
+      })
+    }
+  }
+
+  // yahoo-finance2 fallback (영문 쿼리 또는 미국 시장)
   try {
     const YahooFinance = (await import('yahoo-finance2')).default
     const yahooFinance = new YahooFinance()
 
-    // yahoo-finance2 search API
     const searchResult = await yahooFinance.search(query, {
       newsCount: 0,
       quotesCount: 15,
@@ -35,23 +78,19 @@ export async function GET(request: NextRequest) {
 
     const quotes = (searchResult.quotes || [])
       .filter((q: Record<string, unknown>) => {
-        // 주식/ETF만 필터링
         const quoteType = q.quoteType as string
         if (!['EQUITY', 'ETF'].includes(quoteType)) return false
 
-        // 시장별 필터링
         const exchange = (q.exchange as string || '').toUpperCase()
         if (market === 'KR') {
           return ['KSC', 'KOE', 'KSE'].includes(exchange) ||
                  (q.symbol as string || '').endsWith('.KS') ||
                  (q.symbol as string || '').endsWith('.KQ')
         }
-        // US
         return ['NMS', 'NYQ', 'NGM', 'ASE', 'PCX', 'BTS'].includes(exchange)
       })
       .map((q: Record<string, unknown>) => {
         let ticker = q.symbol as string || ''
-        // 국내 종목: .KS, .KQ 접미사 제거
         if (market === 'KR') {
           ticker = ticker.replace(/\.(KS|KQ)$/, '')
         }
@@ -68,7 +107,8 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ results: quotes })
   } catch (err) {
-    console.error('종목 검색 실패:', err)
+    // 한글 쿼리 등으로 yahoo-finance2 에러 → 조용히 빈 결과
+    console.warn('[ticker-search] yahoo failed:', err instanceof Error ? err.message : err)
     return NextResponse.json({ results: [] })
   }
 }

--- a/dental-clinic-manager/src/components/Investment/TickerSearch.tsx
+++ b/dental-clinic-manager/src/components/Investment/TickerSearch.tsx
@@ -50,14 +50,32 @@ export default function TickerSearch({ onSelect, market, placeholder, className,
     setOpen(false)
   }, [market])
 
+  /**
+   * 입력값이 "검색 가능한 상태"인지 판단
+   * - 빈 문자열/공백만 있는 경우 false
+   * - 한글 자모(ㄱㄴㄷㅏㅑ 등)만 포함된 경우 false (IME 조합 중)
+   * - 완성형 한글, 영문, 숫자가 있으면 true
+   */
+  const isSearchable = (q: string): boolean => {
+    const trimmed = q.trim()
+    if (trimmed.length < 1) return false
+
+    // 한글 자모 범위: U+3131~U+318F (ㄱ-ㅎ, ㅏ-ㅣ 등)
+    // 완성형 한글: U+AC00~U+D7A3 (가-힣)
+    // 자모만 포함 + 완성형 한글/영문/숫자 없음 → 조합 중
+    const hasCompleted = /[\uAC00-\uD7A3a-zA-Z0-9]/.test(trimmed)
+    return hasCompleted
+  }
+
   const search = useCallback(async (q: string) => {
-    if (q.trim().length < 1) {
+    const trimmed = q.trim()
+    if (trimmed.length < 1) {
       setResults([])
       return
     }
     setLoading(true)
     try {
-      const res = await fetch(`/api/investment/ticker-search?q=${encodeURIComponent(q.trim())}&market=${market}`)
+      const res = await fetch(`/api/investment/ticker-search?q=${encodeURIComponent(trimmed)}&market=${market}`)
       const json = await res.json()
       setResults(json.results || [])
       setOpen(true)
@@ -71,7 +89,17 @@ export default function TickerSearch({ onSelect, market, placeholder, className,
 
   const scheduleSearch = useCallback((val: string) => {
     if (debounceRef.current) clearTimeout(debounceRef.current)
-    debounceRef.current = setTimeout(() => search(val), 350)
+    // 검색 가능한 상태가 아니면 예약 자체를 안 함
+    if (!isSearchable(val)) {
+      setResults([])
+      return
+    }
+    // 한글 타이핑 속도 대응: 700ms debounce (완성된 단어 기다림)
+    debounceRef.current = setTimeout(() => {
+      // 실행 시점에 IME 조합 중이면 스킵 (레이스 대응)
+      if (composingRef.current) return
+      search(val)
+    }, 700)
   }, [search])
 
   const handleInputChange = (val: string) => {
@@ -88,10 +116,13 @@ export default function TickerSearch({ onSelect, market, placeholder, className,
   }
 
   const handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
-    composingRef.current = false
     const val = (e.target as HTMLInputElement).value
     setQuery(val)
-    scheduleSearch(val)
+    // React 렌더 사이클과 IME 이벤트 순서 보장을 위해 짧은 지연 후 해제
+    setTimeout(() => {
+      composingRef.current = false
+      scheduleSearch(val)
+    }, 0)
   }
 
   const handleSelect = (result: TickerResult) => {
@@ -191,7 +222,7 @@ export default function TickerSearch({ onSelect, market, placeholder, className,
         </div>
       )}
 
-      {open && !loading && query.trim().length >= 1 && results.length === 0 && !composingRef.current && (
+      {open && !loading && isSearchable(query) && results.length === 0 && !composingRef.current && (
         <div className="absolute z-50 mt-1 w-full bg-white rounded-xl shadow-lg border border-at-border p-3 text-center text-sm text-at-text-weak">
           검색 결과가 없습니다
         </div>

--- a/dental-clinic-manager/src/lib/krTickerDict.ts
+++ b/dental-clinic-manager/src/lib/krTickerDict.ts
@@ -1,0 +1,133 @@
+/**
+ * 국내 주요 종목 한글 매핑 (Yahoo Finance는 한글 검색 미지원 대응)
+ *
+ * 구성: KOSPI + KOSDAQ 시가총액 상위 + 주요 관심 종목
+ */
+
+export interface KRTickerEntry {
+  ticker: string
+  name: string
+  alias?: string[]  // 검색 보조어 (영문명, 줄임말 등)
+}
+
+export const KR_TICKER_DICT: KRTickerEntry[] = [
+  // KOSPI 대형주
+  { ticker: '005930', name: '삼성전자', alias: ['samsung', 'samsung electronics'] },
+  { ticker: '000660', name: 'SK하이닉스', alias: ['sk hynix', 'hynix'] },
+  { ticker: '373220', name: 'LG에너지솔루션', alias: ['lg energy', 'lges'] },
+  { ticker: '207940', name: '삼성바이오로직스', alias: ['samsung biologics'] },
+  { ticker: '005380', name: '현대차', alias: ['hyundai motor', 'hyundai'] },
+  { ticker: '000270', name: '기아', alias: ['kia', 'kia motors'] },
+  { ticker: '035420', name: 'NAVER', alias: ['네이버', 'naver'] },
+  { ticker: '035720', name: '카카오', alias: ['kakao'] },
+  { ticker: '051910', name: 'LG화학', alias: ['lg chem'] },
+  { ticker: '006400', name: '삼성SDI', alias: ['samsung sdi'] },
+  { ticker: '068270', name: '셀트리온', alias: ['celltrion'] },
+  { ticker: '105560', name: 'KB금융', alias: ['kb financial'] },
+  { ticker: '055550', name: '신한지주', alias: ['shinhan', 'shinhan financial'] },
+  { ticker: '086790', name: '하나금융지주', alias: ['hana financial'] },
+  { ticker: '316140', name: '우리금융지주', alias: ['woori financial'] },
+  { ticker: '032830', name: '삼성생명', alias: ['samsung life'] },
+  { ticker: '003550', name: 'LG', alias: ['lg corp'] },
+  { ticker: '034730', name: 'SK', alias: ['sk holdings'] },
+  { ticker: '017670', name: 'SK텔레콤', alias: ['sk telecom', 'skt'] },
+  { ticker: '015760', name: '한국전력', alias: ['kepco', '한전'] },
+  { ticker: '033780', name: 'KT&G', alias: ['kt&g'] },
+  { ticker: '030200', name: 'KT', alias: ['kt corp'] },
+  { ticker: '032640', name: 'LG유플러스', alias: ['lg u+', 'lg uplus'] },
+  { ticker: '096770', name: 'SK이노베이션', alias: ['sk innovation'] },
+  { ticker: '010130', name: '고려아연', alias: ['korea zinc'] },
+  { ticker: '011170', name: '롯데케미칼', alias: ['lotte chemical'] },
+  { ticker: '009150', name: '삼성전기', alias: ['samsung electro-mechanics'] },
+  { ticker: '018260', name: '삼성에스디에스', alias: ['samsung sds'] },
+  { ticker: '066570', name: 'LG전자', alias: ['lg electronics'] },
+  { ticker: '010950', name: 'S-Oil', alias: ['s-oil', 's oil', '에스오일'] },
+  { ticker: '012330', name: '현대모비스', alias: ['hyundai mobis'] },
+  { ticker: '028260', name: '삼성물산', alias: ['samsung c&t'] },
+  { ticker: '000810', name: '삼성화재', alias: ['samsung fire'] },
+  { ticker: '005490', name: 'POSCO홀딩스', alias: ['posco', '포스코홀딩스', '포스코'] },
+  { ticker: '251270', name: '넷마블', alias: ['netmarble'] },
+  { ticker: '036570', name: '엔씨소프트', alias: ['ncsoft', 'nc soft'] },
+  { ticker: '352820', name: '하이브', alias: ['hybe', 'bts'] },
+  { ticker: '041510', name: '에스엠', alias: ['sm entertainment', 'sm ent'] },
+  { ticker: '035900', name: 'JYP Ent.', alias: ['jyp', 'jyp엔터'] },
+  { ticker: '122870', name: '와이지엔터테인먼트', alias: ['yg', 'yg엔터', 'yg entertainment'] },
+
+  // 코스닥 주요
+  { ticker: '091990', name: '셀트리온헬스케어', alias: ['celltrion healthcare'] },
+  { ticker: '247540', name: '에코프로비엠', alias: ['ecopro bm'] },
+  { ticker: '086520', name: '에코프로', alias: ['ecopro'] },
+  { ticker: '196170', name: '알테오젠', alias: ['alteogen'] },
+  { ticker: '357780', name: '솔브레인', alias: ['soulbrain'] },
+  { ticker: '293490', name: '카카오게임즈', alias: ['kakao games'] },
+  { ticker: '112040', name: '위메이드', alias: ['wemade'] },
+  { ticker: '263750', name: '펄어비스', alias: ['pearl abyss'] },
+  { ticker: '039030', name: '이오테크닉스', alias: ['eo technics'] },
+  { ticker: '214150', name: '클래시스', alias: ['classys'] },
+  { ticker: '078130', name: '국일제지', alias: ['kook il paper'] },
+  { ticker: '032500', name: '케이엠더블유', alias: ['kmw'] },
+  { ticker: '278280', name: '천보', alias: ['chunbo'] },
+  { ticker: '058470', name: '리노공업', alias: ['leeno industrial'] },
+  { ticker: '067310', name: '하나마이크론', alias: ['hana micron'] },
+  { ticker: '131970', name: '두산테스나', alias: ['doosan tesna'] },
+
+  // 기타 관심
+  { ticker: '090430', name: '아모레퍼시픽', alias: ['amore pacific'] },
+  { ticker: '051900', name: 'LG생활건강', alias: ['lg h&h'] },
+  { ticker: '097950', name: 'CJ제일제당', alias: ['cj cheiljedang'] },
+  { ticker: '271560', name: '오리온', alias: ['orion'] },
+  { ticker: '004020', name: '현대제철', alias: ['hyundai steel'] },
+  { ticker: '329180', name: '현대중공업', alias: ['hyundai heavy industries'] },
+  { ticker: '042660', name: '한화오션', alias: ['hanwha ocean'] },
+  { ticker: '010620', name: '현대미포조선', alias: ['hyundai mipo'] },
+  { ticker: '047810', name: '한국항공우주', alias: ['kai', '한국우주항공'] },
+  { ticker: '012450', name: '한화에어로스페이스', alias: ['hanwha aerospace'] },
+]
+
+/**
+ * 한글/영문 쿼리로 국내 종목 검색
+ */
+export function searchKRTicker(query: string, limit = 10): KRTickerEntry[] {
+  const q = query.trim().toLowerCase()
+  if (q.length < 1) return []
+
+  const scored: { entry: KRTickerEntry; score: number }[] = []
+
+  for (const entry of KR_TICKER_DICT) {
+    // 1. 정확한 코드 일치
+    if (entry.ticker === q) {
+      return [entry]
+    }
+    // 2. 코드 접두사 일치
+    if (entry.ticker.startsWith(q)) {
+      scored.push({ entry, score: 100 - entry.ticker.length })
+      continue
+    }
+    // 3. 한글 이름 정확히 일치
+    const nameLower = entry.name.toLowerCase()
+    if (nameLower === q) {
+      scored.push({ entry, score: 90 })
+      continue
+    }
+    // 4. 한글 이름 접두사 일치 ("삼성" → 삼성전자, 삼성바이오로직스 등)
+    if (nameLower.startsWith(q) || entry.name.startsWith(query)) {
+      scored.push({ entry, score: 80 - entry.name.length })
+      continue
+    }
+    // 5. 한글 이름 포함
+    if (nameLower.includes(q) || entry.name.includes(query)) {
+      scored.push({ entry, score: 60 - entry.name.length })
+      continue
+    }
+    // 6. alias 일치
+    if (entry.alias?.some(a => a.toLowerCase().includes(q))) {
+      scored.push({ entry, score: 50 })
+      continue
+    }
+  }
+
+  return scored
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(s => s.entry)
+}


### PR DESCRIPTION
## 진짜 원인

**yahoo-finance2 API가 한글 쿼리를 지원하지 않음** → \"Invalid Search Query\" 에러 반환. 한글 입력마다 API 호출 실패 → \"검색 결과 없음\" 반복 표시.

테스트:
- \`삼성전자\` → ERR Invalid Search Query
- \`Samsung\` → 7개 결과 ✅

## 해결

### 1. 국내 종목 로컬 딕셔너리 (65개)
\`src/lib/krTickerDict.ts\`
- KOSPI 대형주 + KOSDAQ 주요 + 엔터/제약/조선/화학
- 코드/한글명/영문별칭 기반 점수제 검색
- 접두사/포함/정확일치 우선순위

### 2. ticker-search API 개선
- 한글 쿼리 → 로컬 딕셔너리 우선
- 영문/숫자 → 로컬 먼저 + yahoo 보강
- 자모만 있는 쿼리 → 빈 결과 즉시 반환

### 3. TickerSearch debounce
350ms → **700ms** (Android PWA 한글 IME 대응)

## E2E 테스트 결과 (Playwright)

| 쿼리 | 결과 |
|------|------|
| \`삼성전자\` | ✅ 1개 (삼성전자) |
| \`삼성\` | ✅ 8개 (삼성 계열사) |
| \`samsung\` | ✅ 8개 |
| \`005930\` | ✅ 1개 |
| \`ㅅ\` 자모만 | ✅ 빈 결과 |
| UI 선택 후 | ✅ 감시 종목 태그 추가 |