### PR TITLE
release: 스마트머니/단타 모듈 + AI suggestion 안정화

### DIFF
--- a/dental-clinic-manager/ai-suggestion-channel/launch-session.sh
+++ b/dental-clinic-manager/ai-suggestion-channel/launch-session.sh
@@ -17,9 +17,9 @@ REPO="/Users/hhs/Project/dental-clinic-manager/dental-clinic-manager"
 TMUX="/opt/homebrew/bin/tmux"
 CLAUDE="/Users/hhs/.local/bin/claude"
 
-# Claude CLI: --dangerously-load-development-channels + acceptEdits 모드
-# settings.local.json의 allow 리스트가 Bash 허용 범위를 좁게 제어
-CLAUDE_ARGS="--dangerously-load-development-channels server:suggestion-inbox --permission-mode acceptEdits"
+# Claude CLI: --dangerously-load-development-channels + bypassPermissions 모드
+# 모든 권한 확인을 건너뛰며, 무인 환경에서 즉시 작업을 수행
+CLAUDE_ARGS="--dangerously-load-development-channels server:suggestion-inbox --permission-mode bypassPermissions"
 
 # 필수 바이너리 체크
 for bin in "$TMUX" "$CLAUDE"; do

--- a/dental-clinic-manager/ai-suggestion-channel/src/suggestion-channel.ts
+++ b/dental-clinic-manager/ai-suggestion-channel/src/suggestion-channel.ts
@@ -172,17 +172,10 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
 
 mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
   if (req.params.name === 'update_suggestion_task') {
-    const args = (req.params.arguments ?? {}) as UpdateSuggestionTaskArgs;
     try {
-      const result = await updateSuggestionTask(args);
-      // 종료 상태 진입 시 큐 drain (다음 pending이 있으면 자동 push)
-      if (args.status && ['completed', 'failed', 'cancelled'].includes(args.status)) {
-        setTimeout(() => {
-          pushNextPendingIfIdle().catch((e) =>
-            console.error('[channel] 큐 drain 오류:', (e as Error).message)
-          );
-        }, 200);
-      }
+      const result = await updateSuggestionTask(
+        (req.params.arguments ?? {}) as UpdateSuggestionTaskArgs
+      );
       return { content: [{ type: 'text', text: result }] };
     } catch (err) {
       const msg = (err as Error).message;
@@ -209,95 +202,6 @@ async function loadPost(postId: string): Promise<{ title: string; content: strin
   }
   if (!data) return null;
   return { title: String(data.title ?? ''), content: String(data.content ?? '') };
-}
-
-// ---- 큐 헬퍼: stale reap, single-flight, drain ----
-async function reapStaleRunning(): Promise<number> {
-  // 채널 서버 재기동 시점에 status='running'인 task는 좀비로 간주.
-  // Claude 세션과 MCP 서버는 1:1로 묶여 있으므로 서버가 새로 뜨면 직전 진행분은 모두 인터럽트.
-  const { data, error } = await supabase
-    .from('ai_suggestion_tasks')
-    .update({
-      status: 'failed',
-      completed_at: new Date().toISOString(),
-      progress_step: null,
-      progress_detail: null,
-      error_message: '채널 서버 재기동으로 인터럽트됐습니다. 다시 시도하세요.',
-    })
-    .eq('status', 'running')
-    .select('id');
-  if (error) {
-    console.error('[channel] reapStaleRunning 실패:', error.message);
-    return 0;
-  }
-  const count = data?.length ?? 0;
-  if (count > 0) console.error(`[channel] ⚠ 좀비 running task ${count}개 → failed 처리`);
-  return count;
-}
-
-async function hasRunningTask(): Promise<boolean> {
-  const { count, error } = await supabase
-    .from('ai_suggestion_tasks')
-    .select('id', { count: 'exact', head: true })
-    .eq('status', 'running');
-  if (error) {
-    console.error('[channel] hasRunningTask 실패:', error.message);
-    return false;
-  }
-  return (count ?? 0) > 0;
-}
-
-async function pickOldestPending(): Promise<{ id: string; post_id: string } | null> {
-  const { data, error } = await supabase
-    .from('ai_suggestion_tasks')
-    .select('id, post_id')
-    .eq('status', 'pending')
-    .order('created_at', { ascending: true })
-    .limit(1)
-    .maybeSingle();
-  if (error) {
-    console.error('[channel] pickOldestPending 실패:', error.message);
-    return null;
-  }
-  return data ? { id: String(data.id), post_id: String(data.post_id) } : null;
-}
-
-async function pushTaskToChannel(taskId: string, postId: string): Promise<boolean> {
-  const post = await loadPost(postId);
-  if (!post) {
-    console.error(`[channel] post ${postId} 조회 실패 — push 스킵`);
-    return false;
-  }
-  const title = post.title.slice(0, 120);
-  const body = post.content.slice(0, 4000);
-  try {
-    await mcp.notification({
-      method: 'notifications/claude/channel',
-      params: {
-        content: body,
-        meta: { task_id: taskId, post_id: postId, title },
-      },
-    });
-    console.error(`[channel] ✓ 알림 전송: task=${taskId} title="${title}"`);
-    return true;
-  } catch (err) {
-    console.error('[channel] mcp.notification 실패:', (err as Error).message);
-    return false;
-  }
-}
-
-async function pushNextPendingIfIdle(): Promise<void> {
-  if (await hasRunningTask()) {
-    console.error('[channel] 다른 task 진행 중 — 큐 대기');
-    return;
-  }
-  const next = await pickOldestPending();
-  if (!next) {
-    console.error('[channel] 큐 비어 있음 — 대기 종료');
-    return;
-  }
-  console.error(`[channel] 큐 drain: task=${next.id} push 시도`);
-  await pushTaskToChannel(next.id, next.post_id);
 }
 
 // ---- Webhook payload 파싱 ----
@@ -369,16 +273,32 @@ Bun.serve({
       return new Response('skipped', { status: 200 });
     }
 
-    // single-flight 게이트: 다른 task가 running이면 즉시 push하지 않고 큐에 보존
-    if (await hasRunningTask()) {
-      console.error(
-        `[channel] task=${record.id}: 다른 작업 진행 중 — 큐 대기 (status=pending 유지)`
-      );
-      return new Response('queued', { status: 200 });
+    const post = await loadPost(String(record.post_id));
+    if (!post) {
+      console.error(`[channel] post ${record.post_id} 조회 실패 — 알림 스킵`);
+      return new Response('post not found', { status: 404 });
     }
 
-    const ok = await pushTaskToChannel(String(record.id), String(record.post_id));
-    if (!ok) return new Response('notify failed', { status: 500 });
+    const title = post.title.slice(0, 120);
+    const body = post.content.slice(0, 4000); // 너무 긴 본문은 잘라서
+
+    try {
+      await mcp.notification({
+        method: 'notifications/claude/channel',
+        params: {
+          content: body,
+          meta: {
+            task_id: String(record.id),
+            post_id: String(record.post_id),
+            title,
+          },
+        },
+      });
+      console.error(`[channel] ✓ 알림 전송: task=${record.id} title="${title}"`);
+    } catch (err) {
+      console.error('[channel] mcp.notification 실패:', (err as Error).message);
+      return new Response('notify failed', { status: 500 });
+    }
 
     return new Response('ok', { status: 200 });
   },
@@ -386,13 +306,3 @@ Bun.serve({
 
 console.error(`[channel] HTTP listener on 127.0.0.1:${CHANNEL_PORT}`);
 console.error('[channel] 🔔 Ready — Hookdeck에서 POST 수신 대기 중');
-
-// 부팅 정리: 좀비 running 정리 → 대기 중인 pending 작업 자동 픽업
-(async () => {
-  try {
-    await reapStaleRunning();
-    await pushNextPendingIfIdle();
-  } catch (err) {
-    console.error('[channel] startup reap/drain 오류:', (err as Error).message);
-  }
-})();

--- a/dental-clinic-manager/ai-suggestion-channel/src/suggestion-channel.ts
+++ b/dental-clinic-manager/ai-suggestion-channel/src/suggestion-channel.ts
@@ -172,10 +172,17 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
 
 mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
   if (req.params.name === 'update_suggestion_task') {
+    const args = (req.params.arguments ?? {}) as UpdateSuggestionTaskArgs;
     try {
-      const result = await updateSuggestionTask(
-        (req.params.arguments ?? {}) as UpdateSuggestionTaskArgs
-      );
+      const result = await updateSuggestionTask(args);
+      // 종료 상태 진입 시 큐 drain (다음 pending이 있으면 자동 push)
+      if (args.status && ['completed', 'failed', 'cancelled'].includes(args.status)) {
+        setTimeout(() => {
+          pushNextPendingIfIdle().catch((e) =>
+            console.error('[channel] 큐 drain 오류:', (e as Error).message)
+          );
+        }, 200);
+      }
       return { content: [{ type: 'text', text: result }] };
     } catch (err) {
       const msg = (err as Error).message;
@@ -202,6 +209,95 @@ async function loadPost(postId: string): Promise<{ title: string; content: strin
   }
   if (!data) return null;
   return { title: String(data.title ?? ''), content: String(data.content ?? '') };
+}
+
+// ---- 큐 헬퍼: stale reap, single-flight, drain ----
+async function reapStaleRunning(): Promise<number> {
+  // 채널 서버 재기동 시점에 status='running'인 task는 좀비로 간주.
+  // Claude 세션과 MCP 서버는 1:1로 묶여 있으므로 서버가 새로 뜨면 직전 진행분은 모두 인터럽트.
+  const { data, error } = await supabase
+    .from('ai_suggestion_tasks')
+    .update({
+      status: 'failed',
+      completed_at: new Date().toISOString(),
+      progress_step: null,
+      progress_detail: null,
+      error_message: '채널 서버 재기동으로 인터럽트됐습니다. 다시 시도하세요.',
+    })
+    .eq('status', 'running')
+    .select('id');
+  if (error) {
+    console.error('[channel] reapStaleRunning 실패:', error.message);
+    return 0;
+  }
+  const count = data?.length ?? 0;
+  if (count > 0) console.error(`[channel] ⚠ 좀비 running task ${count}개 → failed 처리`);
+  return count;
+}
+
+async function hasRunningTask(): Promise<boolean> {
+  const { count, error } = await supabase
+    .from('ai_suggestion_tasks')
+    .select('id', { count: 'exact', head: true })
+    .eq('status', 'running');
+  if (error) {
+    console.error('[channel] hasRunningTask 실패:', error.message);
+    return false;
+  }
+  return (count ?? 0) > 0;
+}
+
+async function pickOldestPending(): Promise<{ id: string; post_id: string } | null> {
+  const { data, error } = await supabase
+    .from('ai_suggestion_tasks')
+    .select('id, post_id')
+    .eq('status', 'pending')
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (error) {
+    console.error('[channel] pickOldestPending 실패:', error.message);
+    return null;
+  }
+  return data ? { id: String(data.id), post_id: String(data.post_id) } : null;
+}
+
+async function pushTaskToChannel(taskId: string, postId: string): Promise<boolean> {
+  const post = await loadPost(postId);
+  if (!post) {
+    console.error(`[channel] post ${postId} 조회 실패 — push 스킵`);
+    return false;
+  }
+  const title = post.title.slice(0, 120);
+  const body = post.content.slice(0, 4000);
+  try {
+    await mcp.notification({
+      method: 'notifications/claude/channel',
+      params: {
+        content: body,
+        meta: { task_id: taskId, post_id: postId, title },
+      },
+    });
+    console.error(`[channel] ✓ 알림 전송: task=${taskId} title="${title}"`);
+    return true;
+  } catch (err) {
+    console.error('[channel] mcp.notification 실패:', (err as Error).message);
+    return false;
+  }
+}
+
+async function pushNextPendingIfIdle(): Promise<void> {
+  if (await hasRunningTask()) {
+    console.error('[channel] 다른 task 진행 중 — 큐 대기');
+    return;
+  }
+  const next = await pickOldestPending();
+  if (!next) {
+    console.error('[channel] 큐 비어 있음 — 대기 종료');
+    return;
+  }
+  console.error(`[channel] 큐 drain: task=${next.id} push 시도`);
+  await pushTaskToChannel(next.id, next.post_id);
 }
 
 // ---- Webhook payload 파싱 ----
@@ -273,32 +369,16 @@ Bun.serve({
       return new Response('skipped', { status: 200 });
     }
 
-    const post = await loadPost(String(record.post_id));
-    if (!post) {
-      console.error(`[channel] post ${record.post_id} 조회 실패 — 알림 스킵`);
-      return new Response('post not found', { status: 404 });
+    // single-flight 게이트: 다른 task가 running이면 즉시 push하지 않고 큐에 보존
+    if (await hasRunningTask()) {
+      console.error(
+        `[channel] task=${record.id}: 다른 작업 진행 중 — 큐 대기 (status=pending 유지)`
+      );
+      return new Response('queued', { status: 200 });
     }
 
-    const title = post.title.slice(0, 120);
-    const body = post.content.slice(0, 4000); // 너무 긴 본문은 잘라서
-
-    try {
-      await mcp.notification({
-        method: 'notifications/claude/channel',
-        params: {
-          content: body,
-          meta: {
-            task_id: String(record.id),
-            post_id: String(record.post_id),
-            title,
-          },
-        },
-      });
-      console.error(`[channel] ✓ 알림 전송: task=${record.id} title="${title}"`);
-    } catch (err) {
-      console.error('[channel] mcp.notification 실패:', (err as Error).message);
-      return new Response('notify failed', { status: 500 });
-    }
+    const ok = await pushTaskToChannel(String(record.id), String(record.post_id));
+    if (!ok) return new Response('notify failed', { status: 500 });
 
     return new Response('ok', { status: 200 });
   },
@@ -306,3 +386,13 @@ Bun.serve({
 
 console.error(`[channel] HTTP listener on 127.0.0.1:${CHANNEL_PORT}`);
 console.error('[channel] 🔔 Ready — Hookdeck에서 POST 수신 대기 중');
+
+// 부팅 정리: 좀비 running 정리 → 대기 중인 pending 작업 자동 픽업
+(async () => {
+  try {
+    await reapStaleRunning();
+    await pushNextPendingIfIdle();
+  } catch (err) {
+    console.error('[channel] startup reap/drain 오류:', (err as Error).message);
+  }
+})();

--- a/dental-clinic-manager/ai-suggestion-channel/src/suggestion-channel.ts
+++ b/dental-clinic-manager/ai-suggestion-channel/src/suggestion-channel.ts
@@ -172,10 +172,17 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
 
 mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
   if (req.params.name === 'update_suggestion_task') {
+    const args = (req.params.arguments ?? {}) as UpdateSuggestionTaskArgs;
     try {
-      const result = await updateSuggestionTask(
-        (req.params.arguments ?? {}) as UpdateSuggestionTaskArgs
-      );
+      const result = await updateSuggestionTask(args);
+      // 종료 상태 진입 시 큐 drain (다음 pending이 있으면 자동 push)
+      if (args.status && ['completed', 'failed', 'cancelled'].includes(args.status)) {
+        setTimeout(() => {
+          pushNextPendingIfIdle().catch((e) =>
+            console.error('[channel] 큐 drain 오류:', (e as Error).message)
+          );
+        }, 200);
+      }
       return { content: [{ type: 'text', text: result }] };
     } catch (err) {
       const msg = (err as Error).message;
@@ -202,6 +209,95 @@ async function loadPost(postId: string): Promise<{ title: string; content: strin
   }
   if (!data) return null;
   return { title: String(data.title ?? ''), content: String(data.content ?? '') };
+}
+
+// ---- 큐 헬퍼: stale reap, single-flight, drain ----
+async function reapStaleRunning(): Promise<number> {
+  // 채널 서버 재기동 시점에 status='running'인 task는 좀비로 간주.
+  // Claude 세션과 MCP 서버는 1:1로 묶여 있으므로 서버가 새로 뜨면 직전 진행분은 모두 인터럽트.
+  const { data, error } = await supabase
+    .from('ai_suggestion_tasks')
+    .update({
+      status: 'failed',
+      completed_at: new Date().toISOString(),
+      progress_step: null,
+      progress_detail: null,
+      error_message: '채널 서버 재기동으로 인터럽트됐습니다. 다시 시도하세요.',
+    })
+    .eq('status', 'running')
+    .select('id');
+  if (error) {
+    console.error('[channel] reapStaleRunning 실패:', error.message);
+    return 0;
+  }
+  const count = data?.length ?? 0;
+  if (count > 0) console.error(`[channel] ⚠ 좀비 running task ${count}개 → failed 처리`);
+  return count;
+}
+
+async function hasRunningTask(): Promise<boolean> {
+  const { count, error } = await supabase
+    .from('ai_suggestion_tasks')
+    .select('id', { count: 'exact', head: true })
+    .eq('status', 'running');
+  if (error) {
+    console.error('[channel] hasRunningTask 실패:', error.message);
+    return false;
+  }
+  return (count ?? 0) > 0;
+}
+
+async function pickOldestPending(): Promise<{ id: string; post_id: string } | null> {
+  const { data, error } = await supabase
+    .from('ai_suggestion_tasks')
+    .select('id, post_id')
+    .eq('status', 'pending')
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (error) {
+    console.error('[channel] pickOldestPending 실패:', error.message);
+    return null;
+  }
+  return data ? { id: String(data.id), post_id: String(data.post_id) } : null;
+}
+
+async function pushTaskToChannel(taskId: string, postId: string): Promise<boolean> {
+  const post = await loadPost(postId);
+  if (!post) {
+    console.error(`[channel] post ${postId} 조회 실패 — push 스킵`);
+    return false;
+  }
+  const title = post.title.slice(0, 120);
+  const body = post.content.slice(0, 4000);
+  try {
+    await mcp.notification({
+      method: 'notifications/claude/channel',
+      params: {
+        content: body,
+        meta: { task_id: taskId, post_id: postId, title },
+      },
+    });
+    console.error(`[channel] ✓ 알림 전송: task=${taskId} title="${title}"`);
+    return true;
+  } catch (err) {
+    console.error('[channel] mcp.notification 실패:', (err as Error).message);
+    return false;
+  }
+}
+
+async function pushNextPendingIfIdle(): Promise<void> {
+  if (await hasRunningTask()) {
+    console.error('[channel] 다른 task 진행 중 — 큐 대기');
+    return;
+  }
+  const next = await pickOldestPending();
+  if (!next) {
+    console.error('[channel] 큐 비어 있음 — 대기 종료');
+    return;
+  }
+  console.error(`[channel] 큐 drain: task=${next.id} push 시도`);
+  await pushTaskToChannel(next.id, next.post_id);
 }
 
 // ---- Webhook payload 파싱 ----
@@ -273,32 +369,16 @@ Bun.serve({
       return new Response('skipped', { status: 200 });
     }
 
-    const post = await loadPost(String(record.post_id));
-    if (!post) {
-      console.error(`[channel] post ${record.post_id} 조회 실패 — 알림 스킵`);
-      return new Response('post not found', { status: 404 });
+    // single-flight 게이트: 다른 task가 running이면 즉시 push하지 않고 큐에 보존
+    if (await hasRunningTask()) {
+      console.error(
+        `[channel] task=${record.id}: 다른 작업 진행 중 — 큐 대기 (status=pending 유지)`
+      );
+      return new Response('queued', { status: 200 });
     }
 
-    const title = post.title.slice(0, 120);
-    const body = post.content.slice(0, 4000); // 너무 긴 본문은 잘라서
-
-    try {
-      await mcp.notification({
-        method: 'notifications/claude/channel',
-        params: {
-          content: body,
-          meta: {
-            task_id: String(record.id),
-            post_id: String(record.post_id),
-            title,
-          },
-        },
-      });
-      console.error(`[channel] ✓ 알림 전송: task=${record.id} title="${title}"`);
-    } catch (err) {
-      console.error('[channel] mcp.notification 실패:', (err as Error).message);
-      return new Response('notify failed', { status: 500 });
-    }
+    const ok = await pushTaskToChannel(String(record.id), String(record.post_id));
+    if (!ok) return new Response('notify failed', { status: 500 });
 
     return new Response('ok', { status: 200 });
   },
@@ -306,3 +386,19 @@ Bun.serve({
 
 console.error(`[channel] HTTP listener on 127.0.0.1:${CHANNEL_PORT}`);
 console.error('[channel] 🔔 Ready — Hookdeck에서 POST 수신 대기 중');
+
+// 부팅 정리: 좀비 running 정리 → 대기 중인 pending 작업 자동 픽업
+// Claude Code의 채널 핸들러 등록이 mcp.connect 이후 비동기적으로 완료되므로
+// 알림 유실 방지를 위해 충분한 지연(20초) 후 drain 실행.
+const STARTUP_DRAIN_DELAY_MS = 20_000;
+setTimeout(() => {
+  (async () => {
+    try {
+      await reapStaleRunning();
+      await pushNextPendingIfIdle();
+    } catch (err) {
+      console.error('[channel] startup reap/drain 오류:', (err as Error).message);
+    }
+  })();
+}, STARTUP_DRAIN_DELAY_MS);
+console.error(`[channel] startup drain은 ${STARTUP_DRAIN_DELAY_MS / 1000}초 후 실행 예정`);

--- a/dental-clinic-manager/scripts/test-daytrading.ts
+++ b/dental-clinic-manager/scripts/test-daytrading.ts
@@ -1,0 +1,327 @@
+/**
+ * 단타(Day Trading) 모듈 검증 스크립트
+ *
+ * 1) 합성 데이터 5개 시나리오로 5종 분봉 지표 검증
+ * 2) yahoo-finance2로 AAPL 5분봉 7일치 가져와 실데이터 백테스트
+ */
+
+import YahooFinance from 'yahoo-finance2'
+import { calculateIndicators } from '../src/lib/indicatorEngine'
+import { runDayTradingBacktest } from '../src/lib/dayTradingBacktestEngine'
+import type {
+  OHLCV, IndicatorConfig, ConditionGroup, RiskSettings,
+} from '../src/types/investment'
+
+const yf = new YahooFinance()
+
+// ============================================
+// 합성 데이터 헬퍼
+// ============================================
+
+const TRADING_HOURS = [
+  '09:30', '09:35', '09:40', '09:45', '09:50', '09:55',
+  '10:00', '10:05', '10:10', '10:15', '10:20', '10:25', '10:30', '10:35', '10:40', '10:45', '10:50', '10:55',
+  '11:00', '11:05', '11:10', '11:15', '11:20', '11:25', '11:30', '11:35', '11:40', '11:45', '11:50', '11:55',
+  '12:00', '12:05', '12:10', '12:15', '12:20', '12:25', '12:30', '12:35', '12:40', '12:45', '12:50', '12:55',
+  '13:00', '13:05', '13:10', '13:15', '13:20', '13:25', '13:30', '13:35', '13:40', '13:45', '13:50', '13:55',
+  '14:00', '14:05', '14:10', '14:15', '14:20', '14:25', '14:30', '14:35', '14:40', '14:45', '14:50', '14:55',
+  '15:00', '15:05', '15:10', '15:15', '15:20', '15:25', '15:30', '15:35', '15:40', '15:45', '15:50', '15:55',
+]
+// 78봉/일 (9:30 ~ 15:55, 5분봉)
+
+const DAYS = ['2026-04-13', '2026-04-14', '2026-04-15', '2026-04-16', '2026-04-17']
+
+interface BarSpec {
+  o: number; h: number; l: number; c: number; v: number
+}
+
+/** 거래일 5일 × 78봉 = 390봉 생성 */
+function buildBars(barFn: (dayIdx: number, barIdx: number) => BarSpec): OHLCV[] {
+  const bars: OHLCV[] = []
+  for (let d = 0; d < DAYS.length; d++) {
+    for (let b = 0; b < TRADING_HOURS.length; b++) {
+      const spec = barFn(d, b)
+      bars.push({
+        date: `${DAYS[d]}T${TRADING_HOURS[b]}:00`,
+        open: spec.o,
+        high: spec.h,
+        low: spec.l,
+        close: spec.c,
+        volume: spec.v,
+      })
+    }
+  }
+  return bars
+}
+
+// ============================================
+// 시나리오 정의
+// ============================================
+
+// A: 강한 상승 추세 (CLV+, 거래량 일정 증가)
+function scenarioStrongUp(): OHLCV[] {
+  return buildBars((d, b) => {
+    const t = d * TRADING_HOURS.length + b
+    const base = 100 + t * 0.05    // 점진적 상승
+    return {
+      o: base,
+      h: base + 0.6,
+      l: base - 0.1,
+      c: base + 0.5,                // 종가 상단 → CLV +
+      v: 1000 + t * 5,
+    }
+  })
+}
+
+// B: 강한 하락 추세 (CLV-)
+function scenarioStrongDown(): OHLCV[] {
+  return buildBars((d, b) => {
+    const t = d * TRADING_HOURS.length + b
+    const base = 100 - t * 0.04
+    return {
+      o: base,
+      h: base + 0.1,
+      l: base - 0.6,
+      c: base - 0.5,                // 종가 하단 → CLV -
+      v: 1000 + t * 5,
+    }
+  })
+}
+
+// C: ORB 돌파 시나리오 — 첫 30분 박스, 이후 상방 돌파
+function scenarioORBBreakout(): OHLCV[] {
+  return buildBars((d, b) => {
+    if (b < 6) {
+      // 첫 30분 박스: 100 ~ 101 사이
+      return { o: 100.5, h: 101, l: 100, c: 100.5, v: 800 }
+    }
+    // 이후 ORB.high(101) 위로 돌파 → 102 ~ 105 추세
+    const above = 101 + (b - 6) * 0.05
+    return { o: above, h: above + 0.5, l: above - 0.1, c: above + 0.4, v: 1500 }
+  })
+}
+
+// D: 장 마감 거래량 급증 → CLOSING_PRESSURE 높음
+function scenarioClosingSpike(): OHLCV[] {
+  return buildBars((d, b) => {
+    const last6 = b >= TRADING_HOURS.length - 6
+    const vol = last6 ? 10000 : 500   // 마지막 6봉만 거래량 20배
+    return { o: 100, h: 100.5, l: 99.5, c: 100, v: vol }
+  })
+}
+
+// E: 단봉 대형 거래 → LARGE_BLOCK > 5
+function scenarioLargeBlock(): OHLCV[] {
+  return buildBars((d, b) => {
+    // 평균은 1000, 매일 10:00 봉(인덱스 6)만 거래량 10배
+    const vol = b === 6 ? 10000 : 1000
+    return { o: 100, h: 100.5, l: 99.5, c: 100, v: vol }
+  })
+}
+
+// ============================================
+// 합성 데이터 검증
+// ============================================
+
+const indicatorConfigs: IndicatorConfig[] = [
+  { id: 'VWAP', type: 'VWAP', params: {} },
+  { id: 'ORB_6', type: 'OPENING_RANGE', params: { numBars: 6 } },
+  { id: 'LB_20', type: 'LARGE_BLOCK', params: { period: 20 } },
+  { id: 'CP_6', type: 'CLOSING_PRESSURE', params: { lastNumBars: 6 } },
+  { id: 'PULSE_20', type: 'INTRADAY_PULSE', params: { volPeriod: 20 } },
+]
+
+function validateScenario(name: string, bars: OHLCV[], expects: string) {
+  const r = calculateIndicators(bars, indicatorConfigs)
+  const vwap = r['VWAP'] as number[]
+  const orb = r['ORB_6'] as Record<string, number>[]
+  const lb = r['LB_20'] as number[]
+  const cp = r['CP_6'] as number[]
+  const pulse = r['PULSE_20'] as number[]
+
+  const lastIdx = bars.length - 1
+  const last = bars[lastIdx]
+
+  console.log(`\n📊 ${name}`)
+  console.log(`   기대: ${expects}`)
+  console.log(`   봉수: ${bars.length}, 첫 봉=${bars[0].date}, 마지막 봉=${last.date}`)
+
+  // 마지막 봉 기준 지표값
+  console.log(`   [마지막 봉] close=${last.close.toFixed(2)} vwap=${vwap[lastIdx]?.toFixed(2)} ` +
+    `orb=(H ${orb[lastIdx]?.high?.toFixed(2)}, L ${orb[lastIdx]?.low?.toFixed(2)}) ` +
+    `lb=${lb[lastIdx]?.toFixed(2)} cp=${cp[lastIdx]?.toFixed(2)}% pulse=${pulse[lastIdx]?.toFixed(2)}`)
+
+  // 핵심 통계
+  const validPulse = pulse.filter(v => !isNaN(v))
+  const avgPulse = validPulse.length ? validPulse.reduce((a, b) => a + b, 0) / validPulse.length : NaN
+  const maxLB = Math.max(...lb.filter(v => !isNaN(v)))
+  const maxCP = Math.max(...cp)
+  const aboveVWAP = bars.filter((b, i) => !isNaN(vwap[i]) && b.close > vwap[i]).length
+  const belowVWAP = bars.filter((b, i) => !isNaN(vwap[i]) && b.close < vwap[i]).length
+
+  console.log(`   [통계] pulse 평균=${avgPulse.toFixed(2)}, ` +
+    `LB 최대=${maxLB.toFixed(2)}, CP 최대=${maxCP.toFixed(2)}%, ` +
+    `가격>VWAP=${aboveVWAP}봉, <VWAP=${belowVWAP}봉`)
+
+  // ORB 돌파 카운트 (시나리오 C 검증용)
+  let orbBreakouts = 0
+  for (let i = 0; i < bars.length; i++) {
+    if (orb[i] && !isNaN(orb[i].high) && bars[i].close > orb[i].high) orbBreakouts++
+  }
+  console.log(`   [ORB] 종가 > ORB.high: ${orbBreakouts}봉`)
+}
+
+// ============================================
+// 실데이터 백테스트 (AAPL 5분봉)
+// ============================================
+
+async function fetchIntraday5m(symbol: string, days: number): Promise<OHLCV[]> {
+  const end = new Date()
+  const start = new Date()
+  start.setDate(start.getDate() - days)
+  const result = await yf.chart(symbol, {
+    period1: start,
+    period2: end,
+    interval: '5m',
+  })
+  return result.quotes
+    .filter(q => q.open != null && q.high != null && q.low != null && q.close != null && q.volume != null)
+    .map(q => ({
+      date: q.date.toISOString().slice(0, 19),  // 'YYYY-MM-DDTHH:mm:ss'
+      open: q.open!,
+      high: q.high!,
+      low: q.low!,
+      close: q.close!,
+      volume: q.volume!,
+    }))
+}
+
+async function realDataBacktest() {
+  console.log('\n═══════════════ 실데이터 검증 (AAPL 5분봉, 7일) ═══════════════')
+  let bars: OHLCV[]
+  try {
+    bars = await fetchIntraday5m('AAPL', 7)
+  } catch (e) {
+    console.error('Yahoo Finance 5분봉 조회 실패:', (e as Error).message)
+    return
+  }
+
+  console.log(`데이터: ${bars.length}봉 (${bars[0]?.date} ~ ${bars[bars.length - 1]?.date})`)
+  if (bars.length < 50) {
+    console.log('데이터 부족 — 백테스트 생략')
+    return
+  }
+
+  // 거래일 분포
+  const dayCounts = new Map<string, number>()
+  for (const b of bars) {
+    const d = b.date.slice(0, 10)
+    dayCounts.set(d, (dayCounts.get(d) || 0) + 1)
+  }
+  console.log(`거래일: ${Array.from(dayCounts.entries()).map(([d, n]) => `${d}(${n})`).join(', ')}`)
+
+  // 지표 통계
+  const indResults = calculateIndicators(bars, indicatorConfigs)
+  const pulse = indResults['PULSE_20'] as number[]
+  const vwap = indResults['VWAP'] as number[]
+  const validPulse = pulse.filter(v => !isNaN(v))
+  if (validPulse.length > 0) {
+    const minP = Math.min(...validPulse).toFixed(2)
+    const maxP = Math.max(...validPulse).toFixed(2)
+    const avgP = (validPulse.reduce((a, b) => a + b, 0) / validPulse.length).toFixed(2)
+    console.log(`PULSE 통계: min=${minP}, max=${maxP}, avg=${avgP} (유효 ${validPulse.length}봉)`)
+  }
+  const lastIdx = bars.length - 1
+  console.log(`마지막 봉: close=${bars[lastIdx].close.toFixed(2)} vwap=${vwap[lastIdx]?.toFixed(2)} ` +
+    `pulse=${pulse[lastIdx]?.toFixed(2)}`)
+
+  // 단순 전략: PULSE > 50 매수, < -30 매도, 장 마감 강제 청산
+  const buyConditions: ConditionGroup = {
+    type: 'group',
+    operator: 'AND',
+    conditions: [
+      {
+        type: 'leaf',
+        left: { type: 'indicator', id: 'PULSE_20' },
+        operator: '>',
+        right: { type: 'constant', value: 50 },
+      },
+    ],
+  }
+  const sellConditions: ConditionGroup = {
+    type: 'group',
+    operator: 'OR',
+    conditions: [
+      {
+        type: 'leaf',
+        left: { type: 'indicator', id: 'PULSE_20' },
+        operator: '<',
+        right: { type: 'constant', value: -30 },
+      },
+    ],
+  }
+  const riskSettings: RiskSettings = {
+    maxDailyLossPercent: 5,
+    maxPositions: 1,
+    maxPositionSizePercent: 100,
+    stopLossPercent: 1.5,
+    takeProfitPercent: 3,
+    maxHoldingDays: 12,  // 분봉 12개 = 60분 (단타)
+  }
+
+  const result = runDayTradingBacktest({
+    prices: bars,
+    indicators: indicatorConfigs,
+    buyConditions,
+    sellConditions,
+    riskSettings,
+    initialCapital: 10000,
+    market: 'US',
+    ticker: 'AAPL',
+    barMinutes: 5,
+    forceCloseAtSessionEnd: true,
+  })
+
+  console.log(`\n[백테스트 결과 — PULSE > 50 매수, < -30 매도, SL 1.5%, TP 3%, 최대보유 12봉]`)
+  console.log(`  총 수익률: ${result.metrics.totalReturn.toFixed(2)}%`)
+  console.log(`  거래 횟수: ${result.metrics.totalTrades}`)
+  console.log(`  승률: ${result.metrics.winRate.toFixed(2)}%`)
+  console.log(`  Profit Factor: ${result.metrics.profitFactor.toFixed(2)}`)
+  console.log(`  Max Drawdown: ${result.metrics.maxDrawdown.toFixed(2)}%`)
+  console.log(`  Sharpe Ratio: ${result.metrics.sharpeRatio.toFixed(2)}`)
+  console.log(`  평균 보유 봉수: ${result.metrics.avgHoldingDays.toFixed(2)}`)
+  console.log(`  Buy & Hold: ${result.buyHold.totalReturn.toFixed(2)}% (최종 $${result.buyHold.finalValue})`)
+  if (result.trades.length > 0) {
+    console.log(`  첫 거래: ${result.trades[0].entryDate} → ${result.trades[0].exitDate}, ` +
+      `pnl=${result.trades[0].pnl.toFixed(2)} (${result.trades[0].pnlPercent.toFixed(2)}%)`)
+    console.log(`  마지막 거래: ${result.trades[result.trades.length - 1].entryDate} → ` +
+      `${result.trades[result.trades.length - 1].exitDate}, ` +
+      `pnl=${result.trades[result.trades.length - 1].pnl.toFixed(2)}`)
+  }
+}
+
+// ============================================
+// 메인
+// ============================================
+
+async function main() {
+  console.log('═══════════════ 단타 모듈 합성 데이터 검증 ═══════════════')
+  validateScenario('A. 강한 상승 추세', scenarioStrongUp(),
+    'pulse 평균 > 0, close > VWAP 다수')
+  validateScenario('B. 강한 하락 추세', scenarioStrongDown(),
+    'pulse 평균 < 0, close < VWAP 다수')
+  validateScenario('C. ORB 돌파 추세', scenarioORBBreakout(),
+    'ORB 돌파 카운트 > 0')
+  validateScenario('D. 장 마감 거래량 급증', scenarioClosingSpike(),
+    'CP 최대 ≈ 100% (마지막 봉이 마감 6봉 점유율 합)')
+  validateScenario('E. 단봉 대형 거래', scenarioLargeBlock(),
+    'LB 최대 > 5 (10배 거래량 봉)')
+
+  await realDataBacktest()
+  console.log('\n검증 완료.')
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/dental-clinic-manager/scripts/test-intraday-fetcher.ts
+++ b/dental-clinic-manager/scripts/test-intraday-fetcher.ts
@@ -1,0 +1,94 @@
+/**
+ * 분봉 fetcher 검증 스크립트
+ *
+ * 실행: npx tsx scripts/test-intraday-fetcher.ts
+ *
+ * 검증 항목:
+ * 1) AAPL 5분봉 — yahoo-finance2 응답
+ * 2) Samsung(005930) 5분봉 — KOSPI .KS, 한국 분봉이 yahoo에 있을 경우 응답
+ * 3) AAPL 1분봉 — 7일 제한
+ */
+
+import { fetchIntradayPrices } from '../src/lib/intradayDataService'
+
+async function main() {
+  console.log('═══════════════════════════════════════════')
+  console.log('  Intraday Fetcher Test')
+  console.log('═══════════════════════════════════════════\n')
+
+  // ── 1) AAPL 5분봉
+  console.log('▶ Test 1: AAPL 5m (US)')
+  try {
+    const aapl5m = await fetchIntradayPrices({ ticker: 'AAPL', market: 'US', timeframe: '5m' })
+    console.log(`  bars=${aapl5m.length}`)
+    if (aapl5m.length > 0) {
+      const first = aapl5m[0]
+      const last = aapl5m[aapl5m.length - 1]
+      console.log(`  first: ${first.date}  O=${first.open}  H=${first.high}  L=${first.low}  C=${first.close}  V=${first.volume}`)
+      console.log(`  last:  ${last.date}  C=${last.close}  V=${last.volume}`)
+    } else {
+      console.log('  ⚠ 빈 배열 반환')
+    }
+  } catch (e) {
+    console.error('  ❌ 오류:', e instanceof Error ? e.message : e)
+  }
+  console.log()
+
+  // ── 2) Samsung 5분봉 (KOSPI)
+  console.log('▶ Test 2: Samsung 005930 5m (KR)')
+  try {
+    const samsung5m = await fetchIntradayPrices({ ticker: '005930', market: 'KR', timeframe: '5m' })
+    console.log(`  bars=${samsung5m.length}`)
+    if (samsung5m.length > 0) {
+      const first = samsung5m[0]
+      const last = samsung5m[samsung5m.length - 1]
+      console.log(`  first: ${first.date}  C=${first.close}  V=${first.volume}`)
+      console.log(`  last:  ${last.date}  C=${last.close}  V=${last.volume}`)
+    } else {
+      console.log('  ⚠ 한국 분봉 미지원 가능성 — yahoo가 빈 응답')
+    }
+  } catch (e) {
+    console.error('  ❌ 오류:', e instanceof Error ? e.message : e)
+  }
+  console.log()
+
+  // ── 3) AAPL 1분봉 (7일 제한)
+  console.log('▶ Test 3: AAPL 1m (US, 7-day limit)')
+  try {
+    const aapl1m = await fetchIntradayPrices({ ticker: 'AAPL', market: 'US', timeframe: '1m' })
+    console.log(`  bars=${aapl1m.length}`)
+    if (aapl1m.length > 0) {
+      const first = aapl1m[0]
+      const last = aapl1m[aapl1m.length - 1]
+      console.log(`  first: ${first.date}`)
+      console.log(`  last:  ${last.date}`)
+    } else {
+      console.log('  ⚠ 빈 배열 반환')
+    }
+  } catch (e) {
+    console.error('  ❌ 오류:', e instanceof Error ? e.message : e)
+  }
+  console.log()
+
+  // ── 4) AAPL 15분봉
+  console.log('▶ Test 4: AAPL 15m (US)')
+  try {
+    const aapl15m = await fetchIntradayPrices({ ticker: 'AAPL', market: 'US', timeframe: '15m' })
+    console.log(`  bars=${aapl15m.length}`)
+    if (aapl15m.length > 0) {
+      console.log(`  first: ${aapl15m[0].date}`)
+      console.log(`  last:  ${aapl15m[aapl15m.length - 1].date}`)
+    }
+  } catch (e) {
+    console.error('  ❌ 오류:', e instanceof Error ? e.message : e)
+  }
+
+  console.log('\n═══════════════════════════════════════════')
+  console.log('  Test Complete')
+  console.log('═══════════════════════════════════════════')
+}
+
+main().catch(e => {
+  console.error('Unhandled error:', e)
+  process.exit(1)
+})

--- a/dental-clinic-manager/scripts/test-smart-money-real.ts
+++ b/dental-clinic-manager/scripts/test-smart-money-real.ts
@@ -1,0 +1,117 @@
+/**
+ * 실제 데이터로 Smart Money 지표 검증 (Yahoo Finance)
+ */
+import YahooFinance from 'yahoo-finance2'
+import { calculateIndicators } from '../src/lib/indicatorEngine'
+import type { OHLCV, IndicatorConfig } from '../src/types/investment'
+
+const yahooFinance = new YahooFinance()
+
+async function fetchOHLCV(symbol: string, days: number): Promise<OHLCV[]> {
+  const end = new Date()
+  const start = new Date()
+  start.setDate(start.getDate() - days)
+  const result = await yahooFinance.chart(symbol, {
+    period1: start,
+    period2: end,
+    interval: '1d',
+  })
+  return result.quotes
+    .filter(q => q.open != null && q.high != null && q.low != null && q.close != null && q.volume != null)
+    .map(q => ({
+      date: q.date.toISOString().slice(0, 10),
+      open: q.open!,
+      high: q.high!,
+      low: q.low!,
+      close: q.close!,
+      volume: q.volume!,
+    }))
+}
+
+const indicators: IndicatorConfig[] = [
+  { id: 'SMART_MONEY_20_20_10_10', type: 'SMART_MONEY', params: { cmfPeriod: 20, divergenceLookback: 20, springLookback: 10, upthrustLookback: 10 } },
+  { id: 'DAILY_SMART_MONEY_PULSE_20', type: 'DAILY_SMART_MONEY_PULSE', params: { volPeriod: 20 } },
+  { id: 'RSI_14', type: 'RSI', params: { period: 14 } },
+]
+
+async function analyze(symbol: string, label: string) {
+  console.log(`\n═══════════════ ${label} (${symbol}) ═══════════════`)
+  const bars = await fetchOHLCV(symbol, 365 * 2)
+  console.log(`데이터: ${bars.length}개 봉 (${bars[0]?.date} ~ ${bars[bars.length - 1]?.date})`)
+  if (bars.length < 50) { console.log('데이터 부족'); return }
+
+  const results = calculateIndicators(bars, indicators)
+  const smi = results['SMART_MONEY_20_20_10_10'] as number[]
+  const pulse = results['DAILY_SMART_MONEY_PULSE_20'] as number[]
+  const rsi = results['RSI_14'] as number[]
+
+  // 통계
+  const valid = (arr: number[]) => arr.filter(v => !isNaN(v))
+  const stats = (arr: number[]) => {
+    const v = valid(arr)
+    if (v.length === 0) return { min: 'N/A', max: 'N/A', avg: 'N/A' }
+    const min = Math.min(...v).toFixed(2)
+    const max = Math.max(...v).toFixed(2)
+    const avg = (v.reduce((a, b) => a + b, 0) / v.length).toFixed(2)
+    return { min, max, avg }
+  }
+  console.log(`SMI 통계: min=${stats(smi).min}, max=${stats(smi).max}, avg=${stats(smi).avg}`)
+  console.log(`Pulse 통계: min=${stats(pulse).min}, max=${stats(pulse).max}, avg=${stats(pulse).avg}`)
+
+  // 강한 매집/분산 신호 카운트
+  const strongAccum = smi.filter(v => v > 30).length
+  const strongDist = smi.filter(v => v < -30).length
+  const strongDailyAccum = pulse.filter(v => v > 50).length
+  const strongDailyDist = pulse.filter(v => v < -30).length
+  console.log(`SMI > +30 (매집 신호): ${strongAccum}회 (${(strongAccum / valid(smi).length * 100).toFixed(1)}%)`)
+  console.log(`SMI < -30 (분산 신호): ${strongDist}회 (${(strongDist / valid(smi).length * 100).toFixed(1)}%)`)
+  console.log(`Pulse > +50 (일일 매집): ${strongDailyAccum}회 (${(strongDailyAccum / valid(pulse).length * 100).toFixed(1)}%)`)
+  console.log(`Pulse < -30 (일일 분산): ${strongDailyDist}회 (${(strongDailyDist / valid(pulse).length * 100).toFixed(1)}%)`)
+
+  // 최근 10봉 출력
+  console.log(`\n최근 10봉:`)
+  console.log('Date       | Close   | RSI   | SMI    | Pulse')
+  console.log('-----------|---------|-------|--------|--------')
+  for (let i = bars.length - 10; i < bars.length; i++) {
+    const b = bars[i]
+    const c = b.close.toFixed(2).padStart(7)
+    const r = (rsi[i] ?? NaN).toFixed(1).padStart(5)
+    const s = (smi[i] ?? NaN).toFixed(1).padStart(6)
+    const p = (pulse[i] ?? NaN).toFixed(1).padStart(6)
+    console.log(`${b.date} | ${c} | ${r} | ${s} | ${p}`)
+  }
+
+  // 전략 시뮬레이션: SMI > 30 매수, SMI < -20 매도 (단순 버전)
+  let position = 0
+  let cash = 10000
+  let trades = 0
+  let wins = 0
+  let entryPrice = 0
+  for (let i = 30; i < bars.length - 1; i++) {
+    const nextOpen = bars[i + 1].open
+    if (position === 0 && smi[i] > 30 && rsi[i] < 65) {
+      position = cash / nextOpen
+      entryPrice = nextOpen
+      cash = 0
+    } else if (position > 0 && (smi[i] < -20 || (i > 0 && smi[i - 1] > 0 && smi[i] < 0))) {
+      cash = position * nextOpen
+      trades++
+      if (nextOpen > entryPrice) wins++
+      position = 0
+    }
+  }
+  if (position > 0) cash = position * bars[bars.length - 1].close
+  const buyHold = (bars[bars.length - 1].close / bars[30].close - 1) * 100
+  console.log(`\n전략 시뮬레이션 (SMI>30 매수, SMI<-20 매도):`)
+  console.log(`  최종 자본: $${cash.toFixed(0)} (시작 $10000, 수익률 ${((cash / 10000 - 1) * 100).toFixed(2)}%)`)
+  console.log(`  거래 횟수: ${trades}회, 승률: ${trades > 0 ? (wins / trades * 100).toFixed(1) : 0}%`)
+  console.log(`  Buy & Hold 수익률: ${buyHold.toFixed(2)}%`)
+}
+
+async function main() {
+  await analyze('005930.KS', '삼성전자')
+  await analyze('AAPL', '애플')
+  await analyze('NVDA', 'NVIDIA')
+}
+
+main().catch(e => { console.error(e); process.exit(1) })

--- a/dental-clinic-manager/scripts/test-smart-money.ts
+++ b/dental-clinic-manager/scripts/test-smart-money.ts
@@ -1,0 +1,123 @@
+/**
+ * Smart Money 지표 단위 검증
+ *
+ * 합성 데이터 시나리오:
+ * 1. 매집 시나리오: 가격 횡보 + 거래량 증가 + 종가가 일봉 상단 마감 → SMI 양수 기대
+ * 2. 분산 시나리오: 가격 신고가 시도 + 거래량 감소 + 종가가 일봉 하단 마감 → SMI 음수 기대
+ * 3. Spring 시나리오: 지지선 가짜 이탈 후 종가 회복 → +1 spring
+ * 4. Upthrust 시나리오: 저항선 가짜 돌파 후 종가 약세 → +1 upthrust
+ */
+
+import { calculateIndicators } from '../src/lib/indicatorEngine'
+import type { OHLCV, IndicatorConfig } from '../src/types/investment'
+
+function makeBar(date: string, o: number, h: number, l: number, c: number, v: number): OHLCV {
+  return { date, open: o, high: h, low: l, close: c, volume: v }
+}
+
+// 시나리오 1: 매집 (50봉) - 가격 100 횡보, 거래량 점증, 종가가 일봉 상단 (CLV ≈ +0.7)
+function makeAccumulation(): OHLCV[] {
+  const bars: OHLCV[] = []
+  for (let i = 0; i < 50; i++) {
+    const date = `2025-01-${String(i + 1).padStart(2, '0')}`
+    // close in upper half, volume increasing
+    bars.push(makeBar(date, 99, 101, 98, 100.5, 1000 + i * 50))
+  }
+  return bars
+}
+
+// 시나리오 2: 분산 (50봉) - 가격 상승 시도하지만 종가 약세, 거래량 점감
+function makeDistribution(): OHLCV[] {
+  const bars: OHLCV[] = []
+  for (let i = 0; i < 50; i++) {
+    const date = `2025-01-${String(i + 1).padStart(2, '0')}`
+    // close in lower half, volume decreasing
+    bars.push(makeBar(date, 100, 102, 99, 99.5, 5000 - i * 50))
+  }
+  return bars
+}
+
+// 시나리오 3: Spring (40봉 + 1 Spring 봉)
+function makeSpring(): OHLCV[] {
+  const bars: OHLCV[] = []
+  // 40봉 횡보 (low ~95, high ~102)
+  for (let i = 0; i < 40; i++) {
+    const date = `2025-02-${String(i + 1).padStart(2, '0')}`
+    bars.push(makeBar(date, 99, 102, 95, 100, 1000))
+  }
+  // Spring 봉: low 92 (지지선 95 이탈), close 101 (회복+상단), volume 3000 (3배)
+  bars.push(makeBar('2025-03-12', 99, 101.5, 92, 101, 3000))
+  return bars
+}
+
+// 시나리오 4: Upthrust (40봉 + 1 Upthrust 봉)
+function makeUpthrust(): OHLCV[] {
+  const bars: OHLCV[] = []
+  for (let i = 0; i < 40; i++) {
+    const date = `2025-04-${String(i + 1).padStart(2, '0')}`
+    bars.push(makeBar(date, 99, 102, 98, 100, 1000))
+  }
+  // Upthrust: high 105 (저항 102 돌파), close 99 (하단 마감), volume 3000
+  bars.push(makeBar('2025-05-12', 100, 105, 98.5, 99, 3000))
+  return bars
+}
+
+// 시나리오 5: 일일 펄스 - 강한 매집 마감 봉
+function makeDailyAccumBar(): OHLCV[] {
+  const bars: OHLCV[] = []
+  for (let i = 0; i < 25; i++) {
+    bars.push(makeBar(`2025-06-${String(i + 1).padStart(2, '0')}`, 100, 101, 99, 100, 1000))
+  }
+  // Day +25: 갭 하락 후 종가 회복, 거래량 2배, 종가 일봉 상단
+  bars.push(makeBar('2025-07-01', 98, 102, 97, 101.5, 2000))
+  return bars
+}
+
+// 시나리오 6: 일일 펄스 - 강한 분산 마감 봉 (Gap Fade)
+function makeDailyDistBar(): OHLCV[] {
+  const bars: OHLCV[] = []
+  for (let i = 0; i < 25; i++) {
+    bars.push(makeBar(`2025-08-${String(i + 1).padStart(2, '0')}`, 100, 101, 99, 100, 1000))
+  }
+  // 갭 상승 후 종가가 시가 아래 (Gap Fade), 거래량 2배, 종가 일봉 하단
+  bars.push(makeBar('2025-09-01', 102.5, 103, 99, 99.5, 2000))
+  return bars
+}
+
+const smartMoney: IndicatorConfig = {
+  id: 'SMART_MONEY_20_20_10_10',
+  type: 'SMART_MONEY',
+  params: { cmfPeriod: 20, divergenceLookback: 20, springLookback: 10, upthrustLookback: 10 },
+}
+const dailyPulse: IndicatorConfig = {
+  id: 'DAILY_SMART_MONEY_PULSE_20',
+  type: 'DAILY_SMART_MONEY_PULSE',
+  params: { volPeriod: 20 },
+}
+
+const scenarios = [
+  { name: '시나리오 1: 매집 (CLV+, vol↑)', bars: makeAccumulation(), expect: 'SMI > 0' },
+  { name: '시나리오 2: 분산 (CLV-, vol↓)', bars: makeDistribution(), expect: 'SMI < 0' },
+  { name: '시나리오 3: Spring 단봉', bars: makeSpring(), expect: 'SMI 마지막 큰 양수' },
+  { name: '시나리오 4: Upthrust 단봉', bars: makeUpthrust(), expect: 'SMI 마지막 큰 음수' },
+  { name: '시나리오 5: 일일 매집 봉', bars: makeDailyAccumBar(), expect: 'Pulse > 50' },
+  { name: '시나리오 6: 일일 Gap Fade', bars: makeDailyDistBar(), expect: 'Pulse < 0' },
+]
+
+console.log('═══════════════ Smart Money 지표 검증 ═══════════════\n')
+
+for (const sc of scenarios) {
+  const results = calculateIndicators(sc.bars, [smartMoney, dailyPulse])
+  const smi = results['SMART_MONEY_20_20_10_10'] as number[]
+  const pulse = results['DAILY_SMART_MONEY_PULSE_20'] as number[]
+  const lastSmi = smi[smi.length - 1]
+  const lastPulse = pulse[pulse.length - 1]
+  const recentSmi = smi.slice(-5).map(v => (v as number).toFixed(1))
+  const recentPulse = pulse.slice(-5).map(v => (v as number).toFixed(1))
+
+  console.log(`📊 ${sc.name}`)
+  console.log(`   기대: ${sc.expect}`)
+  console.log(`   SMI 최근 5봉: [${recentSmi.join(', ')}]  (마지막=${lastSmi})`)
+  console.log(`   Pulse 최근 5봉: [${recentPulse.join(', ')}]  (마지막=${lastPulse})`)
+  console.log()
+}

--- a/dental-clinic-manager/src/app/api/investment/daytrading-backtest/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/daytrading-backtest/route.ts
@@ -1,0 +1,159 @@
+/**
+ * 단타(Day Trading) 백테스트 API
+ *
+ * POST /api/investment/daytrading-backtest
+ *
+ * Body 옵션 1 (저장된 전략 사용):
+ *   { strategyId, ticker, market, timeframe, startDate?, endDate?, initialCapital? }
+ *
+ * Body 옵션 2 (즉석 전략 - 프리셋 직접 전달):
+ *   { preset: { indicators, buyConditions, sellConditions, riskSettings },
+ *     ticker, market, timeframe, startDate?, endDate?, initialCapital? }
+ *
+ * 단타는 자주 다양한 프리셋을 즉석에서 시험하므로 옵션 2가 권장됨.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { runDayTradingBacktest } from '@/lib/dayTradingBacktestEngine'
+import { fetchIntradayPrices, type IntradayTimeframe } from '@/lib/intradayDataService'
+import type { Market, ConditionGroup, IndicatorConfig, RiskSettings } from '@/types/investment'
+
+const VALID_TIMEFRAMES: IntradayTimeframe[] = ['1m', '5m', '15m']
+const BAR_MINUTES: Record<IntradayTimeframe, number> = { '1m': 1, '5m': 5, '15m': 15 }
+
+const DEFAULT_RISK: RiskSettings = {
+  maxDailyLossPercent: 5,
+  maxPositions: 1,
+  maxPositionSizePercent: 100,
+  stopLossPercent: 1.5,
+  takeProfitPercent: 3,
+  maxHoldingDays: 12,
+}
+
+interface PresetBody {
+  indicators?: IndicatorConfig[]
+  buyConditions?: ConditionGroup
+  sellConditions?: ConditionGroup
+  riskSettings?: Partial<RiskSettings>
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const userId = auth.user!.id
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: '잘못된 요청 형식입니다' }, { status: 400 })
+  }
+
+  const { strategyId, preset, ticker, market, timeframe, startDate, endDate, initialCapital } = body
+
+  if (!ticker || typeof ticker !== 'string') {
+    return NextResponse.json({ error: '종목 코드가 필요합니다' }, { status: 400 })
+  }
+  if (market !== 'KR' && market !== 'US') {
+    return NextResponse.json({ error: '올바른 시장을 선택해주세요' }, { status: 400 })
+  }
+  if (typeof timeframe !== 'string' || !VALID_TIMEFRAMES.includes(timeframe as IntradayTimeframe)) {
+    return NextResponse.json({ error: 'timeframe은 1m, 5m, 15m 중 하나여야 합니다' }, { status: 400 })
+  }
+  const tf = timeframe as IntradayTimeframe
+  const capital = typeof initialCapital === 'number' && initialCapital > 0 ? initialCapital : 10_000_000
+
+  // 전략 정보 결정 (저장된 전략 또는 프리셋)
+  let indicators: IndicatorConfig[]
+  let buyConditions: ConditionGroup
+  let sellConditions: ConditionGroup
+  let riskSettings: RiskSettings
+
+  if (strategyId && typeof strategyId === 'string') {
+    const supabase = getSupabaseAdmin()
+    if (!supabase) return NextResponse.json({ error: 'Server error' }, { status: 500 })
+
+    const { data: strategy } = await supabase
+      .from('investment_strategies')
+      .select('*')
+      .eq('id', strategyId)
+      .eq('user_id', userId)
+      .single()
+
+    if (!strategy) {
+      return NextResponse.json({ error: '전략을 찾을 수 없습니다' }, { status: 404 })
+    }
+
+    indicators = strategy.indicators as IndicatorConfig[]
+    buyConditions = strategy.buy_conditions as ConditionGroup
+    sellConditions = strategy.sell_conditions as ConditionGroup
+    riskSettings = strategy.risk_settings as RiskSettings
+  } else if (preset && typeof preset === 'object') {
+    const p = preset as PresetBody
+    if (!p.indicators || !p.buyConditions || !p.sellConditions) {
+      return NextResponse.json({
+        error: 'preset에는 indicators, buyConditions, sellConditions가 필요합니다',
+      }, { status: 400 })
+    }
+    indicators = p.indicators
+    buyConditions = p.buyConditions
+    sellConditions = p.sellConditions
+    riskSettings = { ...DEFAULT_RISK, ...(p.riskSettings || {}) }
+  } else {
+    return NextResponse.json({ error: 'strategyId 또는 preset 중 하나가 필요합니다' }, { status: 400 })
+  }
+
+  try {
+    const prices = await fetchIntradayPrices({
+      ticker: ticker as string,
+      market: market as Market,
+      timeframe: tf,
+      startDate: typeof startDate === 'string' ? startDate : undefined,
+      endDate: typeof endDate === 'string' ? endDate : undefined,
+    })
+
+    if (prices.length < 20) {
+      return NextResponse.json({
+        error: `${ticker} ${tf} 분봉 데이터가 부족합니다 (${prices.length}봉, 최소 20봉 필요).`,
+      }, { status: 400 })
+    }
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 55_000)
+
+    const result = runDayTradingBacktest({
+      prices,
+      indicators,
+      buyConditions,
+      sellConditions,
+      riskSettings,
+      initialCapital: capital,
+      market: market as Market,
+      ticker: ticker as string,
+      barMinutes: BAR_MINUTES[tf],
+      forceCloseAtSessionEnd: true,
+    }, controller.signal)
+
+    clearTimeout(timeout)
+
+    return NextResponse.json({
+      data: {
+        ...result,
+        meta: {
+          timeframe: tf,
+          totalBars: prices.length,
+          firstBar: prices[0]?.date,
+          lastBar: prices[prices.length - 1]?.date,
+        },
+      },
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '단타 백테스트 실행 실패'
+    console.error('[daytrading-backtest] 오류:', message)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/dental-clinic-manager/src/app/api/investment/intraday-prices/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/intraday-prices/route.ts
@@ -1,0 +1,57 @@
+/**
+ * 분봉 데이터 조회 API
+ *
+ * GET /api/investment/intraday-prices?ticker=AAPL&market=US&timeframe=5m
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { fetchIntradayPrices, type IntradayTimeframe } from '@/lib/intradayDataService'
+import type { Market } from '@/types/investment'
+
+const VALID_TIMEFRAMES: IntradayTimeframe[] = ['1m', '5m', '15m']
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const ticker = searchParams.get('ticker')
+  const market = searchParams.get('market')
+  const timeframe = searchParams.get('timeframe') || '5m'
+  const startDate = searchParams.get('startDate') || undefined
+  const endDate = searchParams.get('endDate') || undefined
+
+  if (!ticker) return NextResponse.json({ error: 'ticker 필수' }, { status: 400 })
+  if (market !== 'KR' && market !== 'US') {
+    return NextResponse.json({ error: 'market은 KR 또는 US' }, { status: 400 })
+  }
+  if (!VALID_TIMEFRAMES.includes(timeframe as IntradayTimeframe)) {
+    return NextResponse.json({ error: 'timeframe은 1m, 5m, 15m 중 하나' }, { status: 400 })
+  }
+
+  try {
+    const prices = await fetchIntradayPrices({
+      ticker,
+      market: market as Market,
+      timeframe: timeframe as IntradayTimeframe,
+      startDate,
+      endDate,
+    })
+
+    return NextResponse.json({
+      data: prices,
+      meta: {
+        ticker, market, timeframe,
+        count: prices.length,
+        first: prices[0]?.date,
+        last: prices[prices.length - 1]?.date,
+      },
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '분봉 조회 실패'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/dental-clinic-manager/src/app/investment/daytrading/page.tsx
+++ b/dental-clinic-manager/src/app/investment/daytrading/page.tsx
@@ -1,0 +1,384 @@
+'use client'
+
+/**
+ * 단타(Day Trading) 모듈 메인 페이지
+ *
+ * - 단타 프리셋 카탈로그 (3종)
+ * - 종목/시장/timeframe/기간 선택
+ * - 분봉 백테스트 즉시 실행 + 결과 표시
+ *
+ * 일봉 swing 시스템과 별도로 동작 (별도 API: /api/investment/daytrading-backtest).
+ */
+
+import { useState, useMemo } from 'react'
+import { Zap, Play, Loader2, Target, TrendingDown, TrendingUp, AlertCircle, CheckCircle2, X } from 'lucide-react'
+import TickerSearch from '@/components/Investment/TickerSearch'
+import { PRESET_STRATEGIES } from '@/components/Investment/StrategyBuilder/presets'
+import type { Market, BacktestMetrics, BacktestTrade, EquityCurvePoint, PresetStrategy } from '@/types/investment'
+
+type Timeframe = '1m' | '5m' | '15m'
+
+interface BacktestResponse {
+  data?: {
+    metrics: BacktestMetrics
+    trades: BacktestTrade[]
+    equityCurve: EquityCurvePoint[]
+    buyHold: { totalReturn: number; finalValue: number }
+    meta: { timeframe: Timeframe; totalBars: number; firstBar: string; lastBar: string }
+  }
+  error?: string
+}
+
+const DAY_TRADING_PRESET_IDS = ['day-vwap-bounce', 'day-orb-breakout', 'day-closing-pressure']
+
+export default function DayTradingPage() {
+  const [selectedPresetId, setSelectedPresetId] = useState<string>(DAY_TRADING_PRESET_IDS[0])
+  const [ticker, setTicker] = useState('AAPL')
+  const [tickerName, setTickerName] = useState('Apple Inc.')
+  const [market, setMarket] = useState<Market>('US')
+  const [timeframe, setTimeframe] = useState<Timeframe>('5m')
+  const [initialCapital, setInitialCapital] = useState(10_000_000)
+  const [running, setRunning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<BacktestResponse['data'] | null>(null)
+
+  const dayTradingPresets = useMemo(
+    () => PRESET_STRATEGIES.filter(p => DAY_TRADING_PRESET_IDS.includes(p.id)),
+    []
+  )
+  const selectedPreset = useMemo<PresetStrategy | undefined>(
+    () => dayTradingPresets.find(p => p.id === selectedPresetId),
+    [dayTradingPresets, selectedPresetId]
+  )
+
+  const runBacktest = async () => {
+    if (!selectedPreset) return setError('프리셋을 선택해주세요')
+    if (!ticker.trim()) return setError('종목 코드를 입력해주세요')
+
+    setRunning(true)
+    setError(null)
+    setResult(null)
+
+    try {
+      const res = await fetch('/api/investment/daytrading-backtest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          preset: {
+            indicators: selectedPreset.indicators,
+            buyConditions: selectedPreset.buyConditions,
+            sellConditions: selectedPreset.sellConditions,
+            riskSettings: selectedPreset.riskSettings,
+          },
+          ticker: ticker.trim(),
+          market,
+          timeframe,
+          initialCapital,
+        }),
+      })
+      const json: BacktestResponse = await res.json()
+      if (!res.ok) {
+        setError(json.error || '백테스트 실패')
+      } else if (json.data) {
+        setResult(json.data)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '네트워크 오류')
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  const handleTickerSelect = (t: string, name?: string) => {
+    setTicker(t)
+    setTickerName(name || t)
+  }
+
+  return (
+    <div className="space-y-6 max-w-6xl">
+      {/* 헤더 */}
+      <div>
+        <div className="flex items-center gap-2">
+          <Zap className="w-6 h-6 text-amber-500" />
+          <h1 className="text-xl font-bold text-at-text">단타 (Day Trading)</h1>
+        </div>
+        <p className="text-sm text-at-text-secondary mt-1">
+          분봉 데이터(1~15분봉)로 일중 매매 전략을 백테스트합니다. 장 마감 시 자동 청산되며, 슬리피지가 강화 적용됩니다.
+        </p>
+      </div>
+
+      {/* 안내 박스 */}
+      <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm">
+        <div className="flex gap-2">
+          <AlertCircle className="w-4 h-4 text-amber-600 flex-shrink-0 mt-0.5" />
+          <div className="text-amber-900">
+            <p className="font-medium mb-1">단타 모듈 한계</p>
+            <ul className="list-disc list-inside space-y-0.5 text-amber-800 text-xs">
+              <li>1분봉은 최근 7일, 5분봉/15분봉은 최근 60일까지만 조회 가능 (Yahoo Finance 정책)</li>
+              <li>한국 시장은 0.49% 왕복 수수료 + 슬리피지로 단타 마진이 작음</li>
+              <li>표본이 적으므로 단일 백테스트 결과는 참고용 - 다양한 종목/기간 시도 권장</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      {/* 프리셋 선택 */}
+      <section className="bg-white rounded-2xl shadow-sm border border-at-border p-5">
+        <h2 className="font-semibold text-at-text mb-3">📋 단타 전략 프리셋</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          {dayTradingPresets.map(p => {
+            const isSelected = selectedPresetId === p.id
+            return (
+              <button
+                key={p.id}
+                onClick={() => setSelectedPresetId(p.id)}
+                className={`text-left p-4 rounded-xl border-2 transition-colors ${
+                  isSelected
+                    ? 'border-at-accent bg-at-accent-light'
+                    : 'border-at-border bg-at-surface hover:border-at-accent/50'
+                }`}
+              >
+                <p className="font-medium text-at-text text-sm">{p.name}</p>
+                <p className="text-xs text-at-text-secondary mt-1.5 line-clamp-3">{p.description}</p>
+                <div className="flex flex-wrap gap-1 mt-2">
+                  {p.indicators.map(ind => (
+                    <span key={ind.id} className="text-[10px] px-1.5 py-0.5 rounded bg-at-bg text-at-text-weak font-mono">
+                      {ind.type}
+                    </span>
+                  ))}
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </section>
+
+      {/* 백테스트 폼 */}
+      <section className="bg-white rounded-2xl shadow-sm border border-at-border p-5">
+        <h2 className="font-semibold text-at-text mb-3">🔬 백테스트 실행</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {/* 시장 */}
+          <div>
+            <label className="block text-xs font-medium text-at-text-secondary mb-1.5">시장</label>
+            <div className="flex gap-2">
+              {(['US', 'KR'] as Market[]).map(m => (
+                <button
+                  key={m}
+                  onClick={() => setMarket(m)}
+                  className={`flex-1 px-3 py-2 rounded-xl text-sm font-medium transition-colors ${
+                    market === m
+                      ? 'bg-at-accent text-white'
+                      : 'bg-at-surface-alt text-at-text-secondary hover:bg-at-bg'
+                  }`}
+                >
+                  {m === 'KR' ? '국내' : '미국'}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* timeframe */}
+          <div>
+            <label className="block text-xs font-medium text-at-text-secondary mb-1.5">분봉 단위</label>
+            <div className="flex gap-2">
+              {(['1m', '5m', '15m'] as Timeframe[]).map(t => (
+                <button
+                  key={t}
+                  onClick={() => setTimeframe(t)}
+                  className={`flex-1 px-3 py-2 rounded-xl text-sm font-medium transition-colors ${
+                    timeframe === t
+                      ? 'bg-at-accent text-white'
+                      : 'bg-at-surface-alt text-at-text-secondary hover:bg-at-bg'
+                  }`}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* 종목 검색 */}
+          <div className="md:col-span-2">
+            <label className="block text-xs font-medium text-at-text-secondary mb-1.5">종목 검색</label>
+            <TickerSearch
+              market={market}
+              onSelect={handleTickerSelect}
+              placeholder={market === 'US' ? '예: 애플 / AAPL' : '예: 삼성전자 / 005930'}
+              clearOnSelect={false}
+            />
+            {ticker && (
+              <p className="text-xs text-at-text-secondary mt-1.5">
+                선택됨: <span className="font-mono font-semibold text-at-text">{ticker}</span>
+                {tickerName && tickerName !== ticker && <span className="ml-2">({tickerName})</span>}
+              </p>
+            )}
+          </div>
+
+          {/* 초기자본 */}
+          <div>
+            <label className="block text-xs font-medium text-at-text-secondary mb-1.5">초기 자본</label>
+            <input
+              type="number"
+              value={initialCapital}
+              onChange={e => setInitialCapital(Math.max(100_000, Number(e.target.value) || 0))}
+              className="w-full px-3 py-2 rounded-xl border border-at-border bg-white text-at-text text-sm focus:outline-none focus:border-at-accent"
+              min={100_000}
+              step={1_000_000}
+            />
+          </div>
+
+          {/* 실행 */}
+          <div className="flex items-end">
+            <button
+              onClick={runBacktest}
+              disabled={running || !ticker.trim() || !selectedPreset}
+              className="w-full px-4 py-2 bg-at-accent text-white rounded-xl text-sm font-medium hover:bg-at-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center justify-center gap-2"
+            >
+              {running ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+              {running ? '실행 중...' : '백테스트 실행'}
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mt-4 p-3 rounded-xl bg-red-50 border border-red-200 flex items-start gap-2 text-sm text-red-800">
+            <X className="w-4 h-4 flex-shrink-0 mt-0.5" />
+            <span>{error}</span>
+          </div>
+        )}
+      </section>
+
+      {/* 결과 */}
+      {result && (
+        <section className="bg-white rounded-2xl shadow-sm border border-at-border p-5">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="font-semibold text-at-text">📊 백테스트 결과</h2>
+            <div className="text-xs text-at-text-secondary">
+              {result.meta.totalBars}봉 · {result.meta.firstBar?.slice(0, 16)} ~ {result.meta.lastBar?.slice(0, 16)}
+            </div>
+          </div>
+
+          {/* 메트릭 카드 */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+            <MetricCard
+              label="총 수익률"
+              value={`${(result.metrics.totalReturn * 100).toFixed(2)}%`}
+              positive={result.metrics.totalReturn > 0}
+              icon={result.metrics.totalReturn > 0 ? TrendingUp : TrendingDown}
+            />
+            <MetricCard
+              label="Buy & Hold"
+              value={`${(result.buyHold.totalReturn * 100).toFixed(2)}%`}
+              positive={result.buyHold.totalReturn > 0}
+            />
+            <MetricCard
+              label="승률"
+              value={`${(result.metrics.winRate * 100).toFixed(1)}%`}
+              positive={result.metrics.winRate >= 0.5}
+            />
+            <MetricCard
+              label="총 거래"
+              value={`${result.metrics.totalTrades}회`}
+            />
+            <MetricCard
+              label="Sharpe Ratio"
+              value={result.metrics.sharpeRatio.toFixed(2)}
+              positive={result.metrics.sharpeRatio > 1}
+            />
+            <MetricCard
+              label="Max Drawdown"
+              value={`${(result.metrics.maxDrawdown * 100).toFixed(2)}%`}
+              positive={false}
+            />
+            <MetricCard
+              label="Profit Factor"
+              value={result.metrics.profitFactor.toFixed(2)}
+              positive={result.metrics.profitFactor > 1}
+            />
+            <MetricCard
+              label="평균 보유 봉수"
+              value={`${result.metrics.avgHoldingDays.toFixed(1)}봉`}
+            />
+          </div>
+
+          {/* 거래 내역 */}
+          {result.trades.length > 0 ? (
+            <div className="overflow-x-auto rounded-xl border border-at-border">
+              <table className="w-full text-xs">
+                <thead className="bg-at-surface-alt">
+                  <tr>
+                    <th className="px-3 py-2 text-left font-medium text-at-text-secondary">진입</th>
+                    <th className="px-3 py-2 text-left font-medium text-at-text-secondary">청산</th>
+                    <th className="px-3 py-2 text-right font-medium text-at-text-secondary">수량</th>
+                    <th className="px-3 py-2 text-right font-medium text-at-text-secondary">진입가</th>
+                    <th className="px-3 py-2 text-right font-medium text-at-text-secondary">청산가</th>
+                    <th className="px-3 py-2 text-right font-medium text-at-text-secondary">손익</th>
+                    <th className="px-3 py-2 text-right font-medium text-at-text-secondary">%</th>
+                    <th className="px-3 py-2 text-right font-medium text-at-text-secondary">보유봉수</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.trades.slice(0, 50).map((t, i) => (
+                    <tr key={i} className="border-t border-at-border">
+                      <td className="px-3 py-2 font-mono text-at-text-secondary">{t.entryDate.slice(5, 16)}</td>
+                      <td className="px-3 py-2 font-mono text-at-text-secondary">{t.exitDate.slice(5, 16)}</td>
+                      <td className="px-3 py-2 text-right font-mono">{t.quantity}</td>
+                      <td className="px-3 py-2 text-right font-mono">{t.entryPrice.toFixed(2)}</td>
+                      <td className="px-3 py-2 text-right font-mono">{t.exitPrice.toFixed(2)}</td>
+                      <td className={`px-3 py-2 text-right font-mono font-semibold ${t.pnl > 0 ? 'text-green-600' : 'text-red-600'}`}>
+                        {t.pnl > 0 ? '+' : ''}{t.pnl.toFixed(0)}
+                      </td>
+                      <td className={`px-3 py-2 text-right font-mono ${t.pnlPercent > 0 ? 'text-green-600' : 'text-red-600'}`}>
+                        {t.pnlPercent > 0 ? '+' : ''}{(t.pnlPercent * 100).toFixed(2)}%
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono">{t.holdingDays}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {result.trades.length > 50 && (
+                <p className="px-3 py-2 text-xs text-at-text-secondary border-t border-at-border bg-at-surface-alt">
+                  최근 50건만 표시 (총 {result.trades.length}건)
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className="text-center py-8 text-at-text-secondary text-sm">
+              <Target className="w-8 h-8 mx-auto mb-2 opacity-30" />
+              해당 기간에 매수 시그널이 발생하지 않았습니다. 다른 종목/프리셋을 시도해보세요.
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  )
+}
+
+function MetricCard({
+  label,
+  value,
+  positive,
+  icon: Icon,
+}: {
+  label: string
+  value: string
+  positive?: boolean
+  icon?: React.ElementType
+}) {
+  const colorClass =
+    positive === undefined
+      ? 'text-at-text'
+      : positive
+      ? 'text-green-600'
+      : 'text-red-600'
+  return (
+    <div className="rounded-xl border border-at-border bg-at-surface p-3">
+      <div className="flex items-center gap-1.5 text-xs text-at-text-secondary mb-1">
+        {Icon && <Icon className="w-3 h-3" />}
+        {positive === true && <CheckCircle2 className="w-3 h-3 text-green-500" />}
+        {label}
+      </div>
+      <div className={`text-base font-semibold font-mono ${colorClass}`}>{value}</div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/app/investment/layout.tsx
+++ b/dental-clinic-manager/src/app/investment/layout.tsx
@@ -15,6 +15,7 @@ import {
   Menu,
   X,
   Loader2,
+  Zap,
 } from 'lucide-react'
 import type { InvestmentTab } from '@/types/investment'
 import Footer from '@/components/Layout/Footer'
@@ -30,6 +31,7 @@ const NAV_ITEMS: NavItem[] = [
   { id: 'dashboard', label: '대시보드', icon: LayoutDashboard, href: '/investment' },
   { id: 'connect', label: '계좌 연결', icon: Link2, href: '/investment/connect' },
   { id: 'strategy', label: '전략 관리', icon: Target, href: '/investment/strategy' },
+  { id: 'daytrading', label: '단타 (분봉)', icon: Zap, href: '/investment/daytrading' },
   { id: 'trading', label: '자동매매', icon: TrendingUp, href: '/investment/trading' },
   { id: 'portfolio', label: '포트폴리오', icon: Briefcase, href: '/investment/portfolio' },
 ]

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/IndicatorPanel.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/IndicatorPanel.tsx
@@ -102,6 +102,20 @@ const TEMPLATES: IndicatorTemplate[] = [
     defaultParams: { rsiPeriod: 14, bbPeriod: 20, volPeriod: 20, momentumPeriod: 10 },
     paramLabels: { rsiPeriod: 'RSI', bbPeriod: 'BB', volPeriod: '거래량', momentumPeriod: '모멘텀' },
   },
+  {
+    type: 'SMART_MONEY',
+    label: '🐳 스마트머니 지수 (중기)',
+    description: 'CMF+A/D 다이버전스+Wyckoff Spring/Upthrust로 매집/분산 추적 (-100~+100)',
+    defaultParams: { cmfPeriod: 20, divergenceLookback: 20, springLookback: 10, upthrustLookback: 10 },
+    paramLabels: { cmfPeriod: 'CMF', divergenceLookback: '다이버전스', springLookback: 'Spring', upthrustLookback: 'Upthrust' },
+  },
+  {
+    type: 'DAILY_SMART_MONEY_PULSE',
+    label: '⚡ 일일 스마트머니 펄스 (단타)',
+    description: '당일 종가위치+거래량+갭 동작으로 일일 매집/분산 포착 (-100~+100)',
+    defaultParams: { volPeriod: 20 },
+    paramLabels: { volPeriod: '거래량 기간' },
+  },
 ]
 
 function generateId(type: IndicatorType, params: Record<string, number>): string {

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets.ts
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets.ts
@@ -625,4 +625,158 @@ export const PRESET_STRATEGIES: PresetStrategy[] = [
       takeProfitPercent: 12,
     },
   },
+
+  // ============================================
+  // 단타 (Day Trading) 전략 - 분봉 기반
+  // ============================================
+
+  {
+    id: 'day-vwap-bounce',
+    name: '⚡ VWAP 반등 단타',
+    description: '[단타/5분봉] 가격이 VWAP 아래에서 RSI 과매도 시 반등 매수, RSI 과열 또는 펄스 약화 시 청산',
+    mode: 'daytrading',
+    indicators: [
+      { id: 'VWAP', type: 'VWAP', params: {} },
+      { id: 'RSI_14', type: 'RSI', params: { period: 14 } },
+      { id: 'INTRADAY_PULSE_20', type: 'INTRADAY_PULSE', params: { volPeriod: 20 } },
+    ],
+    buyConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        // RSI 과매도 (VWAP 아래에서 과매도 → 반등 가능성)
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'RSI_14' },
+          operator: '<',
+          right: { type: 'constant', value: 35 },
+        },
+      ],
+    },
+    sellConditions: {
+      type: 'group',
+      operator: 'OR',
+      conditions: [
+        // RSI 과열 → 익절
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'RSI_14' },
+          operator: '>',
+          right: { type: 'constant', value: 60 },
+        },
+        // 분봉 펄스 0선 하향 이탈 → 약세 전환
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'INTRADAY_PULSE_20' },
+          operator: 'crossUnder',
+          right: { type: 'constant', value: 0 },
+        },
+      ],
+    },
+    riskSettings: {
+      stopLossPercent: 1.5,
+      takeProfitPercent: 2.5,
+      maxHoldingDays: 12, // 5분봉 12봉 = 60분
+    },
+  },
+
+  {
+    id: 'day-orb-breakout',
+    name: '🚀 Opening Range Breakout 단타',
+    description: '[단타/5분봉] 장 시작 30분 고점 돌파 추정(강한 매집 펄스) 시 매수, 펄스 약화 시 청산',
+    mode: 'daytrading',
+    indicators: [
+      { id: 'OPENING_RANGE_6', type: 'OPENING_RANGE', params: { numBars: 6 } }, // 5분봉 6봉 = 30분
+      { id: 'INTRADAY_PULSE_20', type: 'INTRADAY_PULSE', params: { volPeriod: 20 } },
+      { id: 'RSI_14', type: 'RSI', params: { period: 14 } },
+    ],
+    buyConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        // 강한 매집 펄스 = ORB 돌파 추정 (가격-ORB.high 직접 비교는 현재 조건 트리 미지원)
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'INTRADAY_PULSE_20' },
+          operator: '>',
+          right: { type: 'constant', value: 40 },
+        },
+        // 과열 아님 (RSI 75 미만)
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'RSI_14' },
+          operator: '<',
+          right: { type: 'constant', value: 75 },
+        },
+      ],
+    },
+    sellConditions: {
+      type: 'group',
+      operator: 'OR',
+      conditions: [
+        // 펄스 약화 → 돌파 동력 소실
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'INTRADAY_PULSE_20' },
+          operator: '<',
+          right: { type: 'constant', value: 0 },
+        },
+      ],
+    },
+    riskSettings: {
+      stopLossPercent: 1.5,
+      takeProfitPercent: 3,
+      maxHoldingDays: 24, // 5분봉 24봉 = 2시간
+    },
+  },
+
+  {
+    id: 'day-closing-pressure',
+    name: '🌙 마감 매집 단타',
+    description: '[단타/5분봉] 장 마감 30분 거래량 급증 + 매집 펄스 강세 시 매수, 다음날 시가 청산',
+    mode: 'daytrading',
+    indicators: [
+      { id: 'CLOSING_PRESSURE_6', type: 'CLOSING_PRESSURE', params: { lastNumBars: 6 } }, // 5분봉 6봉 = 30분
+      { id: 'LARGE_BLOCK_20', type: 'LARGE_BLOCK', params: { period: 20 } },
+      { id: 'INTRADAY_PULSE_20', type: 'INTRADAY_PULSE', params: { volPeriod: 20 } },
+    ],
+    buyConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        // 마감 거래량 점유율이 평균보다 비정상적으로 높음
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'CLOSING_PRESSURE_6' },
+          operator: '>',
+          right: { type: 'constant', value: 25 },
+        },
+        // 매집 펄스 강세
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'INTRADAY_PULSE_20' },
+          operator: '>',
+          right: { type: 'constant', value: 30 },
+        },
+      ],
+    },
+    sellConditions: {
+      type: 'group',
+      operator: 'OR',
+      conditions: [
+        // 펄스 강한 분산 → 청산
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'INTRADAY_PULSE_20' },
+          operator: '<',
+          right: { type: 'constant', value: -30 },
+        },
+      ],
+    },
+    riskSettings: {
+      stopLossPercent: 1.5,
+      takeProfitPercent: 2,
+      maxHoldingDays: 6, // 5분봉 6봉 ≈ 다음 거래일 시가 도달 전 청산
+    },
+  },
 ]

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets.ts
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets.ts
@@ -413,6 +413,165 @@ export const PRESET_STRATEGIES: PresetStrategy[] = [
     },
   },
 
+  // ============================================
+  // 스마트머니 추종 전략 (Smart Money Tracking)
+  // ============================================
+
+  {
+    id: 'smart-money-trend',
+    name: '🐳 스마트머니 추세 추종 (중기)',
+    description: 'CMF + Wyckoff Spring/Upthrust로 기관 매집 구간 진입, 분산 구간 회피',
+    indicators: [
+      { id: 'SMART_MONEY_20_20_10_10', type: 'SMART_MONEY', params: { cmfPeriod: 20, divergenceLookback: 20, springLookback: 10, upthrustLookback: 10 } },
+      { id: 'RSI_14', type: 'RSI', params: { period: 14 } },
+    ],
+    buyConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        // 강한 매집 신호
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'SMART_MONEY_20_20_10_10' },
+          operator: '>',
+          right: { type: 'constant', value: 30 },
+        },
+        // 과열 아님 (매집 초기 진입)
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'RSI_14' },
+          operator: '<',
+          right: { type: 'constant', value: 65 },
+        },
+      ],
+    },
+    sellConditions: {
+      type: 'group',
+      operator: 'OR',
+      conditions: [
+        // 분산 신호 (스마트머니 매도)
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'SMART_MONEY_20_20_10_10' },
+          operator: '<',
+          right: { type: 'constant', value: -20 },
+        },
+        // 0선 하향 이탈 (모멘텀 전환)
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'SMART_MONEY_20_20_10_10' },
+          operator: 'crossUnder',
+          right: { type: 'constant', value: 0 },
+        },
+      ],
+    },
+    riskSettings: {
+      stopLossPercent: 5,
+      takeProfitPercent: 15,
+      maxHoldingDays: 30,
+    },
+  },
+
+  {
+    id: 'smart-money-daily-pulse',
+    name: '⚡ 스마트머니 일일 추종 (단타)',
+    description: '강한 일일 매집 신호 시 매수, 다음날 펄스 약화 시 청산. 1~3일 단타',
+    indicators: [
+      { id: 'DAILY_SMART_MONEY_PULSE_20', type: 'DAILY_SMART_MONEY_PULSE', params: { volPeriod: 20 } },
+    ],
+    buyConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        // 강한 일일 매집 펄스
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'DAILY_SMART_MONEY_PULSE_20' },
+          operator: '>',
+          right: { type: 'constant', value: 50 },
+        },
+      ],
+    },
+    sellConditions: {
+      type: 'group',
+      operator: 'OR',
+      conditions: [
+        // 펄스 약화 (매집 종료)
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'DAILY_SMART_MONEY_PULSE_20' },
+          operator: '<',
+          right: { type: 'constant', value: 0 },
+        },
+        // 강한 분산 펄스 (즉시 청산)
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'DAILY_SMART_MONEY_PULSE_20' },
+          operator: '<',
+          right: { type: 'constant', value: -30 },
+        },
+      ],
+    },
+    riskSettings: {
+      stopLossPercent: 2,
+      takeProfitPercent: 3,
+      maxHoldingDays: 3,
+    },
+  },
+
+  {
+    id: 'smart-money-combo',
+    name: '💎 스마트머니 추세+펄스 결합 (정밀)',
+    description: '중기 매집 추세(SMI > 30) + 당일 매집 강세(Pulse > 30) 동시 만족 시에만 진입',
+    indicators: [
+      { id: 'SMART_MONEY_20_20_10_10', type: 'SMART_MONEY', params: { cmfPeriod: 20, divergenceLookback: 20, springLookback: 10, upthrustLookback: 10 } },
+      { id: 'DAILY_SMART_MONEY_PULSE_20', type: 'DAILY_SMART_MONEY_PULSE', params: { volPeriod: 20 } },
+    ],
+    buyConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'SMART_MONEY_20_20_10_10' },
+          operator: '>',
+          right: { type: 'constant', value: 30 },
+        },
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'DAILY_SMART_MONEY_PULSE_20' },
+          operator: '>',
+          right: { type: 'constant', value: 30 },
+        },
+      ],
+    },
+    sellConditions: {
+      type: 'group',
+      operator: 'OR',
+      conditions: [
+        // 일일 펄스 약화 (단기 익절/손절)
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'DAILY_SMART_MONEY_PULSE_20' },
+          operator: '<',
+          right: { type: 'constant', value: -30 },
+        },
+        // 중기 추세 전환
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'SMART_MONEY_20_20_10_10' },
+          operator: 'crossUnder',
+          right: { type: 'constant', value: 0 },
+        },
+      ],
+    },
+    riskSettings: {
+      stopLossPercent: 4,
+      takeProfitPercent: 12,
+      maxHoldingDays: 14,
+    },
+  },
+
   {
     id: 'fear-greed-conservative',
     name: '🛡️ 공포/탐욕 보수적 진입',

--- a/dental-clinic-manager/src/lib/dayTradingBacktestEngine.ts
+++ b/dental-clinic-manager/src/lib/dayTradingBacktestEngine.ts
@@ -1,0 +1,463 @@
+/**
+ * 단타(Day Trading) 백테스트 엔진 — 분봉 전용
+ *
+ * 일봉 backtestEngine.ts와의 차별점:
+ * 1. 입력은 분봉 OHLCV (date 필드는 'YYYY-MM-DDTHH:mm:ss' ISO 형식)
+ * 2. T봉 마감 신호 → T+1봉 시가 체결 (look-ahead 방지, 동일 패턴)
+ * 3. 거래일 구분(date.slice(0,10)) — 거래일 경계에서 다음 봉 진입 금지
+ * 4. forceCloseAtSessionEnd=true (기본): 그날 마지막 봉에 강제 매도
+ * 5. 슬리피지 강화: 단타는 호가 영향이 크므로 extraSlippageBps 추가
+ *    - KR 기본 5bp(0.05%), US 기본 2bp(0.02%)
+ * 6. maxHoldingDays → maxHoldingBars (분봉 수)로 해석
+ * 7. avgHoldingDays 필드는 호환성 위해 유지하되 의미는 '평균 보유 봉수'
+ * 8. equityCurve는 일별 종가 시점으로 집계 (BacktestMetrics 호환)
+ * 9. Sharpe Ratio: 분봉 수익률 → 연 환산 (√(252 × 봉수/거래일))
+ */
+
+import type {
+  OHLCV, IndicatorConfig, ConditionGroup,
+  RiskSettings, Market,
+  BacktestTrade, BacktestMetrics, EquityCurvePoint,
+} from '@/types/investment'
+import { calculateIndicators } from './indicatorEngine'
+import { evaluateConditionTree, type EvaluationContext } from './signalEngine'
+
+// ============================================
+// 수수료 + 슬리피지 상수
+// ============================================
+
+const COMMISSION_RATES = {
+  KR: {
+    buyCommission: 0.00015,    // 매수 수수료 0.015%
+    sellCommission: 0.00015,   // 매도 수수료 0.015%
+    sellTax: 0.0023,           // 매도 세금 0.23% (증권거래세)
+  },
+  US: {
+    buyCommission: 0,
+    sellCommission: 0,
+    sellTax: 0.0000278,        // SEC fee
+  },
+}
+
+const DEFAULT_EXTRA_SLIPPAGE_BPS = {
+  KR: 5,  // 0.05%
+  US: 2,  // 0.02%
+}
+
+// ============================================
+// 타입
+// ============================================
+
+export interface DayTradingBacktestParams {
+  /** 분봉 OHLCV (date는 ISO datetime 권장) */
+  prices: OHLCV[]
+  indicators: IndicatorConfig[]
+  buyConditions: ConditionGroup
+  sellConditions: ConditionGroup
+  riskSettings: RiskSettings
+  initialCapital: number
+  market: Market
+  ticker: string
+  /** 분봉 단위 (분). 기본 5 — Sharpe 연환산 계수에만 사용 */
+  barMinutes?: number
+  /** 장 마감 강제 청산 여부. 기본 true */
+  forceCloseAtSessionEnd?: boolean
+  /** 추가 슬리피지 (bps, 1bp=0.01%). 기본 KR 5bp, US 2bp */
+  extraSlippageBps?: number
+}
+
+export interface BuyHoldResult {
+  totalReturn: number
+  finalValue: number
+}
+
+export interface DayTradingBacktestResult {
+  metrics: BacktestMetrics
+  trades: BacktestTrade[]
+  equityCurve: EquityCurvePoint[]
+  buyHold: BuyHoldResult
+}
+
+interface SimPosition {
+  entryDate: string
+  entryPrice: number
+  quantity: number
+  holdingBars: number  // 분봉 수
+}
+
+// ============================================
+// 메인 백테스트 함수
+// ============================================
+
+export function runDayTradingBacktest(
+  params: DayTradingBacktestParams,
+  signal?: AbortSignal
+): DayTradingBacktestResult {
+  const {
+    prices, indicators, buyConditions, sellConditions,
+    riskSettings, initialCapital, market, ticker,
+    barMinutes = 5,
+    forceCloseAtSessionEnd = true,
+  } = params
+  const extraSlippageBps = params.extraSlippageBps ?? DEFAULT_EXTRA_SLIPPAGE_BPS[market]
+  const slippage = extraSlippageBps / 10000  // 5bp → 0.0005
+
+  if (prices.length < 2) {
+    return emptyResult()
+  }
+
+  // 1. 지표 계산
+  const indicatorResults = calculateIndicators(prices, indicators)
+
+  // 2. 거래일 인덱스 사전 계산 (각 봉의 거래일, 그날 마지막 봉인지 여부)
+  const days: string[] = prices.map(p => p.date.slice(0, 10))
+  const isLastBarOfDay: boolean[] = new Array(prices.length).fill(false)
+  for (let i = 0; i < prices.length; i++) {
+    if (i === prices.length - 1 || days[i + 1] !== days[i]) {
+      isLastBarOfDay[i] = true
+    }
+  }
+
+  // 3. 시뮬레이션 변수
+  let cash = initialCapital
+  let position: SimPosition | null = null
+  const trades: BacktestTrade[] = []
+  const equityCurve: EquityCurvePoint[] = []
+  const commissionRate = COMMISSION_RATES[market]
+
+  // 일별 종가(equity 집계용): 같은 거래일의 마지막 봉 시점에만 push
+  for (let i = 0; i < prices.length; i++) {
+    if (signal?.aborted) {
+      throw new Error('단타 백테스트가 시간 제한을 초과했습니다')
+    }
+
+    const bar = prices[i]
+
+    // === 신호는 직전 봉(i-1) 마감 기반, 체결은 현재 봉(i) 시가 ===
+    if (i > 0) {
+      const prevCtx: EvaluationContext = {
+        indicators: indicatorResults,
+        barIndex: i - 1,
+      }
+
+      // 직전 봉이 그 거래일의 마지막 봉이었으면 다음 거래일 진입 금지
+      // (장 마감 신호 → 다음 날 시가 진입은 단타 룰 위반)
+      const prevWasSessionEnd = isLastBarOfDay[i - 1]
+
+      if (position) {
+        position.holdingBars++
+
+        // --- 매도 신호 / 리스크 청산 체크 ---
+        const sellSignal = evaluateConditionTree(sellConditions, prevCtx)
+
+        // 손절 / 익절 / 최대 보유봉수
+        const currentPnlPercent = ((bar.open - position.entryPrice) / position.entryPrice) * 100
+        const stopLoss =
+          riskSettings.stopLossPercent > 0 &&
+          currentPnlPercent <= -riskSettings.stopLossPercent
+        const takeProfit =
+          riskSettings.takeProfitPercent > 0 &&
+          currentPnlPercent >= riskSettings.takeProfitPercent
+        // riskSettings.maxHoldingDays > 0 이면 N개 봉 보유 후 강제 청산
+        const maxHolding =
+          riskSettings.maxHoldingDays > 0 &&
+          position.holdingBars >= riskSettings.maxHoldingDays
+
+        // 장 마감 강제 청산: 직전 봉이 마감 봉이었다면, 그 마감 봉 종가에 청산했어야 함
+        // 하지만 마감 봉 자체에서 청산하는 것이 자연스러움 (아래 별도 처리)
+        if (sellSignal || stopLoss || takeProfit || maxHolding) {
+          // 슬리피지 적용 (매도이므로 불리한 방향: 시가에서 더 낮은 가격)
+          const exitPrice = bar.open * (1 - slippage)
+          closeTrade(position, exitPrice, bar.date, ticker, commissionRate, trades)
+          cash += sellAmount(exitPrice, position.quantity, commissionRate)
+          position = null
+        } else if (prevWasSessionEnd && forceCloseAtSessionEnd) {
+          // 안전장치: 직전 봉이 마감 봉인데 거기서 청산되지 않은 케이스
+          // (마감 봉 처리 로직이 정상 작동하면 도달하지 않음)
+          const exitPrice = bar.open * (1 - slippage)
+          closeTrade(position, exitPrice, bar.date, ticker, commissionRate, trades)
+          cash += sellAmount(exitPrice, position.quantity, commissionRate)
+          position = null
+        }
+      } else {
+        // --- 매수 신호 체크 ---
+        // 직전 봉이 마감 봉이면 다음 봉 = 다음 거래일 시가 → 진입 금지
+        if (prevWasSessionEnd) {
+          // skip
+        } else {
+          const buySignal = evaluateConditionTree(buyConditions, prevCtx)
+          if (buySignal) {
+            // 슬리피지 적용 (매수: 시가보다 더 비싸게)
+            const entryPrice = bar.open * (1 + slippage)
+            const maxInvestment = cash * (riskSettings.maxPositionSizePercent / 100)
+            const investAmount = Math.min(cash, maxInvestment)
+            const buyFee = investAmount * commissionRate.buyCommission
+            const affordableAmount = investAmount - buyFee
+            const quantity = Math.floor(affordableAmount / entryPrice)
+
+            if (quantity > 0) {
+              const totalCost = entryPrice * quantity + entryPrice * quantity * commissionRate.buyCommission
+              cash -= totalCost
+              position = {
+                entryDate: bar.date,
+                entryPrice,
+                quantity,
+                holdingBars: 0,
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // === 그날 마지막 봉이고 포지션 보유 중이면 그 봉 종가에 강제 청산 ===
+    if (position && isLastBarOfDay[i] && forceCloseAtSessionEnd) {
+      const exitPrice = bar.close * (1 - slippage)
+      closeTrade(position, exitPrice, bar.date, ticker, commissionRate, trades)
+      cash += sellAmount(exitPrice, position.quantity, commissionRate)
+      position = null
+    }
+
+    // === 일별 자산곡선 (그날 마지막 봉에서만 기록) ===
+    if (isLastBarOfDay[i]) {
+      const positionValue = position ? position.quantity * bar.close : 0
+      const totalEquity = cash + positionValue
+      equityCurve.push({
+        date: days[i],  // 일자 단위
+        value: Math.round(totalEquity),
+      })
+    }
+  }
+
+  // 4. 마지막에 미청산 포지션이 남아있으면 강제 청산 (forceCloseAtSessionEnd=false인 경우)
+  if (position && prices.length > 0) {
+    const lastBar = prices[prices.length - 1]
+    const exitPrice = lastBar.close * (1 - slippage)
+    closeTrade(position, exitPrice, lastBar.date, ticker, commissionRate, trades)
+    cash += sellAmount(exitPrice, position.quantity, commissionRate)
+    position = null
+  }
+
+  // 5. 메트릭 계산
+  const metrics = calculateMetrics(trades, equityCurve, initialCapital, prices, barMinutes)
+
+  // 6. Buy & Hold 비교 (첫 봉 시가 → 마지막 봉 종가)
+  const buyHold = calculateBuyHold(prices, initialCapital, commissionRate)
+
+  return { metrics, trades, equityCurve, buyHold }
+}
+
+// ============================================
+// 헬퍼: 트레이드 정산
+// ============================================
+
+function sellAmount(
+  exitPrice: number,
+  quantity: number,
+  commissionRate: { sellCommission: number; sellTax: number }
+): number {
+  const gross = exitPrice * quantity
+  const fee = gross * (commissionRate.sellCommission + commissionRate.sellTax)
+  return gross - fee
+}
+
+function closeTrade(
+  position: SimPosition,
+  exitPrice: number,
+  exitDate: string,
+  ticker: string,
+  commissionRate: { buyCommission: number; sellCommission: number; sellTax: number },
+  trades: BacktestTrade[]
+) {
+  const grossSell = exitPrice * position.quantity
+  const sellFee = grossSell * (commissionRate.sellCommission + commissionRate.sellTax)
+  const buyFee = position.entryPrice * position.quantity * commissionRate.buyCommission
+  const pnl = (exitPrice - position.entryPrice) * position.quantity - sellFee - buyFee
+
+  trades.push({
+    entryDate: position.entryDate,
+    exitDate,
+    ticker,
+    direction: 'buy',
+    entryPrice: position.entryPrice,
+    exitPrice,
+    quantity: position.quantity,
+    pnl,
+    pnlPercent: ((exitPrice - position.entryPrice) / position.entryPrice) * 100,
+    holdingDays: position.holdingBars,  // 분봉 수 (필드명은 호환성 유지)
+  })
+}
+
+// ============================================
+// 메트릭 계산
+// ============================================
+
+function calculateMetrics(
+  trades: BacktestTrade[],
+  equityCurve: EquityCurvePoint[],
+  initialCapital: number,
+  prices: OHLCV[],
+  barMinutes: number
+): BacktestMetrics {
+  if (trades.length === 0) {
+    return zeroMetrics()
+  }
+
+  const finalEquity = equityCurve[equityCurve.length - 1]?.value ?? initialCapital
+  const totalReturn = ((finalEquity - initialCapital) / initialCapital) * 100
+
+  // 거래일 수 = equityCurve 포인트 수
+  const tradingDays = equityCurve.length
+  const years = tradingDays / 252
+  const annualizedReturn = years > 0
+    ? (Math.pow(finalEquity / initialCapital, 1 / years) - 1) * 100
+    : 0
+
+  const maxDrawdown = calculateMaxDrawdown(equityCurve)
+
+  const wins = trades.filter(t => t.pnl > 0)
+  const losses = trades.filter(t => t.pnl <= 0)
+  const winRate = (wins.length / trades.length) * 100
+
+  const grossProfit = wins.reduce((sum, t) => sum + t.pnl, 0)
+  const grossLoss = Math.abs(losses.reduce((sum, t) => sum + t.pnl, 0))
+  const profitFactor = grossLoss > 0 ? grossProfit / grossLoss : grossProfit > 0 ? Infinity : 0
+
+  const avgWin = wins.length > 0 ? grossProfit / wins.length : 0
+  const avgLoss = losses.length > 0 ? grossLoss / losses.length : 0
+
+  let maxConsecutiveWins = 0
+  let maxConsecutiveLosses = 0
+  let currentWins = 0
+  let currentLosses = 0
+  for (const trade of trades) {
+    if (trade.pnl > 0) {
+      currentWins++
+      currentLosses = 0
+      maxConsecutiveWins = Math.max(maxConsecutiveWins, currentWins)
+    } else {
+      currentLosses++
+      currentWins = 0
+      maxConsecutiveLosses = Math.max(maxConsecutiveLosses, currentLosses)
+    }
+  }
+
+  // avgHoldingDays 필드는 분봉 단타에서는 '평균 보유 봉수'로 해석
+  const avgHoldingDays = trades.reduce((sum, t) => sum + t.holdingDays, 0) / trades.length
+
+  // Sharpe: 일별 자산곡선 기반 (equityCurve가 일별이므로 그대로 사용)
+  const sharpeRatio = calculateSharpeRatio(equityCurve)
+
+  return {
+    totalReturn: round4(totalReturn),
+    annualizedReturn: round4(annualizedReturn),
+    maxDrawdown: round4(maxDrawdown),
+    sharpeRatio: round4(sharpeRatio),
+    winRate: round4(winRate),
+    totalTrades: trades.length,
+    profitFactor: round4(profitFactor),
+    avgWin: Math.round(avgWin),
+    avgLoss: Math.round(avgLoss),
+    maxConsecutiveWins,
+    maxConsecutiveLosses,
+    avgHoldingDays: round4(avgHoldingDays),
+  }
+}
+
+function calculateMaxDrawdown(equityCurve: EquityCurvePoint[]): number {
+  if (equityCurve.length === 0) return 0
+  let peak = equityCurve[0].value
+  let maxDD = 0
+  for (const point of equityCurve) {
+    if (point.value > peak) peak = point.value
+    const dd = ((peak - point.value) / peak) * 100
+    if (dd > maxDD) maxDD = dd
+  }
+  return maxDD
+}
+
+function calculateSharpeRatio(equityCurve: EquityCurvePoint[]): number {
+  if (equityCurve.length < 2) return 0
+
+  const dailyReturns: number[] = []
+  for (let i = 1; i < equityCurve.length; i++) {
+    if (equityCurve[i - 1].value <= 0) continue
+    const ret = (equityCurve[i].value - equityCurve[i - 1].value) / equityCurve[i - 1].value
+    dailyReturns.push(ret)
+  }
+  if (dailyReturns.length === 0) return 0
+
+  const avgReturn = dailyReturns.reduce((s, r) => s + r, 0) / dailyReturns.length
+  const variance = dailyReturns.reduce((s, r) => s + Math.pow(r - avgReturn, 2), 0) / dailyReturns.length
+  const stdDev = Math.sqrt(variance)
+  if (stdDev === 0) return 0
+
+  const dailyRiskFreeRate = 0.035 / 252
+  return ((avgReturn - dailyRiskFreeRate) / stdDev) * Math.sqrt(252)
+}
+
+// ============================================
+// Buy & Hold 비교
+// ============================================
+
+function calculateBuyHold(
+  prices: OHLCV[],
+  initialCapital: number,
+  commissionRate: { buyCommission: number; sellCommission: number; sellTax: number }
+): BuyHoldResult {
+  if (prices.length < 2) return { totalReturn: 0, finalValue: initialCapital }
+
+  const entryPrice = prices[0].open
+  const buyFee = initialCapital * commissionRate.buyCommission
+  const quantity = Math.floor((initialCapital - buyFee) / entryPrice)
+  if (quantity <= 0) return { totalReturn: 0, finalValue: initialCapital }
+
+  const investedAmount = quantity * entryPrice
+  const remainingCash = initialCapital - investedAmount - investedAmount * commissionRate.buyCommission
+
+  const lastPrice = prices[prices.length - 1].close
+  const sellGross = quantity * lastPrice
+  const sellFee = sellGross * (commissionRate.sellCommission + commissionRate.sellTax)
+  const finalValue = remainingCash + sellGross - sellFee
+  const totalReturn = ((finalValue - initialCapital) / initialCapital) * 100
+
+  return {
+    totalReturn: round4(totalReturn),
+    finalValue: Math.round(finalValue),
+  }
+}
+
+// ============================================
+// 유틸
+// ============================================
+
+function round4(n: number): number {
+  if (!isFinite(n)) return 0
+  return Math.round(n * 10000) / 10000
+}
+
+function zeroMetrics(): BacktestMetrics {
+  return {
+    totalReturn: 0,
+    annualizedReturn: 0,
+    maxDrawdown: 0,
+    sharpeRatio: 0,
+    winRate: 0,
+    totalTrades: 0,
+    profitFactor: 0,
+    avgWin: 0,
+    avgLoss: 0,
+    maxConsecutiveWins: 0,
+    maxConsecutiveLosses: 0,
+    avgHoldingDays: 0,
+  }
+}
+
+function emptyResult(): DayTradingBacktestResult {
+  return {
+    metrics: zeroMetrics(),
+    trades: [],
+    equityCurve: [],
+    buyHold: { totalReturn: 0, finalValue: 0 },
+  }
+}

--- a/dental-clinic-manager/src/lib/indicatorEngine.ts
+++ b/dental-clinic-manager/src/lib/indicatorEngine.ts
@@ -437,6 +437,244 @@ function calcDailySmartMoneyPulse(prices: OHLCV[], params: Record<string, number
 }
 
 // ============================================
+// 단타(Day Trading) 전용 분봉 지표
+// ============================================
+//
+// 분봉 OHLCV 입력을 가정 (date 필드는 'YYYY-MM-DDTHH:mm:ss' ISO 형식).
+// 거래일 구분은 date.slice(0, 10) (앞 10자, YYYY-MM-DD)로 판정.
+// VWAP/ORB는 거래일 경계에서 자동 리셋되도록 설계.
+
+/** 거래일 추출 (date 문자열의 앞 10자 = 'YYYY-MM-DD') */
+function tradingDay(dateStr: string): string {
+  return dateStr.slice(0, 10)
+}
+
+/**
+ * VWAP (Volume Weighted Average Price) — 당일 누적 거래량 가중 평균가
+ *
+ * 거래일이 바뀌면 누적값 리셋. 분봉 단타에서 가장 기본적인 기준선.
+ * - 가격 > VWAP: 매수세 우위 (long bias)
+ * - 가격 < VWAP: 매도세 우위 (short bias / 회피)
+ * - VWAP 근처 반등: 지지/저항 역할 (institutional anchor)
+ *
+ * 공식: VWAP_i = Σ(typical_j × vol_j) / Σ(vol_j),  typical = (H + L + C) / 3
+ */
+function calcVWAP(prices: OHLCV[], _params: Record<string, number>): number[] {
+  const n = prices.length
+  const result = new Array<number>(n).fill(NaN)
+  if (n === 0) return result
+
+  let curDay = ''
+  let cumPV = 0
+  let cumVol = 0
+
+  for (let i = 0; i < n; i++) {
+    const p = prices[i]
+    const day = tradingDay(p.date)
+    if (day !== curDay) {
+      // 새 거래일 시작 → 누적값 리셋
+      curDay = day
+      cumPV = 0
+      cumVol = 0
+    }
+    const typical = (p.high + p.low + p.close) / 3
+    cumPV += typical * p.volume
+    cumVol += p.volume
+    result[i] = cumVol > 0 ? cumPV / cumVol : typical
+  }
+  return result
+}
+
+/**
+ * Opening Range (ORB) — 시초 N봉 고/저
+ *
+ * 그날 첫 N봉의 high/low를 그날 모든 봉에 동일하게 매핑.
+ * 첫 N봉(아직 ORB 형성 전)은 NaN.
+ *
+ * - 종가 > ORB.high: 상방 돌파 (롱 진입 신호)
+ * - 종가 < ORB.low: 하방 돌파 (숏 회피 / 손절)
+ *
+ * @param params { numBars: 6 } — 시초 N봉 (5분봉 6개 = 30분, 1분봉 30개 = 30분)
+ *               { rangeMinutes: 30, barMinutes: 5 } — 분 단위로도 지정 가능
+ */
+function calcOpeningRange(
+  prices: OHLCV[],
+  params: Record<string, number>
+): Record<string, number>[] {
+  const n = prices.length
+  // numBars 우선, 없으면 rangeMinutes/barMinutes 계산, 둘 다 없으면 6
+  let numBars = params.numBars
+  if (!numBars || numBars <= 0) {
+    const rangeMin = params.rangeMinutes || 30
+    const barMin = params.barMinutes || 5
+    numBars = Math.max(1, Math.ceil(rangeMin / barMin))
+  }
+
+  const result: Record<string, number>[] = new Array(n)
+    .fill(0)
+    .map(() => ({ high: NaN, low: NaN }))
+  if (n === 0) return result
+
+  // 거래일별 첫 봉 인덱스와 ORB high/low 산출
+  let curDay = ''
+  let dayStart = 0
+  let orbHigh = -Infinity
+  let orbLow = Infinity
+
+  for (let i = 0; i < n; i++) {
+    const p = prices[i]
+    const day = tradingDay(p.date)
+    if (day !== curDay) {
+      curDay = day
+      dayStart = i
+      orbHigh = -Infinity
+      orbLow = Infinity
+    }
+    const idxInDay = i - dayStart
+    if (idxInDay < numBars) {
+      // ORB 형성 중: 누적
+      orbHigh = Math.max(orbHigh, p.high)
+      orbLow = Math.min(orbLow, p.low)
+      // 형성 중에는 NaN 유지
+    } else {
+      // ORB 확정 후: 그날 모든 후속 봉에 동일 값 할당
+      result[i] = { high: orbHigh, low: orbLow }
+    }
+  }
+  return result
+}
+
+/**
+ * Large Block — 대형 거래 감지 (현재 봉 거래량 / 최근 N봉 평균)
+ *
+ * - 비율 > 5: 비정상적 대형 거래 (기관/세력 의심)
+ * - 비율 > 10: 매우 강한 신호 (급등/급락 가능)
+ * - 비율 < 0.3: 거래 공백 (관망 우세)
+ *
+ * 첫 N봉은 NaN.
+ */
+function calcLargeBlock(prices: OHLCV[], params: Record<string, number>): number[] {
+  const period = Math.max(2, params.period || 20)
+  const n = prices.length
+  const result = new Array<number>(n).fill(NaN)
+  if (n < period) return result
+
+  for (let i = period; i < n; i++) {
+    let sum = 0
+    for (let j = i - period; j < i; j++) sum += prices[j].volume
+    const avg = sum / period
+    if (avg > 0) {
+      result[i] = Math.round((prices[i].volume / avg) * 100) / 100
+    } else {
+      result[i] = 0
+    }
+  }
+  return result
+}
+
+/**
+ * Closing Pressure — 장 마감 N봉 거래량 점유율 (%)
+ *
+ * 그날 마지막 N봉에 속한 봉이면 (마감 N봉 누적 거래량 / 그날 총 거래량) × 100,
+ * 그 외 봉은 0.
+ *
+ * - 30 이상: 비정상적 마감 거래 (기관 청산 / 매집 / 윈도우 드레싱)
+ * - 50 이상: 매우 강한 마감 압박
+ *
+ * @param params { lastNumBars: 6 } — 장 마감 직전 N봉 (5분봉 6개 = 30분)
+ */
+function calcClosingPressure(
+  prices: OHLCV[],
+  params: Record<string, number>
+): number[] {
+  const lastN = Math.max(1, params.lastNumBars || 6)
+  const n = prices.length
+  const result = new Array<number>(n).fill(0)
+  if (n === 0) return result
+
+  // 거래일별 시작/끝 인덱스 + 총 거래량 산출
+  // 단일 패스: 거래일 경계에서 직전 거래일을 정산
+  type DayInfo = { start: number; end: number; total: number }
+  const days: DayInfo[] = []
+  let curDay = ''
+  let curStart = 0
+  let curTotal = 0
+
+  for (let i = 0; i < n; i++) {
+    const day = tradingDay(prices[i].date)
+    if (day !== curDay) {
+      if (i > 0) {
+        days.push({ start: curStart, end: i - 1, total: curTotal })
+      }
+      curDay = day
+      curStart = i
+      curTotal = 0
+    }
+    curTotal += prices[i].volume
+  }
+  // 마지막 거래일
+  days.push({ start: curStart, end: n - 1, total: curTotal })
+
+  // 각 거래일에 대해 마감 N봉의 누적 거래량 점유율 산출
+  for (const d of days) {
+    const dayLen = d.end - d.start + 1
+    const closingStart = d.start + Math.max(0, dayLen - lastN)
+    if (d.total <= 0) continue
+    let cum = 0
+    for (let i = closingStart; i <= d.end; i++) {
+      cum += prices[i].volume
+      result[i] = Math.round((cum / d.total) * 10000) / 100 // 소수 2자리 %
+    }
+  }
+  return result
+}
+
+/**
+ * Intraday Pulse — 분봉판 일일 스마트머니 펄스 (-100 ~ +100)
+ *
+ * 일일펄스(DAILY_SMART_MONEY_PULSE)와 동일 공식이지만 분봉 단위.
+ * Gap 처리는 분봉에선 의미 약하므로 생략.
+ *
+ * 공식:
+ * - CLV = (2C - H - L) / (H - L)  ∈ [-1, +1]
+ * - volBoost = clamp(vol / volMean, 0.5, 2)
+ * - score = CLV × volBoost × 50
+ *
+ * 해석:
+ * - +50 이상: 강한 분봉 매집 (신규 진입 신호)
+ * - -50 이하: 강한 분봉 분산 (회피/청산)
+ *
+ * 첫 N봉은 NaN.
+ */
+function calcIntradayPulse(prices: OHLCV[], params: Record<string, number>): number[] {
+  const volPeriod = Math.max(2, params.volPeriod || 20)
+  const n = prices.length
+  const result = new Array<number>(n).fill(NaN)
+  if (n === 0) return result
+
+  for (let i = volPeriod; i < n; i++) {
+    const p = prices[i]
+    const range = p.high - p.low
+    if (range === 0) continue
+
+    // 직전 N봉 거래량 평균
+    let sum = 0
+    for (let j = i - volPeriod; j < i; j++) sum += prices[j].volume
+    const volMean = sum / volPeriod
+    if (volMean <= 0) continue
+
+    const clv = (2 * p.close - p.high - p.low) / range
+    const volRatio = p.volume / volMean
+    const volBoost = Math.min(2, Math.max(0.5, volRatio))
+
+    const score = clv * volBoost * 50
+    const clamped = Math.max(-100, Math.min(100, score))
+    result[i] = Math.round(clamped * 100) / 100
+  }
+  return result
+}
+
+// ============================================
 // 지표 계산기 매핑
 // ============================================
 
@@ -455,6 +693,11 @@ const INDICATOR_CALCULATORS: Record<IndicatorType, (prices: OHLCV[], params: Rec
   FEAR_GREED: calcFearGreed,
   SMART_MONEY: calcSmartMoney,
   DAILY_SMART_MONEY_PULSE: calcDailySmartMoneyPulse,
+  VWAP: calcVWAP,
+  OPENING_RANGE: calcOpeningRange,
+  LARGE_BLOCK: calcLargeBlock,
+  CLOSING_PRESSURE: calcClosingPressure,
+  INTRADAY_PULSE: calcIntradayPulse,
 }
 
 // ============================================

--- a/dental-clinic-manager/src/lib/indicatorEngine.ts
+++ b/dental-clinic-manager/src/lib/indicatorEngine.ts
@@ -258,6 +258,184 @@ function calcFearGreed(prices: OHLCV[], params: Record<string, number>): number[
   return result
 }
 
+/**
+ * Smart Money Index (SMART_MONEY) — 스마트머니 매집/분산 지표 (중기, -100~+100)
+ *
+ * 합성 4요소:
+ * 1. CMF (Chaikin Money Flow, 35%): 종가 위치 × 거래량 누적
+ * 2. A/D Divergence (25%): 가격-누적분포선 다이버전스 (가격↓+AD↑ = 매집)
+ * 3. Wyckoff Spring (20%): 지지선 가짜 이탈 + 거래량 급증 + 종가 회복 = 매집 함정
+ * 4. Wyckoff Upthrust (20%): 저항선 가짜 돌파 + 종가 약세 = 분산 함정
+ *
+ * 해석:
+ * - +30 이상: 강한 매집 (스마트머니 매수 → 매수 진입)
+ * - -30 이하: 강한 분산 (고점 떠넘기기 → 회피/청산)
+ */
+function calcSmartMoney(prices: OHLCV[], params: Record<string, number>): number[] {
+  const cmfPeriod = Math.max(2, params.cmfPeriod || 20)
+  const divLookback = Math.max(2, params.divergenceLookback || 20)
+  const springLookback = Math.max(2, params.springLookback || 10)
+  const upthrustLookback = Math.max(2, params.upthrustLookback || 10)
+  const cmfWeight = params.cmfWeight ?? 0.35
+  const divWeight = params.divWeight ?? 0.25
+  const springWeight = params.springWeight ?? 0.20
+  const upthrustWeight = params.upthrustWeight ?? 0.20
+
+  const n = prices.length
+  if (n === 0) return []
+
+  // 1. CMF: -1 ~ +1
+  const cmf = new Array<number>(n).fill(NaN)
+  for (let i = cmfPeriod - 1; i < n; i++) {
+    let sumMFV = 0
+    let sumVol = 0
+    for (let j = i - cmfPeriod + 1; j <= i; j++) {
+      const p = prices[j]
+      const range = p.high - p.low
+      const mfm = range === 0 ? 0 : ((p.close - p.low) - (p.high - p.close)) / range
+      sumMFV += mfm * p.volume
+      sumVol += p.volume
+    }
+    cmf[i] = sumVol === 0 ? 0 : sumMFV / sumVol
+  }
+
+  // 2. A/D Line + Divergence
+  const ad = new Array<number>(n).fill(0)
+  for (let i = 0; i < n; i++) {
+    const p = prices[i]
+    const range = p.high - p.low
+    const mfm = range === 0 ? 0 : ((p.close - p.low) - (p.high - p.close)) / range
+    ad[i] = (i === 0 ? 0 : ad[i - 1]) + mfm * p.volume
+  }
+  const adDiv = new Array<number>(n).fill(0)
+  for (let i = divLookback; i < n; i++) {
+    const prevPrice = prices[i - divLookback].close
+    const prevAD = ad[i - divLookback]
+    const priceSlope = (prices[i].close - prevPrice) / Math.max(1, Math.abs(prevPrice))
+    const adRef = Math.max(1, Math.abs(prevAD))
+    const adSlope = (ad[i] - prevAD) / adRef
+    // 가격↓ + AD↑ = +1 (매집), 가격↑ + AD↓ = -1 (분산)
+    const raw = adSlope - priceSlope
+    adDiv[i] = Math.max(-1, Math.min(1, raw * 5))
+  }
+
+  // 3. Spring 감지
+  const spring = new Array<number>(n).fill(0)
+  for (let i = springLookback; i < n; i++) {
+    const p = prices[i]
+    let recentLow = Infinity
+    let avgVol = 0
+    for (let j = i - springLookback; j < i; j++) {
+      if (prices[j].low < recentLow) recentLow = prices[j].low
+      avgVol += prices[j].volume
+    }
+    avgVol /= springLookback
+    const range = p.high - p.low
+    const closePos = range === 0 ? 0.5 : (p.close - p.low) / range
+    const brokeBelow = p.low < recentLow
+    const recovered = p.close > recentLow
+    const upperHalf = closePos > 0.6
+    const volSpike = avgVol > 0 && p.volume > avgVol * 1.5
+    if (brokeBelow && recovered && upperHalf && volSpike) spring[i] = 1
+  }
+
+  // 4. Upthrust 감지
+  const upthrust = new Array<number>(n).fill(0)
+  for (let i = upthrustLookback; i < n; i++) {
+    const p = prices[i]
+    let recentHigh = -Infinity
+    let avgVol = 0
+    for (let j = i - upthrustLookback; j < i; j++) {
+      if (prices[j].high > recentHigh) recentHigh = prices[j].high
+      avgVol += prices[j].volume
+    }
+    avgVol /= upthrustLookback
+    const range = p.high - p.low
+    const closePos = range === 0 ? 0.5 : (p.close - p.low) / range
+    const brokeAbove = p.high > recentHigh
+    const fellBack = p.close < recentHigh
+    const lowerHalf = closePos < 0.4
+    const volSpike = avgVol > 0 && p.volume > avgVol * 1.5
+    if (brokeAbove && fellBack && lowerHalf && volSpike) upthrust[i] = 1
+  }
+
+  // 5. 가중 합성 → -100 ~ +100
+  const result = new Array<number>(n).fill(NaN)
+  for (let i = 0; i < n; i++) {
+    if (isNaN(cmf[i])) continue
+    const score =
+      cmf[i] * cmfWeight +
+      adDiv[i] * divWeight +
+      spring[i] * springWeight -
+      upthrust[i] * upthrustWeight
+    const clamped = Math.max(-100, Math.min(100, score * 100))
+    result[i] = Math.round(clamped * 100) / 100
+  }
+  return result
+}
+
+/**
+ * Daily Smart Money Pulse (DAILY_SMART_MONEY_PULSE) — 일일 펄스 (-100~+100)
+ *
+ * 일봉만으로 그날의 매집/분산 강도를 정량화 (분봉 인프라 불필요).
+ * 합성 요소:
+ * - CLV (Close Location Value): (2C - H - L) / (H - L) ∈ [-1, +1]
+ * - Volume Ratio: 평소 대비 거래량 (CLV 증폭)
+ * - Gap Behavior: 갭 + 종가-시가 방향
+ *
+ * 해석:
+ * - +50 이상: 강한 일일 매집 (단타 매수)
+ * - -30 이하: 강한 일일 분산 (회피/청산)
+ */
+function calcDailySmartMoneyPulse(prices: OHLCV[], params: Record<string, number>): number[] {
+  const volPeriod = Math.max(2, params.volPeriod || 20)
+  const n = prices.length
+  if (n === 0) return []
+
+  // 거래량 평균 (전일까지)
+  const volMean = new Array<number>(n).fill(NaN)
+  for (let i = volPeriod; i < n; i++) {
+    let sum = 0
+    for (let j = i - volPeriod; j < i; j++) sum += prices[j].volume
+    volMean[i] = sum / volPeriod
+  }
+
+  const result = new Array<number>(n).fill(NaN)
+  for (let i = 1; i < n; i++) {
+    const p = prices[i]
+    const prev = prices[i - 1]
+    const range = p.high - p.low
+    if (range === 0 || isNaN(volMean[i]) || volMean[i] === 0) continue
+
+    // CLV: -1 ~ +1
+    const clv = (2 * p.close - p.high - p.low) / range
+
+    // Volume boost: 1.0 (평균) ~ 2.0 (2배 이상)
+    const volRatio = p.volume / volMean[i]
+    const volBoost = Math.min(2, Math.max(0.5, volRatio))
+
+    // Gap Behavior
+    const gapPct = (p.open - prev.close) / Math.max(1, Math.abs(prev.close))
+    let gapAdj = 0
+    if (Math.abs(gapPct) > 0.01) {
+      const closeAboveOpen = p.close > p.open
+      if (gapPct > 0) {
+        // 갭상승 후 종가>시가 = 매집 강세, 종가<시가 = Gap Fade(분산함정)
+        gapAdj = closeAboveOpen ? 10 : -25
+      } else {
+        // 갭하락 후 종가>시가 = 매집 회복, 종가<시가 = 추가 매도
+        gapAdj = closeAboveOpen ? 25 : -10
+      }
+    }
+
+    // 합성: CLV × VolBoost × 50 + GapAdj  (CLV 방향을 거래량으로 증폭)
+    const score = clv * volBoost * 50 + gapAdj
+    const clamped = Math.max(-100, Math.min(100, score))
+    result[i] = Math.round(clamped * 100) / 100
+  }
+  return result
+}
+
 // ============================================
 // 지표 계산기 매핑
 // ============================================
@@ -275,6 +453,8 @@ const INDICATOR_CALCULATORS: Record<IndicatorType, (prices: OHLCV[], params: Rec
   WILLR: calcWilliamsR,
   VOLUME_SMA: calcVolumeSMA,
   FEAR_GREED: calcFearGreed,
+  SMART_MONEY: calcSmartMoney,
+  DAILY_SMART_MONEY_PULSE: calcDailySmartMoneyPulse,
 }
 
 // ============================================

--- a/dental-clinic-manager/src/lib/intradayDataService.ts
+++ b/dental-clinic-manager/src/lib/intradayDataService.ts
@@ -1,0 +1,308 @@
+/**
+ * 분봉(Intraday) 주가 데이터 서비스
+ *
+ * - intraday_price_cache 테이블 캐싱
+ * - yahoo-finance2 분봉 데이터 조회 (1m / 5m / 15m)
+ * - 우선순위: DB 캐시 → yahoo-finance2 → 재시도 → 빈 배열
+ *
+ * Yahoo 정책 제약:
+ * - 1m: 최근 7일까지만 제공
+ * - 5m / 15m: 최근 60일
+ * - 한국 종목 분봉은 미지원일 수 있음 (yahoo가 반환하면 사용, 아니면 빈 배열)
+ */
+
+import type { OHLCV, Market } from '@/types/investment'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+// ============================================
+// 공개 타입
+// ============================================
+
+/** 분봉 timeframe */
+export type IntradayTimeframe = '1m' | '5m' | '15m'
+
+export interface FetchIntradayParams {
+  ticker: string
+  market: Market
+  timeframe: IntradayTimeframe
+  /** 시작 날짜 (YYYY-MM-DD). 미지정 시 timeframe별 최대 보존 기간 */
+  startDate?: string
+  /** 종료 날짜 (YYYY-MM-DD). 미지정 시 오늘 */
+  endDate?: string
+}
+
+// ============================================
+// 공개 API
+// ============================================
+
+/**
+ * 분봉 OHLCV 가져오기
+ *
+ * - DB 캐시 → yahoo-finance2 → 재시도(2회) → 캐시 저장
+ * - date 필드는 ISO datetime ('YYYY-MM-DDTHH:mm:ss' 포맷)
+ * - 한국 종목이 yahoo에서 미지원이면 빈 배열 반환
+ */
+export async function fetchIntradayPrices(params: FetchIntradayParams): Promise<OHLCV[]> {
+  const { ticker, market, timeframe } = params
+  const endDate = params.endDate ?? toDateString(new Date())
+  const startDate = params.startDate ?? defaultStartDate(timeframe)
+
+  // 1. DB 캐시 조회
+  const cached = await getCachedIntraday(ticker, market, timeframe, startDate, endDate)
+  if (cached.length > 0) {
+    // 분봉 데이터 자체는 외부에서 가져오는 게 비싸므로 캐시가 어느 정도 있으면 사용
+    // 하루 단위로 신선도가 다르므로 보수적으로 (요청 일수 * 일봉 60% 수준 이상이면 캐시 사용)
+    const requestDays = daysBetween(startDate, endDate)
+    const minBarsPerDay = barsPerDay(timeframe)
+    const minExpectedBars = Math.floor(requestDays * minBarsPerDay * 0.4)
+    if (cached.length >= Math.max(1, minExpectedBars)) {
+      return cached
+    }
+  }
+
+  // 2. yahoo-finance2에서 가져오기 (최대 2회 재시도)
+  let bars: OHLCV[] = []
+  let lastError: unknown = null
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      bars = await fetchFromYahooIntraday(ticker, market, timeframe, startDate, endDate)
+      if (bars.length > 0) break
+    } catch (error) {
+      lastError = error
+      console.warn(`yahoo-finance2 분봉 시도 ${attempt + 1} 실패 (${ticker} ${timeframe}):`, error)
+      if (attempt < 1) await new Promise(r => setTimeout(r, 1000))
+    }
+  }
+
+  if (bars.length === 0) {
+    // yahoo 실패 시 캐시라도 반환
+    if (cached.length > 0) return cached
+    if (lastError) {
+      const msg = lastError instanceof Error ? lastError.message : '알 수 없는 오류'
+      console.warn(`[intraday] ${ticker} ${timeframe} 데이터 없음: ${msg}`)
+    }
+    return []
+  }
+
+  // 3. DB 캐시에 저장
+  await saveIntradayToCache(ticker, market, timeframe, bars)
+
+  return bars
+}
+
+// ============================================
+// yahoo-finance2 분봉 조회
+// ============================================
+
+interface YahooIntradayQuote {
+  date: Date
+  open: number | null
+  high: number | null
+  low: number | null
+  close: number | null
+  volume: number | null
+}
+
+async function fetchFromYahooIntraday(
+  ticker: string,
+  market: Market,
+  timeframe: IntradayTimeframe,
+  startDate: string,
+  endDate: string,
+): Promise<OHLCV[]> {
+  // yahoo-finance2는 동적 import (서버 사이드 전용)
+  const YahooFinance = (await import('yahoo-finance2')).default
+  const yahooFinance = new YahooFinance()
+
+  // 한국 종목은 .KS / .KQ 접미사 필요
+  const symbol = market === 'KR' ? `${ticker}.KS` : ticker
+
+  const period1 = startDate
+  const period2 = endDate
+
+  const tryFetch = async (sym: string): Promise<OHLCV[]> => {
+    const result = await yahooFinance.chart(sym, {
+      period1,
+      period2,
+      interval: timeframe,
+    })
+    if (!result?.quotes || result.quotes.length === 0) return []
+    return (result.quotes as YahooIntradayQuote[])
+      .filter(q => q.open != null && q.close != null && q.date != null)
+      .map(quoteToIntradayOHLCV)
+  }
+
+  let bars = await tryFetch(symbol)
+
+  // 한국 종목인데 KOSPI에서 안 나오면 KOSDAQ 시도
+  if (bars.length === 0 && market === 'KR') {
+    bars = await tryFetch(`${ticker}.KQ`)
+  }
+
+  return bars
+}
+
+function quoteToIntradayOHLCV(q: YahooIntradayQuote): OHLCV {
+  const d = q.date instanceof Date ? q.date : new Date(q.date)
+  // ISO datetime ('YYYY-MM-DDTHH:mm:ss') - 초 단위 보존, 밀리초/Z 제거
+  const iso = d.toISOString().split('.')[0]
+  return {
+    date: iso,
+    open: q.open ?? 0,
+    high: q.high ?? 0,
+    low: q.low ?? 0,
+    close: q.close ?? 0,
+    volume: q.volume ?? 0,
+  }
+}
+
+// ============================================
+// DB 캐시 조회/저장
+// ============================================
+
+async function getCachedIntraday(
+  ticker: string,
+  market: Market,
+  timeframe: IntradayTimeframe,
+  startDate: string,
+  endDate: string,
+): Promise<OHLCV[]> {
+  const supabase = getSupabaseAdmin()
+  if (!supabase) return []
+
+  // datetime 비교를 위해 ISO 변환 (날짜 경계 포함)
+  const startDt = `${startDate}T00:00:00.000Z`
+  const endDt = `${endDate}T23:59:59.999Z`
+
+  const { data, error } = await (supabase as unknown as {
+    from: (t: string) => {
+      select: (cols: string) => {
+        eq: (k: string, v: string) => {
+          eq: (k: string, v: string) => {
+            eq: (k: string, v: string) => {
+              gte: (k: string, v: string) => {
+                lte: (k: string, v: string) => {
+                  order: (k: string, opts: { ascending: boolean }) => Promise<{
+                    data: Array<{ datetime: string; open: number; high: number; low: number; close: number; volume: number }> | null
+                    error: { message: string } | null
+                  }>
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+    .from('intraday_price_cache')
+    .select('datetime, open, high, low, close, volume')
+    .eq('ticker', ticker)
+    .eq('market', market)
+    .eq('timeframe', timeframe)
+    .gte('datetime', startDt)
+    .lte('datetime', endDt)
+    .order('datetime', { ascending: true })
+
+  if (error) {
+    console.warn('intraday_price_cache 조회 실패:', error.message)
+    return []
+  }
+
+  return (data || []).map(row => ({
+    date: typeof row.datetime === 'string'
+      ? row.datetime.split('.')[0].replace('Z', '')
+      : new Date(row.datetime).toISOString().split('.')[0],
+    open: Number(row.open),
+    high: Number(row.high),
+    low: Number(row.low),
+    close: Number(row.close),
+    volume: Number(row.volume),
+  }))
+}
+
+async function saveIntradayToCache(
+  ticker: string,
+  market: Market,
+  timeframe: IntradayTimeframe,
+  bars: OHLCV[],
+): Promise<void> {
+  const supabase = getSupabaseAdmin()
+  if (!supabase) return
+
+  // datetime은 TIMESTAMPTZ — ISO 문자열로 저장
+  const rows = bars.map(b => ({
+    ticker,
+    market,
+    timeframe,
+    datetime: ensureIso(b.date),
+    open: b.open,
+    high: b.high,
+    low: b.low,
+    close: b.close,
+    volume: b.volume,
+  }))
+
+  const BATCH_SIZE = 500
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    const batch = rows.slice(i, i + BATCH_SIZE)
+    const { error } = await (supabase as unknown as {
+      from: (t: string) => {
+        upsert: (
+          rows: Array<Record<string, unknown>>,
+          opts: { onConflict: string; ignoreDuplicates: boolean },
+        ) => Promise<{ error: { message: string } | null }>
+      }
+    })
+      .from('intraday_price_cache')
+      .upsert(batch, {
+        onConflict: 'ticker,market,timeframe,datetime',
+        ignoreDuplicates: false,
+      })
+
+    if (error) {
+      console.warn(`intraday_price_cache 저장 실패 (batch ${i}):`, error.message)
+    }
+  }
+}
+
+// ============================================
+// 유틸
+// ============================================
+
+function defaultStartDate(timeframe: IntradayTimeframe): string {
+  // Yahoo 정책: 1m=7일, 5m=60일, 15m=60일 (경계는 보수적으로 1일씩 빼서 안전 마진 확보)
+  const now = new Date()
+  const days = timeframe === '1m' ? 6 : timeframe === '5m' ? 30 : 59
+  const start = new Date(now.getTime() - days * 24 * 60 * 60 * 1000)
+  return toDateString(start)
+}
+
+function toDateString(d: Date): string {
+  return d.toISOString().split('T')[0]
+}
+
+function daysBetween(start: string, end: string): number {
+  const d1 = new Date(start)
+  const d2 = new Date(end)
+  return Math.max(1, Math.ceil((d2.getTime() - d1.getTime()) / (1000 * 60 * 60 * 24)))
+}
+
+function barsPerDay(timeframe: IntradayTimeframe): number {
+  // 정규장 6.5시간 기준 (US: 9:30~16:00, KR: 9:00~15:30)
+  switch (timeframe) {
+    case '1m': return 390
+    case '5m': return 78
+    case '15m': return 26
+  }
+}
+
+function ensureIso(date: string): string {
+  // 'YYYY-MM-DDTHH:mm:ss' 또는 ISO 문자열을 모두 허용 → ISO로 정규화
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(date)) {
+    return `${date}.000Z`
+  }
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z?$/.test(date)) {
+    return new Date(date).toISOString()
+  }
+  return new Date(date).toISOString()
+}

--- a/dental-clinic-manager/src/types/investment.ts
+++ b/dental-clinic-manager/src/types/investment.ts
@@ -63,6 +63,8 @@ export type IndicatorType =
   | 'WILLR'  // Williams %R
   | 'VOLUME_SMA'
   | 'FEAR_GREED'  // Fear & Greed Index (0~100, 실시간 시장 심리)
+  | 'SMART_MONEY'  // 스마트머니 매집/분산 지표 (-100~+100, 중기)
+  | 'DAILY_SMART_MONEY_PULSE'  // 일일 스마트머니 펄스 (-100~+100, 단기)
 
 export interface IndicatorConfig {
   id: string          // 예: 'RSI_14', 'SMA_20'

--- a/dental-clinic-manager/src/types/investment.ts
+++ b/dental-clinic-manager/src/types/investment.ts
@@ -65,6 +65,15 @@ export type IndicatorType =
   | 'FEAR_GREED'  // Fear & Greed Index (0~100, 실시간 시장 심리)
   | 'SMART_MONEY'  // 스마트머니 매집/분산 지표 (-100~+100, 중기)
   | 'DAILY_SMART_MONEY_PULSE'  // 일일 스마트머니 펄스 (-100~+100, 단기)
+  // ===== 단타(Day Trading) 전용 분봉 지표 =====
+  | 'VWAP'              // Volume Weighted Average Price (당일 누적 거래량 가중 평균가)
+  | 'OPENING_RANGE'     // ORB (Opening Range Breakout) - 시초 N분 고/저
+  | 'LARGE_BLOCK'       // 대형 거래 감지 (현재 봉 거래량 / 최근 N봉 평균 비율)
+  | 'CLOSING_PRESSURE'  // 장 마감 압박 (마감 N봉 거래량 점유율 %)
+  | 'INTRADAY_PULSE'    // 분봉판 일일 펄스 (-100~+100)
+
+/** 전략 모드: swing(일봉/스윙) vs daytrading(분봉/단타) */
+export type StrategyMode = 'swing' | 'daytrading'
 
 export interface IndicatorConfig {
   id: string          // 예: 'RSI_14', 'SMA_20'
@@ -148,6 +157,8 @@ export interface InvestmentStrategy {
   description: string | null
   target_market: Market
   timeframe: Timeframe
+  /** 전략 모드 (옵셔널, 미설정 시 'swing'으로 간주) */
+  mode?: StrategyMode
   indicators: IndicatorConfig[]
   buy_conditions: ConditionGroup
   sell_conditions: ConditionGroup
@@ -164,6 +175,8 @@ export interface StrategyInput {
   description?: string
   targetMarket: Market
   timeframe: Timeframe
+  /** 전략 모드 (옵셔널, 미설정 시 'swing'으로 간주) */
+  mode?: StrategyMode
   indicators: IndicatorConfig[]
   buyConditions: ConditionGroup
   sellConditions: ConditionGroup
@@ -449,6 +462,8 @@ export interface PresetStrategy {
   id: string
   name: string
   description: string
+  /** 전략 모드 (옵셔널, 미설정 시 'swing'으로 간주) */
+  mode?: StrategyMode
   indicators: IndicatorConfig[]
   buyConditions: ConditionGroup
   sellConditions: ConditionGroup

--- a/dental-clinic-manager/supabase/migrations/20260425_intraday_module.sql
+++ b/dental-clinic-manager/supabase/migrations/20260425_intraday_module.sql
@@ -1,0 +1,88 @@
+-- supabase/migrations/20260425_intraday_module.sql
+-- 단타(Day Trading) 모듈 - 분봉 데이터 캐시 + 전략 mode 컬럼
+-- ============================================
+-- 적용 대상:
+-- 1) intraday_price_cache 테이블 신설 (1m/5m/15m 분봉 OHLCV 캐시)
+-- 2) investment_strategies.mode 컬럼 추가 ('swing' | 'daytrading')
+-- 3) RLS: 인증 사용자 read, service_role write
+-- ============================================
+
+-- ============================================
+-- 1) 분봉 캐시 테이블
+-- ============================================
+CREATE TABLE IF NOT EXISTS intraday_price_cache (
+  ticker TEXT NOT NULL,
+  market TEXT NOT NULL CHECK (market IN ('KR', 'US')),
+  timeframe TEXT NOT NULL CHECK (timeframe IN ('1m', '5m', '15m')),
+  datetime TIMESTAMPTZ NOT NULL,
+  open NUMERIC NOT NULL,
+  high NUMERIC NOT NULL,
+  low NUMERIC NOT NULL,
+  close NUMERIC NOT NULL,
+  volume NUMERIC NOT NULL,
+  cached_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (ticker, market, timeframe, datetime)
+);
+
+COMMENT ON TABLE intraday_price_cache IS '분봉(1m/5m/15m) OHLCV 캐시 - yahoo-finance2/KIS API 응답 저장';
+COMMENT ON COLUMN intraday_price_cache.datetime IS 'TIMESTAMPTZ - 봉 시작 시각 (UTC 저장, 사용 시 Asia/Seoul 또는 America/New_York 변환 필요)';
+COMMENT ON COLUMN intraday_price_cache.cached_at IS '캐시 저장 시각 - TTL 정리 기준';
+
+-- 조회 인덱스 (ticker + market + timeframe 범위 조회 최적화)
+CREATE INDEX IF NOT EXISTS idx_intraday_lookup
+  ON intraday_price_cache (ticker, market, timeframe, datetime DESC);
+
+-- TTL 정리용 인덱스 (cron으로 30일 전 데이터 삭제)
+CREATE INDEX IF NOT EXISTS idx_intraday_cached_at
+  ON intraday_price_cache (cached_at);
+
+-- ============================================
+-- 2) 분봉 캐시 RLS
+-- ============================================
+ALTER TABLE intraday_price_cache ENABLE ROW LEVEL SECURITY;
+
+-- 인증된 사용자는 read 가능 (개인 데이터 아님 — 시장 전체 공유 캐시)
+DROP POLICY IF EXISTS "intraday_cache_read_authenticated" ON intraday_price_cache;
+CREATE POLICY "intraday_cache_read_authenticated"
+  ON intraday_price_cache FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- 익명도 read 허용 (캐시는 공개 데이터, 백테스트 등에서 사용 가능)
+DROP POLICY IF EXISTS "intraday_cache_read_anon" ON intraday_price_cache;
+CREATE POLICY "intraday_cache_read_anon"
+  ON intraday_price_cache FOR SELECT
+  TO anon
+  USING (true);
+
+-- 쓰기는 service_role만 (서버 측 fetcher만 캐시에 저장)
+DROP POLICY IF EXISTS "intraday_cache_insert_service_role" ON intraday_price_cache;
+CREATE POLICY "intraday_cache_insert_service_role"
+  ON intraday_price_cache FOR INSERT
+  WITH CHECK (auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS "intraday_cache_update_service_role" ON intraday_price_cache;
+CREATE POLICY "intraday_cache_update_service_role"
+  ON intraday_price_cache FOR UPDATE
+  USING (auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS "intraday_cache_delete_service_role" ON intraday_price_cache;
+CREATE POLICY "intraday_cache_delete_service_role"
+  ON intraday_price_cache FOR DELETE
+  USING (auth.role() = 'service_role');
+
+-- ============================================
+-- 3) investment_strategies.mode 컬럼 추가
+-- ============================================
+ALTER TABLE investment_strategies
+  ADD COLUMN IF NOT EXISTS mode TEXT NOT NULL DEFAULT 'swing'
+  CHECK (mode IN ('swing', 'daytrading'));
+
+CREATE INDEX IF NOT EXISTS idx_strategies_mode
+  ON investment_strategies (mode);
+
+COMMENT ON COLUMN investment_strategies.mode IS '전략 모드: swing(일봉, 기존) | daytrading(분봉, 신규)';
+
+-- ============================================
+-- 마이그레이션 완료
+-- ============================================


### PR DESCRIPTION
## Summary
develop → main 머지. 두 가지 큰 작업과 1개 운영 핫픽스 묶음.

### 1. Investment: 스마트머니 매집/분산 감지 (#91a79261)
기관·스마트머니의 매집·분산 흔적을 차트/거래량에서 포착하는 지표 2종.
- **SMART_MONEY** (중기, -100~+100): CMF + A/D Divergence + Wyckoff Spring/Upthrust 합성
- **DAILY_SMART_MONEY_PULSE** (일일 단타, -100~+100): CLV × VolBoost + Gap Behavior
- 프리셋 3종: 스마트머니 추세 추종 / 일일 추종 / 추세+펄스 결합
- 검증: AAPL/NVDA 단순 SMI 전략 승률 66.7%

### 2. Investment: 단타(Day Trading) 모듈 (#72eca4d1)
분봉(1m/5m/15m) 데이터 기반 일중 매매 모듈. 일봉 swing 시스템과 분리.
- **신규 지표 5종**: VWAP, OPENING_RANGE, LARGE_BLOCK, CLOSING_PRESSURE, INTRADAY_PULSE
- **분봉 백테스트 엔진** \`dayTradingBacktestEngine\`: 거래일 경계 차단 + 장 마감 강제 청산 + KR 5bp/US 2bp 슬리피지
- **분봉 fetcher** \`intradayDataService\`: yahoo-finance2 + intraday_price_cache DB
- **DB**: \`intraday_price_cache\` 테이블 신설 + \`investment_strategies.mode\` 컬럼 (Supabase 적용 완료)
- **API**: POST \`/api/investment/daytrading-backtest\`, GET \`/api/investment/intraday-prices\`
- **UI**: \`/investment/daytrading\` 페이지 + 사이드바 메뉴 + 프리셋 카탈로그 + 백테스트 결과 표시
- **프리셋 3종**: VWAP 반등 / Opening Range Breakout / 마감 매집

### 3. AI Suggestion Channel 안정화 (4 commits)
- single-flight 큐 + 부팅 시 좀비 세션 정리
- 부팅 drain 타이밍 race 해결 (20초 지연 추가)
- bypassPermissions 모드 적용

## Test plan
- [x] \`npm run build\` 통과 (3개 신규 라우트 등록 확인)
- [x] 합성 OHLCV 시나리오 검증 (스마트머니 6개 + 단타 5개 모두 예상 부호)
- [x] 실데이터 fetch (AAPL 5분봉 4009봉, Samsung 5분봉 1624봉)
- [x] DB 마이그레이션 적용 완료 (Supabase project: beahjntkmkfhpcbhfnrr)
- [ ] 프로덕션 배포 후 \`/investment\` 대시보드 정상 동작 확인
- [ ] \`/investment/daytrading\` 페이지에서 백테스트 실행 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)