### PR TITLE
feat(investment): 미국 한글 검색 + 대시보드 전략 토글

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/ticker-search/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/ticker-search/route.ts
@@ -10,6 +10,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuth } from '@/lib/auth/requireAuth'
 import { searchKRTicker } from '@/lib/krTickerDict'
+import { searchUSTicker } from '@/lib/usTickerDict'
 
 // 한글 자모 감지 (자모만 있는 쿼리는 빈 결과 반환)
 const HANGUL_JAMO = /[\u3131-\u318E]/
@@ -36,31 +37,46 @@ export async function GET(request: NextRequest) {
 
   const isKorean = HANGUL_COMPLETE.test(query)
 
-  // 국내 시장 + 한글 검색 → 로컬 딕셔너리 우선
-  if (market === 'KR' && isKorean) {
-    const entries = searchKRTicker(query, 10)
-    return NextResponse.json({
-      results: entries.map(e => ({
-        ticker: e.ticker,
-        name: e.name,
-        exchange: 'KSC',
-        type: 'EQUITY',
-        market: 'KR',
-      })),
-    })
-  }
-
-  // 국내 + 영문/숫자 → 로컬 먼저 시도 후 yahoo 보강
+  // 국내 시장 → 로컬 딕셔너리 우선 (한글/영문/코드 모두)
   if (market === 'KR') {
-    const localEntries = searchKRTicker(query, 10)
-    if (localEntries.length > 0) {
+    const entries = searchKRTicker(query, 10)
+    if (entries.length > 0 || isKorean) {
       return NextResponse.json({
-        results: localEntries.map(e => ({
+        results: entries.map(e => ({
           ticker: e.ticker,
           name: e.name,
           exchange: 'KSC',
           type: 'EQUITY',
           market: 'KR',
+        })),
+      })
+    }
+  }
+
+  // 미국 시장 → 로컬 한글 딕셔너리 우선 (한글 쿼리 or 영문 별칭)
+  if (market === 'US') {
+    const entries = searchUSTicker(query, 10)
+    if (isKorean) {
+      // 한글 쿼리는 로컬만 (yahoo는 한글 미지원)
+      return NextResponse.json({
+        results: entries.map(e => ({
+          ticker: e.ticker,
+          name: e.name,
+          exchange: e.exchange || 'NMS',
+          type: 'EQUITY',
+          market: 'US',
+        })),
+      })
+    }
+    // 영문/숫자 쿼리: 로컬 먼저 반환 + yahoo 보강 (아래에서)
+    if (entries.length >= 5) {
+      return NextResponse.json({
+        results: entries.map(e => ({
+          ticker: e.ticker,
+          name: e.name,
+          exchange: e.exchange || 'NMS',
+          type: 'EQUITY',
+          market: 'US',
         })),
       })
     }
@@ -103,12 +119,40 @@ export async function GET(request: NextRequest) {
           market,
         }
       })
-      .slice(0, 10)
+      .slice(0, 15)
 
-    return NextResponse.json({ results: quotes })
+    // 미국 시장: 로컬 결과를 상위에 두고 yahoo 결과 병합 (중복 제거)
+    if (market === 'US') {
+      const localEntries = searchUSTicker(query, 5)
+      const localTickers = new Set(localEntries.map(e => e.ticker))
+      const localResults = localEntries.map(e => ({
+        ticker: e.ticker,
+        name: e.name,
+        exchange: e.exchange || 'NMS',
+        type: 'EQUITY',
+        market: 'US',
+      }))
+      const yahooFiltered = quotes.filter(q => !localTickers.has(q.ticker))
+      return NextResponse.json({ results: [...localResults, ...yahooFiltered].slice(0, 15) })
+    }
+
+    return NextResponse.json({ results: quotes.slice(0, 10) })
   } catch (err) {
     // 한글 쿼리 등으로 yahoo-finance2 에러 → 조용히 빈 결과
     console.warn('[ticker-search] yahoo failed:', err instanceof Error ? err.message : err)
+    // 미국 시장이면 로컬 결과라도 반환
+    if (market === 'US') {
+      const entries = searchUSTicker(query, 10)
+      return NextResponse.json({
+        results: entries.map(e => ({
+          ticker: e.ticker,
+          name: e.name,
+          exchange: e.exchange || 'NMS',
+          type: 'EQUITY',
+          market: 'US',
+        })),
+      })
+    }
     return NextResponse.json({ results: [] })
   }
 }

--- a/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
@@ -167,6 +167,7 @@ export default function InvestmentTab() {
             balanceLoading={balanceLoading}
             balanceError={balanceError}
             onRefreshBalance={loadBalance}
+            onRefresh={loadData}
           />
         )}
         {subTab === 'connect' && (
@@ -196,7 +197,7 @@ export default function InvestmentTab() {
 // 서브탭 컴포넌트들
 // ============================================
 
-function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergencyStopping, onEmergencyStop, onNavigate, balance, balanceLoading, balanceError, onRefreshBalance }: {
+function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergencyStopping, onEmergencyStop, onNavigate, balance, balanceLoading, balanceError, onRefreshBalance, onRefresh }: {
   hasCredential: boolean | null
   strategies: InvestmentStrategy[]
   activeStrategies: InvestmentStrategy[]
@@ -207,7 +208,32 @@ function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergenc
   balanceLoading: boolean
   balanceError: string | null
   onRefreshBalance: () => void
+  onRefresh: () => void
 }) {
+  const [togglingId, setTogglingId] = useState<string | null>(null)
+
+  const toggleActive = async (s: InvestmentStrategy) => {
+    setTogglingId(s.id)
+    try {
+      const res = await fetch('/api/investment/strategies', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: s.id, isActive: !s.is_active }),
+      })
+      const json = await res.json()
+      if (res.ok) {
+        onRefresh()
+      } else {
+        if (json.code === 'NO_WATCHLIST') {
+          alert('⚠️ 감시 종목이 없습니다.\n\n전략 관리 탭에서 자동매매할 종목을 먼저 추가해주세요.')
+        } else if (json.code === 'NO_CREDENTIAL') {
+          alert('⚠️ 증권 계좌 연결이 필요합니다.\n\n계좌 연결 탭에서 KIS 계좌를 먼저 연결해주세요.')
+        } else {
+          alert(json.error || '전환 실패')
+        }
+      }
+    } catch { alert('네트워크 오류') } finally { setTogglingId(null) }
+  }
   if (!hasCredential) {
     return (
       <div className="max-w-lg mx-auto mt-8">
@@ -337,33 +363,71 @@ function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergenc
       )}
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* 활성 전략 */}
+        {/* 전략 목록 (활성/비활성 모두) */}
         <div className="bg-white rounded-3xl shadow-sm border border-at-border overflow-hidden">
