### PR TITLE
feat(investment): StrategyCard에 수정 버튼 추가 + 모바일 보강

### DIFF
--- a/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import Link from 'next/link'
 import {
-  Play, Pause, Trash2, BarChart3, ChevronDown, ChevronUp,
-  Plus, X, CheckCircle2, AlertCircle, Target, Eye,
+  Play, Pause, Trash2, BarChart3, ChevronDown, ChevronUp, Edit3,
+  X, CheckCircle2, AlertCircle, Target, Eye,
 } from 'lucide-react'
 import TickerSearch from './TickerSearch'
 import type { InvestmentStrategy, Market } from '@/types/investment'
@@ -105,10 +106,10 @@ export default function StrategyCard({ strategy, hasCredential, onRefresh, onBac
   return (
     <div className="bg-white rounded-2xl shadow-sm border border-at-border p-5">
       {/* 상단 헤더 */}
-      <div className="flex items-start justify-between mb-3">
-        <div className="flex-1">
+      <div className="flex items-start justify-between gap-2 mb-3">
+        <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            <h3 className="font-semibold text-at-text">{strategy.name}</h3>
+            <h3 className="font-semibold text-at-text break-all">{strategy.name}</h3>
             <span className={`px-2 py-0.5 text-xs rounded-full font-medium ${
               strategy.is_active
                 ? 'bg-green-50 text-at-success border border-green-200'
@@ -121,18 +122,25 @@ export default function StrategyCard({ strategy, hasCredential, onRefresh, onBac
               Level {strategy.automation_level} ({strategy.automation_level === 1 ? '알림만' : '완전자동'})
             </span>
           </div>
-          {strategy.description && <p className="text-xs text-at-text-secondary mt-1">{strategy.description}</p>}
-          <div className="flex items-center gap-4 mt-2 text-xs text-at-text-weak">
+          {strategy.description && <p className="text-xs text-at-text-secondary mt-1 break-words">{strategy.description}</p>}
+          <div className="flex items-center gap-x-4 gap-y-1 mt-2 text-xs text-at-text-weak flex-wrap">
             <span>지표 {(strategy.indicators as unknown[]).length}개</span>
             <span className="flex items-center gap-1">
               <Eye className="w-3 h-3" /> 감시 종목 {watchlistLoading ? '...' : `${watchlist.length}개`}
             </span>
           </div>
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1 flex-shrink-0 flex-wrap justify-end">
           <button onClick={() => onBacktest(strategy.id)} className="p-2 rounded-lg hover:bg-at-surface-alt transition-colors text-at-text-secondary" title="백테스트">
             <BarChart3 className="w-4 h-4" />
           </button>
+          <Link
+            href={`/investment/strategy/${strategy.id}/edit`}
+            className="p-2 rounded-lg hover:bg-at-surface-alt transition-colors text-at-text-secondary"
+            title="수정"
+          >
+            <Edit3 className="w-4 h-4" />
+          </Link>
           <button
             onClick={toggleActive}
             disabled={toggling}
@@ -150,7 +158,7 @@ export default function StrategyCard({ strategy, hasCredential, onRefresh, onBac
           <button onClick={deleteStrategy} disabled={strategy.is_active} className="p-2 rounded-lg hover:bg-red-50 transition-colors text-at-error/60 hover:text-at-error disabled:opacity-40 disabled:cursor-not-allowed" title="삭제">
             <Trash2 className="w-4 h-4" />
           </button>
-          <button onClick={() => setExpanded(e => !e)} className="p-2 rounded-lg hover:bg-at-surface-alt transition-colors text-at-text-secondary ml-1" title={expanded ? '접기' : '펼치기'}>
+          <button onClick={() => setExpanded(e => !e)} className="p-2 rounded-lg hover:bg-at-surface-alt transition-colors text-at-text-secondary" title={expanded ? '접기' : '펼치기'}>
             {expanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
           </button>
         </div>


### PR DESCRIPTION
## 원인 분석
스크린샷 분석 결과, 실제로 렌더링된 카드는 이전에 제가 수정했던 `src/app/investment/strategy/page.tsx`가 아니라 **`InvestmentTab`에서 사용하는 `src/components/Investment/StrategyCard.tsx`** 였습니다. 이 컴포넌트에는 수정(Edit3) 아이콘 버튼이 **아예 존재하지 않아** 모바일/데스크톱 모두에서 전략 수정 진입이 불가능했습니다.

## 변경 내용
`src/components/Investment/StrategyCard.tsx`

**기능 추가**
- `BarChart3`와 `Play/Pause` 사이에 `Edit3` 아이콘 버튼 추가
- 클릭 시 `/investment/strategy/[id]/edit`로 이동 (이전 PR에서 구현한 편집 페이지)
- Next.js `Link` 사용 (CSR 최적화)

**모바일 레이아웃 보강** (아이콘이 5개로 늘면서 좁은 화면에서 밀릴 가능성 대응)
- 좌측 `flex-1` → `flex-1 min-w-0` (콘텐츠 자연 폭 축소 허용)
- 전략명/설명 `break-all` / `break-words`
- 메타데이터 행: `flex-wrap + gap-x-4 gap-y-1`
- 우측 액션 컬럼: `flex-shrink-0 + flex-wrap + justify-end` → 좁은 화면에서 다음 줄로 자연스럽게 wrap, 항상 노출 보장

**정리**
- 미사용 `Plus` import 제거

## Test plan
- [ ] 모바일에서 전략 카드에 연필 아이콘이 보이는지 확인
- [ ] 연필 아이콘 클릭 시 `/investment/strategy/[id]/edit`로 이동하여 프리필 폼 표시
- [ ] 좁은 화면에서 아이콘들이 다음 줄로 wrap되어도 모두 보이는지 확인
- [ ] 데스크톱에서 기존 한 줄 레이아웃 유지
- [ ] 활성 전략에서 삭제 disabled, 편집은 진입 가능하며 일부 필드 수정 가능

https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvLMP4jXGqJFfx9AcGLdyb)_