### PR TITLE
feat(community): 자유게시판 본문 에디터에 이미지 인라인 삽입 지원

### DIFF
--- a/dental-clinic-manager/src/components/Community/CommunityPostForm.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityPostForm.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, Loader2, Plus, X, BarChart3, Paperclip, Upload, FileText, 
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { communityPostService, communityAttachmentService } from '@/lib/communityService'
+import CommunityRichEditor from './CommunityRichEditor'
 import type {
   CommunityCategory,
   CommunityPost,
@@ -52,6 +53,19 @@ const formatBytes = (bytes: number): string => {
 }
 
 const isImageType = (type?: string) => !!type && type.startsWith('image/')
+
+// 리치 에디터의 빈 상태(`<p></p>`, 공백뿐인 HTML)를 걸러내고
+// 이미지/비디오 등 미디어가 들어 있으면 유효 콘텐츠로 간주.
+const hasMeaningfulContent = (html: string): boolean => {
+  if (!html) return false
+  if (/<(img|iframe|video|figure|table)\b/i.test(html)) return true
+  const text = html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return text.length > 0
+}
 
 const inferExtensionFromType = (type: string): string => {
   if (type === 'image/png') return 'png'
@@ -225,11 +239,13 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
     const filesFromList = clipboardData.files
     const pastedFiles: File[] = []
 
+    // 이미지 파일은 본문 에디터(CommunityRichEditor)가 직접 인라인 삽입을 처리하므로
+    // 폼 레벨에서는 이미지 외 파일(PDF/Office/ZIP 등)만 첨부 큐에 추가한다.
     // 1순위: items에서 kind === 'file' 추출 (가장 표준)
     if (items && items.length > 0) {
       for (let i = 0; i < items.length; i++) {
         const item = items[i]
-        if (item.kind === 'file') {
+        if (item.kind === 'file' && !item.type.startsWith('image/')) {
           const file = item.getAsFile()
           if (file) pastedFiles.push(file)
         }
@@ -240,7 +256,7 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
     if (pastedFiles.length === 0 && filesFromList && filesFromList.length > 0) {
       for (let i = 0; i < filesFromList.length; i++) {
         const file = filesFromList.item(i)
-        if (file) pastedFiles.push(file)
+        if (file && !file.type.startsWith('image/')) pastedFiles.push(file)
       }
     }
 
@@ -265,7 +281,7 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!title.trim() || !content.trim()) return
+    if (!title.trim() || !hasMeaningfulContent(content)) return
 
     setSubmitting(true)
     setError(null)
@@ -378,16 +394,13 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
             />
           </div>
 
-          {/* 내용 */}
+          {/* 내용 (TipTap 기반 리치 에디터 — 이미지 인라인 삽입 지원) */}
           <div>
             <label className="block text-sm font-medium text-at-text-secondary mb-1">내용</label>
-            <textarea
+            <CommunityRichEditor
               value={content}
-              onChange={(e) => setContent(e.target.value)}
-              onPaste={handlePaste}
-              placeholder="내용을 입력하세요. 캡쳐한 이미지를 바로 붙여넣기(Ctrl/Cmd+V)할 수 있습니다."
-              rows={12}
-              className="w-full border border-at-border rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-at-accent resize-y"
+              onChange={setContent}
+              profileId={profileId}
             />
           </div>
 
@@ -550,7 +563,7 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
 
           <div className="flex gap-2 pt-2">
             <Button type="button" variant="outline" onClick={onCancel} className="flex-1">취소</Button>
-            <Button type="submit" disabled={!title.trim() || !content.trim() || submitting} className="flex-1">
+            <Button type="submit" disabled={!title.trim() || !hasMeaningfulContent(content) || submitting} className="flex-1">
               {submitting ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
               {editingPost ? '수정하기' : '작성하기'}
             </Button>

--- a/dental-clinic-manager/src/components/Community/CommunityRichEditor.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityRichEditor.tsx
@@ -1,0 +1,221 @@
+'use client'
+
+import { useEffect, useRef, useCallback } from 'react'
+import { useEditor, EditorContent } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import Image from '@tiptap/extension-image'
+import Placeholder from '@tiptap/extension-placeholder'
+import { Bold, Italic, List, ListOrdered, Image as ImageIcon, Loader2 } from 'lucide-react'
+import { communityAttachmentService } from '@/lib/communityService'
+
+interface CommunityRichEditorProps {
+  value: string
+  onChange: (html: string) => void
+  profileId: string
+  placeholder?: string
+}
+
+const DEFAULT_PLACEHOLDER =
+  '내용을 입력하세요. 캡쳐한 이미지(Cmd/Ctrl+V)나 드래그앤드롭으로 본문에 이미지를 삽입할 수 있습니다.'
+
+export default function CommunityRichEditor({
+  value,
+  onChange,
+  profileId,
+  placeholder,
+}: CommunityRichEditorProps) {
+  const uploadingCountRef = useRef(0)
+  const uploadAndInsertRef = useRef<(file: File) => void>(() => {})
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      Image.configure({
+        HTMLAttributes: {
+          class: 'community-content-image rounded-lg max-w-full h-auto my-2',
+        },
+      }),
+      Placeholder.configure({
+        placeholder: placeholder || DEFAULT_PLACEHOLDER,
+      }),
+    ],
+    content: value,
+    immediatelyRender: false,
+    onUpdate({ editor }) {
+      onChange(editor.getHTML())
+    },
+    editorProps: {
+      attributes: {
+        class:
+          'prose max-w-none focus:outline-none min-h-[280px] px-3 py-2 text-sm leading-relaxed',
+      },
+      handlePaste(_view, event) {
+        const items = event.clipboardData?.items
+        if (!items || items.length === 0) return false
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i]
+          if (item.kind === 'file' && item.type.startsWith('image/')) {
+            const file = item.getAsFile()
+            if (file) {
+              event.preventDefault()
+              uploadAndInsertRef.current(file)
+              return true
+            }
+          }
+        }
+        return false
+      },
+      handleDrop(_view, event, _slice, moved) {
+        if (moved) return false
+        const files = event.dataTransfer?.files
+        if (!files || files.length === 0) return false
+        const imageFiles: File[] = []
+        for (let i = 0; i < files.length; i++) {
+          const f = files.item(i)
+          if (f && f.type.startsWith('image/')) imageFiles.push(f)
+        }
+        if (imageFiles.length === 0) return false
+        event.preventDefault()
+        imageFiles.forEach((f) => uploadAndInsertRef.current(f))
+        return true
+      },
+    },
+  })
+
+  // 외부 value 변경(수정 모드 진입 등) 시 에디터 동기화
+  useEffect(() => {
+    if (!editor) return
+    if (value !== editor.getHTML()) {
+      editor.commands.setContent(value || '', { emitUpdate: false })
+    }
+    // editor가 바뀔 때마다 dep으로 추가해 무한루프 방지를 위해 ref 비교만 사용
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, editor])
+
+  const uploadAndInsert = useCallback(
+    async (file: File) => {
+      if (!editor) return
+      uploadingCountRef.current += 1
+      const tempUrl = URL.createObjectURL(file)
+      editor.chain().focus().setImage({ src: tempUrl }).run()
+
+      const { url, error } = await communityAttachmentService.uploadInlineImage({
+        profileId,
+        file,
+      })
+
+      uploadingCountRef.current = Math.max(0, uploadingCountRef.current - 1)
+
+      if (url) {
+        const { state } = editor
+        state.doc.descendants((node, pos) => {
+          if (node.type.name === 'image' && node.attrs.src === tempUrl) {
+            editor.chain().setNodeSelection(pos).setImage({ src: url }).run()
+          }
+        })
+        URL.revokeObjectURL(tempUrl)
+      } else {
+        // 업로드 실패: 임시 이미지 제거
+        const { state } = editor
+        state.doc.descendants((node, pos) => {
+          if (node.type.name === 'image' && node.attrs.src === tempUrl) {
+            editor.chain().setNodeSelection(pos).deleteSelection().run()
+          }
+        })
+        URL.revokeObjectURL(tempUrl)
+        if (typeof window !== 'undefined') {
+          window.alert(error || '이미지 업로드에 실패했습니다.')
+        }
+      }
+    },
+    [editor, profileId]
+  )
+
+  // ref에 최신 함수 보관 (editorProps 클로저가 stale해지지 않도록)
+  useEffect(() => {
+    uploadAndInsertRef.current = uploadAndInsert
+  }, [uploadAndInsert])
+
+  const handleImageButton = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file && file.type.startsWith('image/')) uploadAndInsert(file)
+    e.target.value = ''
+  }
+
+  if (!editor) {
+    return (
+      <div className="border border-at-border rounded-xl min-h-[300px] flex items-center justify-center text-at-text-weak text-sm">
+        에디터 로딩 중...
+      </div>
+    )
+  }
+
+  const btnBase =
+    'p-1.5 rounded transition-colors text-at-text-secondary hover:bg-at-surface-hover disabled:opacity-40 disabled:cursor-not-allowed'
+  const btnActive = 'bg-at-accent-light text-at-accent hover:bg-at-accent-light'
+
+  return (
+    <div className="border border-at-border rounded-xl bg-white">
+      {/* 툴바 */}
+      <div className="flex items-center gap-1 border-b border-at-border px-2 py-1.5">
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleBold().run()}
+          className={`${btnBase} ${editor.isActive('bold') ? btnActive : ''}`}
+          title="굵게 (Cmd/Ctrl+B)"
+          aria-label="굵게"
+        >
+          <Bold className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+          className={`${btnBase} ${editor.isActive('italic') ? btnActive : ''}`}
+          title="기울임 (Cmd/Ctrl+I)"
+          aria-label="기울임"
+        >
+          <Italic className="w-4 h-4" />
+        </button>
+        <span className="w-px h-5 bg-at-border mx-1" />
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleBulletList().run()}
+          className={`${btnBase} ${editor.isActive('bulletList') ? btnActive : ''}`}
+          title="글머리 기호 목록"
+          aria-label="글머리 기호 목록"
+        >
+          <List className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          className={`${btnBase} ${editor.isActive('orderedList') ? btnActive : ''}`}
+          title="번호 매기기 목록"
+          aria-label="번호 매기기 목록"
+        >
+          <ListOrdered className="w-4 h-4" />
+        </button>
+        <span className="w-px h-5 bg-at-border mx-1" />
+        <label
+          className={`${btnBase} cursor-pointer flex items-center`}
+          title="이미지 삽입"
+          aria-label="이미지 삽입"
+        >
+          <ImageIcon className="w-4 h-4" />
+          <input
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleImageButton}
+          />
+        </label>
+        <span className="ml-auto text-[11px] text-at-text-weak hidden sm:inline">
+          이미지는 Cmd/Ctrl+V 또는 드래그로 삽입
+        </span>
+      </div>
+
+      {/* 본문 */}
+      <EditorContent editor={editor} />
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/lib/communityService.ts
+++ b/dental-clinic-manager/src/lib/communityService.ts
@@ -1503,6 +1503,57 @@ export const communityAttachmentService = {
   },
 
   /**
+   * 본문 인라인 이미지 업로드 (post_id 없이 즉시 업로드)
+   * - 첨부 파일 메타(community_post_attachments)에는 기록하지 않음
+   * - 본문 HTML에 <img src="..."> 형태로 직접 삽입되어 그 URL만으로 영구 노출
+   * - 경로: community/inline/{profileId}/{timestamp}_{name}
+   */
+  async uploadInlineImage(params: {
+    profileId: string
+    file: File
+  }): Promise<{ url: string | null; error: string | null }> {
+    const { profileId, file } = params
+    try {
+      if (!file) throw new Error('파일이 없습니다.')
+      if (file.size <= 0) throw new Error('빈 파일은 업로드할 수 없습니다.')
+      if (file.size > COMMUNITY_ATTACHMENT_MAX_SIZE) {
+        throw new Error(`이미지 크기는 최대 ${Math.floor(COMMUNITY_ATTACHMENT_MAX_SIZE / 1024 / 1024)}MB 까지입니다.`)
+      }
+      const contentType = file.type || 'image/png'
+      if (!contentType.startsWith('image/')) {
+        throw new Error('이미지 파일만 인라인 삽입할 수 있습니다.')
+      }
+
+      const supabase = await ensureConnection()
+      if (!supabase) throw new Error('Database connection failed')
+
+      const safeName = sanitizeFileName(file.name || `pasted.${(contentType.split('/')[1] || 'png').toLowerCase()}`)
+      const uniquePart = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+      const storagePath = `${COMMUNITY_ATTACHMENT_PREFIX}/inline/${profileId}/${uniquePart}_${safeName}`
+
+      const { error: uploadError } = await (supabase as any).storage
+        .from(BULLETIN_BUCKET)
+        .upload(storagePath, file, {
+          contentType,
+          upsert: false,
+          cacheControl: '3600',
+        })
+      if (uploadError) throw uploadError
+
+      const { data: urlData } = (supabase as any).storage
+        .from(BULLETIN_BUCKET)
+        .getPublicUrl(storagePath)
+      const publicUrl: string = urlData?.publicUrl || ''
+      if (!publicUrl) throw new Error('Public URL 생성 실패')
+
+      return { url: publicUrl, error: null }
+    } catch (error) {
+      console.error('[communityAttachmentService.uploadInlineImage] Error:', error)
+      return { url: null, error: extractErrorMessage(error) }
+    }
+  },
+
+  /**
    * 여러 파일을 순차 업로드 (진행 콜백 지원)
    */
   async uploadAttachments(params: {


### PR DESCRIPTION
## 사용자 요구
> 캡쳐한 이미지를 복사 붙여 넣기 하면 에디터 안에 이미지가 삽입되도록 해줘. 현재는 첨부 파일 형태로 삽입되고 있어.

## 동작 변경
| 시나리오 | Before | After |
|---|---|---|
| 본문 영역에서 캡쳐 이미지 Cmd/Ctrl+V | 첨부 파일 카드로 추가 | **본문 안에 인라인 \<img\> 삽입** |
| 본문 영역에 이미지 드래그앤드롭 | (textarea라 불가) | **본문 안에 인라인 \<img\> 삽입** |
| 본문 영역에서 이미지 외 파일 paste | (변화 없음) | 첨부 파일 카드로 추가 |
| 첨부 파일 영역(드롭존/파일선택) | (그대로) | (그대로) |

## 구현

### 1) 새 컴포넌트 `CommunityRichEditor.tsx`
- TipTap StarterKit + Image + Placeholder
- 최소 toolbar: Bold / Italic / 글머리 목록 / 번호 목록 / 이미지 삽입 버튼
- `editorProps.handlePaste` / `handleDrop`로 image file을 즉시 캐치
- 임시 `blob:` URL로 즉시 미리 삽입 → Storage 업로드 완료 후 실제 public URL로 교체
- `immediatelyRender: false` (Next.js SSR hydration 안전)

### 2) `communityAttachmentService.uploadInlineImage`
- `post_id` 없이 즉시 업로드 (글이 아직 생성되지 않은 시점)
- 경로: `community/inline/{profileId}/{timestamp}_{name}` (bulletin-files 버킷)
- `community_post_attachments` 메타 row는 만들지 않음 — 본문 HTML 안 \<img src\>로만 존재
- 10MB / `image/*` 검증

### 3) `CommunityPostForm` 수정
- \<textarea\>를 \<CommunityRichEditor\>로 교체
- form-level `handlePaste`에서 `image/*` MIME은 제외 (에디터가 처리)
- 비-이미지 파일(PDF/Office/ZIP 등)만 첨부 큐로 추가
- 빈 에디터 상태(\`\<p\>\</p\>\`) 검증 보강: `hasMeaningfulContent()` 헬퍼로 작성하기 활성화 조건 정확화 (이미지만 들어 있어도 유효 콘텐츠로 인정)

## 호환성
- 기존 plain text 게시글: 상세 페이지의 `sanitizeHtml(post.content)`가 그대로 렌더링 → 동일 표시
- 새 게시글: HTML로 저장. \<img\>는 sanitize의 ALLOWED_TAGS에 이미 포함되어 안전 렌더링
- 첨부 파일 기능: 그대로 유지 (사용자가 명시적으로 파일 첨부할 때만 사용)

## 빌드
\`npm run build\` 통과 ✅
- /dashboard/community 라우트: 21.9 → 23.5 kB (TipTap 추가로 First Load 217 → 335 kB, 수용 가능 수준)

🤖 Generated with [Claude Code](https://claude.com/claude-code)