### PR TITLE
fix(ai-analysis): 사이드바 메뉴 라우트를 신규 페이지로 변경

### DIFF
--- a/dental-clinic-manager/src/app/dashboard/layout.tsx
+++ b/dental-clinic-manager/src/app/dashboard/layout.tsx
@@ -38,6 +38,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     if (pathname.startsWith('/dashboard/community/telegram')) return 'community-groups'
     if (pathname.startsWith('/dashboard/community')) return 'community-board'
     if (pathname.startsWith('/dashboard/financial')) return 'financial'
+    if (pathname.startsWith('/dashboard/ai-analysis')) return 'ai-analysis'
     return searchParams.get('tab') || 'home'
   }
   const [activeTab, setActiveTab] = useState<string>(getInitialTab)

--- a/dental-clinic-manager/src/app/dashboard/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { useSearchParams, useRouter } from 'next/navigation'
 import { useAuth } from '@/contexts/AuthContext'
 import { usePermissions } from '@/hooks/usePermissions'
 import { createClient } from '@/lib/supabase/client'
@@ -44,8 +44,16 @@ import PendingApprovalBanner from '@/components/Dashboard/PendingApprovalBanner'
 
 export default function DashboardPage() {
   const searchParams = useSearchParams()
+  const router = useRouter()
   const { user } = useAuth()
   const { hasPermission } = usePermissions()
+
+  // 레거시 URL 리다이렉트: /dashboard?tab=ai-analysis → /dashboard/ai-analysis
+  useEffect(() => {
+    if (searchParams.get('tab') === 'ai-analysis') {
+      router.replace('/dashboard/ai-analysis')
+    }
+  }, [searchParams, router])
 
   // 권한 상태 정의
   const canCreateReport = hasPermission('daily_report_create')

--- a/dental-clinic-manager/src/config/menuConfig.ts
+++ b/dental-clinic-manager/src/config/menuConfig.ts
@@ -174,7 +174,7 @@ export const MENU_CONFIG: MenuConfigItem[] = [
     id: 'ai-analysis',
     label: 'AI 데이터 분석',
     icon: 'Sparkles',
-    route: '/dashboard?tab=ai-analysis',
+    route: '/dashboard/ai-analysis',
     permissions: [],  // 권한 체크는 ownerOnly로 대체
     categoryId: 'work',
     order: 6,


### PR DESCRIPTION
## 문제

사이드바의 'AI 데이터 분석' 메뉴를 클릭하면 서브탭(AI 채팅 / 이벤트 효과 분석)이 보이지 않는 문제가 지속됨.

## 원인 (하드코딩된 라우트)

[menuConfig.ts:177](src/config/menuConfig.ts#L177)에서 메뉴 route가 `/dashboard?tab=ai-analysis`로 하드코딩되어 있어, 사이드바 클릭 시 옛날 통합 dashboard 페이지([dashboard/page.tsx:839](src/app/dashboard/page.tsx#L839))로 이동.

옛 페이지는 서브탭 없이 `<AIChat />`만 직접 렌더링하므로, 신규 `/dashboard/ai-analysis` 페이지(서브탭 포함)에 절대 도달하지 못함.

## 수정

- `src/config/menuConfig.ts`: route를 `/dashboard/ai-analysis`로 변경
- `src/app/dashboard/layout.tsx`: 신규 경로에서 activeTab 동기화 로직 추가
- `src/app/dashboard/page.tsx`: 레거시 URL 접근 시 자동 리다이렉트

## 테스트 계획
- [ ] 사이드바 'AI 데이터 분석' 클릭 → 서브탭 표시 확인
- [ ] 레거시 URL(/dashboard?tab=ai-analysis) 접근 → 신규 페이지로 리다이렉트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)