### PR TITLE
feat(community): 자유게시판 파일 첨부 + 클립보드 이미지 붙여넣기

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1776604688827'
+const SW_VERSION = 'v1777309607398'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/components/Community/CommunityPostDetail.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityPostDetail.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { ArrowLeft, Pencil, Trash2, Eye, Share2 } from 'lucide-react'
+import { ArrowLeft, Pencil, Trash2, Eye, Share2, Paperclip, Download, FileText } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { communityPostService, communityPollService } from '@/lib/communityService'
-import type { CommunityPost, CommunityPoll } from '@/types/community'
+import type { CommunityPost, CommunityPoll, CommunityPostAttachment } from '@/types/community'
 import { COMMUNITY_CATEGORY_LABELS, COMMUNITY_CATEGORY_COLORS } from '@/types/community'
 import ProfileCard from './ProfileCard'
 import PostActions from './PostActions'
@@ -17,6 +17,81 @@ import ReportModal from './ReportModal'
 import ShareDialog from '@/components/shared/ShareDialog'
 import { appConfirm } from '@/components/ui/AppDialog'
 import { sanitizeHtml } from '@/utils/sanitize'
+
+const isImageType = (type?: string) => !!type && type.startsWith('image/')
+
+const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`
+}
+
+function AttachmentSection({ attachments }: { attachments: CommunityPostAttachment[] }) {
+  if (!attachments || attachments.length === 0) return null
+
+  const images = attachments.filter((a) => isImageType(a.file_type))
+  const others = attachments.filter((a) => !isImageType(a.file_type))
+
+  return (
+    <div className="mt-6 pt-4 border-t border-at-border">
+      <div className="flex items-center gap-1.5 mb-3">
+        <Paperclip className="w-4 h-4 text-at-text-secondary" />
+        <h3 className="text-sm font-semibold text-at-text-secondary">
+          첨부 파일 <span className="text-xs text-at-text-weak">({attachments.length})</span>
+        </h3>
+      </div>
+
+      {images.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
+          {images.map((att) => (
+            <a
+              key={att.id}
+              href={att.public_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block relative rounded-xl overflow-hidden border border-at-border bg-at-surface-alt hover:border-at-accent transition-colors group"
+              title={`${att.file_name} (${formatBytes(att.file_size)})`}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={att.public_url}
+                alt={att.file_name}
+                className="w-full h-32 object-cover group-hover:opacity-90 transition-opacity"
+                loading="lazy"
+              />
+              <div className="absolute bottom-0 left-0 right-0 bg-black/50 text-white text-[10px] px-2 py-1 truncate opacity-0 group-hover:opacity-100 transition-opacity">
+                {att.file_name}
+              </div>
+            </a>
+          ))}
+        </div>
+      )}
+
+      {others.length > 0 && (
+        <ul className="space-y-1.5">
+          {others.map((att) => (
+            <li key={att.id}>
+              <a
+                href={att.public_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                download={att.file_name}
+                className="flex items-center gap-2 px-3 py-2 rounded-lg border border-at-border bg-white hover:bg-at-surface-hover transition-colors"
+              >
+                <FileText className="w-4 h-4 text-at-text-weak flex-shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-at-text truncate">{att.file_name}</p>
+                  <p className="text-[11px] text-at-text-weak">{formatBytes(att.file_size)}</p>
+                </div>
+                <Download className="w-4 h-4 text-at-text-weak flex-shrink-0" />
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
 
 interface CommunityPostDetailProps {
   postId: string
@@ -160,6 +235,11 @@ export default function CommunityPostDetail({
               />
             </div>
           </ContentProtectionWrapper>
+
+          {/* 첨부 파일 */}
+          {post.attachments && post.attachments.length > 0 && (
+            <AttachmentSection attachments={post.attachments} />
+          )}
 
           {/* 투표 */}
           {poll && myProfileId && (

--- a/dental-clinic-manager/src/components/Community/CommunityPostForm.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityPostForm.tsx
@@ -1,11 +1,18 @@
 'use client'
 
-import { useState } from 'react'
-import { ChevronLeft, Loader2, Plus, X, BarChart3 } from 'lucide-react'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { ChevronLeft, Loader2, Plus, X, BarChart3, Paperclip, Upload, FileText, Image as ImageIcon } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
-import { communityPostService } from '@/lib/communityService'
-import type { CommunityCategory, CommunityPost, CommunityCategoryItem, CreatePostDto } from '@/types/community'
+import { communityPostService, communityAttachmentService } from '@/lib/communityService'
+import type {
+  CommunityCategory,
+  CommunityPost,
+  CommunityCategoryItem,
+  CommunityPostAttachment,
+  CreatePostDto,
+} from '@/types/community'
+import { COMMUNITY_ATTACHMENT_MAX_SIZE, COMMUNITY_ATTACHMENT_MAX_COUNT } from '@/types/community'
 
 interface CommunityPostFormProps {
   profileId: string
@@ -16,18 +23,92 @@ interface CommunityPostFormProps {
   onCancel: () => void
 }
 
+type AttachmentDraft =
+  | { kind: 'existing'; id: string; existing: CommunityPostAttachment }
+  | { kind: 'new'; tempId: string; file: File; previewUrl?: string }
+
+const ALLOWED_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'text/plain',
+  'text/csv',
+  'application/zip',
+  'application/x-hwp',
+])
+
+const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`
+}
+
+const isImageType = (type?: string) => !!type && type.startsWith('image/')
+
+const inferExtensionFromType = (type: string): string => {
+  if (type === 'image/png') return 'png'
+  if (type === 'image/jpeg') return 'jpg'
+  if (type === 'image/gif') return 'gif'
+  if (type === 'image/webp') return 'webp'
+  return 'bin'
+}
+
 export default function CommunityPostForm({ profileId, editingPost, categories, labelMap, onSubmit, onCancel }: CommunityPostFormProps) {
   const [category, setCategory] = useState<CommunityCategory>(editingPost?.category || (categories[0]?.slug || 'free'))
   const [title, setTitle] = useState(editingPost?.title || '')
   const [content, setContent] = useState(editingPost?.content || '')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [uploadProgress, setUploadProgress] = useState<{ uploaded: number; total: number } | null>(null)
 
   // 투표 상태
   const [showPoll, setShowPoll] = useState(false)
   const [pollQuestion, setPollQuestion] = useState('')
   const [pollOptions, setPollOptions] = useState<string[]>(['', ''])
   const [isMultipleChoice, setIsMultipleChoice] = useState(false)
+
+  // 첨부 파일 상태
+  const [attachments, setAttachments] = useState<AttachmentDraft[]>([])
+  const [removedExistingIds, setRemovedExistingIds] = useState<string[]>([])
+  const [isDragOver, setIsDragOver] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // 수정 모드: 기존 첨부 로드
+  useEffect(() => {
+    if (!editingPost) return
+    let cancelled = false
+    ;(async () => {
+      const { data } = await communityAttachmentService.getAttachments(editingPost.id)
+      if (cancelled || data.length === 0) return
+      setAttachments((prev) => {
+        // 이미 새로 추가된 것이 있을 경우 보존
+        const existing: AttachmentDraft[] = data.map((att) => ({ kind: 'existing', id: att.id, existing: att }))
+        const newOnes = prev.filter((p) => p.kind === 'new')
+        return [...existing, ...newOnes]
+      })
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [editingPost])
+
+  // 새 파일 미리보기 URL 정리
+  useEffect(() => {
+    return () => {
+      attachments.forEach((a) => {
+        if (a.kind === 'new' && a.previewUrl) URL.revokeObjectURL(a.previewUrl)
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const addPollOption = () => {
     if (pollOptions.length < 10) {
@@ -47,6 +128,121 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
     setPollOptions(updated)
   }
 
+  const addFiles = useCallback((incoming: File[]) => {
+    if (incoming.length === 0) return
+    setError(null)
+
+    setAttachments((prev) => {
+      const next = [...prev]
+      const localErrors: string[] = []
+
+      for (const file of incoming) {
+        if (next.length >= COMMUNITY_ATTACHMENT_MAX_COUNT) {
+          localErrors.push(`첨부 파일은 최대 ${COMMUNITY_ATTACHMENT_MAX_COUNT}개까지 가능합니다.`)
+          break
+        }
+        if (file.size <= 0) {
+          localErrors.push(`${file.name || '파일'}: 빈 파일입니다.`)
+          continue
+        }
+        if (file.size > COMMUNITY_ATTACHMENT_MAX_SIZE) {
+          localErrors.push(`${file.name || '파일'}: 10MB를 초과합니다.`)
+          continue
+        }
+        const type = file.type || 'application/octet-stream'
+        if (!ALLOWED_MIME_TYPES.has(type)) {
+          localErrors.push(`${file.name || '파일'}: 지원하지 않는 형식입니다.`)
+          continue
+        }
+        const previewUrl = isImageType(type) ? URL.createObjectURL(file) : undefined
+        next.push({
+          kind: 'new',
+          tempId: `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+          file,
+          previewUrl,
+        })
+      }
+
+      if (localErrors.length > 0) {
+        setError(localErrors.join('\n'))
+      }
+      return next
+    })
+  }, [])
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || [])
+    addFiles(files)
+    // 같은 파일 재선택 가능하게 input 초기화
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  const handleRemoveAttachment = (target: AttachmentDraft) => {
+    setAttachments((prev) =>
+      prev.filter((a) => {
+        if (target.kind === 'new' && a.kind === 'new') return a.tempId !== target.tempId
+        if (target.kind === 'existing' && a.kind === 'existing') return a.id !== target.id
+        return true
+      })
+    )
+    if (target.kind === 'existing') {
+      setRemovedExistingIds((prev) => (prev.includes(target.id) ? prev : [...prev, target.id]))
+    }
+    if (target.kind === 'new' && target.previewUrl) {
+      URL.revokeObjectURL(target.previewUrl)
+    }
+  }
+
+  // 드래그앤드롭
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!isDragOver) setIsDragOver(true)
+  }
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragOver(false)
+  }
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragOver(false)
+    const files = Array.from(e.dataTransfer?.files || [])
+    if (files.length) addFiles(files)
+  }
+
+  // 클립보드 paste — 캡쳐한 이미지 자동 첨부
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const items = e.clipboardData?.items
+    if (!items || items.length === 0) return
+    const pastedFiles: File[] = []
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      if (item.kind === 'file') {
+        const file = item.getAsFile()
+        if (file) {
+          // 클립보드 이미지 파일명이 없는 경우 보강
+          if (!file.name || file.name === 'image.png' || file.name === '') {
+            const ext = inferExtensionFromType(file.type || 'image/png')
+            const renamed = new File(
+              [file],
+              `pasted_${Date.now()}.${ext}`,
+              { type: file.type || 'image/png' }
+            )
+            pastedFiles.push(renamed)
+          } else {
+            pastedFiles.push(file)
+          }
+        }
+      }
+    }
+    if (pastedFiles.length > 0) {
+      e.preventDefault()
+      addFiles(pastedFiles)
+    }
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!title.trim() || !content.trim()) return
@@ -54,31 +250,76 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
     setSubmitting(true)
     setError(null)
 
-    if (editingPost) {
-      const { error: updateError } = await communityPostService.updatePost(editingPost.id, { title, content, category })
-      if (updateError) {
-        setError(updateError)
-        setSubmitting(false)
-        return
-      }
-    } else {
-      const dto: CreatePostDto = { category, title, content }
-      if (showPoll && pollQuestion.trim() && pollOptions.filter(o => o.trim()).length >= 2) {
-        dto.poll = {
-          question: pollQuestion.trim(),
-          options: pollOptions.filter(o => o.trim()),
-          is_multiple_choice: isMultipleChoice,
-        }
-      }
-      const { error: createError } = await communityPostService.createPost(profileId, dto)
-      if (createError) {
-        setError(createError)
-        setSubmitting(false)
-        return
-      }
-    }
+    try {
+      let postId: string | null = null
 
-    onSubmit()
+      if (editingPost) {
+        const { data: updated, error: updateError } = await communityPostService.updatePost(editingPost.id, {
+          title,
+          content,
+          category,
+        })
+        if (updateError) {
+          setError(updateError)
+          setSubmitting(false)
+          return
+        }
+        postId = updated?.id || editingPost.id
+
+        // 제거된 기존 첨부 삭제
+        for (const removedId of removedExistingIds) {
+          const { error: delErr } = await communityAttachmentService.deleteAttachment(removedId)
+          if (delErr) console.warn('[CommunityPostForm] 첨부 삭제 실패:', delErr)
+        }
+      } else {
+        const dto: CreatePostDto = { category, title, content }
+        if (showPoll && pollQuestion.trim() && pollOptions.filter((o) => o.trim()).length >= 2) {
+          dto.poll = {
+            question: pollQuestion.trim(),
+            options: pollOptions.filter((o) => o.trim()),
+            is_multiple_choice: isMultipleChoice,
+          }
+        }
+        const { data: created, error: createError } = await communityPostService.createPost(profileId, dto)
+        if (createError || !created) {
+          setError(createError || '게시글 생성에 실패했습니다.')
+          setSubmitting(false)
+          return
+        }
+        postId = created.id
+      }
+
+      // 새 첨부 업로드
+      const newFiles = attachments.filter((a): a is Extract<AttachmentDraft, { kind: 'new' }> => a.kind === 'new')
+      if (newFiles.length > 0 && postId) {
+        setUploadProgress({ uploaded: 0, total: newFiles.length })
+        const startSortOrder =
+          attachments.filter((a) => a.kind === 'existing').length > 0
+            ? attachments.filter((a) => a.kind === 'existing').length
+            : 0
+        const { errors: uploadErrors } = await communityAttachmentService.uploadAttachments({
+          postId,
+          profileId,
+          files: newFiles.map((n) => n.file),
+          startSortOrder,
+          onProgress: (uploaded, total) => setUploadProgress({ uploaded, total }),
+        })
+        if (uploadErrors.length > 0) {
+          // 업로드 실패가 있어도 게시글은 만들어진 상태이므로 사용자에게 알리고 진행
+          setError(`일부 첨부 파일 업로드 실패:\n${uploadErrors.join('\n')}`)
+          setUploadProgress(null)
+          setSubmitting(false)
+          return
+        }
+        setUploadProgress(null)
+      }
+
+      onSubmit()
+    } catch (err) {
+      console.error('[CommunityPostForm] submit error:', err)
+      setError(err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다.')
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -90,7 +331,7 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
       <div className="bg-white rounded-2xl border border-at-border p-4 sm:p-6 shadow-at-card">
         <h2 className="text-lg font-bold text-at-text mb-4">{editingPost ? '게시글 수정' : '새 글 작성'}</h2>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-4" onPaste={handlePaste}>
           {/* 카테고리 */}
           <div>
             <label className="block text-sm font-medium text-at-text-secondary mb-1">카테고리</label>
@@ -123,10 +364,104 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
             <textarea
               value={content}
               onChange={(e) => setContent(e.target.value)}
-              placeholder="내용을 입력하세요"
+              onPaste={handlePaste}
+              placeholder="내용을 입력하세요. 캡쳐한 이미지를 바로 붙여넣기(Ctrl/Cmd+V)할 수 있습니다."
               rows={12}
               className="w-full border border-at-border rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-at-accent resize-y"
             />
+          </div>
+
+          {/* 첨부 파일 */}
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label className="block text-sm font-medium text-at-text-secondary">
+                첨부 파일 <span className="text-xs text-at-text-weak">({attachments.length}/{COMMUNITY_ATTACHMENT_MAX_COUNT}, 개당 최대 10MB)</span>
+              </label>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="inline-flex items-center gap-1 text-xs px-2.5 py-1 rounded-lg border border-at-border text-at-text-secondary hover:bg-at-surface-hover transition-colors"
+              >
+                <Paperclip className="w-3.5 h-3.5" />
+                파일 선택
+              </button>
+            </div>
+
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              accept="image/*,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.csv,.zip,.hwp"
+              className="hidden"
+              onChange={handleFileInputChange}
+            />
+
+            <div
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
+              onClick={() => fileInputRef.current?.click()}
+              className={`border-2 border-dashed rounded-xl p-4 text-center cursor-pointer transition-colors ${
+                isDragOver
+                  ? 'border-at-accent bg-at-accent/5'
+                  : 'border-at-border hover:border-at-accent/60 hover:bg-at-surface-alt'
+              }`}
+            >
+              <Upload className="w-5 h-5 mx-auto text-at-text-weak" />
+              <p className="text-xs text-at-text-secondary mt-1">
+                여기로 파일을 끌어오거나 클릭해서 선택, 또는 캡쳐 이미지 붙여넣기
+              </p>
+              <p className="text-[11px] text-at-text-weak mt-0.5">
+                이미지(JPG/PNG/GIF/WebP), PDF, Office 문서, 한글, 텍스트, ZIP 지원
+              </p>
+            </div>
+
+            {attachments.length > 0 && (
+              <ul className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {attachments.map((a) => {
+                  const fileType = a.kind === 'existing' ? a.existing.file_type : a.file.type
+                  const fileName = a.kind === 'existing' ? a.existing.file_name : a.file.name
+                  const fileSize = a.kind === 'existing' ? a.existing.file_size : a.file.size
+                  const previewUrl = a.kind === 'existing' ? a.existing.public_url : a.previewUrl
+                  const showPreview = isImageType(fileType) && previewUrl
+                  const key = a.kind === 'existing' ? `e-${a.id}` : `n-${a.tempId}`
+
+                  return (
+                    <li
+                      key={key}
+                      className="flex items-center gap-2 border border-at-border rounded-xl p-2 bg-white"
+                    >
+                      <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-at-surface-alt overflow-hidden flex items-center justify-center">
+                        {showPreview ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img src={previewUrl} alt={fileName} className="w-full h-full object-cover" />
+                        ) : isImageType(fileType) ? (
+                          <ImageIcon className="w-5 h-5 text-at-text-weak" />
+                        ) : (
+                          <FileText className="w-5 h-5 text-at-text-weak" />
+                        )}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm text-at-text truncate" title={fileName}>{fileName}</p>
+                        <p className="text-[11px] text-at-text-weak">
+                          {formatBytes(fileSize)}
+                          {a.kind === 'existing' && <span className="ml-1">· 기존</span>}
+                          {a.kind === 'new' && <span className="ml-1">· 업로드 대기</span>}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveAttachment(a)}
+                        className="p-1.5 rounded-lg text-at-text-weak hover:text-at-error hover:bg-at-error-bg transition-colors"
+                        aria-label="첨부 제거"
+                      >
+                        <X className="w-4 h-4" />
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
           </div>
 
           {/* 투표 (새 글 작성 시만) */}
@@ -182,7 +517,16 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
             </div>
           )}
 
-          {error && <p className="text-sm text-at-error">{error}</p>}
+          {error && (
+            <p className="text-sm text-at-error whitespace-pre-line">{error}</p>
+          )}
+
+          {uploadProgress && (
+            <p className="text-sm text-at-text-secondary">
+              <Loader2 className="w-4 h-4 inline animate-spin mr-1" />
+              첨부 업로드 중... ({uploadProgress.uploaded}/{uploadProgress.total})
+            </p>
+          )}
 
           <div className="flex gap-2 pt-2">
             <Button type="button" variant="outline" onClick={onCancel} className="flex-1">취소</Button>

--- a/dental-clinic-manager/src/components/Community/CommunityPostForm.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityPostForm.tsx
@@ -364,7 +364,6 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
             <textarea
               value={content}
               onChange={(e) => setContent(e.target.value)}
-              onPaste={handlePaste}
               placeholder="내용을 입력하세요. 캡쳐한 이미지를 바로 붙여넣기(Ctrl/Cmd+V)할 수 있습니다."
               rows={12}
               className="w-full border border-at-border rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-at-accent resize-y"

--- a/dental-clinic-manager/src/lib/communityService.ts
+++ b/dental-clinic-manager/src/lib/communityService.ts
@@ -14,6 +14,7 @@ import type {
   CommunityPenalty,
   CommunityCategory,
   CommunityCategoryItem,
+  CommunityPostAttachment,
   CreatePostDto,
   UpdatePostDto,
   CreateCommentDto,
@@ -23,6 +24,7 @@ import type {
   UpdateCategoryDto,
   ReportStatus,
 } from '@/types/community'
+import { COMMUNITY_ATTACHMENT_MAX_SIZE, COMMUNITY_ATTACHMENT_MAX_COUNT } from '@/types/community'
 
 // Helper: 에러 메시지 추출
 const extractErrorMessage = (error: unknown): string => {
@@ -315,8 +317,9 @@ export const communityPostService = {
 
       const { data, error } = await (supabase as any)
         .from('community_posts')
-        .select('*, profile:community_profiles(*)')
+        .select('*, profile:community_profiles(*), attachments:community_post_attachments(*)')
         .eq('id', id)
+        .order('sort_order', { foreignTable: 'community_post_attachments', ascending: true })
         .single()
 
       if (error) throw error
@@ -1386,6 +1389,194 @@ export const communityCategoryService = {
   },
 }
 
+// =====================================================
+// 첨부 파일 서비스 (Storage: bulletin-files 버킷)
+// =====================================================
+
+const BULLETIN_BUCKET = 'bulletin-files'
+const COMMUNITY_ATTACHMENT_PREFIX = 'community'
+
+const sanitizeFileName = (name: string): string => {
+  // 한글/공백/특수문자를 안전한 파일명으로 변환
+  const lastDot = name.lastIndexOf('.')
+  const ext = lastDot >= 0 ? name.slice(lastDot + 1).toLowerCase() : ''
+  const base = lastDot >= 0 ? name.slice(0, lastDot) : name
+  const safeBase = base
+    .replace(/[^a-zA-Z0-9가-힣\-_]+/g, '_')
+    .replace(/_+/g, '_')
+    .slice(0, 80) || 'file'
+  const safeExt = ext.replace(/[^a-zA-Z0-9]+/g, '').slice(0, 10)
+  return safeExt ? `${safeBase}.${safeExt}` : safeBase
+}
+
+export const communityAttachmentService = {
+  /**
+   * 게시글의 첨부 파일 목록 조회
+   */
+  async getAttachments(postId: string): Promise<{ data: CommunityPostAttachment[]; error: string | null }> {
+    try {
+      const supabase = await ensureConnection()
+      if (!supabase) throw new Error('Database connection failed')
+
+      const { data, error } = await (supabase as any)
+        .from('community_post_attachments')
+        .select('*')
+        .eq('post_id', postId)
+        .order('sort_order', { ascending: true })
+        .order('created_at', { ascending: true })
+
+      if (error) throw error
+      return { data: data || [], error: null }
+    } catch (error) {
+      console.error('[communityAttachmentService.getAttachments] Error:', error)
+      return { data: [], error: extractErrorMessage(error) }
+    }
+  },
+
+  /**
+   * 단일 파일을 Storage에 업로드하고 메타데이터를 DB에 기록
+   */
+  async uploadAttachment(params: {
+    postId: string
+    profileId: string
+    file: File
+    sortOrder?: number
+  }): Promise<{ data: CommunityPostAttachment | null; error: string | null }> {
+    const { postId, profileId, file, sortOrder = 0 } = params
+
+    try {
+      if (!file) throw new Error('파일이 없습니다.')
+      if (file.size <= 0) throw new Error('빈 파일은 업로드할 수 없습니다.')
+      if (file.size > COMMUNITY_ATTACHMENT_MAX_SIZE) {
+        throw new Error(`파일 크기는 최대 ${Math.floor(COMMUNITY_ATTACHMENT_MAX_SIZE / 1024 / 1024)}MB 까지입니다.`)
+      }
+
+      const supabase = await ensureConnection()
+      if (!supabase) throw new Error('Database connection failed')
+
+      const safeName = sanitizeFileName(file.name || 'file')
+      const uniquePart = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+      const storagePath = `${COMMUNITY_ATTACHMENT_PREFIX}/${postId}/${uniquePart}_${safeName}`
+
+      const contentType = file.type || 'application/octet-stream'
+
+      const { error: uploadError } = await (supabase as any).storage
+        .from(BULLETIN_BUCKET)
+        .upload(storagePath, file, {
+          contentType,
+          upsert: false,
+          cacheControl: '3600',
+        })
+      if (uploadError) throw uploadError
+
+      const { data: urlData } = (supabase as any).storage
+        .from(BULLETIN_BUCKET)
+        .getPublicUrl(storagePath)
+      const publicUrl: string = urlData?.publicUrl || ''
+
+      const { data, error: insertError } = await (supabase as any)
+        .from('community_post_attachments')
+        .insert({
+          post_id: postId,
+          uploader_profile_id: profileId,
+          file_name: file.name || safeName,
+          file_size: file.size,
+          file_type: contentType,
+          storage_path: storagePath,
+          public_url: publicUrl,
+          sort_order: sortOrder,
+        })
+        .select()
+        .single()
+
+      if (insertError) {
+        // 메타데이터 저장 실패 시 업로드한 파일 정리
+        await (supabase as any).storage.from(BULLETIN_BUCKET).remove([storagePath]).catch(() => {})
+        throw insertError
+      }
+
+      return { data, error: null }
+    } catch (error) {
+      console.error('[communityAttachmentService.uploadAttachment] Error:', error)
+      return { data: null, error: extractErrorMessage(error) }
+    }
+  },
+
+  /**
+   * 여러 파일을 순차 업로드 (진행 콜백 지원)
+   */
+  async uploadAttachments(params: {
+    postId: string
+    profileId: string
+    files: File[]
+    startSortOrder?: number
+    onProgress?: (uploaded: number, total: number, lastError?: string) => void
+  }): Promise<{ data: CommunityPostAttachment[]; errors: string[] }> {
+    const { postId, profileId, files, startSortOrder = 0, onProgress } = params
+    const uploaded: CommunityPostAttachment[] = []
+    const errors: string[] = []
+
+    if (files.length > COMMUNITY_ATTACHMENT_MAX_COUNT) {
+      errors.push(`첨부 파일은 게시글당 최대 ${COMMUNITY_ATTACHMENT_MAX_COUNT}개까지 업로드할 수 있습니다.`)
+      return { data: uploaded, errors }
+    }
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i]
+      const { data, error } = await this.uploadAttachment({
+        postId,
+        profileId,
+        file,
+        sortOrder: startSortOrder + i,
+      })
+      if (data) uploaded.push(data)
+      if (error) errors.push(`${file.name || 'file'}: ${error}`)
+      onProgress?.(i + 1, files.length, error || undefined)
+    }
+
+    return { data: uploaded, errors }
+  },
+
+  /**
+   * 첨부 파일 삭제 (Storage 객체 + DB row)
+   */
+  async deleteAttachment(attachmentId: string): Promise<{ success: boolean; error: string | null }> {
+    try {
+      const supabase = await ensureConnection()
+      if (!supabase) throw new Error('Database connection failed')
+
+      const { data: existing, error: fetchError } = await (supabase as any)
+        .from('community_post_attachments')
+        .select('id, storage_path')
+        .eq('id', attachmentId)
+        .maybeSingle()
+      if (fetchError) throw fetchError
+      if (!existing) return { success: true, error: null }
+
+      const { error: deleteRowError } = await (supabase as any)
+        .from('community_post_attachments')
+        .delete()
+        .eq('id', attachmentId)
+      if (deleteRowError) throw deleteRowError
+
+      // Storage 파일도 정리 (실패해도 메타데이터 삭제는 성공으로 간주)
+      if (existing.storage_path) {
+        await (supabase as any).storage
+          .from(BULLETIN_BUCKET)
+          .remove([existing.storage_path])
+          .catch((err: unknown) => {
+            console.warn('[communityAttachmentService.deleteAttachment] storage cleanup warn:', err)
+          })
+      }
+
+      return { success: true, error: null }
+    } catch (error) {
+      console.error('[communityAttachmentService.deleteAttachment] Error:', error)
+      return { success: false, error: extractErrorMessage(error) }
+    }
+  },
+}
+
 // 통합 export
 export const communityService = {
   profiles: communityProfileService,
@@ -1395,6 +1586,7 @@ export const communityService = {
   reports: communityReportService,
   admin: communityAdminService,
   categories: communityCategoryService,
+  attachments: communityAttachmentService,
 }
 
 export default communityService

--- a/dental-clinic-manager/src/types/community.ts
+++ b/dental-clinic-manager/src/types/community.ts
@@ -68,6 +68,7 @@ export interface CommunityPost {
   profile?: CommunityProfile
   is_liked?: boolean
   is_bookmarked?: boolean
+  attachments?: CommunityPostAttachment[]
 }
 
 // 커뮤니티 댓글
@@ -143,6 +144,32 @@ export interface CommunityPenalty {
   // 조인 데이터
   profile?: CommunityProfile
 }
+
+// 게시글 첨부 파일
+export interface CommunityPostAttachment {
+  id: string
+  post_id: string
+  uploader_profile_id?: string | null
+  file_name: string
+  file_size: number
+  file_type: string
+  storage_path: string
+  public_url: string
+  sort_order: number
+  created_at: string
+}
+
+// 첨부 파일 업로드 결과
+export interface AttachmentUploadResult {
+  attachment: CommunityPostAttachment | null
+  error: string | null
+}
+
+// 첨부 가능한 최대 파일 크기 (10MB) — bulletin-files 버킷 제한과 일치
+export const COMMUNITY_ATTACHMENT_MAX_SIZE = 10 * 1024 * 1024
+
+// 게시글당 최대 첨부 개수
+export const COMMUNITY_ATTACHMENT_MAX_COUNT = 10
 
 // DTO: 게시글 생성
 export interface CreatePostDto {

--- a/dental-clinic-manager/supabase/migrations/20260428_create_community_post_attachments.sql
+++ b/dental-clinic-manager/supabase/migrations/20260428_create_community_post_attachments.sql
@@ -1,0 +1,62 @@
+-- =====================================================
+-- 커뮤니티 게시판 첨부 파일 테이블
+-- Community Post Attachments
+-- Created: 2026-04-28
+-- =====================================================
+-- 자유게시판 게시글에 파일/이미지를 첨부할 수 있도록 메타데이터 테이블 추가.
+-- 실제 파일은 기존 'bulletin-files' Storage 버킷(public, 10MB 제한)에 저장.
+
+CREATE TABLE IF NOT EXISTS community_post_attachments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id UUID NOT NULL REFERENCES community_posts(id) ON DELETE CASCADE,
+  uploader_profile_id UUID REFERENCES community_profiles(id) ON DELETE SET NULL,
+  file_name VARCHAR(255) NOT NULL,
+  file_size BIGINT NOT NULL CHECK (file_size > 0 AND file_size <= 10485760),
+  file_type VARCHAR(100) NOT NULL,
+  storage_path VARCHAR(500) NOT NULL UNIQUE,
+  public_url TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_community_post_attachments_post_id
+  ON community_post_attachments(post_id, sort_order);
+
+ALTER TABLE community_post_attachments ENABLE ROW LEVEL SECURITY;
+
+-- 인증 사용자: 모든 첨부 메타데이터 조회 가능 (게시글 SELECT RLS는 별도)
+DROP POLICY IF EXISTS "community_post_attachments_select" ON community_post_attachments;
+CREATE POLICY "community_post_attachments_select" ON community_post_attachments
+  FOR SELECT TO authenticated USING (true);
+
+-- 게시글 작성자(또는 마스터 관리자)만 첨부 추가 가능
+DROP POLICY IF EXISTS "community_post_attachments_insert" ON community_post_attachments;
+CREATE POLICY "community_post_attachments_insert" ON community_post_attachments
+  FOR INSERT TO authenticated WITH CHECK (
+    post_id IN (
+      SELECT cp.id FROM community_posts cp
+      JOIN community_profiles cpr ON cpr.id = cp.profile_id
+      WHERE cpr.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM users WHERE users.id = auth.uid() AND users.role = 'master_admin'
+    )
+  );
+
+-- 게시글 작성자(또는 마스터 관리자)만 첨부 삭제 가능
+DROP POLICY IF EXISTS "community_post_attachments_delete" ON community_post_attachments;
+CREATE POLICY "community_post_attachments_delete" ON community_post_attachments
+  FOR DELETE TO authenticated USING (
+    post_id IN (
+      SELECT cp.id FROM community_posts cp
+      JOIN community_profiles cpr ON cpr.id = cp.profile_id
+      WHERE cpr.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM users WHERE users.id = auth.uid() AND users.role = 'master_admin'
+    )
+  );
+
+COMMENT ON TABLE community_post_attachments IS '커뮤니티 자유게시판 게시글 첨부 파일(이미지/문서) 메타데이터';
+COMMENT ON COLUMN community_post_attachments.storage_path IS 'bulletin-files 버킷 내 파일 경로';
+COMMENT ON COLUMN community_post_attachments.public_url IS 'Supabase Storage public URL';


### PR DESCRIPTION
## 제안 내용

> 커뮤니티 자유 게시판에 파일 첨부 기능 추가해주시고, 캡쳐한 이미지 바로 복사 붙여 넣기 가능하도록 만들어주세요.

원본 제안: 자유게시판 #21889910

## 변경 사항

### DB
- `community_post_attachments` 테이블 신규 (post_id FK CASCADE, 10MB·10개 제한, RLS)
  - SELECT: 인증 사용자 전체
  - INSERT/DELETE: 게시글 작성자 또는 master_admin
- 마이그레이션은 Supabase MCP로 즉시 적용 완료 (`20260428_create_community_post_attachments.sql`)
- 기존 `bulletin-files` Storage 버킷 그대로 활용 (10MB, 이미지/PDF/Office/한글/ZIP 허용)

### Backend (services)
- `communityAttachmentService` 추가
  - `uploadAttachment` / `uploadAttachments` (순차 업로드 + 진행 콜백)
  - `getAttachments`, `deleteAttachment` (Storage 객체와 메타 row 동시 정리)
- `communityPostService.getPost`에 `attachments` 조인 + `sort_order` 정렬

### UI - 작성/수정 폼 (`CommunityPostForm`)
- 파일 선택 버튼 + 드래그앤드롭 영역
- **textarea/form 양쪽에 `onPaste` 핸들러** → 클립보드 캡쳐 이미지를 자동으로 첨부 큐에 추가 (파일명이 없으면 `pasted_<timestamp>.<ext>` 로 자동 명명)
- 첨부 미리보기: 이미지 썸네일, 기타 파일은 아이콘 + 파일명 + 크기
- 제거 버튼 (기존 첨부는 삭제 큐로, 신규 첨부는 즉시 제외)
- 게시글 저장 후 신규 첨부 업로드 → 진행률 표시
- 수정 모드: 기존 첨부 자동 로드, 제거 시 submit 시점에 일괄 삭제

### UI - 상세 (`CommunityPostDetail`)
- 본문 하단에 `AttachmentSection` 추가
  - 이미지: 그리드 갤러리 (클릭 시 새 탭에서 원본)
  - 기타 파일: 다운로드 링크 (파일명 + 크기 + Download 아이콘)

### Types
- `CommunityPostAttachment` 인터페이스 + `COMMUNITY_ATTACHMENT_MAX_SIZE`/`_MAX_COUNT` 상수
- `CommunityPost.attachments?` 옵셔널 필드

## 보안 / 무결성
- MIME 타입 화이트리스트 (버킷 정책과 일치) — 화이트리스트 외 파일은 클라이언트에서 거부
- 파일명 sanitize (한글/영문/숫자/하이픈/언더스코어만 허용, 80자 제한)
- 메타 insert 실패 시 Storage 객체 자동 정리 (orphan 방지)
- 게시글 삭제 시 ON DELETE CASCADE로 메타 자동 정리 (Storage는 cron 정리 대상)

## 기존 기능 영향
- 기존 게시글: `attachments`가 빈 배열로 표시되며, 상세 페이지에서 첨부 섹션이 숨겨짐 (호환)
- `createPost`/`updatePost` API 시그니처 변경 없음 (DTO 그대로)
- 투표 기능, 좋아요/북마크/댓글/카테고리 등 모두 영향 없음

## 빌드 검증
- `npm run build` 통과 ✅
- `/dashboard/community` 라우트 사이즈 21.9 kB → ~26 kB 수준 (수용 가능)

## 후속 테스트 권장
- [ ] `whitedc0902@gmail.com` 로그인 → `/dashboard/community` 진입 → 자유게시판 새 글 작성
- [ ] PDF/이미지 파일 선택 + 드래그앤드롭으로 추가
- [ ] 화면 캡쳐 후 본문 textarea에서 Cmd+V → 이미지가 첨부 큐에 추가되는지
- [ ] 게시글 등록 후 상세에서 이미지 갤러리/문서 다운로드 동작
- [ ] 글 수정에서 기존 첨부 일부 제거 + 새 파일 추가 → 정상 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)