### PR TITLE
feat(investment): 전략 관리 페이지 전략 수정 기능 구현

### DIFF
--- a/dental-clinic-manager/src/app/investment/strategy/[id]/edit/page.tsx
+++ b/dental-clinic-manager/src/app/investment/strategy/[id]/edit/page.tsx
@@ -1,27 +1,401 @@
 'use client'
 
-import { ArrowLeft, Edit3 } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
+import { ArrowLeft, ChevronRight, Sparkles, Settings2, Shield, Zap, AlertCircle } from 'lucide-react'
+import IndicatorPanel from '@/components/Investment/StrategyBuilder/IndicatorPanel'
+import ConditionBuilder from '@/components/Investment/StrategyBuilder/ConditionBuilder'
+import RiskSettingsPanel from '@/components/Investment/StrategyBuilder/RiskSettingsPanel'
+import type {
+  InvestmentStrategy,
+  Market, Timeframe, AutomationLevel,
+  IndicatorConfig, ConditionGroup, RiskSettings,
+} from '@/types/investment'
+
+type Step = 'basic' | 'indicators' | 'conditions' | 'risk'
+
+const EMPTY_GROUP: ConditionGroup = { type: 'group', operator: 'AND', conditions: [] }
+const DEFAULT_RISK: RiskSettings = {
+  maxDailyLossPercent: 2,
+  maxPositions: 5,
+  maxPositionSizePercent: 20,
+  stopLossPercent: 7,
+  takeProfitPercent: 15,
+  maxHoldingDays: 30,
+}
 
 export default function EditStrategyPage() {
+  const params = useParams<{ id: string }>()
+  const router = useRouter()
+  const strategyId = params?.id
+
+  const [step, setStep] = useState<Step>('basic')
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [isActive, setIsActive] = useState(false)
+
+  // 폼 상태
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [market, setMarket] = useState<Market>('KR')
+  const [timeframe, setTimeframe] = useState<Timeframe>('1d')
+  const [automationLevel, setAutomationLevel] = useState<AutomationLevel>(1)
+  const [indicators, setIndicators] = useState<IndicatorConfig[]>([])
+  const [buyConditions, setBuyConditions] = useState<ConditionGroup>(EMPTY_GROUP)
+  const [sellConditions, setSellConditions] = useState<ConditionGroup>(EMPTY_GROUP)
+  const [riskSettings, setRiskSettings] = useState<RiskSettings>(DEFAULT_RISK)
+
+  // 기존 전략 로드
+  useEffect(() => {
+    if (!strategyId) return
+    let cancelled = false
+    ;(async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetch('/api/investment/strategies')
+        const json = await res.json()
+        if (!res.ok) throw new Error(json.error || '전략 조회 실패')
+        const list: InvestmentStrategy[] = json.data || []
+        const found = list.find(s => s.id === strategyId)
+        if (!found) throw new Error('전략을 찾을 수 없습니다')
+        if (cancelled) return
+        setName(found.name || '')
+        setDescription(found.description || '')
+        setMarket(found.target_market)
+        setTimeframe(found.timeframe)
+        setAutomationLevel(found.automation_level)
+        setIndicators(found.indicators || [])
+        setBuyConditions(found.buy_conditions || EMPTY_GROUP)
+        setSellConditions(found.sell_conditions || EMPTY_GROUP)
+        setRiskSettings({ ...DEFAULT_RISK, ...(found.risk_settings || {}) })
+        setIsActive(!!found.is_active)
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : '불러오기 실패')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [strategyId])
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      alert('전략 이름을 입력해주세요')
+      return
+    }
+    if (!strategyId) return
+    setSaving(true)
+    try {
+      const payload: Record<string, unknown> = {
+        id: strategyId,
+        name: name.trim(),
+        description: description.trim() || null,
+        riskSettings,
+        automationLevel,
+      }
+      // 비활성 전략일 때만 불변 필드 전송 (활성 전략에서는 API가 거부)
+      if (!isActive) {
+        payload.targetMarket = market
+        payload.timeframe = timeframe
+        payload.indicators = indicators
+        payload.buyConditions = buyConditions
+        payload.sellConditions = sellConditions
+      }
+
+      const res = await fetch('/api/investment/strategies', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const json = await res.json()
+      if (res.ok) {
+        router.push('/investment/strategy')
+      } else {
+        alert(json.error || '저장 실패')
+      }
+    } catch {
+      alert('네트워크 오류')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const steps: { id: Step; label: string; icon: React.ReactNode }[] = [
+    { id: 'basic', label: '기본 설정', icon: <Settings2 className="w-4 h-4" /> },
+    { id: 'indicators', label: '지표 선택', icon: <Sparkles className="w-4 h-4" /> },
+    { id: 'conditions', label: '매매 조건', icon: <Zap className="w-4 h-4" /> },
+    { id: 'risk', label: '리스크 관리', icon: <Shield className="w-4 h-4" /> },
+  ]
+  const currentIndex = steps.findIndex(s => s.id === step)
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <Link href="/investment/strategy" className="p-2 rounded-lg hover:bg-at-surface-alt transition-colors">
+            <ArrowLeft className="w-5 h-5 text-at-text-secondary" />
+          </Link>
+          <h1 className="text-xl font-bold text-at-text">전략 수정</h1>
+        </div>
+        <div className="bg-white rounded-2xl shadow-sm border border-at-border p-12 flex items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-at-accent" />
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <Link href="/investment/strategy" className="p-2 rounded-lg hover:bg-at-surface-alt transition-colors">
+            <ArrowLeft className="w-5 h-5 text-at-text-secondary" />
+          </Link>
+          <h1 className="text-xl font-bold text-at-text">전략 수정</h1>
+        </div>
+        <div className="bg-white rounded-2xl shadow-sm border border-at-border p-8 text-center">
+          <AlertCircle className="w-10 h-10 text-at-error mx-auto mb-3" />
+          <p className="text-sm text-at-text">{error}</p>
+          <Link
+            href="/investment/strategy"
+            className="inline-block mt-4 px-4 py-2 rounded-xl bg-at-surface-alt text-at-text-secondary text-sm hover:bg-at-border transition-colors"
+          >
+            목록으로 돌아가기
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-6">
+      {/* 헤더 */}
       <div className="flex items-center gap-3">
-        <Link href="/dashboard?tab=investment" className="p-2 rounded-lg hover:bg-at-surface-alt transition-colors">
+        <Link href="/investment/strategy" className="p-2 rounded-lg hover:bg-at-surface-alt transition-colors">
           <ArrowLeft className="w-5 h-5 text-at-text-secondary" />
         </Link>
         <div>
           <h1 className="text-xl font-bold text-at-text">전략 수정</h1>
+          <p className="text-sm text-at-text-secondary mt-0.5">기존 전략의 설정을 변경합니다</p>
         </div>
       </div>
 
-      <div className="bg-white rounded-2xl shadow-sm border border-at-border p-8">
-        <div className="flex flex-col items-center justify-center py-8 text-at-text-weak">
-          <Edit3 className="w-12 h-12 mb-3 opacity-30" />
-          <p className="text-sm font-medium">전략 편집 기능은 다음 업데이트에서 제공됩니다</p>
-          <p className="text-xs mt-1">현재는 전략을 삭제하고 새로 만들어주세요</p>
+      {/* 활성 전략 경고 */}
+      {isActive && (
+        <div className="flex items-start gap-3 bg-at-warning-bg border border-at-warning/30 rounded-xl p-4">
+          <AlertCircle className="w-5 h-5 text-at-warning flex-shrink-0 mt-0.5" />
+          <div className="text-sm">
+            <p className="font-medium text-at-warning">활성 중인 전략입니다</p>
+            <p className="text-at-text-secondary mt-1">
+              이름/설명/리스크/자동화 수준만 수정할 수 있습니다. 시장·시간프레임·지표·매매 조건을 바꾸려면 먼저 목록 페이지에서 전략을 비활성화해주세요.
+            </p>
+          </div>
         </div>
+      )}
+
+      {/* 스텝 인디케이터 */}
+      <div className="flex items-center gap-2 flex-wrap">
+        {steps.map((s, i) => (
+          <div key={s.id} className="flex items-center">
+            <button
+              onClick={() => setStep(s.id)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                s.id === step
+                  ? 'bg-at-accent text-white'
+                  : i < currentIndex
+                    ? 'bg-at-accent-light text-at-accent'
+                    : 'bg-at-bg text-at-text-weak'
+              }`}
+            >
+              {s.icon}
+              <span className="hidden sm:inline">{s.label}</span>
+            </button>
+            {i < steps.length - 1 && <ChevronRight className="w-4 h-4 text-at-text-weak mx-1" />}
+          </div>
+        ))}
       </div>
+
+      {/* 스텝별 콘텐츠 */}
+      {step === 'basic' && (
+        <div className="space-y-6">
+          <div className="bg-white rounded-2xl shadow-sm border border-at-border p-5 space-y-4">
+            <h2 className="font-semibold text-at-text">기본 설정</h2>
+            <div>
+              <label className="block text-sm text-at-text-secondary mb-1">전략 이름 *</label>
+              <input
+                type="text"
+                value={name}
+                onChange={e => setName(e.target.value)}
+                placeholder="예: RSI 과매도 반등"
+                className="w-full px-3 py-2 rounded-xl border border-at-border bg-at-bg text-at-text text-sm focus:outline-none focus:border-at-accent"
+                maxLength={100}
+              />
+            </div>
+            <div>
+              <label className="block text-sm text-at-text-secondary mb-1">설명</label>
+              <textarea
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                placeholder="전략에 대한 간단한 설명"
+                rows={2}
+                className="w-full px-3 py-2 rounded-xl border border-at-border bg-at-bg text-at-text text-sm focus:outline-none focus:border-at-accent resize-none"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm text-at-text-secondary mb-1">시장</label>
+                <select
+                  value={market}
+                  onChange={e => setMarket(e.target.value as Market)}
+                  disabled={isActive}
+                  className="w-full px-3 py-2 rounded-xl border border-at-border bg-at-bg text-at-text text-sm focus:outline-none focus:border-at-accent disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  <option value="KR">국내 (KOSPI/KOSDAQ)</option>
+                  <option value="US">미국 (NYSE/NASDAQ)</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm text-at-text-secondary mb-1">시간 프레임</label>
+                <select
+                  value={timeframe}
+                  onChange={e => setTimeframe(e.target.value as Timeframe)}
+                  disabled={isActive}
+                  className="w-full px-3 py-2 rounded-xl border border-at-border bg-at-bg text-at-text text-sm focus:outline-none focus:border-at-accent disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  <option value="1d">일봉</option>
+                  <option value="1h">1시간봉</option>
+                  <option value="15m">15분봉</option>
+                  <option value="5m">5분봉</option>
+                  <option value="1w">주봉</option>
+                </select>
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm text-at-text-secondary mb-1">자동화 수준</label>
+              <div className="flex gap-3">
+                <button
+                  onClick={() => setAutomationLevel(1)}
+                  className={`flex-1 p-3 rounded-xl border text-sm text-left transition-colors ${
+                    automationLevel === 1
+                      ? 'border-at-accent bg-at-accent-light/30'
+                      : 'border-at-border hover:border-at-accent/50'
+                  }`}
+                >
+                  <p className="font-medium text-at-text">Level 1: 알림만</p>
+                  <p className="text-xs text-at-text-secondary mt-0.5">신호 발생 시 Telegram 알림</p>
+                </button>
+                <button
+                  onClick={() => setAutomationLevel(2)}
+                  className={`flex-1 p-3 rounded-xl border text-sm text-left transition-colors ${
+                    automationLevel === 2
+                      ? 'border-at-accent bg-at-accent-light/30'
+                      : 'border-at-border hover:border-at-accent/50'
+                  }`}
+                >
+                  <p className="font-medium text-at-text">Level 2: 완전 자동</p>
+                  <p className="text-xs text-at-text-secondary mt-0.5">자동 주문 + 결과 보고</p>
+                </button>
+              </div>
+            </div>
+          </div>
+          <button
+            onClick={() => setStep('indicators')}
+            className="w-full py-3 bg-at-accent text-white rounded-xl font-medium hover:bg-at-accent-hover transition-colors"
+          >
+            다음: 지표 선택
+          </button>
+        </div>
+      )}
+
+      {step === 'indicators' && (
+        <div className="space-y-4">
+          {isActive && (
+            <div className="text-xs text-at-text-secondary bg-at-surface-alt rounded-lg px-3 py-2">
+              활성 전략에서는 지표를 수정할 수 없습니다 (읽기 전용).
+            </div>
+          )}
+          <div className={isActive ? 'pointer-events-none opacity-60' : ''}>
+            <IndicatorPanel indicators={indicators} onChange={setIndicators} />
+          </div>
+          <div className="flex gap-3">
+            <button
+              onClick={() => setStep('basic')}
+              className="flex-1 py-3 border border-at-border text-at-text rounded-xl font-medium hover:bg-at-surface-alt transition-colors"
+            >
+              이전
+            </button>
+            <button
+              onClick={() => setStep('conditions')}
+              className="flex-1 py-3 bg-at-accent text-white rounded-xl font-medium hover:bg-at-accent-hover transition-colors"
+            >
+              다음: 매매 조건
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === 'conditions' && (
+        <div className="space-y-4">
+          {isActive && (
+            <div className="text-xs text-at-text-secondary bg-at-surface-alt rounded-lg px-3 py-2">
+              활성 전략에서는 매매 조건을 수정할 수 없습니다 (읽기 전용).
+            </div>
+          )}
+          <div className={isActive ? 'pointer-events-none opacity-60' : ''}>
+            <ConditionBuilder
+              label="매수 조건"
+              conditions={buyConditions}
+              onChange={setBuyConditions}
+              indicators={indicators}
+            />
+            <div className="h-4" />
+            <ConditionBuilder
+              label="매도 조건"
+              conditions={sellConditions}
+              onChange={setSellConditions}
+              indicators={indicators}
+            />
+          </div>
+          <div className="flex gap-3">
+            <button
+              onClick={() => setStep('indicators')}
+              className="flex-1 py-3 border border-at-border text-at-text rounded-xl font-medium hover:bg-at-surface-alt transition-colors"
+            >
+              이전
+            </button>
+            <button
+              onClick={() => setStep('risk')}
+              className="flex-1 py-3 bg-at-accent text-white rounded-xl font-medium hover:bg-at-accent-hover transition-colors"
+            >
+              다음: 리스크 관리
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === 'risk' && (
+        <div className="space-y-4">
+          <RiskSettingsPanel riskSettings={riskSettings} onChange={setRiskSettings} />
+          <div className="flex gap-3">
+            <button
+              onClick={() => setStep('conditions')}
+              className="flex-1 py-3 border border-at-border text-at-text rounded-xl font-medium hover:bg-at-surface-alt transition-colors"
+            >
+              이전
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving || !name.trim()}
+              className="flex-1 py-3 bg-at-accent text-white rounded-xl font-medium hover:bg-at-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {saving ? '저장 중...' : '변경 사항 저장'}
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
주식 자동 매매의 **전략 관리 페이지에 전략 수정 기능** 구현. 기존 `/investment/strategy/[id]/edit` 페이지는 "다음 업데이트" 메시지만 보여주는 스텁 상태였음.

## 구현 내용
- GET `/api/investment/strategies`로 기존 전략 조회 후 `id`로 필터링하여 폼에 프리필
- 새 전략 페이지(`/investment/strategy/new`)와 동일한 **4-스텝 UI**(기본/지표/매매조건/리스크)를 재사용해 UX 일관성 유지
- 저장은 PATCH `/api/investment/strategies`로 전송
- **활성(is_active=true) 전략은 API 정책에 따라 일부 필드만 수정 가능**
  - 시장/시간프레임 select는 `disabled`
  - 지표/매매조건 섹션은 `pointer-events-none + opacity-60` + 안내 문구 표시
  - 저장 payload에서도 불변 필드를 자동 제외해 서버에서 4xx 오류가 나지 않도록 방지
- 로딩/에러 상태 UI 포함 (전략을 찾을 수 없을 때 목록으로 돌아가기 링크)

## 변경 파일
- `src/app/investment/strategy/[id]/edit/page.tsx`

## 기존 기능 영향
- 전략 관리 리스트 페이지의 Edit 버튼 링크(`/investment/strategy/[id]/edit`)는 이미 연결돼 있었음 → 별도 수정 불필요
- POST/GET/PATCH/DELETE API 라우트 변경 없음
- 공용 컴포넌트(IndicatorPanel/ConditionBuilder/RiskSettingsPanel) 변경 없음

## Test plan
- [ ] 전략 관리 페이지에서 연필 아이콘 클릭 → 편집 페이지 정상 진입
- [ ] 기존 이름/설명/시장/시간프레임/자동화/지표/매매조건/리스크 값이 프리필되는지 확인
- [ ] 비활성 전략에서 모든 필드 수정 + 저장 성공 시 목록으로 복귀
- [ ] 활성 전략에서 이름/설명/리스크/자동화 수정 가능, 지표·조건은 읽기 전용으로 표시
- [ ] 잘못된 id로 접근 시 "전략을 찾을 수 없습니다" 에러 UI + 목록으로 돌아가기 링크

https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb)_