-          <div className="px-6 py-4 border-b border-at-border">
-            <h3 className="text-base font-semibold text-at-text">활성 전략</h3>
+          <div className="px-6 py-4 border-b border-at-border flex items-center justify-between">
+            <div>
+              <h3 className="text-base font-semibold text-at-text">내 전략</h3>
+              <p className="text-xs text-at-text-secondary mt-0.5">
+                클릭하여 자동매매 활성/비활성 전환
+              </p>
+            </div>
+            <button onClick={() => onNavigate('strategy')} className="text-xs text-at-accent hover:underline">
+              전략 관리 →
+            </button>
           </div>
           <div className="p-6">
-            {activeStrategies.length === 0 ? (
+            {strategies.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-6 text-at-text-weak">
                 <Target className="w-10 h-10 mb-3 opacity-30" />
-                <p className="text-sm">활성화된 전략이 없습니다</p>
+                <p className="text-sm">아직 생성된 전략이 없습니다</p>
                 <button onClick={() => onNavigate('strategy')} className="mt-3 text-sm text-at-accent hover:underline">
                   전략 만들기 →
                 </button>
               </div>
             ) : (
-              <div className="space-y-3">
-                {activeStrategies.map(s => (
-                  <div key={s.id} className="flex items-center justify-between p-3 rounded-xl bg-at-surface-alt border border-at-border">
-                    <div>
-                      <p className="text-sm font-medium text-at-text">{s.name}</p>
-                      <p className="text-xs text-at-text-secondary mt-0.5">
-                        {s.target_market === 'KR' ? '국내' : '미국'} · {s.timeframe} · Level {s.automation_level}
-                      </p>
+              <div className="space-y-2">
+                {strategies.map(s => {
+                  const isToggling = togglingId === s.id
+                  return (
+                    <div key={s.id} className={`flex items-center justify-between gap-2 p-3 rounded-xl border transition-colors ${
+                      s.is_active
+                        ? 'bg-green-50/40 border-green-200'
+                        : 'bg-at-surface-alt border-at-border'
+                    }`}>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-at-text truncate">{s.name}</p>
+                        <p className="text-xs text-at-text-secondary mt-0.5">
+                          {s.target_market === 'KR' ? '국내' : '미국'} · {s.timeframe} · Level {s.automation_level}
+                        </p>
+                      </div>
+                      <button
+                        onClick={() => toggleActive(s)}
+                        disabled={isToggling}
+                        className={`flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold transition-colors disabled:opacity-50 ${
+                          s.is_active
+                            ? 'bg-green-500 text-white hover:bg-green-600'
+                            : 'bg-white text-at-text-secondary border border-at-border hover:bg-at-accent hover:text-white hover:border-at-accent'
+                        }`}
+                        title={s.is_active ? '자동매매 중지' : '자동매매 시작'}
+                      >
+                        {isToggling ? (
+                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                        ) : s.is_active ? (
+                          <>
+                            <Pause className="w-3.5 h-3.5" />
+                            <span>활성</span>
+                          </>
+                        ) : (
+                          <>
+                            <Play className="w-3.5 h-3.5" />
+                            <span>비활성</span>
+                          </>
+                        )}
+                      </button>
                     </div>
-                    <span className="px-2 py-0.5 text-xs rounded-full bg-green-50 text-at-success border border-green-200 font-medium">활성</span>
-                  </div>
-                ))}
+                  )
+                })}
               </div>
             )}
           </div>

--- a/dental-clinic-manager/src/lib/krTickerDict.ts
+++ b/dental-clinic-manager/src/lib/krTickerDict.ts
@@ -85,43 +85,52 @@ export const KR_TICKER_DICT: KRTickerEntry[] = [
 ]
 
 /**
- * 한글/영문 쿼리로 국내 종목 검색
+ * 제네릭 종목 딕셔너리 검색 (한글/영문/코드 지원)
  */
-export function searchKRTicker(query: string, limit = 10): KRTickerEntry[] {
+export function searchTickerDict<T extends { ticker: string; name: string; alias?: string[] }>(
+  dict: T[],
+  query: string,
+  limit = 10
+): T[] {
   const q = query.trim().toLowerCase()
   if (q.length < 1) return []
 
-  const scored: { entry: KRTickerEntry; score: number }[] = []
+  const scored: { entry: T; score: number }[] = []
 
-  for (const entry of KR_TICKER_DICT) {
+  for (const entry of dict) {
+    const tickerLower = entry.ticker.toLowerCase()
     // 1. 정확한 코드 일치
-    if (entry.ticker === q) {
+    if (tickerLower === q) {
       return [entry]
     }
     // 2. 코드 접두사 일치
-    if (entry.ticker.startsWith(q)) {
+    if (tickerLower.startsWith(q)) {
       scored.push({ entry, score: 100 - entry.ticker.length })
       continue
     }
-    // 3. 한글 이름 정확히 일치
+    // 3. 이름 정확히 일치
     const nameLower = entry.name.toLowerCase()
     if (nameLower === q) {
       scored.push({ entry, score: 90 })
       continue
     }
-    // 4. 한글 이름 접두사 일치 ("삼성" → 삼성전자, 삼성바이오로직스 등)
+    // 4. 이름 접두사 일치
     if (nameLower.startsWith(q) || entry.name.startsWith(query)) {
       scored.push({ entry, score: 80 - entry.name.length })
       continue
     }
-    // 5. 한글 이름 포함
+    // 5. 이름 포함
     if (nameLower.includes(q) || entry.name.includes(query)) {
       scored.push({ entry, score: 60 - entry.name.length })
       continue
     }
-    // 6. alias 일치
+    // 6. alias 일치 (접두사 우선, 포함은 낮은 점수)
+    if (entry.alias?.some(a => a.toLowerCase().startsWith(q))) {
+      scored.push({ entry, score: 55 })
+      continue
+    }
     if (entry.alias?.some(a => a.toLowerCase().includes(q))) {
-      scored.push({ entry, score: 50 })
+      scored.push({ entry, score: 45 })
       continue
     }
   }
@@ -130,4 +139,11 @@ export function searchKRTicker(query: string, limit = 10): KRTickerEntry[] {
     .sort((a, b) => b.score - a.score)
     .slice(0, limit)
     .map(s => s.entry)
+}
+
+/**
+ * 한글/영문 쿼리로 국내 종목 검색
+ */
+export function searchKRTicker(query: string, limit = 10): KRTickerEntry[] {
+  return searchTickerDict(KR_TICKER_DICT, query, limit)
 }

--- a/dental-clinic-manager/src/lib/usTickerDict.ts
+++ b/dental-clinic-manager/src/lib/usTickerDict.ts
@@ -1,0 +1,146 @@
+/**
+ * 미국 주요 종목 한글 매핑 (Yahoo Finance 한글 검색 미지원 대응)
+ *
+ * 구성: S&P 500 상위 + 주요 관심주 + 한국 투자자 선호 ETF
+ */
+
+import { searchTickerDict } from './krTickerDict'
+
+export interface USTickerEntry {
+  ticker: string
+  name: string  // 영문 정식 명칭
+  alias?: string[]  // 한글 별칭 + 영문 약칭
+  exchange?: string
+}
+
+export const US_TICKER_DICT: USTickerEntry[] = [
+  // 빅테크 (Mega Cap)
+  { ticker: 'AAPL', name: 'Apple Inc.', alias: ['애플', 'apple'], exchange: 'NMS' },
+  { ticker: 'MSFT', name: 'Microsoft Corp.', alias: ['마이크로소프트', 'microsoft', 'MS'], exchange: 'NMS' },
+  { ticker: 'GOOGL', name: 'Alphabet Inc. (Class A)', alias: ['구글', '알파벳', 'google', 'alphabet'], exchange: 'NMS' },
+  { ticker: 'GOOG', name: 'Alphabet Inc. (Class C)', alias: ['구글', '알파벳', 'google', 'alphabet'], exchange: 'NMS' },
+  { ticker: 'AMZN', name: 'Amazon.com Inc.', alias: ['아마존', 'amazon'], exchange: 'NMS' },
+  { ticker: 'META', name: 'Meta Platforms Inc.', alias: ['메타', '페이스북', 'facebook', 'meta'], exchange: 'NMS' },
+  { ticker: 'NVDA', name: 'NVIDIA Corp.', alias: ['엔비디아', 'nvidia'], exchange: 'NMS' },
+  { ticker: 'TSLA', name: 'Tesla Inc.', alias: ['테슬라', 'tesla'], exchange: 'NMS' },
+
+  // 반도체
+  { ticker: 'AMD', name: 'Advanced Micro Devices', alias: ['에이엠디', 'amd'], exchange: 'NMS' },
+  { ticker: 'INTC', name: 'Intel Corp.', alias: ['인텔', 'intel'], exchange: 'NMS' },
+  { ticker: 'TSM', name: 'Taiwan Semiconductor', alias: ['TSMC', '타이완반도체', 'tsmc', 'taiwan semi'], exchange: 'NYQ' },
+  { ticker: 'QCOM', name: 'Qualcomm Inc.', alias: ['퀄컴', 'qualcomm'], exchange: 'NMS' },
+  { ticker: 'AVGO', name: 'Broadcom Inc.', alias: ['브로드컴', 'broadcom'], exchange: 'NMS' },
+  { ticker: 'MU', name: 'Micron Technology', alias: ['마이크론', 'micron'], exchange: 'NMS' },
+  { ticker: 'TXN', name: 'Texas Instruments', alias: ['텍사스인스트루먼트', 'texas instruments', 'TI'], exchange: 'NMS' },
+  { ticker: 'AMAT', name: 'Applied Materials', alias: ['어플라이드머티리얼즈', 'applied materials'], exchange: 'NMS' },
+  { ticker: 'ASML', name: 'ASML Holding NV', alias: ['ASML', '에이에스엠엘'], exchange: 'NMS' },
+  { ticker: 'LRCX', name: 'Lam Research Corp.', alias: ['램리서치', 'lam research'], exchange: 'NMS' },
+
+  // 금융
+  { ticker: 'JPM', name: 'JPMorgan Chase & Co.', alias: ['JP모건', '제이피모건', 'jpmorgan', 'jp morgan'], exchange: 'NYQ' },
+  { ticker: 'BAC', name: 'Bank of America', alias: ['뱅크오브아메리카', '뱅크오브어메리카', 'bank of america', 'BoA'], exchange: 'NYQ' },
+  { ticker: 'WFC', name: 'Wells Fargo & Co.', alias: ['웰스파고', 'wells fargo'], exchange: 'NYQ' },
+  { ticker: 'GS', name: 'Goldman Sachs Group', alias: ['골드만삭스', 'goldman sachs'], exchange: 'NYQ' },
+  { ticker: 'MS', name: 'Morgan Stanley', alias: ['모건스탠리', 'morgan stanley'], exchange: 'NYQ' },
+  { ticker: 'BRK.B', name: 'Berkshire Hathaway (Class B)', alias: ['버크셔해서웨이', '버크셔', 'berkshire', 'buffett'], exchange: 'NYQ' },
+  { ticker: 'V', name: 'Visa Inc.', alias: ['비자', 'visa'], exchange: 'NYQ' },
+  { ticker: 'MA', name: 'Mastercard Inc.', alias: ['마스터카드', 'mastercard'], exchange: 'NYQ' },
+  { ticker: 'PYPL', name: 'PayPal Holdings', alias: ['페이팔', 'paypal'], exchange: 'NMS' },
+  { ticker: 'AXP', name: 'American Express', alias: ['아메리칸익스프레스', 'american express', 'amex'], exchange: 'NYQ' },
+
+  // 헬스케어
+  { ticker: 'JNJ', name: 'Johnson & Johnson', alias: ['존슨앤존슨', 'johnson & johnson', 'JNJ'], exchange: 'NYQ' },
+  { ticker: 'PFE', name: 'Pfizer Inc.', alias: ['화이자', 'pfizer'], exchange: 'NYQ' },
+  { ticker: 'MRNA', name: 'Moderna Inc.', alias: ['모더나', 'moderna'], exchange: 'NMS' },
+  { ticker: 'LLY', name: 'Eli Lilly and Co.', alias: ['일라이릴리', '릴리', 'eli lilly', 'lilly'], exchange: 'NYQ' },
+  { ticker: 'UNH', name: 'UnitedHealth Group', alias: ['유나이티드헬스', 'unitedhealth'], exchange: 'NYQ' },
+  { ticker: 'ABBV', name: 'AbbVie Inc.', alias: ['애브비', 'abbvie'], exchange: 'NYQ' },
+  { ticker: 'MRK', name: 'Merck & Co.', alias: ['머크', 'merck'], exchange: 'NYQ' },
+
+  // 소비재/리테일
+  { ticker: 'WMT', name: 'Walmart Inc.', alias: ['월마트', 'walmart'], exchange: 'NYQ' },
+  { ticker: 'COST', name: 'Costco Wholesale', alias: ['코스트코', 'costco'], exchange: 'NMS' },
+  { ticker: 'HD', name: 'Home Depot Inc.', alias: ['홈디포', 'home depot'], exchange: 'NYQ' },
+  { ticker: 'TGT', name: 'Target Corp.', alias: ['타겟', 'target'], exchange: 'NYQ' },
+  { ticker: 'NKE', name: 'Nike Inc.', alias: ['나이키', 'nike'], exchange: 'NYQ' },
+  { ticker: 'MCD', name: "McDonald's Corp.", alias: ['맥도날드', 'mcdonalds'], exchange: 'NYQ' },
+  { ticker: 'SBUX', name: 'Starbucks Corp.', alias: ['스타벅스', 'starbucks'], exchange: 'NMS' },
+  { ticker: 'KO', name: 'Coca-Cola Co.', alias: ['코카콜라', 'coca-cola', 'coke'], exchange: 'NYQ' },
+  { ticker: 'PEP', name: 'PepsiCo Inc.', alias: ['펩시', '펩시코', 'pepsi', 'pepsico'], exchange: 'NMS' },
+  { ticker: 'PG', name: 'Procter & Gamble', alias: ['P&G', 'procter gamble', '프록터앤갬블'], exchange: 'NYQ' },
+  { ticker: 'LULU', name: 'Lululemon Athletica', alias: ['룰루레몬', 'lululemon'], exchange: 'NMS' },
+
+  // 엔터테인먼트/미디어
+  { ticker: 'DIS', name: 'Walt Disney Co.', alias: ['디즈니', 'disney'], exchange: 'NYQ' },
+  { ticker: 'NFLX', name: 'Netflix Inc.', alias: ['넷플릭스', 'netflix'], exchange: 'NMS' },
+  { ticker: 'SPOT', name: 'Spotify Technology', alias: ['스포티파이', 'spotify'], exchange: 'NYQ' },
+  { ticker: 'RBLX', name: 'Roblox Corp.', alias: ['로블록스', 'roblox'], exchange: 'NYQ' },
+
+  // 에너지
+  { ticker: 'XOM', name: 'Exxon Mobil Corp.', alias: ['엑슨모빌', 'exxon', 'exxonmobil'], exchange: 'NYQ' },
+  { ticker: 'CVX', name: 'Chevron Corp.', alias: ['셰브론', 'chevron'], exchange: 'NYQ' },
+  { ticker: 'COP', name: 'ConocoPhillips', alias: ['코노코필립스', 'conoco phillips'], exchange: 'NYQ' },
+
+  // 전기차/자동차
+  { ticker: 'F', name: 'Ford Motor Co.', alias: ['포드', 'ford'], exchange: 'NYQ' },
+  { ticker: 'GM', name: 'General Motors', alias: ['GM', '제너럴모터스', 'general motors'], exchange: 'NYQ' },
+  { ticker: 'RIVN', name: 'Rivian Automotive', alias: ['리비안', 'rivian'], exchange: 'NMS' },
+  { ticker: 'LCID', name: 'Lucid Group', alias: ['루시드', 'lucid'], exchange: 'NMS' },
+  { ticker: 'NIO', name: 'NIO Inc.', alias: ['니오', 'nio', '중국전기차'], exchange: 'NYQ' },
+  { ticker: 'XPEV', name: 'XPeng Inc.', alias: ['샤오펑', 'xpeng'], exchange: 'NYQ' },
+  { ticker: 'LI', name: 'Li Auto Inc.', alias: ['리오토', 'li auto'], exchange: 'NMS' },
+
+  // 소프트웨어/클라우드
+  { ticker: 'CRM', name: 'Salesforce Inc.', alias: ['세일즈포스', 'salesforce'], exchange: 'NYQ' },
+  { ticker: 'ORCL', name: 'Oracle Corp.', alias: ['오라클', 'oracle'], exchange: 'NYQ' },
+  { ticker: 'ADBE', name: 'Adobe Inc.', alias: ['어도비', 'adobe'], exchange: 'NMS' },
+  { ticker: 'NOW', name: 'ServiceNow Inc.', alias: ['서비스나우', 'servicenow'], exchange: 'NYQ' },
+  { ticker: 'IBM', name: 'IBM Corp.', alias: ['IBM', '아이비엠'], exchange: 'NYQ' },
+  { ticker: 'CSCO', name: 'Cisco Systems Inc.', alias: ['시스코', 'cisco'], exchange: 'NMS' },
+  { ticker: 'INTU', name: 'Intuit Inc.', alias: ['인튜이트', 'intuit'], exchange: 'NMS' },
+  { ticker: 'SHOP', name: 'Shopify Inc.', alias: ['쇼피파이', 'shopify'], exchange: 'NMS' },
+  { ticker: 'PLTR', name: 'Palantir Technologies', alias: ['팔란티어', 'palantir'], exchange: 'NYQ' },
+  { ticker: 'SNOW', name: 'Snowflake Inc.', alias: ['스노우플레이크', 'snowflake'], exchange: 'NYQ' },
+  { ticker: 'NET', name: 'Cloudflare Inc.', alias: ['클라우드플레어', 'cloudflare'], exchange: 'NYQ' },
+  { ticker: 'ZM', name: 'Zoom Video', alias: ['줌', 'zoom'], exchange: 'NMS' },
+
+  // 통신/네트워크
+  { ticker: 'VZ', name: 'Verizon Communications', alias: ['버라이즌', 'verizon'], exchange: 'NYQ' },
+  { ticker: 'T', name: 'AT&T Inc.', alias: ['AT&T', '에이티앤티'], exchange: 'NYQ' },
+  { ticker: 'TMUS', name: 'T-Mobile US Inc.', alias: ['티모바일', 't-mobile'], exchange: 'NMS' },
+
+  // 항공/여행
+  { ticker: 'BA', name: 'Boeing Co.', alias: ['보잉', 'boeing'], exchange: 'NYQ' },
+  { ticker: 'UBER', name: 'Uber Technologies', alias: ['우버', 'uber'], exchange: 'NYQ' },
+  { ticker: 'ABNB', name: 'Airbnb Inc.', alias: ['에어비앤비', 'airbnb'], exchange: 'NMS' },
+  { ticker: 'DAL', name: 'Delta Air Lines', alias: ['델타항공', 'delta airlines'], exchange: 'NYQ' },
+
+  // 암호화폐 관련
+  { ticker: 'COIN', name: 'Coinbase Global', alias: ['코인베이스', 'coinbase'], exchange: 'NMS' },
+  { ticker: 'MSTR', name: 'MicroStrategy Inc.', alias: ['마이크로스트래티지', 'microstrategy'], exchange: 'NMS' },
+
+  // 주요 ETF (한국 투자자 선호)
+  { ticker: 'SPY', name: 'SPDR S&P 500 ETF', alias: ['SPY', 'S&P500 ETF', '에스앤피 ETF'], exchange: 'PCX' },
+  { ticker: 'VOO', name: 'Vanguard S&P 500 ETF', alias: ['VOO', '뱅가드 S&P500'], exchange: 'PCX' },
+  { ticker: 'QQQ', name: 'Invesco QQQ Trust', alias: ['QQQ', '나스닥 ETF', '나스닥100'], exchange: 'NMS' },
+  { ticker: 'VTI', name: 'Vanguard Total Stock Market ETF', alias: ['VTI', '뱅가드 전체시장'], exchange: 'PCX' },
+  { ticker: 'DIA', name: 'SPDR Dow Jones Industrial Average ETF', alias: ['DIA', '다우 ETF'], exchange: 'PCX' },
+  { ticker: 'IWM', name: 'iShares Russell 2000 ETF', alias: ['IWM', '러셀 2000', 'russell'], exchange: 'PCX' },
+  { ticker: 'ARKK', name: 'ARK Innovation ETF', alias: ['ARKK', 'ARK 혁신 ETF', '캐시우드'], exchange: 'PCX' },
+  { ticker: 'TQQQ', name: 'ProShares UltraPro QQQ (3x)', alias: ['TQQQ', '나스닥 3배', '3배 레버리지'], exchange: 'NMS' },
+  { ticker: 'SQQQ', name: 'ProShares UltraPro Short QQQ (3x Inverse)', alias: ['SQQQ', '나스닥 3배 인버스', '나스닥 숏'], exchange: 'NMS' },
+  { ticker: 'SCHD', name: 'Schwab U.S. Dividend Equity ETF', alias: ['SCHD', '슈왑 배당 ETF', '배당 ETF'], exchange: 'PCX' },
+  { ticker: 'VYM', name: 'Vanguard High Dividend Yield ETF', alias: ['VYM', '뱅가드 고배당'], exchange: 'PCX' },
+  { ticker: 'JEPI', name: 'JPMorgan Equity Premium Income ETF', alias: ['JEPI', 'JP모건 프리미엄 인컴'], exchange: 'PCX' },
+  { ticker: 'GLD', name: 'SPDR Gold Shares', alias: ['GLD', '금 ETF', 'gold'], exchange: 'PCX' },
+  { ticker: 'TLT', name: '20+ Year Treasury Bond ETF', alias: ['TLT', '장기채권 ETF', '미국채'], exchange: 'NMS' },
+  { ticker: 'SOXL', name: 'Direxion Semiconductor Bull 3x', alias: ['SOXL', '반도체 3배', '반도체 레버리지'], exchange: 'PCX' },
+  { ticker: 'SOXS', name: 'Direxion Semiconductor Bear 3x', alias: ['SOXS', '반도체 3배 인버스'], exchange: 'PCX' },
+]
+
+/**
+ * 한글/영문 쿼리로 미국 종목 검색
+ */
+export function searchUSTicker(query: string, limit = 10): USTickerEntry[] {
+  return searchTickerDict(US_TICKER_DICT, query, limit)
+}


### PR DESCRIPTION
## 1. 미국 종목 한글 검색 지원

미국 주요 종목 85개에 대한 한글 별칭 매핑 추가 (\`usTickerDict.ts\`).

E2E 테스트:
- \`애플\` → AAPL ✅
- \`테슬라\` → TSLA ✅
- \`엔비디아\` → NVDA ✅
- \`나스닥\` → QQQ, TQQQ, SQQQ ✅
- \`배당\` → SCHD, VYM ✅

구성: 빅테크, 반도체, 금융, 헬스케어, 소비재, 엔터, 에너지, 전기차, 클라우드, 통신, 항공, 암호화폐, 주요 ETF

## 2. 대시보드 전략 활성/비활성 토글

- \"활성 전략\" → \"내 전략\" (전체 표시)
- 각 전략에 [Play/Pause] 토글 버튼
- 활성: 초록 배경, 비활성: 회색 (호버 시 초록)
- NO_WATCHLIST/NO_CREDENTIAL 친화적 에러