### PR TITLE
fix(community): 자유게시판 글쓰기 입력 보존 (탭 복귀 시 초기화 방지)

### DIFF
--- a/dental-clinic-manager/src/app/dashboard/community/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/community/page.tsx
@@ -97,7 +97,10 @@ export default function CommunityPage() {
     setSelectedPostId(null)
   }
 
-  if (authLoading || profileLoading) {
+  // 최초 진입 시(profile 미존재)에만 전체화면 스피너 노출.
+  // 탭 복귀로 인한 Supabase TOKEN_REFRESHED → user 갱신 → loadProfile 재실행 시
+  // 이미 profile이 있으면 화면을 유지하여 글쓰기 폼 등 입력 컴포넌트가 언마운트되지 않도록 함.
+  if (authLoading || (profileLoading && !profile)) {
     return (
       <div className="p-4 sm:p-6 bg-white min-h-screen flex items-center justify-center">
         <div className="text-center">

--- a/dental-clinic-manager/src/components/Community/CommunityPostForm.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityPostForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { ChevronLeft, Loader2, Plus, X, BarChart3 } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
@@ -16,6 +16,20 @@ interface CommunityPostFormProps {
   onCancel: () => void
 }
 
+// 임시저장 키 — 사용자별로 분리하여 다른 계정의 초안이 섞이지 않도록 함.
+// sessionStorage 사용: 탭 전환·페이지 이동·새로고침 시 보존되며 탭 종료 시 자동 폐기.
+const DRAFT_KEY_PREFIX = 'community-post-draft:'
+
+interface DraftPayload {
+  title?: string
+  content?: string
+  category?: CommunityCategory
+  showPoll?: boolean
+  pollQuestion?: string
+  pollOptions?: string[]
+  isMultipleChoice?: boolean
+}
+
 export default function CommunityPostForm({ profileId, editingPost, categories, labelMap, onSubmit, onCancel }: CommunityPostFormProps) {
   const [category, setCategory] = useState<CommunityCategory>(editingPost?.category || (categories[0]?.slug || 'free'))
   const [title, setTitle] = useState(editingPost?.title || '')
@@ -28,6 +42,58 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
   const [pollQuestion, setPollQuestion] = useState('')
   const [pollOptions, setPollOptions] = useState<string[]>(['', ''])
   const [isMultipleChoice, setIsMultipleChoice] = useState(false)
+
+  const draftKey = `${DRAFT_KEY_PREFIX}${profileId}`
+
+  // 마운트 시 저장된 초안 복원 (새 글 작성 시에만, 수정 모드에서는 건너뜀).
+  // SSR-safe하게 useEffect에서 처리하여 hydration mismatch 방지.
+  useEffect(() => {
+    if (editingPost) return
+    if (typeof window === 'undefined') return
+    try {
+      const raw = sessionStorage.getItem(draftKey)
+      if (!raw) return
+      const draft: DraftPayload = JSON.parse(raw)
+      if (draft.title) setTitle(draft.title)
+      if (draft.content) setContent(draft.content)
+      if (draft.category) setCategory(draft.category)
+      if (draft.showPoll) setShowPoll(true)
+      if (draft.pollQuestion) setPollQuestion(draft.pollQuestion)
+      if (Array.isArray(draft.pollOptions) && draft.pollOptions.length >= 2) {
+        setPollOptions(draft.pollOptions)
+      }
+      if (typeof draft.isMultipleChoice === 'boolean') setIsMultipleChoice(draft.isMultipleChoice)
+    } catch {
+      // 파싱 실패 시 무시 (초안만 손실, 동작에는 영향 없음)
+    }
+    // 의도적으로 마운트 시 1회만 실행 — 이후 입력은 아래 effect가 저장
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftKey, editingPost])
+
+  // 입력 변경 시마다 sessionStorage에 저장 (수정 모드 제외).
+  // title, content가 모두 비면 저장된 초안 제거.
+  useEffect(() => {
+    if (editingPost) return
+    if (typeof window === 'undefined') return
+    if (!title && !content) {
+      sessionStorage.removeItem(draftKey)
+      return
+    }
+    try {
+      const payload: DraftPayload = {
+        title, content, category,
+        showPoll, pollQuestion, pollOptions, isMultipleChoice,
+      }
+      sessionStorage.setItem(draftKey, JSON.stringify(payload))
+    } catch {
+      // 용량 초과 등 저장 실패 시 무시 (입력은 정상 유지됨)
+    }
+  }, [title, content, category, showPoll, pollQuestion, pollOptions, isMultipleChoice, draftKey, editingPost])
+
+  const clearDraft = () => {
+    if (typeof window === 'undefined') return
+    sessionStorage.removeItem(draftKey)
+  }
 
   const addPollOption = () => {
     if (pollOptions.length < 10) {
@@ -78,6 +144,8 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
       }
     }
 
+    // 작성/수정 성공 시 임시저장 초안 제거
+    clearDraft()
     onSubmit()
   }
 


### PR DESCRIPTION
## Summary
자유게시판에서 글쓰기 폼을 열어둔 채 다른 브라우저 탭으로 갔다가 돌아오면 입력 중이던 제목·내용이 사라지는 문제를 두 단계로 해결.

## Root cause
탭 복귀 → Supabase 자동 토큰 갱신 → `AuthContext` `onAuthStateChange`가 `setUser(new object)` → `CommunityPage` `useEffect([authLoading, user])` 재실행 → `loadProfile()` → `profileLoading=true` → 가드가 전체 페이지를 spinner로 교체 → **`CommunityPostForm` 언마운트** → 재마운트 시 `useState` 초기값(빈 문자열)으로 초기화.

## Fix
1. **근본 수정** — `dashboard/community/page.tsx`: 가드 조건을 `(profileLoading && !profile)`로 변경. 이미 프로필이 로드된 상태에서 백그라운드 재검증 시에는 화면을 유지하여 폼 언마운트 자체를 방지.
2. **방어적 수정** — `CommunityPostForm.tsx`: `sessionStorage` 기반 초안 자동 저장/복원.
   - 키: `community-post-draft:{profileId}` (사용자별 분리)
   - 마운트 시 초안 복원 (수정 모드 제외)
   - title/content/category/투표 필드 변경 시마다 저장
   - 두 필드 모두 비면 저장 초안 자동 제거
   - 작성/수정 성공 시 초안 폐기
   - `sessionStorage`라 탭 종료 시 자동 정리, 다른 탭과 격리

## Files
- `src/app/dashboard/community/page.tsx` (+3/-2)
- `src/components/Community/CommunityPostForm.tsx` (+70/-1)

## Test plan
- [ ] 자유게시판 새 글 작성 → 제목/내용 입력 후 다른 탭 클릭 → 돌아왔을 때 입력 유지 확인
- [ ] 새로고침 후에도 입력 유지 확인 (sessionStorage)
- [ ] 작성 완료 후 다시 새 글 클릭 시 빈 폼으로 시작하는지 확인 (clearDraft)
- [ ] 글 수정 모드에서는 기존 글 내용으로 시작 (draft 영향 없음) 확인
- [ ] `npm run build` 통과 (✅ 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)