### PR TITLE
fix(worker): 손상된 설정 파일 자동 복구 로직 추가

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/src/config-store.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/config-store.ts
@@ -1,4 +1,7 @@
 import Store from 'electron-store';
+import { app } from 'electron';
+import * as path from 'path';
+import * as fs from 'fs';
 
 // ============================================
 // 설정 저장소 (electron-store 기반)
@@ -67,38 +70,69 @@ export interface UpdateMeta {
   updateStatus: string;
 }
 
-const store = new Store<StoreSchema>({
-  name: 'clinic-manager-worker',
-  defaults: {
-    dashboardUrl: 'https://www.hi-clinic.co.kr',
-    workerApiKey: '',
-    autoStart: true,
-    autoUpdate: true,
-    headless: true,
-    isConfigured: false,
-    lastUpdateCheck: '',
-    lastUpdatedAt: '',
-    installedAt: '',
-    currentVersionReleasedAt: '',
-    latestVersion: '',
-    updateStatus: 'up-to-date',
-    githubToken: '',
-    // DentWeb bridge defaults
-    dentwebEnabled: false,
-    dentwebDbServer: 'localhost',
-    dentwebDbPort: 1433,
-    dentwebDbDatabase: 'DENTWEBDB',
-    dentwebDbAuthType: 'windows',
-    dentwebDbUser: '',
-    dentwebDbPassword: '',
-    dentwebClinicId: '',
-    dentwebApiKey: '',
-    dentwebSyncInterval: 300,
-    dentwebLastSyncDate: '',
-    dentwebLastSyncStatus: '',
-    dentwebLastSyncPatientCount: 0,
-  },
-});
+const storeDefaults: StoreSchema = {
+  dashboardUrl: 'https://www.hi-clinic.co.kr',
+  workerApiKey: '',
+  autoStart: true,
+  autoUpdate: true,
+  headless: true,
+  isConfigured: false,
+  lastUpdateCheck: '',
+  lastUpdatedAt: '',
+  installedAt: '',
+  currentVersionReleasedAt: '',
+  latestVersion: '',
+  updateStatus: 'up-to-date',
+  githubToken: '',
+  // DentWeb bridge defaults
+  dentwebEnabled: false,
+  dentwebDbServer: 'localhost',
+  dentwebDbPort: 1433,
+  dentwebDbDatabase: 'DENTWEBDB',
+  dentwebDbAuthType: 'windows',
+  dentwebDbUser: '',
+  dentwebDbPassword: '',
+  dentwebClinicId: '',
+  dentwebApiKey: '',
+  dentwebSyncInterval: 300,
+  dentwebLastSyncDate: '',
+  dentwebLastSyncStatus: '',
+  dentwebLastSyncPatientCount: 0,
+};
+
+function createStore(): Store<StoreSchema> {
+  try {
+    return new Store<StoreSchema>({
+      name: 'clinic-manager-worker',
+      defaults: storeDefaults,
+    });
+  } catch (err) {
+    // 설정 파일이 손상된 경우: 백업 후 삭제하고 재생성
+    console.error('[config-store] 설정 파일 손상 감지, 초기화 진행:', err);
+    try {
+      const userDataPath = app.getPath('userData');
+      const configPath = path.join(userDataPath, 'clinic-manager-worker.json');
+      if (fs.existsSync(configPath)) {
+        const backupPath = configPath + '.corrupt.' + Date.now();
+        fs.renameSync(configPath, backupPath);
+        console.log(`[config-store] 손상된 파일 백업: ${backupPath}`);
+      }
+    } catch (backupErr) {
+      console.error('[config-store] 백업 실패, 파일 직접 삭제 시도:', backupErr);
+      try {
+        const userDataPath = app.getPath('userData');
+        const configPath = path.join(userDataPath, 'clinic-manager-worker.json');
+        fs.unlinkSync(configPath);
+      } catch { /* 무시 */ }
+    }
+    return new Store<StoreSchema>({
+      name: 'clinic-manager-worker',
+      defaults: storeDefaults,
+    });
+  }
+}
+
+const store = createStore();
 
 /**
  * 첫 실행 여부 확인


### PR DESCRIPTION
## Summary
- electron-store 설정 파일(JSON) 손상 시 앱 시작 불가 문제 해결
- 손상 감지 시 `.corrupt.{timestamp}`로 백업 후 기본값으로 자동 재생성
- 비정상 종료로 인한 JSON 파싱 에러 방어

## Test plan
- [ ] 서버에서 `clinic-manager-worker.json` 삭제 후 앱 정상 시작 확인
- [ ] 손상된 JSON 파일로 앱 시작 시 자동 복구 확인
- [ ] 복구 후 설정 재입력 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)