### PR TITLE
fix(community): 모바일 자유 게시판 목록 우측 콘텐츠 잘림 수정

### DIFF
--- a/dental-clinic-manager/src/components/Community/CommunityPostCard.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityPostCard.tsx
@@ -29,7 +29,7 @@ export default function CommunityPostCard({ post, onClick, labelMap, colorMap }:
   return (
     <div
       onClick={() => onClick(post)}
-      className={`flex items-center px-4 py-3 hover:bg-at-surface-hover cursor-pointer transition-colors border-b border-at-border last:border-b-0 border-l-2 ${
+      className={`flex items-center gap-2 px-3 sm:px-4 py-3 hover:bg-at-surface-hover cursor-pointer transition-colors border-b border-at-border last:border-b-0 border-l-2 overflow-hidden ${
         post.is_pinned ? 'border-l-red-400 bg-at-error-bg/30' : 'border-l-transparent'
       }`}
     >
@@ -53,12 +53,12 @@ export default function CommunityPostCard({ post, onClick, labelMap, colorMap }:
         {post.has_poll && (
           <span className="text-xs px-1.5 py-0.5 rounded bg-indigo-100 text-indigo-700 flex-shrink-0">투표</span>
         )}
-        <span className="text-sm text-at-text truncate">{post.title}</span>
+        <span className="flex-1 min-w-0 text-sm text-at-text truncate">{post.title}</span>
         {(() => {
           const created = new Date(post.created_at)
           const now = new Date()
           const isToday = created.getFullYear() === now.getFullYear() && created.getMonth() === now.getMonth() && created.getDate() === now.getDate()
-          return isToday ? <span className="flex-shrink-0 ml-1 px-1 py-0.5 text-[10px] font-bold bg-red-500 text-white rounded">N</span> : null
+          return isToday ? <span className="flex-shrink-0 px-1 py-0.5 text-[10px] font-bold bg-red-500 text-white rounded">N</span> : null
         })()}
         {(post.comment_count ?? 0) > 0 && (
           <span className="flex items-center gap-0.5 text-xs text-sky-500 flex-shrink-0">
@@ -76,7 +76,7 @@ export default function CommunityPostCard({ post, onClick, labelMap, colorMap }:
         {post.profile?.nickname || '익명'}
       </div>
       {/* 작성일 */}
-      <div className="w-20 text-center text-sm text-at-text-secondary flex-shrink-0">
+      <div className="w-12 sm:w-20 text-center text-xs sm:text-sm text-at-text-secondary flex-shrink-0">
         {formatDate(post.created_at)}
       </div>
       {/* 조회수 */}

--- a/dental-clinic-manager/src/components/Community/CommunityPostList.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityPostList.tsx
@@ -186,14 +186,14 @@ export default function CommunityPostList({ profileId, isBanned, isLoggedIn, cat
         </div>
       ) : (
         <>
-          <div className="bg-white rounded-2xl border border-at-border shadow-at-card">
+          <div className="bg-white rounded-2xl border border-at-border shadow-at-card overflow-hidden">
             {/* 테이블 헤더 */}
-            <div className="flex items-center px-4 py-2 border-b border-at-border bg-at-surface-alt text-xs font-medium text-at-text-weak">
+            <div className="flex items-center gap-2 px-3 sm:px-4 py-2 border-b border-at-border bg-at-surface-alt text-xs font-medium text-at-text-weak">
               <div className="w-5 flex-shrink-0" />
               <div className="hidden sm:block w-20 flex-shrink-0 text-center">분류</div>
               <div className="flex-1 min-w-0 text-center">제목</div>
               <div className="hidden sm:block w-20 text-center flex-shrink-0">작성자</div>
-              <div className="w-20 text-center flex-shrink-0">작성일</div>
+              <div className="w-12 sm:w-20 text-center flex-shrink-0">작성일</div>
               <div className="hidden sm:block w-12 text-center flex-shrink-0">조회</div>
             </div>
             {posts.map((post) => (


### PR DESCRIPTION
## Summary
- 모바일(sm 미만)에서 자유 게시판 목록의 **우측 콘텐츠가 잘리는 문제** 수정
- 근본 원인: 제목 영역 내부의 칩(분류/투표/N/댓글/좋아요)이 모두 `flex-shrink-0`인데 제목 `<span>`에 `flex-1 min-w-0`이 없어서 실제 공간이 부족할 때도 truncate가 작동하지 않아 행 전체가 뷰포트 폭을 초과 → 작성일 칸이 화면 밖으로 밀림
- 작성일 칸이 `w-20`(80px)로 모바일에 비해 과도함

## 변경 내역
- `CommunityPostCard.tsx`
  - 제목 span: `flex-1 min-w-0 truncate` 추가 → 공간 부족 시 자동 축약
  - 행: `overflow-hidden`, 모바일 `px-3` (데스크톱 `sm:px-4` 유지), `gap-2` 추가
  - 작성일 칸: `w-12 sm:w-20`, `text-xs sm:text-sm` (모바일에서만 축소)
- `CommunityPostList.tsx`
  - 헤더 행 컬럼 폭을 카드와 동일하게 맞춤 (정렬 유지)
  - 카드 컨테이너에 `overflow-hidden` 추가

## Test plan
- [ ] 모바일 뷰(375px, 414px)에서 목록 행의 작성일이 잘리지 않고 보이는지 확인
- [ ] 제목이 긴 경우 `...` 으로 축약되는지 확인
- [ ] 댓글/좋아요 카운트, N 배지, 투표 배지가 모바일에서도 정상 표기되는지 확인
- [ ] sm 이상(데스크톱)에서 기존 레이아웃(분류/작성자/작성일/조회) 변동 없는지 확인
- [ ] 헤더 행과 카드 행의 컬럼 정렬이 일치하는지 확인

https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb)_