### PR TITLE
feat(marketing): 이미지 생성 모델 선택 (Gemini / OpenAI gpt-image-2)

### DIFF
--- a/dental-clinic-manager/package-lock.json
+++ b/dental-clinic-manager/package-lock.json
@@ -193,7 +193,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -418,7 +417,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
       "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -3050,7 +3048,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
       "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.71.1",
         "@supabase/functions-js": "2.4.6",
@@ -3377,7 +3374,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.9.0.tgz",
       "integrity": "sha512-2f460x1yMJ2vXctrbFw6m4/uZk7g5BgsxsJCJtDDjpyasMk5f+BdJTDCb0dwewWb75U+cbdH88AF7NXtLEs6XQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3626,7 +3622,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.7.2.tgz",
       "integrity": "sha512-/tYHmEkOGcVweAc9ZgnAXkzua5aJfu7TjZcKTq5fmDt6x9MY1eY1+egS7D9hVR2sUSAC10VgXmYdYPDsKF3p2g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3719,7 +3714,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.7.2.tgz",
       "integrity": "sha512-1sBOrYHoMDcygPSuBfunp/bw21rea/r7L8AQaeZ/NIo2RZ6GXWxI9sRzTkLWijZ4xC3md0O/ylmvxvLL4V0SVA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3825,7 +3819,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.9.0.tgz",
       "integrity": "sha512-by/GH4A5kaiQqujA2KtXI1ZfQLMuFbb5tylAupPq+Pv6qzEU+Engx7vwUxb/dYvFHh+pxQPJeG6zxWf+WiGPQw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3865,7 +3858,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.7.2.tgz",
       "integrity": "sha512-FaToSdU9fhQk2swkaXrAQNgdaE0dwLbUHcvilW5F4xTpQfZ3J535u5U2TUYf+f9KKSV5fTmD4QGNY9qxY7ihTg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3880,7 +3872,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.9.0.tgz",
       "integrity": "sha512-MN1gL1OZWD489a/OmwV+InyNoRY+nKMKZ2EuZGL5ouQRdi5qSTvtMCmqzBHqrDzJCDPNCaY4NWW5DiKqIiJ2Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4085,7 +4076,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4095,7 +4085,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -4179,7 +4168,6 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -4726,7 +4714,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6060,7 +6047,6 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6235,7 +6221,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9034,7 +9019,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9374,7 +9358,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
       "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -9404,7 +9387,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -9453,7 +9435,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
       "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -9573,7 +9554,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.2.tgz",
       "integrity": "sha512-MdWVitvLbQULD+4DP8GYjZUrepGW7d+GQkNVqJEzNxE+e9WIa4egVFE/RDfVb1u9u/Jw7dNMmPB4IqxzbFYJ0w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9583,7 +9563,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.2.tgz",
       "integrity": "sha512-dEoydsCp50i7kS1xHOmPXq4zQYoGWedUsvqv9H6zdif2r7yLHygyfP9qou71TulRN0d6ng9EbRVsQhSqfUc19g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10814,7 +10793,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11054,7 +11032,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/dental-clinic-manager/src/app/api/marketing/costs/settings/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/costs/settings/route.ts
@@ -5,6 +5,7 @@ const DEFAULT_SETTINGS = [
   { model: 'claude-sonnet-4-6', input_price_per_1m: 3.0, output_price_per_1m: 15.0, image_price_per_call: 0, usd_to_krw: 1380 },
   { model: 'claude-haiku-4-5', input_price_per_1m: 0.8, output_price_per_1m: 4.0, image_price_per_call: 0, usd_to_krw: 1380 },
   { model: 'gemini-3.0-flash', input_price_per_1m: 0, output_price_per_1m: 0, image_price_per_call: 0.04, usd_to_krw: 1380 },
+  { model: 'gpt-image-2', input_price_per_1m: 0, output_price_per_1m: 0, image_price_per_call: 0.04, usd_to_krw: 1380 },
   { model: 'exchange_rate', input_price_per_1m: 0, output_price_per_1m: 0, image_price_per_call: 0, usd_to_krw: 1380 },
 ];
 

