### PR TITLE
fix(investment): 모바일 종목 검색 결과창 가시성 개선

### DIFF
--- a/dental-clinic-manager/src/components/Investment/BacktestPanel.tsx
+++ b/dental-clinic-manager/src/components/Investment/BacktestPanel.tsx
@@ -176,11 +176,11 @@ export default function BacktestPanel({ strategyId, onBack }: BacktestPanelProps
       {/* 종목 추가 */}
       <div className="bg-white rounded-2xl shadow-sm border border-at-border p-5 space-y-4">
         <h2 className="font-semibold text-at-text">종목 선택</h2>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-2">
           <select
             value={addingMarket}
             onChange={e => setAddingMarket(e.target.value as Market)}
-            className="px-3 py-2 rounded-xl border border-at-border bg-at-bg text-at-text text-sm focus:outline-none focus:border-at-accent w-24"
+            className="px-3 py-2 rounded-xl border border-at-border bg-at-bg text-at-text text-sm focus:outline-none focus:border-at-accent w-full sm:w-24"
           >
             <option value="KR">국내</option>
             <option value="US">미국</option>
@@ -188,7 +188,7 @@ export default function BacktestPanel({ strategyId, onBack }: BacktestPanelProps
           <TickerSearch
             onSelect={(ticker, name) => addTicker(ticker, name)}
             market={addingMarket}
-            className="flex-1"
+            className="w-full sm:flex-1"
           />
         </div>
 

--- a/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
@@ -213,12 +213,12 @@ export default function StrategyCard({ strategy, hasCredential, onRefresh, onBac
               이 전략이 자동으로 매매할 종목을 추가하세요. 전략 활성화 시 이 종목들의 실시간 가격을 감시합니다.
             </p>
 
-            {/* 종목 추가 */}
-            <div className="flex items-center gap-2 mb-3">
+            {/* 종목 추가 - 모바일: 세로 배치, 데스크톱: 가로 배치 */}
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 mb-3">
               <select
                 value={addingMarket}
                 onChange={e => setAddingMarket(e.target.value as Market)}
-                className="px-3 py-2 rounded-xl border border-at-border bg-white text-at-text text-sm focus:outline-none focus:border-at-accent w-24"
+                className="px-3 py-2 rounded-xl border border-at-border bg-white text-at-text text-sm focus:outline-none focus:border-at-accent w-full sm:w-24"
               >
                 <option value="KR">국내</option>
                 <option value="US">미국</option>
@@ -226,7 +226,7 @@ export default function StrategyCard({ strategy, hasCredential, onRefresh, onBac
               <TickerSearch
                 onSelect={(ticker, name) => addTicker(ticker, name)}
                 market={addingMarket}
-                className="flex-1"
+                className="w-full sm:flex-1"
               />
             </div>
 

--- a/dental-clinic-manager/src/components/Investment/TickerSearch.tsx
+++ b/dental-clinic-manager/src/components/Investment/TickerSearch.tsx
@@ -197,33 +197,35 @@ export default function TickerSearch({ onSelect, market, placeholder, className,
         )}
       </div>
 
-      {/* 검색 결과 드롭다운 */}
+      {/* 검색 결과 드롭다운 - 모바일에서도 종목명 전체가 보이도록 충분히 넓게 */}
       {open && results.length > 0 && (
-        <div className="absolute z-50 mt-1 w-full bg-white rounded-xl shadow-lg border border-at-border max-h-60 overflow-y-auto">
+        <div className="absolute z-50 mt-1 left-0 right-0 w-full min-w-[280px] bg-white rounded-xl shadow-lg border border-at-border max-h-[60vh] sm:max-h-72 overflow-y-auto">
           {results.map((r, i) => (
             <button
               key={`${r.ticker}-${i}`}
               type="button"
               onMouseDown={e => e.preventDefault()}
               onClick={() => handleSelect(r)}
-              className={`w-full text-left px-3 py-2.5 transition-colors flex items-center gap-3 border-b border-at-border/50 last:border-0 ${
+              className={`w-full text-left px-3 py-3 transition-colors border-b border-at-border/50 last:border-0 ${
                 highlightIdx === i ? 'bg-at-accent-light' : 'hover:bg-at-surface-alt'
               }`}
             >
-              <span className="font-mono text-sm font-semibold text-at-accent min-w-[60px]">
-                {r.ticker}
-              </span>
-              <span className="text-sm text-at-text truncate flex-1">{r.name}</span>
-              <span className="text-[10px] text-at-text-weak px-1.5 py-0.5 bg-at-surface-alt rounded">
-                {r.type === 'ETF' ? 'ETF' : r.exchange}
-              </span>
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-mono text-sm font-semibold text-at-accent whitespace-nowrap">
+                  {r.ticker}
+                </span>
+                <span className="text-sm text-at-text break-all flex-1 min-w-0">{r.name}</span>
+                <span className="text-[10px] text-at-text-weak px-1.5 py-0.5 bg-at-surface-alt rounded whitespace-nowrap">
+                  {r.type === 'ETF' ? 'ETF' : r.exchange}
+                </span>
+              </div>
             </button>
           ))}
         </div>
       )}
 
       {open && !loading && isSearchable(query) && results.length === 0 && !composingRef.current && (
-        <div className="absolute z-50 mt-1 w-full bg-white rounded-xl shadow-lg border border-at-border p-3 text-center text-sm text-at-text-weak">
+        <div className="absolute z-50 mt-1 left-0 right-0 w-full min-w-[280px] bg-white rounded-xl shadow-lg border border-at-border p-3 text-center text-sm text-at-text-weak">
           검색 결과가 없습니다
         </div>
       )}


### PR DESCRIPTION
핸드폰에서 검색 결과 종목명이 잘리는 문제 해결. 드롭다운 min-width 280px + max-h 60vh + break-all로 전체 표시. 시장 선택과 검색창도 모바일에서 세로 배치로 변경하여 검색창 너비 최대 확보.