### PR TITLE
fix(dashboard): 자정 롤오버 시 today와 데이터 동기화

### DIFF
--- a/dental-clinic-manager/src/components/Dashboard/DashboardHome.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/DashboardHome.tsx
@@ -103,7 +103,26 @@ interface CrawledArticle {
 
 export default function DashboardHome() {
   const { user } = useAuth()
-  const today = new Date().toISOString().split('T')[0]
+
+  // 현재 시각 (1분마다 갱신) — 자정 롤오버 시 today 자동 갱신용
+  const [currentTime, setCurrentTime] = useState(new Date())
+  useEffect(() => {
+    const timer = setInterval(() => setCurrentTime(new Date()), 60000)
+    return () => clearInterval(timer)
+  }, [])
+
+  // 오늘 날짜 (Asia/Seoul 기준 YYYY-MM-DD). UTC 기반 toISOString은
+  // 한국 자정~오전 9시 사이에 어제 날짜를 반환하므로 사용 금지.
+  const today = useMemo(
+    () =>
+      new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'Asia/Seoul',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      }).format(currentTime),
+    [currentTime]
+  )
 
   // 일일 보고서 데이터
   const { dailyReports, consultLogs, giftLogs, loading: dataLoading } = useSupabaseData(user?.clinic_id ?? null)
@@ -383,12 +402,6 @@ export default function DashboardHome() {
       weekday: 'long'
     })
   }
-
-  const [currentTime, setCurrentTime] = useState(new Date())
-  useEffect(() => {
-    const timer = setInterval(() => setCurrentTime(new Date()), 60000)
-    return () => clearInterval(timer)
-  }, [])
 
   // 인라인 확장 패널 상태
   const [todayActivePanel, setTodayActivePanel] = useState<'consult' | 'recall' | 'gift' | null>(null)


### PR DESCRIPTION
## Summary
- 대시보드에서 자정이 지나도 헤더 날짜만 바뀌고 요약 카드는 여전히 전날 데이터를 보여주던 버그 수정.
- `today`를 마운트 시 한 번 계산되는 상수(`new Date().toISOString().split('T')[0]`)에서 `currentTime` state(60초마다 갱신)에 의존하는 `useMemo`로 변경.
- `Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Seoul' })`을 사용해 **KST 기준** YYYY-MM-DD를 생성. 기존 UTC 기반 코드는 한국 자정~오전 9시 사이에 처음부터 어제 날짜를 반환하던 추가 버그도 함께 해결됨.
- 데이터 fetch는 `useSupabaseData`의 Postgres Realtime 구독이 이미 자동 갱신하므로 별도 refetch 추가 없음 (최소 침습).

## Root cause
`DashboardHome.tsx:106`의 `today`가 마운트 시점 1회만 평가되어 `currentTime`은 1분마다 업데이트되는데도 `todaySummary`/`weeklySummary` `useMemo`의 필터 키가 자정 이후에도 어제 날짜로 고정됨.

## Test plan
- [ ] 시스템 시계를 23:59 → 00:01로 변경 후, 헤더 날짜와 함께 "오늘 보고서 요약" 카드가 새 날짜 기준(빈 값)으로 전환되는지 확인
- [ ] 한국 시각 00:30(UTC 15:30 전날)에 처음 페이지 진입 시 today가 KST 기준 오늘로 표시되는지 확인
- [ ] `npm run build` 통과 확인 (✅ 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)