### PR TITLE
fix: AI 분석 function_response 배열 오류 수정

### DIFF
--- a/dental-clinic-manager/ai-suggestion-worker/src/supabase.ts
+++ b/dental-clinic-manager/ai-suggestion-worker/src/supabase.ts
@@ -42,7 +42,7 @@ export interface CommunityPost {
   id: string;
   title: string;
   content: string;
-  author_id?: string | null;
+  profile_id?: string | null;
   created_at?: string;
 }
 
@@ -74,7 +74,7 @@ export async function getTaskById(taskId: string): Promise<AiSuggestionTask | nu
 export async function getPostById(postId: string): Promise<CommunityPost | null> {
   const { data, error } = await getSupabase()
     .from('community_posts')
-    .select('id, title, content, author_id, created_at')
+    .select('id, title, content, profile_id, created_at')
     .eq('id', postId)
     .maybeSingle();
   if (error) {

--- a/dental-clinic-manager/src/lib/aiAnalysisServiceV2.ts
+++ b/dental-clinic-manager/src/lib/aiAnalysisServiceV2.ts
@@ -1250,10 +1250,17 @@ export async function performAnalysisV2(
           );
           console.log(`[AI Analysis V2 Gemini] Tool result for ${name}:`, result.substring(0, 500));
 
-          // function response 구성 (thoughtSignature는 functionResponse 외부, Part 레벨에 배치)
+          // function response 구성
+          // Gemini API는 response 필드가 반드시 객체(Record)여야 함
+          // 배열이나 원시 타입이면 "cannot start list" 오류 발생 → 객체로 감싸기
           let parsedResult: Record<string, unknown>;
           try {
-            parsedResult = JSON.parse(result);
+            const parsed = JSON.parse(result);
+            if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+              parsedResult = { result: parsed };
+            } else {
+              parsedResult = parsed;
+            }
           } catch {
             parsedResult = { result: result };
           }


### PR DESCRIPTION
## Summary
- AI 분석 시 Gemini API에 보내는 function_response 형식 오류 수정
- 일부 도구(getDatabaseSchema 전체 조회 등)가 배열을 반환하면 "cannot start list" 오류 발생
- response 필드는 객체(Record)여야 하므로 배열/원시 타입은 `{ result: ... }`로 감쌈

## Test plan
- [x] `npm run build` 통과
- [ ] "올해 총 매출 알려줘" 같은 분석 질문 정상 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)