### PR TITLE
fix(community): 자유 게시판 모바일 가로 오버플로우 근본 수정

### DIFF
--- a/dental-clinic-manager/src/app/dashboard/community/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/community/page.tsx
@@ -131,7 +131,7 @@ export default function CommunityPage() {
 
       <div className="flex gap-6">
         {/* 메인 영역 */}
-        <div className="flex-1">
+        <div className="flex-1 min-w-0">
           <div className="flex justify-end gap-2 mb-4 xl:hidden">
             {profile && (
               <button

--- a/dental-clinic-manager/src/components/Community/CommunityPostList.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityPostList.tsx
@@ -102,7 +102,7 @@ export default function CommunityPostList({ profileId, isBanned, isLoggedIn, cat
     <div className="space-y-4">
       {/* 상단 액션 바 */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <button
             onClick={() => { setSort('latest'); setPage(1) }}
             className={`text-sm font-medium px-3 py-1 rounded-xl ${sort === 'latest' ? 'bg-at-text text-white' : 'text-at-text-weak hover:bg-at-surface-hover'}`}


### PR DESCRIPTION
## 문제
업로드해 주신 두 스크린샷(자유게시판 리스트 / 게시글 상세)에서 모두 **페이지 우측이 잘려 보이는 현상** 확인.
- 리스트 화면: 상단 "내 스크랩" 텍스트가 "내 스"에서 잘림, 검색창/행 콘텐츠가 오른쪽으로 넘침
- 상세 화면: 전체 레이아웃이 약간 오른쪽으로 밀려 보임

## 근본 원인 (5 Whys)
1. 왜 우측이 잘리나? → **body 전체에 가로 스크롤**이 생기고 있음
2. 왜 가로 스크롤이? → 어떤 자식 요소가 **뷰포트 폭을 초과**
3. 왜? → `CommunityPage`의 메인 영역 `<div className="flex-1">`이 `min-w-0` 없이 렌더링됨. flex 아이템의 기본 `min-width: auto`는 콘텐츠 자연 폭 이하로 축소되지 않아서, 긴 자식이 있으면 flex 아이템이 뷰포트보다 커짐
4. 어떤 자식이 넘치는가? → `CommunityPostList` 상단 정렬 버튼 바(최신/인기/내 좋아요/내 스크랩) 4개 버튼이 `flex-wrap` 없이 한 줄 배치 → 좁은 모바일에서 자연 폭이 뷰포트 초과
5. → 메인 영역 `flex-1`에 `min-w-0` 추가(근본) + 정렬 버튼 컨테이너에 `flex-wrap` 추가(증상)

## 변경 파일
- `src/app/dashboard/community/page.tsx` — `flex-1` → `flex-1 min-w-0`
- `src/components/Community/CommunityPostList.tsx` — 정렬 버튼 컨테이너에 `flex-wrap` 추가

## Test plan
- [ ] 모바일(360, 375, 414px)에서 리스트 페이지 가로 스크롤 없음 확인
- [ ] "내 스크랩" 버튼이 잘리지 않고 다음 줄로 wrap되는지 확인
- [ ] 상세 화면도 우측이 잘리지 않고 전체가 뷰포트 안에 들어오는지 확인
- [ ] 데스크톱(sm 이상)에서 기존 한 줄 레이아웃 유지 확인

https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb)_