### PR TITLE
fix(investment): 모바일 전략 관리 카드 액션 버튼 잘림 수정

### DIFF
--- a/dental-clinic-manager/src/app/investment/strategy/page.tsx
+++ b/dental-clinic-manager/src/app/investment/strategy/page.tsx
@@ -93,10 +93,10 @@ export default function StrategyListPage() {
         <div className="space-y-3">
           {strategies.map(s => (
             <div key={s.id} className="bg-white rounded-2xl shadow-sm border border-at-border p-5">
-              <div className="flex items-start justify-between">
-                <div className="flex-1">
-                  <div className="flex items-center gap-2">
-                    <h3 className="font-semibold text-at-text">{s.name}</h3>
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <h3 className="font-semibold text-at-text break-all">{s.name}</h3>
                     <span className={`px-2 py-0.5 text-xs rounded-full font-medium ${
                       s.is_active
                         ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
@@ -109,15 +109,15 @@ export default function StrategyListPage() {
                     </span>
                   </div>
                   {s.description && (
-                    <p className="text-xs text-at-text-secondary mt-1">{s.description}</p>
+                    <p className="text-xs text-at-text-secondary mt-1 break-words">{s.description}</p>
                   )}
-                  <div className="flex items-center gap-4 mt-2 text-xs text-at-text-weak">
+                  <div className="flex items-center gap-x-4 gap-y-1 mt-2 text-xs text-at-text-weak flex-wrap">
                     <span>시간프레임: {s.timeframe}</span>
                     <span>지표: {(s.indicators as unknown[]).length}개</span>
                     <span>자동화: {LEVEL_LABELS[s.automation_level] || s.automation_level}</span>
                   </div>
                 </div>
-                <div className="flex items-center gap-1.5">
+                <div className="flex items-center gap-1.5 flex-shrink-0">
                   <button
                     onClick={() => setBacktestStrategyId(s.id)}
                     className="p-2 rounded-lg hover:bg-at-bg transition-colors text-at-text-secondary"
@@ -141,8 +141,8 @@ export default function StrategyListPage() {
                   </button>
                   <button
                     onClick={() => deleteStrategy(s.id)}
-                    className="p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors text-red-400"
-                    title="삭제"
+                    className="p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors text-red-400 disabled:opacity-40 disabled:cursor-not-allowed"
+                    title={s.is_active ? '활성 전략은 삭제 전 비활성화 필요' : '삭제'}
                     disabled={s.is_active}
                   >
                     <Trash2 className="w-4 h-4" />


### PR DESCRIPTION
## 문제
모바일에서 **전략 관리 페이지 카드의 우측 액션 아이콘들(백테스트/수정/활성/삭제)이 화면 밖으로 밀려 보이지 않음** → 전략 수정 불가.

## 근본 원인 (5 Whys)
1. 수정 버튼 안 보임 → 우측 액션 컬럼이 뷰포트 밖으로 밀림
2. 왜? → 좌측 `flex-1` 컬럼이 모바일 폭을 초과
3. 왜? → flex 아이템 기본 `min-width: auto` 때문에 콘텐츠 자연 폭 이하로 축소되지 않음
4. 왜 좌측이 넓어지나? → 이름+뱃지 줄과 메타데이터 줄에 `flex-wrap`이 없어 한 줄 고정 배치
5. 수정 방법 → 좌측 `min-w-0` + 내부 `flex-wrap` + 우측 `flex-shrink-0`

## 변경 내용
`src/app/investment/strategy/page.tsx`
- 좌측 `flex-1` → `flex-1 min-w-0`
- 이름/뱃지 행에 `flex-wrap`, 긴 전략명에 대비해 `break-all`
- 메타데이터(시간프레임/지표/자동화) 행에 `flex-wrap` (`gap-x-4 gap-y-1`)
- 설명에 `break-words`
- 우측 액션 컬럼에 `flex-shrink-0` 추가 (항상 노출)
- 삭제 버튼 `disabled`일 때 안내 타이틀 + 스타일 보강 (기존 기능 동작 동일)

## Test plan
- [ ] 모바일(360/375/414px)에서 각 카드의 수정(연필) 버튼이 정상적으로 보이는지 확인
- [ ] 긴 전략명/여러 뱃지가 있어도 우측 버튼이 잘리지 않고 표시되는지
- [ ] 좁은 화면에서 메타데이터가 자연스럽게 다음 줄로 wrap 되는지
- [ ] 데스크톱에서 기존 한 줄 레이아웃 유지
- [ ] 활성 전략일 때 삭제 버튼 disabled + 안내 tooltip 표시

https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb)_