### PR TITLE
fix(community): 다크모드 PostActions 좋아요/스크랩/신고 버튼 가독성 수정

### DIFF
--- a/dental-clinic-manager/src/components/Community/PostActions.tsx
+++ b/dental-clinic-manager/src/components/Community/PostActions.tsx
@@ -42,8 +42,8 @@ export default function PostActions({
         disabled={liking}
         className={
           isLiked
-            ? 'text-at-error border-at-error bg-at-error-bg hover:bg-at-error-bg hover:text-at-error'
-            : 'text-at-text-secondary hover:text-at-error hover:border-at-error hover:bg-at-error-bg'
+            ? 'bg-at-error-bg text-at-error border-at-error hover:bg-at-error-bg hover:text-at-error'
+            : 'bg-white text-at-text-secondary hover:bg-at-error-bg hover:text-at-error hover:border-at-error'
         }
       >
         <Heart className={`w-4 h-4 mr-1.5 ${isLiked ? 'fill-at-error' : ''}`} />
@@ -56,8 +56,8 @@ export default function PostActions({
         disabled={bookmarking}
         className={
           isBookmarked
-            ? 'text-at-warning border-at-warning bg-at-warning-bg hover:bg-at-warning-bg hover:text-at-warning'
-            : 'text-at-text-secondary hover:text-at-warning hover:border-at-warning hover:bg-at-warning-bg'
+            ? 'bg-at-warning-bg text-at-warning border-at-warning hover:bg-at-warning-bg hover:text-at-warning'
+            : 'bg-white text-at-text-secondary hover:bg-at-warning-bg hover:text-at-warning hover:border-at-warning'
         }
       >
         <Bookmark className={`w-4 h-4 mr-1.5 ${isBookmarked ? 'fill-at-warning' : ''}`} />
@@ -68,7 +68,7 @@ export default function PostActions({
         variant="outline"
         size="sm"
         onClick={onReport}
-        className="text-at-error border-at-error/40 hover:text-at-error hover:border-at-error hover:bg-at-error-bg"
+        className="bg-white text-at-error border-at-error/40 hover:bg-at-error-bg hover:text-at-error hover:border-at-error"
       >
         <Flag className="w-4 h-4 mr-1.5" />신고
       </Button>


### PR DESCRIPTION
## Summary
- **모바일 시스템 다크모드**에서 자유 게시판의 **좋아요/스크랩/신고 버튼이 검정으로 보이고 글자가 안 보이는 문제** 수정
- 원인: `Button` `outline` variant가 `bg-background`를 사용하는데, `globals.css`의 `@media (prefers-color-scheme: dark)`에서 `--background`가 `#0a0a0a`(검정)로 덮어써짐. `text-at-text-secondary` 등 디자인 토큰은 다크모드에서도 값이 동일하여 검정 위 어두운 글씨가 되어 안 보임.
- 수정: 세 버튼에 `bg-white`(활성 상태 한정 `bg-at-error-bg` / `bg-at-warning-bg`)을 명시적으로 지정하여 시스템 테마와 무관하게 밝은 배경 유지.

## 변경 파일
- `src/components/Community/PostActions.tsx`

## Test plan
- [ ] 모바일에서 시스템 다크모드 ON 상태로 게시글 상세 진입 시 세 버튼이 흰 배경 + 컬러 텍스트로 또렷하게 보이는지 확인
- [ ] 라이트모드에서도 기존 디자인 그대로 유지되는지 확인
- [ ] 좋아요/스크랩 활성 토글 시 각각 `at-error-bg` / `at-warning-bg` 배경과 컬러 아이콘 fill 정상 동작
- [ ] hover 시 각 semantic 배경으로 부드럽게 전환되는지 확인

https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb)_