### PR TITLE
fix(community): 자유 게시판 좋아요/스크랩/신고 버튼 색상 개선

### DIFF
--- a/dental-clinic-manager/src/components/Community/PostActions.tsx
+++ b/dental-clinic-manager/src/components/Community/PostActions.tsx
@@ -40,9 +40,13 @@ export default function PostActions({
         size="sm"
         onClick={handleLike}
         disabled={liking}
-        className={isLiked ? 'text-red-500 border-at-border bg-at-error-bg' : ''}
+        className={
+          isLiked
+            ? 'text-at-error border-at-error bg-at-error-bg hover:bg-at-error-bg hover:text-at-error'
+            : 'text-at-text-secondary hover:text-at-error hover:border-at-error hover:bg-at-error-bg'
+        }
       >
-        <Heart className={`w-4 h-4 mr-1.5 ${isLiked ? 'fill-red-500' : ''}`} />
+        <Heart className={`w-4 h-4 mr-1.5 ${isLiked ? 'fill-at-error' : ''}`} />
         좋아요 {likeCount > 0 && likeCount}
       </Button>
       <Button
@@ -50,13 +54,22 @@ export default function PostActions({
         size="sm"
         onClick={handleBookmark}
         disabled={bookmarking}
-        className={isBookmarked ? 'text-at-warning border-at-border bg-at-warning-bg' : ''}
+        className={
+          isBookmarked
+            ? 'text-at-warning border-at-warning bg-at-warning-bg hover:bg-at-warning-bg hover:text-at-warning'
+            : 'text-at-text-secondary hover:text-at-warning hover:border-at-warning hover:bg-at-warning-bg'
+        }
       >
-        <Bookmark className={`w-4 h-4 mr-1.5 ${isBookmarked ? 'fill-yellow-500' : ''}`} />
+        <Bookmark className={`w-4 h-4 mr-1.5 ${isBookmarked ? 'fill-at-warning' : ''}`} />
         스크랩 {bookmarkCount > 0 && bookmarkCount}
       </Button>
       <div className="flex-1" />
-      <Button variant="outline" size="sm" onClick={onReport} className="text-at-text-weak">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onReport}
+        className="text-at-error border-at-error/40 hover:text-at-error hover:border-at-error hover:bg-at-error-bg"
+      >
         <Flag className="w-4 h-4 mr-1.5" />신고
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- 자유 게시판 `PostActions` 좋아요/스크랩/신고 버튼의 색상을 Airtable 디자인 시스템 토큰 기반으로 개선
- 신고 버튼이 `text-at-text-weak`로 인해 저대비로 잘 보이지 않던 문제를 해결
- 비활성 상태의 좋아요/스크랩은 `text-at-text-secondary`로 가독성 확보, hover 시 각 semantic 색상(`at-error`/`at-warning`)으로 전환
- 신고 버튼은 `at-error` 컬러로 destructive 액션임을 시각적으로 명확히 표현

## 변경 파일
- `src/components/Community/PostActions.tsx`

## 사용된 디자인 토큰
- `--at-text-secondary` (비활성 텍스트)
- `--at-error`, `--at-error-bg` (좋아요 활성 / 신고)
- `--at-warning`, `--at-warning-bg` (스크랩 활성)

## Test plan
- [ ] 자유 게시판 게시글 상세에서 3개 버튼이 또렷하게 보이는지 확인
- [ ] 좋아요 토글 시 빨강 배경/테두리/아이콘 fill 전환되는지 확인
- [ ] 스크랩 토글 시 앰버 배경/테두리/아이콘 fill 전환되는지 확인
- [ ] 신고 버튼이 빨강 텍스트로 구분되고 hover 시 배경이 연빨강으로 바뀌는지 확인

https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb)_