### PR TITLE
feat(marketing): 발행 완료 글 재발행 가능하도록 글 상세 모달 개선

### DIFF
--- a/dental-clinic-manager/src/app/dashboard/marketing/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/page.tsx
@@ -457,7 +457,10 @@ function PostEditModal({
   const [editingClinicalImage, setEditingClinicalImage] = useState<{ id: string; file?: File | null; previewUrl: string; imageIndex: number } | null>(null)
   const [currentImages, setCurrentImages] = useState(content?.generatedImages || post.generated_images || undefined)
   const statusInfo = STATUS_LABELS[post.status] || STATUS_LABELS.review
-  const canPublish = content?.body && !['published', 'publishing'].includes(post.status)
+  // 발행 중인 글만 차단. 'published' 상태도 재발행 허용 (사용자 확인 필요)
+  const canPublish = content?.body && post.status !== 'publishing'
+  const isAlreadyPublished = post.status === 'published'
+  const previousBlogUrl = post.published_urls?.naverBlog
 
   const handleImageEdit = useCallback((imageIndex: number, currentImage: { fileName: string; prompt: string; path: string }) => {
     // 임상글: ClinicalPhotoEditor로 편집 (File 없이 URL로 로드)
@@ -582,11 +585,32 @@ function PostEditModal({
   }
 
   const handlePublishNow = () => {
+    // 이미 발행된 글이면 사용자 확인 (기존 발행 URL이 새 URL로 대체됨)
+    if (isAlreadyPublished) {
+      const confirmed = window.confirm(
+        '이미 발행된 글입니다. 다시 발행하시겠습니까?\n\n' +
+        (previousBlogUrl ? `기존 발행 URL:\n${previousBlogUrl}\n\n` : '') +
+        '새로 발행되면 별도의 새 글로 네이버 블로그에 게시되며, 기존 발행 URL 정보는 새 URL로 대체됩니다.'
+      )
+      if (!confirmed) return
+    }
     // KST 기준 날짜/시간 계산 (worker-api/poll이 KST로 비교하므로 일치시킴)
     const kst = new Date(Date.now() + 9 * 60 * 60 * 1000)
     const today = kst.toISOString().split('T')[0]
     const now = kst.toISOString().split('T')[1].slice(0, 5)
     handlePublish(today, now, true)
+  }
+
+  const handleScheduleConfirm = (date: string, time: string) => {
+    if (isAlreadyPublished) {
+      const confirmed = window.confirm(
+        '이미 발행된 글입니다. 다시 예약 발행하시겠습니까?\n\n' +
+        (previousBlogUrl ? `기존 발행 URL:\n${previousBlogUrl}\n\n` : '') +
+        '예약 시각이 되면 별도의 새 글로 네이버 블로그에 게시됩니다.'
+      )
+      if (!confirmed) return
+    }
+    handlePublish(date, time, false)
   }
 
   return (
@@ -673,14 +697,14 @@ function PostEditModal({
                   disabled={isPublishing}
                   className="px-4 py-2 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:bg-at-border disabled:cursor-not-allowed transition-colors"
                 >
-                  {isPublishing ? '발행 중...' : '바로 발행'}
+                  {isPublishing ? '발행 중...' : isAlreadyPublished ? '다시 발행' : '바로 발행'}
                 </button>
                 <button
                   onClick={() => setShowScheduleModal(true)}
                   disabled={isPublishing}
                   className="px-4 py-2 text-sm bg-cyan-600 text-white rounded-lg hover:bg-cyan-700 disabled:bg-at-border disabled:cursor-not-allowed transition-colors"
                 >
-                  예약 발행
+                  {isAlreadyPublished ? '다시 예약 발행' : '예약 발행'}
                 </button>
               </>
             )}
@@ -706,7 +730,7 @@ function PostEditModal({
         <ScheduleModal
           isOpen={showScheduleModal}
           onClose={() => setShowScheduleModal(false)}
-          onConfirm={(date, time) => handlePublish(date, time, false)}
+          onConfirm={handleScheduleConfirm}
           isLoading={isPublishing}
         />
 


### PR DESCRIPTION
## 배경

기존에 \`status='published'\`인 글은 글 상세 모달에서 발행 버튼이 숨겨져 재발행이 불가능했습니다. 사용자가 마크다운 이미지 누락 등으로 발행 결과에 문제가 있는 글을 다시 발행하려면 DB에서 status를 수동으로 되돌려야 했습니다.

## 변경

[PostEditModal](src/app/dashboard/marketing/page.tsx) (modal at lines 419-430, body 436-761):

- **canPublish** 조건에서 \`'published'\` 제거 (\`'publishing'\` 상태만 차단 유지)
- 발행 완료 글일 때 버튼 라벨을 **\"다시 발행\"** / **\"다시 예약 발행\"**으로 변경
- 재발행 클릭 시 \`confirm\` 다이얼로그로 사용자 확인:
  - \"이미 발행된 글입니다. 다시 발행하시겠습니까?\"
  - 기존 \`published_urls.naverBlog\`을 함께 표시
  - 새로 발행되면 별도의 새 글로 게시되며 기존 URL이 새 URL로 대체된다는 점을 명시

## 워커 안전성

- [worker-api/poll](src/app/api/marketing/worker-api/poll/route.ts)은 \`status='scheduled'\`만 픽업하므로 재발행 흐름은 기존 \"바로 발행\" 흐름과 동일 (status를 \`scheduled\`로 바꾼 뒤 워커가 처리)
- \`content_publish_logs\`는 매 발행마다 행이 추가되어 이력 보존
- \`published_urls\`는 새 발행 URL로 덮어써짐 (사용자에게 \`confirm\`으로 사전 고지)

## Test plan

- [x] 글 관리 탭에서 \"발행 완료\" 상태 글 클릭 → 모달에 \"다시 발행\" / \"다시 예약 발행\" 버튼 표시 확인
- [x] \"다시 발행\" 클릭 시 confirm 다이얼로그가 기존 발행 URL과 함께 표시 확인
- [x] confirm 취소 시 발행이 진행되지 않는 동작 확인
- [x] TypeScript 타입 체크 통과
- [ ] 운영 배포 후 published 상태 글에서 재발행 버튼이 보이고 정상 발행되는지 확인

## 회귀 위험

- \`canPublish\` 조건은 \`publishing\`만 차단하므로 \`review\`/\`scheduled\`/\`failed\` 상태 동작은 기존과 동일
- 이미 발행된 글의 \`published_urls\`가 새 URL로 대체되는 것은 confirm으로 고지하므로 사용자 의도와 일치
- 워커 로직 변경 없음 (스키마/폴링 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)