### PR TITLE
fix: 리콜 환자 상태 수정 시 연락 횟수 중복 증가 방지

### DIFF
--- a/dental-clinic-manager/src/components/Recall/RecallManagement.tsx
+++ b/dental-clinic-manager/src/components/Recall/RecallManagement.tsx
@@ -249,6 +249,7 @@ export default function RecallManagement() {
       const previousPatient = { ...patient }
       const now = new Date().toISOString()
       const isContact = newStatus !== 'pending'
+      const wasPending = patient.status === 'pending'
       const contactType = newStatus === 'sms_sent' ? 'sms' : 'call'
 
       setPatients(prev => prev.map(p =>
@@ -259,7 +260,8 @@ export default function RecallManagement() {
             recall_datetime: now,
             last_contact_date: now,
             last_contact_type: contactType as ContactType,
-            contact_count: (p.contact_count || 0) + 1
+            // 이전 상태가 pending일 때만 contact_count 증가 (결과 상태 간 수정 시 중복 증가 방지)
+            ...(wasPending ? { contact_count: (p.contact_count || 0) + 1 } : {})
           } : {})
         } : p
       ))

--- a/dental-clinic-manager/src/lib/recallService.ts
+++ b/dental-clinic-manager/src/lib/recallService.ts
@@ -885,10 +885,10 @@ export const recallPatientService = {
     if (!supabase) return { success: false, error: 'Database connection not available' }
 
     try {
-      // 현재 환자 정보 조회 (contact_count, campaign_id)
+      // 현재 환자 정보 조회 (contact_count, campaign_id, status)
       const { data: patient } = await supabase
         .from('recall_patients')
-        .select('campaign_id, contact_count')
+        .select('campaign_id, contact_count, status')
         .eq('id', id)
         .single()
 
@@ -904,7 +904,10 @@ export const recallPatientService = {
         updates.recall_datetime = now
         updates.last_contact_date = now
         updates.last_contact_type = contactType
-        updates.contact_count = (patient?.contact_count || 0) + 1
+        // 이전 상태가 pending일 때만 contact_count 증가 (결과 상태 간 수정 시 중복 증가 방지)
+        if (patient?.status === 'pending') {
+          updates.contact_count = (patient?.contact_count || 0) + 1
+        }
       }
 
       const { error } = await supabase


### PR DESCRIPTION
## Summary
- 리콜 관리에서 환자 상태를 변경할 때마다 `contact_count`(연락 횟수)가 무조건 증가하던 문제 수정
- 이전 상태가 `pending`일 때만 연락 횟수가 증가하도록 변경 → 결과 상태 간 수정(예: `no_answer` → `appointment_made`) 시 중복 증가 방지

## 변경 내용
- `src/lib/recallService.ts` `updatePatientStatus`: 기존 status를 함께 조회하여 `pending → 결과 상태` 전환일 때만 `contact_count` 증가
- `src/components/Recall/RecallManagement.tsx` `handleUpdateStatus`: 낙관적 UI 업데이트에도 동일한 조건 적용(`wasPending`)

## Test plan
- [ ] 리콜 대상 환자를 `pending → no_answer`로 변경: 연락 횟수 +1
- [ ] 동일 환자를 `no_answer → appointment_made`로 변경: 연락 횟수 그대로 유지
- [ ] 동일 환자를 `appointment_made → pending`으로 되돌림: 연락 횟수 그대로 유지
- [ ] `pending → sms_sent` 변경: 연락 횟수 +1
- [ ] CallModal에서 전화 결과 저장 시 +1만 반영되는지 확인
- [ ] 통계 탭의 카운트가 정합성 유지되는지 확인

https://claude.ai/code/session_01T44K15S3R5vyaqpjBz6uyt