--- a/dental-clinic-manager/src/app/api/marketing/image-provider/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/image-provider/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import {
+  getImageProvider,
+  setImageProvider,
+  invalidateImageProviderCache,
+  type ImageProvider,
+} from '@/lib/marketing/image-provider-setting';
+
+// 이미지 생성 프로바이더 조회 (로그인 사용자 허용)
+// GET /api/marketing/image-provider
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 });
+    }
+
+    const provider = await getImageProvider();
+    return NextResponse.json({ provider });
+  } catch (error) {
+    console.error('[API] marketing/image-provider GET:', error);
+    return NextResponse.json({ error: '프로바이더 조회 실패' }, { status: 500 });
+  }
+}
+
+// 이미지 생성 프로바이더 변경 (master_admin 전용)
+// PUT /api/marketing/image-provider
+// Body: { provider: 'gemini' | 'openai' }
+export async function PUT(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 });
+    }
+
+    const { data: userData } = await supabase
+      .from('users')
+      .select('role')
+      .eq('id', user.id)
+      .single();
+
+    if (userData?.role !== 'master_admin') {
+      return NextResponse.json({ error: '권한이 없습니다.' }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const provider = body?.provider as ImageProvider | undefined;
+
+    if (provider !== 'gemini' && provider !== 'openai') {
+      return NextResponse.json(
+        { error: "provider는 'gemini' 또는 'openai'여야 합니다." },
+        { status: 400 },
+      );
+    }
+
+    await setImageProvider(provider, user.id);
+    invalidateImageProviderCache();
+
+    return NextResponse.json({ provider });
+  } catch (error) {
+    console.error('[API] marketing/image-provider PUT:', error);
+    return NextResponse.json({ error: '프로바이더 저장 실패' }, { status: 500 });
+  }
+}

--- a/dental-clinic-manager/src/app/master/marketing/costs/CostDashboardContent.tsx
+++ b/dental-clinic-manager/src/app/master/marketing/costs/CostDashboardContent.tsx
@@ -8,6 +8,7 @@ import CostSummaryCards from './CostSummaryCards'
 import CostChart from './CostChart'
 import CostTable from './CostTable'
 import CostSettings from './CostSettings'
