### PR TITLE
fix(community): 자유 게시판 목록 우측 잘림 재수정 (overflow-hidden)

### DIFF
--- a/dental-clinic-manager/src/components/Community/CommunityPostCard.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityPostCard.tsx
@@ -46,7 +46,7 @@ export default function CommunityPostCard({ post, onClick, labelMap, colorMap }:
         </span>
       </div>
       {/* 제목 */}
-      <div className="flex-1 min-w-0 flex items-center gap-1.5">
+      <div className="flex-1 min-w-0 flex items-center gap-1.5 overflow-hidden">
         <span className={`sm:hidden text-xs px-1.5 py-0.5 rounded flex-shrink-0 ${colors[post.category] || 'bg-at-surface-alt text-at-text-secondary'}`}>
           {labels[post.category] || post.category}
         </span>
@@ -61,12 +61,12 @@ export default function CommunityPostCard({ post, onClick, labelMap, colorMap }:
           return isToday ? <span className="flex-shrink-0 px-1 py-0.5 text-[10px] font-bold bg-red-500 text-white rounded">N</span> : null
         })()}
         {(post.comment_count ?? 0) > 0 && (
-          <span className="flex items-center gap-0.5 text-xs text-sky-500 flex-shrink-0">
+          <span className="hidden sm:flex items-center gap-0.5 text-xs text-sky-500 flex-shrink-0">
             <MessageSquare className="w-3 h-3" />{post.comment_count}
           </span>
         )}
         {(post.like_count ?? 0) > 0 && (
-          <span className="flex items-center gap-0.5 text-xs text-red-400 flex-shrink-0">
+          <span className="hidden sm:flex items-center gap-0.5 text-xs text-red-400 flex-shrink-0">
             <Heart className={`w-3 h-3 ${post.is_liked ? 'fill-red-500 text-red-500' : ''}`} />{post.like_count}
           </span>
         )}


### PR DESCRIPTION
## Summary
- 모바일에서 자유 게시판 목록의 **우측(작성일) 칸이 여전히 가려지는 문제** 재수정
- 이전 PR #363로 `flex-1 min-w-0 truncate`를 제목 span에 적용했지만, 제목 컨테이너가 `overflow: visible`이어서 내부 `flex-shrink-0` 칩들의 자연 폭 합계가 할당된 flex-1 공간을 초과할 때 시각적으로 오른쪽 sibling(작성일)을 덮어버리는 근본 원인이 남아 있었음

## 근본 원인 (5 Whys)
1. 사용자: "우측(작성일)이 안 보인다"
2. 왜? → 제목 내부 칩들이 시각적으로 작성일 칸 위로 올라옴
3. 왜? → 제목 flex 컨테이너가 `overflow: visible`이라 내부 콘텐츠가 자기 박스 밖으로 튀어나감
4. 왜? → 제목 내부 칩은 `flex-shrink-0`이라 축소되지 않고 자연 폭을 유지하기 때문
5. 왜? → 제목 컨테이너에 `overflow-hidden`이 지정돼 있지 않아서 → 여기서 fix

## 변경 내역
`src/components/Community/CommunityPostCard.tsx`
- 제목 flex 컨테이너: `overflow-hidden` 추가 → 칩 오버플로우가 오른쪽 칸(작성일)을 침범하지 않도록 함
- 모바일(sm 미만)에서 댓글/좋아요 카운트 칩: `hidden sm:flex`로 숨김 → 좁은 화면에서 제목을 위한 공간 확보
- 기존 sm 이상(데스크톱) 레이아웃 및 나머지 기능은 동일하게 유지

## Test plan
- [ ] 모바일(375px, 414px)에서 글 목록의 작성일이 항상 온전히 보이는지 확인
- [ ] 제목이 매우 긴 경우 `...`로 축약되고 작성일은 가려지지 않는지 확인
- [ ] 카테고리 칩/투표 칩/N 배지 조합이 모두 있는 글에서도 작성일이 보이는지 확인
- [ ] sm 이상(데스크톱)에서 기존 분류/작성자/작성일/조회 4열 + 댓글·좋아요 카운트 칩이 정상 표시되는지 확인

https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb)_