### PR TITLE
fix(management): /management 레이아웃을 dashboard 표준에 맞춰 통일

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1777309607398'
+const SW_VERSION = 'v1777310314010'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/app/management/page.tsx
+++ b/dental-clinic-manager/src/app/management/page.tsx
@@ -146,9 +146,9 @@ export default function ManagementPage() {
 
   return (
     <div className="min-h-screen bg-at-surface-alt">
-      {/* Header */}
-      <div className="fixed top-0 left-0 right-0 z-30 h-14 bg-white border-b border-at-border">
-        <div className="max-w-[1400px] mx-auto h-full px-3 sm:px-6 flex items-center">
+      {/* Header - 상단 고정 (dashboard layout과 동일 규격) */}
+      <div className="fixed top-0 left-0 right-0 z-30 h-14 bg-at-surface border-b border-at-border fixed-header-safe">
+        <div className="h-full flex items-center px-0 w-full">
           <Header
             dbStatus="connected"
             user={user}
@@ -168,12 +168,12 @@ export default function ManagementPage() {
         />
       )}
 
-      {/* 좌측 사이드바 */}
+      {/* 좌측 사이드바 (dashboard layout 표준 규격) */}
       <aside
         className={`
-          fixed top-14 w-64 lg:w-56 h-[calc(100vh-3.5rem)] bg-white border-r border-at-border z-20 overflow-y-auto py-3 px-3
+          fixed top-14 w-64 lg:w-48 h-[calc(100vh-3.5rem)] bg-at-surface border-r border-at-border z-20 overflow-y-auto py-3 px-0 fixed-sidebar-safe
           transition-transform duration-300 ease-in-out
-          lg:left-[max(0px,calc(50%-700px))]
+          lg:left-0
           ${isMobileMenuOpen ? 'translate-x-0 left-0' : '-translate-x-full left-0 lg:translate-x-0'}
         `}
       >
@@ -185,13 +185,13 @@ export default function ManagementPage() {
         />
       </aside>
 
-      {/* 메인 콘텐츠 */}
-      <div className="pt-14">
-        <main className="max-w-[1400px] mx-auto px-3 sm:px-4 lg:pl-60 lg:pr-6 pt-4 pb-6">
-          <div className="max-w-6xl bg-white min-h-screen rounded-xl border border-at-border">
+      {/* 메인 콘텐츠 (dashboard layout과 동일한 좌측 패딩 / 좌우 여백 0) */}
+      <div className="pt-14 pt-header-safe">
+        <main className="lg:pl-48 px-0">
+          <div>
 
             {/* 서브 탭 네비게이션 - 스크롤 시 고정 */}
-            <div className="sticky top-14 z-10 bg-white border-b border-at-border px-4 sm:px-6 pt-4 pb-3 rounded-t-xl flex flex-wrap gap-2">
+            <div className="sticky top-14 z-10 bg-white border-b border-at-border px-4 sm:px-6 pt-4 pb-3 flex flex-wrap gap-2">
               {subTabs.map((tab) => {
                 const hasTabPermission = tab.permissions.length === 0 || tab.permissions.some(p => hasPermission(p as any))
                 if (!hasTabPermission) return null


### PR DESCRIPTION
## 제안 내용

> 다른 메뉴 눌렀을 때와 달리 여백들이 보임. 다른 기능들 화면 참고해서 여백이나, 패딩 없애주세요.

원본 제안: 자유게시판 #0fe619d9

## 원인

\`/management\` 페이지(\`src/app/management/page.tsx\`)는 \`dashboard/layout.tsx\`를 공유하지 않고 자체적으로 헤더·사이드바·메인을 그리는데, 그 컨테이너 규격이 dashboard 표준과 달랐습니다:

| 요소 | 기존 (`/management`) | 표준 (`/dashboard/*`) |
|---|---|---|
| Header 컨테이너 | `max-w-[1400px] mx-auto px-3 sm:px-6` | `px-0 w-full` |
| 사이드바 폭/위치 | `lg:w-56 lg:left-[max(0px,calc(50%-700px))] px-3` | `lg:w-48 lg:left-0 px-0` |
| 메인 컨테이너 | `max-w-[1400px] mx-auto px-3 sm:px-4 lg:pl-60 lg:pr-6 pt-4 pb-6` | `lg:pl-48 px-0` |
| 콘텐츠 카드 wrapper | `<div className="max-w-6xl bg-white min-h-screen rounded-xl border">` | (없음) |

이 차이로 1440px 화면에서 `/management`만 좌우 양옆에 큰 빈 여백 + 콘텐츠가 카드처럼 떠 있는 형태가 되어 다른 메뉴와 시각적으로 일관성이 깨졌습니다.

## 변경 사항

\`src/app/management/page.tsx\`에서 컨테이너 클래스만 dashboard 표준에 맞춰 통일:

- Header 외곽 div: 좌우 패딩 제거 + 색 토큰을 `bg-at-surface`로
- 사이드바: 폭 `lg:w-56` → `lg:w-48`, 위치 `lg:left-0`으로 좌측 정렬, 패딩 제거, `fixed-sidebar-safe` 추가
- 메인: max-width / 가운데 정렬 / 추가 패딩 제거 → `lg:pl-48 px-0`
- 콘텐츠 카드 wrapper(\`max-w-6xl ... rounded-xl border\`) 제거 → 사이드바 우측 영역 전체를 자연스럽게 사용
- 서브 탭 sticky 영역의 \`rounded-t-xl\` 제거 (카드 wrapper 제거에 맞춰)
- \`pt-header-safe\` 적용

탭 라우팅·권한 체크·모바일 메뉴 동작 등 기존 로직은 모두 그대로 유지.

## 브라우저 검증 (1440x900)

`<main>` 요소 메트릭이 두 페이지에서 완벽 일치:

| 메트릭 | /dashboard | /management (수정 후) |
|---|---|---|
| left | 0 | 0 |
| paddingLeft | 192px | 192px |
| paddingRight | 0 | 0 |
| width | 1425 | 1425 |
| maxWidth | none | none |

콘솔 에러 없음. 메뉴 설정 화면이 사이드바 바로 옆에서 시작하고 좌우로 화면을 자연스럽게 사용합니다.

## 빌드
\`npm run build\` 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)