+import ImageProviderSelector from './ImageProviderSelector'
 
 interface Props {
   embedded?: boolean
@@ -35,7 +36,8 @@ export default function CostDashboardContent({ embedded }: Props) {
           <div className="xl:col-span-2">
             <CostTable />
           </div>
-          <div className="xl:col-span-1">
+          <div className="xl:col-span-1 space-y-6">
+            <ImageProviderSelector />
             <CostSettings />
           </div>
         </div>
@@ -71,7 +73,8 @@ export default function CostDashboardContent({ embedded }: Props) {
           <div className="xl:col-span-2">
             <CostTable />
           </div>
-          <div className="xl:col-span-1">
+          <div className="xl:col-span-1 space-y-6">
+            <ImageProviderSelector />
             <CostSettings />
           </div>
         </div>

--- a/dental-clinic-manager/src/app/master/marketing/costs/CostSettings.tsx
+++ b/dental-clinic-manager/src/app/master/marketing/costs/CostSettings.tsx
@@ -15,6 +15,7 @@ const MODEL_LABELS: Record<string, string> = {
   'claude-sonnet-4-6': 'Claude Sonnet 4.6',
   'claude-haiku-4-5': 'Claude Haiku 4.5',
   'gemini-3.0-flash': 'Gemini 3.0 Flash',
+  'gpt-image-2': 'OpenAI gpt-image-2',
   'exchange_rate': '환율 설정',
 }
 
@@ -151,7 +152,7 @@ export default function CostSettings() {
             )}
 
             {/* 이미지 모델: 건당 단가 */}
-            {s.model.startsWith('gemini') && (
+            {(s.model.startsWith('gemini') || s.model.startsWith('gpt-image')) && (
               <div>
                 <label className="text-[10px] text-at-text-weak block mb-0.5">이미지 1건당 ($)</label>
                 <input

--- a/dental-clinic-manager/src/app/master/marketing/costs/ImageProviderSelector.tsx
+++ b/dental-clinic-manager/src/app/master/marketing/costs/ImageProviderSelector.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+type Provider = 'gemini' | 'openai'
+
+const PROVIDER_INFO: Record<Provider, { label: string; description: string; model: string }> = {
+  gemini: {
+    label: 'Gemini 3.0 Flash',
+    model: 'gemini-3.1-flash-image-preview',
+    description: 'Google 나노바나나 (기본)',
+  },
+  openai: {
+    label: 'OpenAI gpt-image-2',
+    model: 'gpt-image-2',
+    description: 'OpenAI 최신 이미지 생성 모델',
+  },
+}
+
+export default function ImageProviderSelector() {
+  const [provider, setProvider] = useState<Provider | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/marketing/image-provider')
+        const json = await res.json()
+        if (!res.ok) throw new Error(json?.error || '조회 실패')
+        setProvider((json.provider as Provider) ?? 'gemini')
+      } catch {
+        setError('설정을 불러오지 못했습니다.')
+        setProvider('gemini')
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  const handleSelect = async (next: Provider) => {
+    if (!provider || provider === next || saving) return
+    setSaving(true)
+    setError(null)
+    setSuccess(false)
+    try {
+      const res = await fetch('/api/marketing/image-provider', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: next }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json?.error || '저장 실패')
+      setProvider(next)
+      setSuccess(true)
+      setTimeout(() => setSuccess(false), 2500)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '저장에 실패했습니다.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-xl border border-at-border p-5">
+        <h2 className="text-base font-semibold text-at-text mb-4">이미지 생성 모델</h2>
+        <div className="animate-pulse space-y-3">
+          <div className="h-16 bg-at-surface-alt rounded" />
+          <div className="h-16 bg-at-surface-alt rounded" />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-at-border p-5">
+      <h2 className="text-base font-semibold text-at-text mb-1">이미지 생성 모델</h2>
+      <p className="text-xs text-at-text-weak mb-4">
+        AI 글 이미지 생성에 사용할 모델을 선택합니다. 모든 클리닉의 마케팅 이미지 생성에 즉시 반영됩니다.
+      </p>
+
+      <div className="space-y-2">
+        {(Object.keys(PROVIDER_INFO) as Provider[]).map((key) => {
+          const info = PROVIDER_INFO[key]
+          const selected = provider === key
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => handleSelect(key)}
+              disabled={saving}
+              className={`w-full text-left p-3 rounded-xl border transition-colors disabled:opacity-60 disabled:cursor-not-allowed ${
+                selected
+                  ? 'border-emerald-500 bg-emerald-50 ring-2 ring-emerald-500/20'
+                  : 'border-at-border bg-white hover:bg-at-surface-alt'
+              }`}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-sm font-semibold text-at-text">{info.label}</div>
+                  <div className="text-[11px] text-at-text-weak mt-0.5">{info.description}</div>
+                  <div className="text-[10px] text-at-text-weak mt-0.5 font-mono truncate">{info.model}</div>
+                </div>
+                <div
+                  className={`shrink-0 h-4 w-4 rounded-full border ${
+                    selected ? 'bg-emerald-500 border-emerald-500' : 'border-at-border'
+                  }`}
+                  aria-hidden
+                />
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="mt-3 min-h-[18px]">
+        {error && <div className="text-xs text-red-500">{error}</div>}
+        {success && <div className="text-xs text-emerald-600">변경되었습니다.</div>}
+        {saving && <div className="text-xs text-at-text-weak">저장 중...</div>}
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/lib/marketing/api-usage-logger.ts
+++ b/dental-clinic-manager/src/lib/marketing/api-usage-logger.ts
@@ -9,7 +9,7 @@ export interface LogApiUsageParams {
   clinicId: string;
   postId?: string;
   generationSessionId: string;
-  apiProvider: 'anthropic' | 'google';
+  apiProvider: 'anthropic' | 'google' | 'openai';
   model: string;
   callType:
     | 'text_generation'
@@ -101,6 +101,7 @@ export async function getOrSeedCostSettings(clinicId: string): Promise<CostSetti
       { clinic_id: clinicId, model: 'claude-sonnet-4-6', input_price_per_1m: 3.0, output_price_per_1m: 15.0, image_price_per_call: 0 },
       { clinic_id: clinicId, model: 'claude-haiku-4-5', input_price_per_1m: 0.8, output_price_per_1m: 4.0, image_price_per_call: 0 },
       { clinic_id: clinicId, model: 'gemini-3.0-flash', input_price_per_1m: 0, output_price_per_1m: 0, image_price_per_call: 0.04 },
+      { clinic_id: clinicId, model: 'gpt-image-2', input_price_per_1m: 0, output_price_per_1m: 0, image_price_per_call: 0.04 },
       { clinic_id: clinicId, model: 'exchange_rate', input_price_per_1m: 0, output_price_per_1m: 0, image_price_per_call: 0, usd_to_krw: 1380 },
     ];
     await admin.from('marketing_cost_settings').upsert(defaults, { onConflict: 'clinic_id,model', ignoreDuplicates: true });

--- a/dental-clinic-manager/src/lib/marketing/image-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/image-generator.ts
@@ -1,18 +1,26 @@
 import { GoogleGenAI } from '@google/genai';
+import OpenAI, { toFile } from 'openai';
 import Anthropic from '@anthropic-ai/sdk';
 import { createClient } from '@/lib/supabase/server';
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import { seedDefaultPromptsIfNeeded } from './seed-prompts';
 import { logApiUsage } from './api-usage-logger';
+import { getImageProvider, type ImageProvider } from './image-provider-setting';
 import type { GeneratedImageMeta, ImageMarker, ImageStyleOption, ImageVisualStyle } from '@/types/marketing';
 
 // ============================================
-// AI 이미지 생성 (Gemini 3.0 Flash)
+// AI 이미지 생성 (Gemini 3.0 Flash / OpenAI gpt-image-2)
+// - 마스터가 선택한 프로바이더로 디스패치
 // - 블로그 본문의 [IMAGE: 설명] 마커에서 이미지 생성
 // - 한글 파일명 자동 생성
 // ============================================
 
+const GEMINI_IMAGE_MODEL = 'gemini-3.1-flash-image-preview';
+const GEMINI_LOG_MODEL = 'gemini-3.0-flash';
+const OPENAI_IMAGE_MODEL = 'gpt-image-2';
+
 const genai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || '' });
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || '' });
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -146,25 +154,28 @@ export async function generateBlogImage(
   fullPrompt += getImageStyleInstruction(imageStyle);
   fullPrompt += getVisualStyleInstruction(imageVisualStyle);
 
-  // 1. Gemini로 이미지 생성
-  const geminiStart = Date.now();
-  const { imageBase64, usageMetadata } = await generateImageWithGemini(fullPrompt, imageStyle, referenceImageBase64);
-  const geminiDurationMs = Date.now() - geminiStart;
+  // 1. 선택된 프로바이더로 이미지 생성
+  const provider = await getImageProvider();
+  const apiStart = Date.now();
+  const result = await dispatchImageGeneration(provider, fullPrompt, imageStyle, referenceImageBase64);
+  const apiDurationMs = Date.now() - apiStart;
 
   if (generationSessionId && resolvedClinicId) {
     logApiUsage({
       clinicId: resolvedClinicId,
       generationSessionId,
-      apiProvider: 'google',
-      model: 'gemini-3.0-flash',
+      apiProvider: result.apiProvider,
+      model: result.model,
       callType: 'image_generation',
-      inputTokens: usageMetadata?.promptTokenCount ?? 0,
-      outputTokens: usageMetadata?.candidatesTokenCount ?? 0,
-      totalTokens: usageMetadata?.totalTokenCount ?? 0,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      totalTokens: result.totalTokens,
       success: true,
-      durationMs: geminiDurationMs,
+      durationMs: apiDurationMs,
     });
   }
+
+  const imageBase64 = result.imageBase64;
 
   // 2. 한글 파일명 생성
   const fileName = await generateImageFileName(prompt, generationSessionId, resolvedClinicId);
@@ -213,28 +224,29 @@ export async function generatePlatformImage(
   }
   fullPrompt += styleInstruction + visualInstruction;
 
-  const geminiStart = Date.now();
-  const { imageBase64, usageMetadata } = await generateImageWithGemini(fullPrompt, imageStyle, referenceImageBase64);
-  const geminiDurationMs = Date.now() - geminiStart;
+  const provider = await getImageProvider();
+  const apiStart = Date.now();
+  const result = await dispatchImageGeneration(provider, fullPrompt, imageStyle, referenceImageBase64, platform);
+  const apiDurationMs = Date.now() - apiStart;
 
   if (generationSessionId && generationClinicId) {
     logApiUsage({
       clinicId: generationClinicId,
       generationSessionId,
-      apiProvider: 'google',
-      model: 'gemini-3.0-flash',
+      apiProvider: result.apiProvider,
+      model: result.model,
       callType: 'platform_image',
-      inputTokens: usageMetadata?.promptTokenCount ?? 0,
-      outputTokens: usageMetadata?.candidatesTokenCount ?? 0,
-      totalTokens: usageMetadata?.totalTokenCount ?? 0,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      totalTokens: result.totalTokens,
       success: true,
-      durationMs: geminiDurationMs,
+      durationMs: apiDurationMs,
     });
   }
 
   const fileName = await generateImageFileName(`${platform}_${prompt}`, generationSessionId, generationClinicId);
 
-  return { imageBase64, fileName };
+  return { imageBase64: result.imageBase64, fileName };
 }
 
 // ─── 기본 이미지 프롬프트 (DB 미조회 시 폴백) ───
@@ -281,6 +293,47 @@ export async function generateImagesFromMarkers(
   return results;
 }
 
+// ─── 프로바이더 디스패처 ───
+
+interface DispatchResult {
+  imageBase64: string;
+  apiProvider: 'google' | 'openai';
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+async function dispatchImageGeneration(
+  provider: ImageProvider,
+  prompt: string,
+  imageStyle?: ImageStyleOption,
+  referenceImageBase64?: string,
+  platform?: SocialPlatform,
+): Promise<DispatchResult> {
+  if (provider === 'openai') {
+    const { imageBase64, usage } = await generateImageWithOpenAI(prompt, imageStyle, referenceImageBase64, platform);
+    return {
+      imageBase64,
+      apiProvider: 'openai',
+      model: OPENAI_IMAGE_MODEL,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      totalTokens: usage.totalTokens,
+    };
+  }
+
+  const { imageBase64, usageMetadata } = await generateImageWithGemini(prompt, imageStyle, referenceImageBase64);
+  return {
+    imageBase64,
+    apiProvider: 'google',
+    model: GEMINI_LOG_MODEL,
+    inputTokens: usageMetadata?.promptTokenCount ?? 0,
+    outputTokens: usageMetadata?.candidatesTokenCount ?? 0,
+    totalTokens: usageMetadata?.totalTokenCount ?? 0,
+  };
+}
+
 // ─── Gemini 3.0 Flash API 호출 ───
 
 interface GeminiResult {
@@ -321,7 +374,7 @@ async function generateImageWithGemini(
     }
 
     const response = await genai.models.generateContent({
-      model: 'gemini-3.1-flash-image-preview',
+      model: GEMINI_IMAGE_MODEL,
       contents,
       config: {
         responseModalities: ['image', 'text'],
@@ -346,6 +399,78 @@ async function generateImageWithGemini(
     throw new Error('응답에 이미지가 포함되지 않았습니다');
   } catch (error) {
     console.error('[ImageGen] Gemini API 오류:', error);
+    throw error;
+  }
+}
+
+// ─── OpenAI gpt-image-2 API 호출 ───
+
+interface OpenAIImageResult {
+  imageBase64: string;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+  };
+}
+
+// gpt-image-2 지원 사이즈에 플랫폼 매핑
+function resolveOpenAIImageSize(platform?: SocialPlatform): '1024x1024' | '1536x1024' | '1024x1536' {
+  if (platform === 'facebook') return '1536x1024'; // 가로형
+  return '1024x1024'; // 정사각형 (기본)
+}
+
+async function generateImageWithOpenAI(
+  prompt: string,
+  imageStyle?: ImageStyleOption,
+  referenceImageBase64?: string,
+  platform?: SocialPlatform,
+): Promise<OpenAIImageResult> {
+  const size = resolveOpenAIImageSize(platform);
+
+  try {
+    let b64: string | undefined;
+    let usage: { input_tokens?: number; output_tokens?: number; total_tokens?: number } | undefined;
+
+    if (imageStyle === 'use_own_image' && referenceImageBase64) {
+      // 참조 이미지 기반 편집
+      const imageFile = await toFile(
+        Buffer.from(referenceImageBase64, 'base64'),
+        'reference.png',
+        { type: 'image/png' },
+      );
+      const response = await openai.images.edit({
+        model: OPENAI_IMAGE_MODEL,
+        image: imageFile,
+        prompt,
+        size,
+        n: 1,
+      });
+      b64 = response.data?.[0]?.b64_json;
+      usage = (response as { usage?: typeof usage }).usage;
+    } else {
+      const response = await openai.images.generate({
+        model: OPENAI_IMAGE_MODEL,
+        prompt,
+        size,
+        n: 1,
+      });
+      b64 = response.data?.[0]?.b64_json;
+      usage = (response as { usage?: typeof usage }).usage;
+    }
+
+    if (!b64) throw new Error('응답에 이미지가 포함되지 않았습니다');
+
+    return {
+      imageBase64: b64,
+      usage: {
+        inputTokens: usage?.input_tokens ?? 0,
+        outputTokens: usage?.output_tokens ?? 0,
+        totalTokens: usage?.total_tokens ?? 0,
+      },
+    };
+  } catch (error) {
+    console.error('[ImageGen] OpenAI API 오류:', error);
     throw error;
   }
 }

--- a/dental-clinic-manager/src/lib/marketing/image-provider-setting.ts
+++ b/dental-clinic-manager/src/lib/marketing/image-provider-setting.ts
@@ -1,0 +1,81 @@
+import { getSupabaseAdmin } from '@/lib/supabase/admin';
+
+// ============================================
+// 이미지 생성 모델(프로바이더) 전역 설정
+// - 마스터가 'gemini' 또는 'openai' 중 선택
+// - marketing_master_settings 테이블에 저장 (key = 'image_provider')
+// - 5분 메모리 캐시
+// ============================================
+
+export type ImageProvider = 'gemini' | 'openai';
+
+export const DEFAULT_IMAGE_PROVIDER: ImageProvider = 'gemini';
+const SETTING_KEY = 'image_provider';
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  provider: ImageProvider;
+  expiresAt: number;
+}
+
+let cache: CacheEntry | null = null;
+
+function normalize(value: string | null | undefined): ImageProvider {
+  if (value === 'openai') return 'openai';
+  return 'gemini';
+}
+
+export async function getImageProvider(): Promise<ImageProvider> {
+  if (cache && Date.now() < cache.expiresAt) {
+    return cache.provider;
+  }
+
+  const admin = getSupabaseAdmin();
+  if (!admin) return DEFAULT_IMAGE_PROVIDER;
+
+  try {
+    const { data, error } = await admin
+      .from('marketing_master_settings')
+      .select('value')
+      .eq('key', SETTING_KEY)
+      .maybeSingle();
+
+    if (error) {
+      // 테이블 부재 등: 기본값
+      console.warn('[ImageProvider] 설정 조회 실패, 기본값 사용:', error.message);
+      return DEFAULT_IMAGE_PROVIDER;
+    }
+
+    const provider = normalize(data?.value);
+    cache = { provider, expiresAt: Date.now() + CACHE_TTL_MS };
+    return provider;
+  } catch (err) {
+    console.warn('[ImageProvider] 설정 조회 예외, 기본값 사용:', err);
+    return DEFAULT_IMAGE_PROVIDER;
+  }
+}
+
+export async function setImageProvider(provider: ImageProvider, userId?: string): Promise<void> {
+  const admin = getSupabaseAdmin();
+  if (!admin) throw new Error('Admin 클라이언트를 사용할 수 없습니다.');
+
+  const { error } = await admin
+    .from('marketing_master_settings')
+    .upsert(
+      {
+        key: SETTING_KEY,
+        value: provider,
+        updated_at: new Date().toISOString(),
+        updated_by: userId ?? null,
+      },
+      { onConflict: 'key' },
+    );
+
+  if (error) throw error;
+
+  cache = { provider, expiresAt: Date.now() + CACHE_TTL_MS };
+}
+
+export function invalidateImageProviderCache(): void {
+  cache = null;
+}

--- a/dental-clinic-manager/supabase/migrations/20260422_create_marketing_master_settings.sql
+++ b/dental-clinic-manager/supabase/migrations/20260422_create_marketing_master_settings.sql
@@ -1,0 +1,38 @@
+-- ============================================
+-- 마스터 전역 설정 테이블 (key-value)
+-- - 이미지 생성 모델 선택 등 전역 스위치 저장
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS marketing_master_settings (
+  key VARCHAR(50) PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_by UUID REFERENCES users(id)
+);
+
+COMMENT ON TABLE marketing_master_settings IS '마케팅 전역 설정 (마스터 전용 key-value 스토어)';
+
+-- RLS: 읽기는 모든 로그인 사용자 허용, 쓰기는 master_admin만 허용
+ALTER TABLE marketing_master_settings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "marketing_master_settings_read" ON marketing_master_settings;
+CREATE POLICY "marketing_master_settings_read" ON marketing_master_settings
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS "marketing_master_settings_write" ON marketing_master_settings;
+CREATE POLICY "marketing_master_settings_write" ON marketing_master_settings
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'master_admin')
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'master_admin')
+  );
+
+-- 기본값 시드: 이미지 생성 모델 = gemini (기존 동작 유지)
+INSERT INTO marketing_master_settings (key, value)
+VALUES ('image_provider', 'gemini')
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary
- 마스터 계정에서 AI 글 이미지 생성 시 **Gemini 3.0 Flash** / **OpenAI gpt-image-2** 중 하나를 고를 수 있게 구현
- 전역 key-value 설정 테이블(`marketing_master_settings`) 신설 + `/api/marketing/image-provider` GET/PUT 엔드포인트 추가 (PUT은 `master_admin`만)
- `/master/marketing/costs` 페이지에 `ImageProviderSelector` UI 추가 (라디오 카드형 토글, 5분 캐시 무효화)
- 기존 Gemini 로직은 그대로 두고 `dispatchImageGeneration()` 디스패처 추가 → `openai.images.generate`/`openai.images.edit` 호출 구현 (use_own_image 모드는 edit 사용)
- 비용 설정(`marketing_cost_settings`) 기본 시드 및 UI 라벨에 `gpt-image-2` 추가
- `api-usage-logger` `apiProvider` 타입에 `'openai'` 추가, 사용량/비용 로깅은 선택된 모델명으로 기록

## 변경 파일
- `supabase/migrations/20260422_create_marketing_master_settings.sql` (신규)
- `src/lib/marketing/image-provider-setting.ts` (신규, 5분 캐시)
- `src/lib/marketing/image-generator.ts` (dispatch + OpenAI 구현 추가)
- `src/lib/marketing/api-usage-logger.ts` (`openai` 프로바이더 허용 + `gpt-image-2` 시드)
- `src/app/api/marketing/image-provider/route.ts` (신규 GET/PUT)
- `src/app/api/marketing/costs/settings/route.ts` (`gpt-image-2` 기본값 추가)
- `src/app/master/marketing/costs/ImageProviderSelector.tsx` (신규)
- `src/app/master/marketing/costs/CostDashboardContent.tsx` (셀렉터 마운트)
- `src/app/master/marketing/costs/CostSettings.tsx` (`gpt-image-2` 라벨/이미지 단가 필드)

## 배포 체크리스트
- [ ] Supabase MCP로 마이그레이션 적용: `supabase/migrations/20260422_create_marketing_master_settings.sql`
- [ ] 환경변수 `OPENAI_API_KEY` 설정
- [ ] `npm install` (이미 package.json에 `openai@^6.17.0` 포함 → 재설치만 필요)

## Test plan
- [ ] `npm run build` 통과 확인 (로컬 통과됨)
- [ ] 마스터 계정(`sani81@gmail.com`)으로 로그인 → `/master/marketing/costs` 접속 → 모델 셀렉터 렌더 확인
- [ ] Gemini → OpenAI로 토글 후 AI 글 생성 시 실제 `gpt-image-2`가 호출되는지 로그/비용 테이블 확인
- [ ] `use_own_image` 모드(참조 이미지 업로드)에서 OpenAI `images.edit` 경로가 정상 동작하는지 확인
- [ ] OpenAI → Gemini로 되돌렸을 때 기존 플로우가 그대로 동작하는지 회귀 확인
- [ ] `marketing_api_usage` 테이블에 provider/model이 올바르게 기록되는지 확인

https://claude.ai/code/session_012xBoQr2GdMhXzNdXqWbwuJ