### PR TITLE
fix(recall): 상태 변경 시 하루에 한 번만 연락 횟수 증가

### DIFF
--- a/dental-clinic-manager/src/components/Recall/RecallManagement.tsx
+++ b/dental-clinic-manager/src/components/Recall/RecallManagement.tsx
@@ -251,6 +251,13 @@ export default function RecallManagement() {
       const isContact = newStatus !== 'pending'
       const contactType = newStatus === 'sms_sent' ? 'sms' : 'call'
 
+      // 하루에 한 번만 연락 횟수 증가 (한국 시간 기준 같은 날짜면 증가시키지 않음)
+      const todayKST = new Date(now).toLocaleDateString('en-CA', { timeZone: 'Asia/Seoul' })
+      const lastContactKST = patient.last_contact_date
+        ? new Date(patient.last_contact_date).toLocaleDateString('en-CA', { timeZone: 'Asia/Seoul' })
+        : null
+      const shouldIncrementCount = isContact && lastContactKST !== todayKST
+
       setPatients(prev => prev.map(p =>
         p.id === patient.id ? {
           ...p,
@@ -259,7 +266,7 @@ export default function RecallManagement() {
             recall_datetime: now,
             last_contact_date: now,
             last_contact_type: contactType as ContactType,
-            contact_count: (p.contact_count || 0) + 1
+            contact_count: shouldIncrementCount ? (p.contact_count || 0) + 1 : (p.contact_count || 0)
           } : {})
         } : p
       ))

--- a/dental-clinic-manager/src/lib/recallService.ts
+++ b/dental-clinic-manager/src/lib/recallService.ts
@@ -885,10 +885,10 @@ export const recallPatientService = {
     if (!supabase) return { success: false, error: 'Database connection not available' }
 
     try {
-      // 현재 환자 정보 조회 (contact_count, campaign_id)
+      // 현재 환자 정보 조회 (contact_count, campaign_id, last_contact_date)
       const { data: patient } = await supabase
         .from('recall_patients')
-        .select('campaign_id, contact_count')
+        .select('campaign_id, contact_count, last_contact_date')
         .eq('id', id)
         .single()
 
@@ -904,7 +904,15 @@ export const recallPatientService = {
         updates.recall_datetime = now
         updates.last_contact_date = now
         updates.last_contact_type = contactType
-        updates.contact_count = (patient?.contact_count || 0) + 1
+
+        // 하루에 한 번만 연락 횟수 증가 (한국 시간 기준 같은 날짜에 이미 기록이 있으면 증가시키지 않음)
+        const todayKST = new Date(now).toLocaleDateString('en-CA', { timeZone: 'Asia/Seoul' })
+        const lastContactKST = patient?.last_contact_date
+          ? new Date(patient.last_contact_date).toLocaleDateString('en-CA', { timeZone: 'Asia/Seoul' })
+          : null
+        if (lastContactKST !== todayKST) {
+          updates.contact_count = (patient?.contact_count || 0) + 1
+        }
       }
 
       const { error } = await supabase


### PR DESCRIPTION
## Summary
- 리콜 환자의 상태 버튼을 같은 날 여러 번 눌러도 `contact_count`가 1회만 증가하도록 수정
- `last_contact_date`/`last_contact_type`은 최신으로 계속 갱신 (마지막 연락 시각 반영)
- 한국 시간(Asia/Seoul) 기준으로 "같은 날" 여부 판정
- `updatePatientStatus`와 `RecallManagement` 낙관적 업데이트 양쪽에 동일 로직 적용

## Test plan
- [x] 연락 이력 0회 환자(고갑윤)에 부재중 → 통화거부 → 예약보류 3연속 클릭 → `contact_count: 0 → 1` 확인
- [x] 다른 날짜 이력 보유 환자(안재홍, 3/14 이력)에 오늘 첫 상태 변경 → `contact_count: 1 → 2` 정상 증가 확인
- [x] 테스트로 변경한 데이터는 `recall_contact_logs` 원본 참조해 원상복구 완료
- [x] TypeScript 타입 체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)