### PR TITLE
chore: develop → main 동기화 (이벤트 효과 분석 + 자유게시판 이미지 + worker update)

### DIFF
--- a/dental-clinic-manager/src/app/api/workers/status/route.ts
+++ b/dental-clinic-manager/src/app/api/workers/status/route.ts
@@ -8,6 +8,21 @@ let cachedReleaseDate: string | null = null;
 let cacheTimestamp = 0;
 const CACHE_TTL = 5 * 60 * 1000;
 
+// semver 순서 비교: a > b 이면 양수, 같으면 0, a < b 이면 음수.
+// pre-release/build 메타데이터는 무시하고 숫자 부분만 비교한다.
+function compareSemver(a: string, b: string): number {
+  const norm = (v: string) => v.replace(/^v/, '').split(/[-+]/)[0];
+  const pa = norm(a).split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = norm(b).split('.').map((n) => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const x = pa[i] ?? 0;
+    const y = pb[i] ?? 0;
+    if (x !== y) return x - y;
+  }
+  return 0;
+}
+
 async function getLatestWorkerInfo(): Promise<{ version: string | null; releaseDate: string | null }> {
   if (cachedLatestVersion && Date.now() - cacheTimestamp < CACHE_TTL) {
     return { version: cachedLatestVersion, releaseDate: cachedReleaseDate };
@@ -128,7 +143,7 @@ export async function GET(request: NextRequest) {
       }
 
       const { version: latestVersion, releaseDate: latestReleaseDate } = await getLatestWorkerInfo();
-      const updateAvailable = !!(currentVersion && latestVersion && currentVersion !== latestVersion);
+      const updateAvailable = !!(currentVersion && latestVersion && compareSemver(latestVersion, currentVersion) > 0);
 
       result.marketing = { installed, online, currentVersion, latestVersion, updateAvailable, updateStatus, latestReleaseDate };
     }

--- a/dental-clinic-manager/src/components/AIAnalysis/EventImpactAnalysis.tsx
+++ b/dental-clinic-manager/src/components/AIAnalysis/EventImpactAnalysis.tsx
@@ -22,12 +22,12 @@ import {
 } from '@/lib/statistics/eventImpact';
 import { cn } from '@/lib/utils';
 
-interface Announcement {
+interface EventCandidate {
+  // source-prefixed unique id (예: "ann:<uuid>" 또는 "note:<uuid>")
   id: string;
+  source: 'announcement' | 'special_note';
   title: string;
-  start_date: string | null;
-  end_date: string | null;
-  category: string;
+  date: string; // YYYY-MM-DD
 }
 
 interface DailyDataPoint {
@@ -42,8 +42,8 @@ interface Props {
 }
 
 export default function EventImpactAnalysis({ clinicId }: Props) {
-  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
-  const [loadingAnnouncements, setLoadingAnnouncements] = useState(true);
+  const [events, setEvents] = useState<EventCandidate[]>([]);
+  const [loadingEvents, setLoadingEvents] = useState(true);
   const [selectedEventId, setSelectedEventId] = useState<string>('');
   const [metric, setMetric] = useState<Metric>('sales');
   const [windowDays, setWindowDays] = useState(14);
@@ -53,34 +53,82 @@ export default function EventImpactAnalysis({ clinicId }: Props) {
   const [chartData, setChartData] = useState<DailyDataPoint[]>([]);
   const [eventDate, setEventDate] = useState<string>('');
 
-  // 공지사항 목록 로드
+  // 공지사항 + 일일 보고서 특이사항을 이벤트 후보로 통합 로드
   useEffect(() => {
-    const loadAnnouncements = async () => {
+    const loadEventCandidates = async () => {
       try {
-        setLoadingAnnouncements(true);
+        setLoadingEvents(true);
         const supabase = createClient();
         if (!supabase) return;
 
-        const { data, error: fetchError } = await supabase
-          .from('announcements')
-          .select('id, title, start_date, end_date, category')
-          .eq('clinic_id', clinicId)
-          .not('start_date', 'is', null)
-          .order('start_date', { ascending: false })
-          .limit(50);
+        const [announcementsRes, notesRes] = await Promise.all([
+          supabase
+            .from('announcements')
+            .select('id, title, start_date')
+            .eq('clinic_id', clinicId)
+            .not('start_date', 'is', null)
+            .order('start_date', { ascending: false })
+            .limit(50),
+          supabase
+            .from('special_notes_history')
+            .select('id, report_date, content')
+            .eq('clinic_id', clinicId)
+            .not('report_date', 'is', null)
+            .not('content', 'is', null)
+            .order('report_date', { ascending: false })
+            .limit(50),
+        ]);
 
-        if (fetchError) {
-          setError(`공지 목록 조회 실패: ${fetchError.message}`);
+        if (announcementsRes.error) {
+          setError(`공지 목록 조회 실패: ${announcementsRes.error.message}`);
           return;
         }
-        setAnnouncements(data || []);
+        if (notesRes.error) {
+          setError(`특이사항 조회 실패: ${notesRes.error.message}`);
+          return;
+        }
+
+        const annRows = (announcementsRes.data || []) as Array<{
+          id: string;
+          title: string;
+          start_date: string | null;
+        }>;
+        const announcements: EventCandidate[] = annRows
+          .filter((a) => a.start_date)
+          .map((a) => ({
+            id: `ann:${a.id}`,
+            source: 'announcement' as const,
+            title: a.title,
+            date: (a.start_date as string).slice(0, 10),
+          }));
+
+        const noteRows = (notesRes.data || []) as Array<{
+          id: string;
+          content: string | null;
+          report_date: string | null;
+        }>;
+        const notes: EventCandidate[] = noteRows
+          .filter((n) => n.content && n.content.trim().length > 0 && n.report_date)
+          .map((n) => ({
+            id: `note:${n.id}`,
+            source: 'special_note' as const,
+            title: (n.content as string).trim().replace(/\s+/g, ' ').slice(0, 60),
+            date: (n.report_date as string).slice(0, 10),
+          }));
+
+        // 날짜 내림차순으로 합치기
+        const merged = [...announcements, ...notes].sort((a, b) =>
+          a.date < b.date ? 1 : -1
+        );
+
+        setEvents(merged);
       } catch (err) {
         setError(String(err));
       } finally {
-        setLoadingAnnouncements(false);
+        setLoadingEvents(false);
       }
     };
-    loadAnnouncements();
+    loadEventCandidates();
   }, [clinicId]);
 
   const handleAnalyze = async () => {
@@ -89,9 +137,9 @@ export default function EventImpactAnalysis({ clinicId }: Props) {
       return;
     }
 
-    const event = announcements.find((a) => a.id === selectedEventId);
-    if (!event || !event.start_date) {
-      setError('이벤트의 시작일이 없습니다');
+    const event = events.find((e) => e.id === selectedEventId);
+    if (!event || !event.date) {
+      setError('이벤트의 날짜가 없습니다');
       return;
     }
 
@@ -101,8 +149,8 @@ export default function EventImpactAnalysis({ clinicId }: Props) {
     setChartData([]);
 
     try {
-      // 분석 기간 = 이벤트 시작일 ± windowDays
-      const eventTs = new Date(event.start_date).getTime();
+      // 분석 기간 = 이벤트 날짜 ± windowDays
+      const eventTs = new Date(event.date).getTime();
       const startDate = new Date(eventTs - windowDays * 24 * 60 * 60 * 1000)
         .toISOString()
         .slice(0, 10);
@@ -136,10 +184,10 @@ export default function EventImpactAnalysis({ clinicId }: Props) {
       );
 
       // 통계 계산
-      const { before, after } = splitByEvent(rawData, event.start_date, windowDays);
+      const { before, after } = splitByEvent(rawData, event.date, windowDays);
       const stats = welchTTest(before, after);
 
-      setEventDate(event.start_date);
+      setEventDate(event.date);
       setChartData(rawData);
       setResult(stats);
     } catch (err) {
@@ -187,19 +235,36 @@ export default function EventImpactAnalysis({ clinicId }: Props) {
             <select
               value={selectedEventId}
               onChange={(e) => setSelectedEventId(e.target.value)}
-              disabled={loadingAnnouncements || loading}
+              disabled={loadingEvents || loading}
               className="w-full px-3 py-2 border border-at-border rounded-lg text-sm focus:outline-none focus:border-at-accent"
             >
-              <option value="">-- 공지사항 선택 --</option>
-              {announcements.map((a) => (
-                <option key={a.id} value={a.id}>
-                  [{a.start_date?.slice(0, 10)}] {a.title}
-                </option>
-              ))}
+              <option value="">-- 이벤트 선택 --</option>
+              {events.filter((e) => e.source === 'announcement').length > 0 && (
+                <optgroup label="📢 공지사항">
+                  {events
+                    .filter((e) => e.source === 'announcement')
+                    .map((e) => (
+                      <option key={e.id} value={e.id}>
+                        [{e.date}] {e.title}
+                      </option>
+                    ))}
+                </optgroup>
+              )}
+              {events.filter((e) => e.source === 'special_note').length > 0 && (
+                <optgroup label="📝 일일 보고서 특이사항">
+                  {events
+                    .filter((e) => e.source === 'special_note')
+                    .map((e) => (
+                      <option key={e.id} value={e.id}>
+                        [{e.date}] {e.title}
+                      </option>
+                    ))}
+                </optgroup>
+              )}
             </select>
-            {!loadingAnnouncements && announcements.length === 0 && (
+            {!loadingEvents && events.length === 0 && (
               <p className="text-xs text-at-text-weak mt-1">
-                시작일이 설정된 공지사항이 없습니다. 병원 게시판에서 공지를 작성해주세요.
+                이벤트로 사용할 수 있는 공지사항이나 일일 보고서 특이사항이 없습니다.
               </p>
             )}
           </div>

--- a/dental-clinic-manager/src/components/Community/CommunityPostForm.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityPostForm.tsx
@@ -213,34 +213,54 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
   }
 
   // 클립보드 paste — 캡쳐한 이미지 자동 첨부
+  // textarea와 form 양쪽에 부착: textarea native paste가 일부 브라우저에서
+  // form까지 bubble되지 않는 케이스 대비. file을 발견했을 때만 stopPropagation으로
+  // 같은 이벤트가 두 핸들러에서 중복 처리되지 않도록 차단.
   const handlePaste = (e: React.ClipboardEvent) => {
-    const items = e.clipboardData?.items
-    if (!items || items.length === 0) return
+    // ClipboardEvent.clipboardData는 SyntheticEvent에서 native object를 그대로 노출
+    const clipboardData = e.clipboardData || (e.nativeEvent as ClipboardEvent | undefined)?.clipboardData
+    if (!clipboardData) return
+
+    const items = clipboardData.items
+    const filesFromList = clipboardData.files
     const pastedFiles: File[] = []
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i]
-      if (item.kind === 'file') {
-        const file = item.getAsFile()
-        if (file) {
-          // 클립보드 이미지 파일명이 없는 경우 보강
-          if (!file.name || file.name === 'image.png' || file.name === '') {
-            const ext = inferExtensionFromType(file.type || 'image/png')
-            const renamed = new File(
-              [file],
-              `pasted_${Date.now()}.${ext}`,
-              { type: file.type || 'image/png' }
-            )
-            pastedFiles.push(renamed)
-          } else {
-            pastedFiles.push(file)
-          }
+
+    // 1순위: items에서 kind === 'file' 추출 (가장 표준)
+    if (items && items.length > 0) {
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i]
+        if (item.kind === 'file') {
+          const file = item.getAsFile()
+          if (file) pastedFiles.push(file)
         }
       }
     }
-    if (pastedFiles.length > 0) {
-      e.preventDefault()
-      addFiles(pastedFiles)
+
+    // 2순위: items가 비어있거나 file이 없으면 files 컬렉션 직접 확인 (Safari/구형 호환)
+    if (pastedFiles.length === 0 && filesFromList && filesFromList.length > 0) {
+      for (let i = 0; i < filesFromList.length; i++) {
+        const file = filesFromList.item(i)
+        if (file) pastedFiles.push(file)
+      }
     }
+
+    if (pastedFiles.length === 0) return
+
+    // 캡쳐 이미지처럼 파일명이 없는 경우 보강
+    const normalized = pastedFiles.map((file) => {
+      if (!file.name || file.name === 'image.png' || file.name === '') {
+        const ext = inferExtensionFromType(file.type || 'image/png')
+        return new File([file], `pasted_${Date.now()}.${ext}`, {
+          type: file.type || 'image/png',
+        })
+      }
+      return file
+    })
+
+    // 파일 paste 확정 → default(텍스트 paste) 차단 + 다른 핸들러로 bubble되어 중복 처리되는 것 차단
+    e.preventDefault()
+    e.stopPropagation()
+    addFiles(normalized)
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -364,6 +384,7 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
             <textarea
               value={content}
               onChange={(e) => setContent(e.target.value)}
+              onPaste={handlePaste}
               placeholder="내용을 입력하세요. 캡쳐한 이미지를 바로 붙여넣기(Ctrl/Cmd+V)할 수 있습니다."
               rows={12}
               className="w-full border border-at-border rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-at-accent resize-y"

--- a/dental-clinic-manager/src/components/Community/CommunityPostForm.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityPostForm.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, Loader2, Plus, X, BarChart3, Paperclip, Upload, FileText, 
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { communityPostService, communityAttachmentService } from '@/lib/communityService'
+import CommunityRichEditor from './CommunityRichEditor'
 import type {
   CommunityCategory,
   CommunityPost,
@@ -52,6 +53,19 @@ const formatBytes = (bytes: number): string => {
 }
 
 const isImageType = (type?: string) => !!type && type.startsWith('image/')
+
+// 리치 에디터의 빈 상태(`<p></p>`, 공백뿐인 HTML)를 걸러내고
+// 이미지/비디오 등 미디어가 들어 있으면 유효 콘텐츠로 간주.
+const hasMeaningfulContent = (html: string): boolean => {
+  if (!html) return false
+  if (/<(img|iframe|video|figure|table)\b/i.test(html)) return true
+  const text = html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return text.length > 0
+}
 
 const inferExtensionFromType = (type: string): string => {
   if (type === 'image/png') return 'png'
@@ -225,11 +239,13 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
     const filesFromList = clipboardData.files
     const pastedFiles: File[] = []
 
+    // 이미지 파일은 본문 에디터(CommunityRichEditor)가 직접 인라인 삽입을 처리하므로
+    // 폼 레벨에서는 이미지 외 파일(PDF/Office/ZIP 등)만 첨부 큐에 추가한다.
     // 1순위: items에서 kind === 'file' 추출 (가장 표준)
     if (items && items.length > 0) {
       for (let i = 0; i < items.length; i++) {
         const item = items[i]
-        if (item.kind === 'file') {
+        if (item.kind === 'file' && !item.type.startsWith('image/')) {
           const file = item.getAsFile()
           if (file) pastedFiles.push(file)
         }
@@ -240,7 +256,7 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
     if (pastedFiles.length === 0 && filesFromList && filesFromList.length > 0) {
       for (let i = 0; i < filesFromList.length; i++) {
         const file = filesFromList.item(i)
-        if (file) pastedFiles.push(file)
+        if (file && !file.type.startsWith('image/')) pastedFiles.push(file)
       }
     }
 
@@ -265,7 +281,7 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!title.trim() || !content.trim()) return
+    if (!title.trim() || !hasMeaningfulContent(content)) return
 
     setSubmitting(true)
     setError(null)
@@ -378,16 +394,13 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
             />
           </div>
 
-          {/* 내용 */}
+          {/* 내용 (TipTap 기반 리치 에디터 — 이미지 인라인 삽입 지원) */}
           <div>
             <label className="block text-sm font-medium text-at-text-secondary mb-1">내용</label>
-            <textarea
+            <CommunityRichEditor
               value={content}
-              onChange={(e) => setContent(e.target.value)}
-              onPaste={handlePaste}
-              placeholder="내용을 입력하세요. 캡쳐한 이미지를 바로 붙여넣기(Ctrl/Cmd+V)할 수 있습니다."
-              rows={12}
-              className="w-full border border-at-border rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-at-accent resize-y"
+              onChange={setContent}
+              profileId={profileId}
             />
           </div>
 
@@ -550,7 +563,7 @@ export default function CommunityPostForm({ profileId, editingPost, categories, 
 
           <div className="flex gap-2 pt-2">
             <Button type="button" variant="outline" onClick={onCancel} className="flex-1">취소</Button>
-            <Button type="submit" disabled={!title.trim() || !content.trim() || submitting} className="flex-1">
+            <Button type="submit" disabled={!title.trim() || !hasMeaningfulContent(content) || submitting} className="flex-1">
               {submitting ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
               {editingPost ? '수정하기' : '작성하기'}
             </Button>

--- a/dental-clinic-manager/src/components/Community/CommunityRichEditor.tsx
+++ b/dental-clinic-manager/src/components/Community/CommunityRichEditor.tsx
@@ -1,0 +1,221 @@
+'use client'
+
+import { useEffect, useRef, useCallback } from 'react'
+import { useEditor, EditorContent } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import Image from '@tiptap/extension-image'
+import Placeholder from '@tiptap/extension-placeholder'
+import { Bold, Italic, List, ListOrdered, Image as ImageIcon, Loader2 } from 'lucide-react'
+import { communityAttachmentService } from '@/lib/communityService'
+
+interface CommunityRichEditorProps {
+  value: string
+  onChange: (html: string) => void
+  profileId: string
+  placeholder?: string
+}
+
+const DEFAULT_PLACEHOLDER =
+  '내용을 입력하세요. 캡쳐한 이미지(Cmd/Ctrl+V)나 드래그앤드롭으로 본문에 이미지를 삽입할 수 있습니다.'
+
+export default function CommunityRichEditor({
+  value,
+  onChange,
+  profileId,
+  placeholder,
+}: CommunityRichEditorProps) {
+  const uploadingCountRef = useRef(0)
+  const uploadAndInsertRef = useRef<(file: File) => void>(() => {})
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      Image.configure({
+        HTMLAttributes: {
+          class: 'community-content-image rounded-lg max-w-full h-auto my-2',
+        },
+      }),
+      Placeholder.configure({
+        placeholder: placeholder || DEFAULT_PLACEHOLDER,
+      }),
+    ],
+    content: value,
+    immediatelyRender: false,
+    onUpdate({ editor }) {
+      onChange(editor.getHTML())
+    },
+    editorProps: {
+      attributes: {
+        class:
+          'prose max-w-none focus:outline-none min-h-[280px] px-3 py-2 text-sm leading-relaxed',
+      },
+      handlePaste(_view, event) {
+        const items = event.clipboardData?.items
+        if (!items || items.length === 0) return false
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i]
+          if (item.kind === 'file' && item.type.startsWith('image/')) {
+            const file = item.getAsFile()
+            if (file) {
+              event.preventDefault()
+              uploadAndInsertRef.current(file)
+              return true
+            }
+          }
+        }
+        return false
+      },
+      handleDrop(_view, event, _slice, moved) {
+        if (moved) return false
+        const files = event.dataTransfer?.files
+        if (!files || files.length === 0) return false
+        const imageFiles: File[] = []
+        for (let i = 0; i < files.length; i++) {
+          const f = files.item(i)
+          if (f && f.type.startsWith('image/')) imageFiles.push(f)
+        }
+        if (imageFiles.length === 0) return false
+        event.preventDefault()
+        imageFiles.forEach((f) => uploadAndInsertRef.current(f))
+        return true
+      },
+    },
+  })
+
+  // 외부 value 변경(수정 모드 진입 등) 시 에디터 동기화
+  useEffect(() => {
+    if (!editor) return
+    if (value !== editor.getHTML()) {
+      editor.commands.setContent(value || '', { emitUpdate: false })
+    }
+    // editor가 바뀔 때마다 dep으로 추가해 무한루프 방지를 위해 ref 비교만 사용
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, editor])
+
+  const uploadAndInsert = useCallback(
+    async (file: File) => {
+      if (!editor) return
+      uploadingCountRef.current += 1
+      const tempUrl = URL.createObjectURL(file)
+      editor.chain().focus().setImage({ src: tempUrl }).run()
+
+      const { url, error } = await communityAttachmentService.uploadInlineImage({
+        profileId,
+        file,
+      })
+
+      uploadingCountRef.current = Math.max(0, uploadingCountRef.current - 1)
+
+      if (url) {
+        const { state } = editor
+        state.doc.descendants((node, pos) => {
+          if (node.type.name === 'image' && node.attrs.src === tempUrl) {
+            editor.chain().setNodeSelection(pos).setImage({ src: url }).run()
+          }
+        })
+        URL.revokeObjectURL(tempUrl)
+      } else {
+        // 업로드 실패: 임시 이미지 제거
+        const { state } = editor
+        state.doc.descendants((node, pos) => {
+          if (node.type.name === 'image' && node.attrs.src === tempUrl) {
+            editor.chain().setNodeSelection(pos).deleteSelection().run()
+          }
+        })
+        URL.revokeObjectURL(tempUrl)
+        if (typeof window !== 'undefined') {
+          window.alert(error || '이미지 업로드에 실패했습니다.')
+        }
+      }
+    },
+    [editor, profileId]
+  )
+
+  // ref에 최신 함수 보관 (editorProps 클로저가 stale해지지 않도록)
+  useEffect(() => {
+    uploadAndInsertRef.current = uploadAndInsert
+  }, [uploadAndInsert])
+
+  const handleImageButton = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file && file.type.startsWith('image/')) uploadAndInsert(file)
+    e.target.value = ''
+  }
+
+  if (!editor) {
+    return (
+      <div className="border border-at-border rounded-xl min-h-[300px] flex items-center justify-center text-at-text-weak text-sm">
+        에디터 로딩 중...
+      </div>
+    )
+  }
+
+  const btnBase =
+    'p-1.5 rounded transition-colors text-at-text-secondary hover:bg-at-surface-hover disabled:opacity-40 disabled:cursor-not-allowed'
+  const btnActive = 'bg-at-accent-light text-at-accent hover:bg-at-accent-light'
+
+  return (
+    <div className="border border-at-border rounded-xl bg-white">
+      {/* 툴바 */}
+      <div className="flex items-center gap-1 border-b border-at-border px-2 py-1.5">
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleBold().run()}
+          className={`${btnBase} ${editor.isActive('bold') ? btnActive : ''}`}
+          title="굵게 (Cmd/Ctrl+B)"
+          aria-label="굵게"
+        >
+          <Bold className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+          className={`${btnBase} ${editor.isActive('italic') ? btnActive : ''}`}
+          title="기울임 (Cmd/Ctrl+I)"
+          aria-label="기울임"
+        >
+          <Italic className="w-4 h-4" />
+        </button>
+        <span className="w-px h-5 bg-at-border mx-1" />
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleBulletList().run()}
+          className={`${btnBase} ${editor.isActive('bulletList') ? btnActive : ''}`}
+          title="글머리 기호 목록"
+          aria-label="글머리 기호 목록"
+        >
+          <List className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          className={`${btnBase} ${editor.isActive('orderedList') ? btnActive : ''}`}
+          title="번호 매기기 목록"
+          aria-label="번호 매기기 목록"
+        >
+          <ListOrdered className="w-4 h-4" />
+        </button>
+        <span className="w-px h-5 bg-at-border mx-1" />
+        <label
+          className={`${btnBase} cursor-pointer flex items-center`}
+          title="이미지 삽입"
+          aria-label="이미지 삽입"
+        >
+          <ImageIcon className="w-4 h-4" />
+          <input
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleImageButton}
+          />
+        </label>
+        <span className="ml-auto text-[11px] text-at-text-weak hidden sm:inline">
+          이미지는 Cmd/Ctrl+V 또는 드래그로 삽입
+        </span>
+      </div>
+
+      {/* 본문 */}
+      <EditorContent editor={editor} />
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/lib/communityService.ts
+++ b/dental-clinic-manager/src/lib/communityService.ts
@@ -1503,6 +1503,57 @@ export const communityAttachmentService = {
   },
 
   /**
+   * 본문 인라인 이미지 업로드 (post_id 없이 즉시 업로드)
+   * - 첨부 파일 메타(community_post_attachments)에는 기록하지 않음
+   * - 본문 HTML에 <img src="..."> 형태로 직접 삽입되어 그 URL만으로 영구 노출
+   * - 경로: community/inline/{profileId}/{timestamp}_{name}
+   */
+  async uploadInlineImage(params: {
+    profileId: string
+    file: File
+  }): Promise<{ url: string | null; error: string | null }> {
+    const { profileId, file } = params
+    try {
+      if (!file) throw new Error('파일이 없습니다.')
+      if (file.size <= 0) throw new Error('빈 파일은 업로드할 수 없습니다.')
+      if (file.size > COMMUNITY_ATTACHMENT_MAX_SIZE) {
+        throw new Error(`이미지 크기는 최대 ${Math.floor(COMMUNITY_ATTACHMENT_MAX_SIZE / 1024 / 1024)}MB 까지입니다.`)
+      }
+      const contentType = file.type || 'image/png'
+      if (!contentType.startsWith('image/')) {
+        throw new Error('이미지 파일만 인라인 삽입할 수 있습니다.')
+      }
+
+      const supabase = await ensureConnection()
+      if (!supabase) throw new Error('Database connection failed')
+
+      const safeName = sanitizeFileName(file.name || `pasted.${(contentType.split('/')[1] || 'png').toLowerCase()}`)
+      const uniquePart = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+      const storagePath = `${COMMUNITY_ATTACHMENT_PREFIX}/inline/${profileId}/${uniquePart}_${safeName}`
+
+      const { error: uploadError } = await (supabase as any).storage
+        .from(BULLETIN_BUCKET)
+        .upload(storagePath, file, {
+          contentType,
+          upsert: false,
+          cacheControl: '3600',
+        })
+      if (uploadError) throw uploadError
+
+      const { data: urlData } = (supabase as any).storage
+        .from(BULLETIN_BUCKET)
+        .getPublicUrl(storagePath)
+      const publicUrl: string = urlData?.publicUrl || ''
+      if (!publicUrl) throw new Error('Public URL 생성 실패')
+
+      return { url: publicUrl, error: null }
+    } catch (error) {
+      console.error('[communityAttachmentService.uploadInlineImage] Error:', error)
+      return { url: null, error: extractErrorMessage(error) }
+    }
+  },
+
+  /**
    * 여러 파일을 순차 업로드 (진행 콜백 지원)
    */
   async uploadAttachments(params: {


### PR DESCRIPTION
## Summary
develop 브랜치에 누적된 변경사항을 main에 반영합니다.

### 주요 변경
- **AI 분석**: 이벤트 효과 분석 서브탭 표시 문제 + 인증 오류 해결
- **AI 분석**: 이벤트 후보를 공지사항+일일 보고서 특이사항 통합 검색
- **자유게시판**: 본문 에디터에 이미지 인라인 삽입 지원
- **자유게시판**: 캡쳐 이미지 paste 동작 안 하던 문제 수정
- **워커**: 다운그레이드 케이스에서도 업데이트 가능 표시되던 문제 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)