### PR TITLE
feat(community): 자유게시판 제안 글의 AI 자동 구현 카드를 master_admin에게만 노출

### DIFF
--- a/dental-clinic-manager/src/components/Community/CommunityPostDetail.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityPostDetail.tsx
@@ -168,7 +168,7 @@ export default function CommunityPostDetail({
             </div>
           )}
 
-          {/* AI 자동 구현 (제안 카테고리 전용) */}
+          {/* AI 자동 구현 (제안 카테고리 · master_admin 전용) */}
           {post.category === 'suggestion' && (
             <div className="mt-6">
               <SuggestionControlPanel postId={post.id} />

--- a/dental-clinic-manager/src/components/Community/SuggestionControlPanel.tsx
+++ b/dental-clinic-manager/src/components/Community/SuggestionControlPanel.tsx
@@ -131,6 +131,8 @@ export default function SuggestionControlPanel({ postId }: SuggestionControlPane
   const statusLabel = status ? AI_SUGGESTION_STATUS_LABELS[status] : null
   const statusBadgeClass = status ? STATUS_BADGE_CLASSES[status] : ''
 
+  if (!isMasterAdmin) return null
+
   return (
     <div className="bg-white rounded-2xl border border-at-border p-4 sm:p-6 shadow-at-card">
       <div className="flex items-center justify-between flex-wrap gap-2 mb-2">


### PR DESCRIPTION
## Summary
- 자유게시판 제안(suggestion) 카테고리 글 상세에서 일반 사용자에게 노출되던 "AI 자동 구현" 설명 카드를 숨김
- `SuggestionControlPanel`이 `master_admin`이 아닌 사용자에게는 `null`을 반환하도록 변경하여 UI 자체가 렌더링되지 않음
- `master_admin` 계정에서는 기존처럼 자동 구현 버튼과 태스크 상태 패널을 그대로 볼 수 있음

## Test plan
- [ ] 일반 사용자로 로그인 후 `제안` 카테고리 글 상세 진입 시 "AI 자동 구현" 카드가 보이지 않는지 확인
- [ ] master_admin(`sani81@gmail.com`) 계정으로 같은 글 진입 시 "AI 자동 구현" 카드와 시작/취소/재시도 버튼이 정상 노출되는지 확인
- [ ] 기존 기능(좋아요, 북마크, 댓글, 투표 등)에 영향이 없는지 확인
- [ ] `npm run build` 정상 통과 확인

https://claude.ai/code/session_01Xa97HCjLHu5TDT5ZVURJwa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xa97HCjLHu5TDT5ZVURJwa)_