### PR TITLE
feat(marketing): SEO 분석 결과 미리보기 + 글 길이/이미지 개수 사용자 지정

### DIFF
--- a/dental-clinic-manager/src/app/api/marketing/generate/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/generate/route.ts
@@ -77,6 +77,7 @@ export async function POST(request: NextRequest) {
           imageStyle: body.imageStyle || undefined,
           imageVisualStyle: body.imageVisualStyle || undefined,
           imageCount: body.imageCount !== undefined ? Number(body.imageCount) : 3,
+          targetWordCount: body.targetWordCount !== undefined ? Number(body.targetWordCount) : undefined,
           referenceImageBase64: body.referenceImageBase64 || undefined,
           schedule: body.schedule || { snsDelayMinutes: 30 },
           clinical: body.clinical,

--- a/dental-clinic-manager/src/app/api/marketing/seo/preview/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/seo/preview/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getSupabaseAdmin } from '@/lib/supabase/admin';
+import { extractKeywordsFromPosts } from '@/lib/marketing/seo-text-miner';
+import type { SeoKeywordMiningResult } from '@/types/marketing';
+
+// 글 작성 전 SEO 분석 미리보기
+// - 워커가 이미 분석한 결과(24h 캐시)가 있으면 즉시 반환
+// - 없으면 seo_jobs 등록 후 최대 60초 폴링 (워커가 분석 중이면 inProgress 응답)
+// - 결과는 SeoKeywordMiningResult 형식 (avgBodyLength/avgImageCount 등)으로 반환
+
+export const maxDuration = 90;
+
+interface AnalysisRow {
+  id: string;
+  status: string;
+  summary: { textMining?: SeoKeywordMiningResult } | null;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const keyword: string = (body?.keyword || '').toString().trim();
+    if (!keyword) {
+      return NextResponse.json({ error: '키워드를 입력해주세요.' }, { status: 400 });
+    }
+
+    const admin = getSupabaseAdmin();
+    if (!admin) {
+      return NextResponse.json({ error: 'Admin 클라이언트 초기화 실패' }, { status: 500 });
+    }
+
+    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+    // 1) 24시간 내 완료된 분석 우선 조회
+    const { data: completed } = await admin
+      .from('seo_keyword_analyses')
+      .select('id, status, summary')
+      .eq('keyword', keyword)
+      .eq('status', 'completed')
+      .gte('created_at', oneDayAgo)
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    let analysis: AnalysisRow | null = (completed?.[0] as AnalysisRow) || null;
+
+    // 2) 진행 중인 분석 조회
+    if (!analysis) {
+      const { data: inProgress } = await admin
+        .from('seo_keyword_analyses')
+        .select('id, status, summary')
+        .eq('keyword', keyword)
+        .gte('created_at', oneDayAgo)
+        .in('status', ['pending', 'collecting', 'analyzing_quantitative', 'analyzing_qualitative'])
+        .order('created_at', { ascending: false })
+        .limit(1);
+      analysis = (inProgress?.[0] as AnalysisRow) || null;
+    }
+
+    // 3) 둘 다 없으면 새 잡 생성
+    if (!analysis) {
+      const { error: jobError } = await admin
+        .from('seo_jobs')
+        .insert({
+          job_type: 'keyword_analysis',
+          status: 'pending',
+          params: { keyword },
+          created_by: user.id,
+        });
+      if (jobError) {
+        return NextResponse.json({ error: `잡 생성 실패: ${jobError.message}` }, { status: 500 });
+      }
+    }
+
+    // 4) 최대 60초간 5초 간격 폴링 (워커가 SEO 워커인 경우 시간 소요)
+    const POLL_MAX = 12;
+    const POLL_INTERVAL_MS = 5000;
+    for (let i = 0; i < POLL_MAX; i++) {
+      const { data: check } = await admin
+        .from('seo_keyword_analyses')
+        .select('id, status, summary')
+        .eq('keyword', keyword)
+        .gte('created_at', oneDayAgo)
+        .order('created_at', { ascending: false })
+        .limit(1);
+      const row = (check?.[0] as AnalysisRow | undefined);
+      if (row?.status === 'completed') {
+        analysis = row;
+        break;
+      }
+      if (row?.status === 'failed') {
+        return NextResponse.json({ error: '분석 작업이 실패했습니다.', status: 'failed' }, { status: 502 });
+      }
+      // 아직 진행중 → 대기
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    }
+
+    if (!analysis || analysis.status !== 'completed') {
+      return NextResponse.json(
+        { status: 'pending', message: '분석이 진행 중입니다. 잠시 후 다시 시도해주세요.' },
+        { status: 202 }
+      );
+    }
+
+    // 5) 캐시된 textMining 우선 사용, 없으면 on-the-fly 계산
+    let textMining: SeoKeywordMiningResult | null = analysis.summary?.textMining || null;
+    if (!textMining) {
+      const { data: posts } = await admin
+        .from('seo_analyzed_posts')
+        .select('body_text, title, tags, body_length, image_count, heading_count, keyword_count')
+        .eq('analysis_id', analysis.id)
+        .order('rank', { ascending: true });
+      if (posts && posts.length > 0) {
+        textMining = extractKeywordsFromPosts(posts, keyword);
+      }
+    }
+
+    if (!textMining) {
+      return NextResponse.json({ error: '분석 결과를 추출할 수 없습니다.' }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      status: 'completed',
+      analysisId: analysis.id,
+      data: textMining,
+    });
+  } catch (err) {
+    console.error('[SEO Preview] Error:', err);
+    return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 });
+  }
+}

--- a/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
@@ -30,6 +30,7 @@ import {
   type PlatformOptions,
   type ImageStyleOption,
   type ImageVisualStyle,
+  type SeoKeywordMiningResult,
 } from '@/types/marketing'
 import dynamic from 'next/dynamic'
 import { useAIGeneration, type GeneratedResultType } from '@/contexts/AIGenerationContext'
@@ -82,6 +83,12 @@ export default function NewMarketingPostPage() {
   const [imageStyle, setImageStyle] = useState<ImageStyleOption>('infographic_only')
   const [imageVisualStyle, setImageVisualStyle] = useState<ImageVisualStyle>('realistic')
   const [imageCount, setImageCount] = useState(3)
+  const [targetWordCount, setTargetWordCount] = useState<number>(1500)
+  const [useSeoAnalysis, setUseSeoAnalysis] = useState(false)
+  const [seoAnalyzing, setSeoAnalyzing] = useState(false)
+  const [seoResult, setSeoResult] = useState<SeoKeywordMiningResult | null>(null)
+  const [seoError, setSeoError] = useState<string>('')
+  const [seoAppliedKeyword, setSeoAppliedKeyword] = useState<string>('')
   const [referenceImageBase64, setReferenceImageBase64] = useState<string>('')
   const [referenceImagePreview, setReferenceImagePreview] = useState<string>('')
 
@@ -121,6 +128,46 @@ export default function NewMarketingPostPage() {
   const handlePostTypeChange = (type: PostType) => {
     setPostType(type)
     setPlatforms(DEFAULT_PLATFORM_PRESETS[type])
+  }
+
+  // ── SEO 분석 미리보기 ──
+  const runSeoPreview = async () => {
+    if (!keyword.trim()) {
+      setSeoError('키워드를 먼저 입력해주세요.')
+      return
+    }
+    setSeoAnalyzing(true)
+    setSeoError('')
+    setSeoResult(null)
+    try {
+      const res = await fetch('/api/marketing/seo/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ keyword: keyword.trim() }),
+      })
+      const json = await res.json()
+      if (res.status === 202) {
+        setSeoError(json.message || '분석이 진행 중입니다. 1~2분 후 다시 시도해주세요.')
+      } else if (!res.ok) {
+        setSeoError(json.error || 'SEO 분석에 실패했습니다.')
+      } else {
+        setSeoResult(json.data as SeoKeywordMiningResult)
+        setSeoAppliedKeyword(keyword.trim())
+        setUseSeoAnalysis(true)
+      }
+    } catch (err) {
+      setSeoError(err instanceof Error ? err.message : '네트워크 오류')
+    } finally {
+      setSeoAnalyzing(false)
+    }
+  }
+
+  const applySeoRecommendations = () => {
+    if (!seoResult) return
+    const recommendedImages = Math.min(5, Math.max(0, Math.round(seoResult.avgImageCount)))
+    const recommendedLength = Math.max(1000, Math.round(seoResult.avgBodyLength / 100) * 100)
+    setImageCount(recommendedImages)
+    setTargetWordCount(recommendedLength)
   }
 
   const handleResult = useCallback(async (result: GeneratedResultType) => {
@@ -174,8 +221,8 @@ export default function NewMarketingPostPage() {
     setError('')
     setHasUnsavedChanges(false)
     aiGen.startGeneration({
-      topic, keyword, postType, tone, useResearch, factCheck, useSeoAnalysis: false, platforms,
-      imageStyle, imageVisualStyle, imageCount,
+      topic, keyword, postType, tone, useResearch, factCheck, useSeoAnalysis, platforms,
+      imageStyle, imageVisualStyle, imageCount, targetWordCount,
       referenceImageBase64: imageStyle === 'use_own_image' ? referenceImageBase64 : undefined,
     })
   }
@@ -353,6 +400,117 @@ export default function NewMarketingPostPage() {
               </div>
             </label>
           </div>
+
+          {/* SEO 분석 미리보기 */}
+          <div className="mt-4 p-4 rounded-xl border border-at-border bg-at-surface-alt/50 space-y-3">
+            <div className="flex items-start justify-between gap-3 flex-wrap">
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-at-text">경쟁 글 분석 미리보기</p>
+                <p className="text-xs text-at-text-weak mt-0.5">
+                  상위 노출 글의 평균 글자수·이미지 수를 확인한 뒤 글 길이와 이미지 개수를 직접 정할 수 있습니다.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={runSeoPreview}
+                disabled={seoAnalyzing || !keyword.trim() || isFormDisabled}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 disabled:bg-at-border disabled:cursor-not-allowed transition-colors"
+                title={!keyword.trim() ? '키워드를 먼저 입력해주세요' : 'SEO 분석을 실행하여 상위 노출 글의 권장값을 확인합니다'}
+              >
+                {seoAnalyzing ? '분석 중...' : (seoResult ? '다시 분석' : '분석 실행')}
+              </button>
+            </div>
+
+            {seoError && <p className="text-xs text-at-error">{seoError}</p>}
+
+            {seoResult && (
+              <div className="space-y-3">
+                <p className="text-[11px] text-at-text-weak">키워드 “{seoAppliedKeyword}” 상위 노출 글 분석 결과</p>
+                <div className="grid grid-cols-3 gap-2">
+                  <div className="rounded-lg bg-white border border-at-border p-2.5">
+                    <p className="text-[10px] text-at-text-weak">평균 글자수</p>
+                    <p className="text-sm font-semibold text-at-text mt-0.5">{seoResult.avgBodyLength.toLocaleString()}자</p>
+                  </div>
+                  <div className="rounded-lg bg-white border border-at-border p-2.5">
+                    <p className="text-[10px] text-at-text-weak">평균 이미지</p>
+                    <p className="text-sm font-semibold text-at-text mt-0.5">{seoResult.avgImageCount.toFixed(1)}장</p>
+                  </div>
+                  <div className="rounded-lg bg-white border border-at-border p-2.5">
+                    <p className="text-[10px] text-at-text-weak">평균 소제목</p>
+                    <p className="text-sm font-semibold text-at-text mt-0.5">{seoResult.avgHeadingCount.toFixed(1)}개</p>
+                  </div>
+                </div>
+
+                {seoResult.recommendedKeywords && seoResult.recommendedKeywords.length > 0 && (
+                  <div>
+                    <p className="text-[11px] font-medium text-at-text-secondary mb-1">추천 키워드 (자동 반영)</p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {seoResult.recommendedKeywords.slice(0, 8).map((kw) => (
+                        <span key={kw} className="inline-flex px-2 py-0.5 text-[11px] rounded-full bg-indigo-50 text-indigo-700 border border-indigo-100">
+                          {kw}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex items-center gap-2 flex-wrap">
+                  <button
+                    type="button"
+                    onClick={applySeoRecommendations}
+                    disabled={isFormDisabled}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-emerald-600 text-white hover:bg-emerald-700 disabled:bg-at-border disabled:cursor-not-allowed transition-colors"
+                  >
+                    권장값을 글 길이/이미지에 적용
+                  </button>
+                  <span className="text-[11px] text-at-text-weak">
+                    → 글자수 {Math.max(1000, Math.round(seoResult.avgBodyLength / 100) * 100).toLocaleString()}자, 이미지 {Math.min(5, Math.max(0, Math.round(seoResult.avgImageCount)))}장
+                  </span>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* 목표 글자수 */}
+          <div className="mt-4">
+            <label className="block text-sm font-medium text-at-text-secondary mb-1.5">
+              목표 글자수
+              {seoResult && (
+                <span className="ml-2 text-[11px] text-at-text-weak">
+                  (경쟁 평균 {seoResult.avgBodyLength.toLocaleString()}자)
+                </span>
+              )}
+            </label>
+            <div className="flex items-center gap-3">
+              <input
+                type="range"
+                min={1000}
+                max={3500}
+                step={100}
+                value={targetWordCount}
+                onChange={(e) => setTargetWordCount(Number(e.target.value))}
+                disabled={isFormDisabled}
+                className="flex-1 h-2 accent-at-accent cursor-pointer disabled:cursor-not-allowed"
+              />
+              <input
+                type="number"
+                min={1000}
+                max={5000}
+                step={100}
+                value={targetWordCount}
+                onChange={(e) => {
+                  const v = Number(e.target.value)
+                  if (Number.isFinite(v)) setTargetWordCount(Math.max(500, Math.min(5000, v)))
+                }}
+                disabled={isFormDisabled}
+                className="w-24 px-2 py-1.5 border border-at-border rounded-lg text-sm focus:ring-2 focus:ring-at-accent focus:border-at-accent disabled:bg-at-surface-alt"
+              />
+              <span className="text-xs text-at-text-weak">자</span>
+            </div>
+            <p className="text-[11px] text-at-text-weak mt-1">
+              권장 1,500~2,500자. SEO 분석 결과의 평균 글자수에 맞추면 상위 노출 가능성이 높아집니다.
+            </p>
+          </div>
         </fieldset>
       </section>
 
@@ -362,7 +520,12 @@ export default function NewMarketingPostPage() {
         <fieldset disabled={isFormDisabled} className={`space-y-5 transition-opacity ${isFormDisabled ? 'opacity-50' : ''}`}>
           {/* 이미지 개수 */}
           <div>
-            <label className="block text-sm font-medium text-at-text-secondary mb-2">이미지 개수</label>
+            <label className="block text-sm font-medium text-at-text-secondary mb-2">
+              이미지 개수
+              {seoResult && (
+                <span className="ml-2 text-[11px] text-at-text-weak">(경쟁 평균 {seoResult.avgImageCount.toFixed(1)}장)</span>
+              )}
+            </label>
             <div className="flex items-center gap-2 flex-wrap">
               {[0, 1, 2, 3, 4, 5].map((n) => (
                 <button

--- a/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
+++ b/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
@@ -29,6 +29,7 @@ import {
   type ImageVisualStyle,
   type PlatformContent,
   type ClinicalPhotoInput,
+  type SeoKeywordMiningResult,
 } from '@/types/marketing'
 import dynamic from 'next/dynamic'
 import ScheduleModal from '@/components/marketing/ScheduleModal'
@@ -86,6 +87,12 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
   const [imageStyle, setImageStyle] = useState<ImageStyleOption>('infographic_only')
   const [imageVisualStyle, setImageVisualStyle] = useState<ImageVisualStyle>('realistic')
   const [imageCount, setImageCount] = useState(3)
+  const [targetWordCount, setTargetWordCount] = useState<number>(1500)
+  // ── SEO 분석 미리보기 상태 ──
+  const [seoAnalyzing, setSeoAnalyzing] = useState(false)
+  const [seoResult, setSeoResult] = useState<SeoKeywordMiningResult | null>(null)
+  const [seoError, setSeoError] = useState<string>('')
+  const [seoAppliedKeyword, setSeoAppliedKeyword] = useState<string>('')
   const [referenceImageBase64, setReferenceImageBase64] = useState<string>('')
   const [referenceImagePreview, setReferenceImagePreview] = useState<string>('')
   const [clinicalData, setClinicalData] = useState<ClinicalFormData | null>(null)
@@ -137,6 +144,48 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
   const handlePostTypeChange = (type: PostType) => {
     setPostType(type)
     setPlatforms(DEFAULT_PLATFORM_PRESETS[type])
+  }
+
+  // ── SEO 분석 미리보기 ──
+  const runSeoPreview = async () => {
+    if (!keyword.trim()) {
+      setSeoError('키워드를 먼저 입력해주세요.')
+      return
+    }
+    setSeoAnalyzing(true)
+    setSeoError('')
+    setSeoResult(null)
+    try {
+      const res = await fetch('/api/marketing/seo/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ keyword: keyword.trim() }),
+      })
+      const json = await res.json()
+      if (res.status === 202) {
+        setSeoError(json.message || '분석이 진행 중입니다. 1~2분 후 다시 시도해주세요.')
+      } else if (!res.ok) {
+        setSeoError(json.error || 'SEO 분석에 실패했습니다.')
+      } else {
+        setSeoResult(json.data as SeoKeywordMiningResult)
+        setSeoAppliedKeyword(keyword.trim())
+        // 분석 결과를 글 생성 시 자동 반영하도록 useSeoAnalysis 자동 활성화
+        setUseSeoAnalysis(true)
+      }
+    } catch (err) {
+      setSeoError(err instanceof Error ? err.message : '네트워크 오류')
+    } finally {
+      setSeoAnalyzing(false)
+    }
+  }
+
+  // 분석 결과의 권장값을 imageCount/targetWordCount에 적용
+  const applySeoRecommendations = () => {
+    if (!seoResult) return
+    const recommendedImages = Math.min(5, Math.max(0, Math.round(seoResult.avgImageCount)))
+    const recommendedLength = Math.max(1000, Math.round(seoResult.avgBodyLength / 100) * 100)
+    setImageCount(recommendedImages)
+    setTargetWordCount(recommendedLength)
   }
 
   // 컨텍스트에서 결과가 오면 로컬 상태에 반영
@@ -251,7 +300,7 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
     } else {
       aiGen.startGeneration({
         topic, keyword, postType, tone, useResearch, factCheck, useSeoAnalysis, platforms,
-        imageStyle, imageVisualStyle, imageCount,
+        imageStyle, imageVisualStyle, imageCount, targetWordCount,
         referenceImageBase64: imageStyle === 'use_own_image' ? referenceImageBase64 : undefined,
       })
     }
@@ -532,6 +581,118 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
                 </div>
               </label>
             </div>
+
+            {/* SEO 분석 미리보기 카드 */}
+            <div className="mt-4 p-4 rounded-xl border border-at-border bg-at-surface-alt/50 space-y-3">
+              <div className="flex items-start justify-between gap-3 flex-wrap">
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-at-text">경쟁 글 분석 미리보기</p>
+                  <p className="text-xs text-at-text-weak mt-0.5">
+                    상위 노출 글의 평균 글자수·이미지 수를 확인한 뒤 글 길이와 이미지 개수를 직접 정할 수 있습니다.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={runSeoPreview}
+                  disabled={seoAnalyzing || !keyword.trim()}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 disabled:bg-at-border disabled:cursor-not-allowed transition-colors"
+                  title={!keyword.trim() ? '키워드를 먼저 입력해주세요' : 'SEO 분석을 실행하여 상위 노출 글의 권장값을 확인합니다'}
+                >
+                  {seoAnalyzing ? '분석 중...' : (seoResult ? '다시 분석' : '분석 실행')}
+                </button>
+              </div>
+
+              {seoError && (
+                <p className="text-xs text-at-error">{seoError}</p>
+              )}
+
+              {seoResult && (
+                <div className="space-y-3">
+                  <p className="text-[11px] text-at-text-weak">
+                    키워드 “{seoAppliedKeyword}” 상위 노출 글 분석 결과
+                  </p>
+                  <div className="grid grid-cols-3 gap-2">
+                    <div className="rounded-lg bg-white border border-at-border p-2.5">
+                      <p className="text-[10px] text-at-text-weak">평균 글자수</p>
+                      <p className="text-sm font-semibold text-at-text mt-0.5">{seoResult.avgBodyLength.toLocaleString()}자</p>
+                    </div>
+                    <div className="rounded-lg bg-white border border-at-border p-2.5">
+                      <p className="text-[10px] text-at-text-weak">평균 이미지</p>
+                      <p className="text-sm font-semibold text-at-text mt-0.5">{seoResult.avgImageCount.toFixed(1)}장</p>
+                    </div>
+                    <div className="rounded-lg bg-white border border-at-border p-2.5">
+                      <p className="text-[10px] text-at-text-weak">평균 소제목</p>
+                      <p className="text-sm font-semibold text-at-text mt-0.5">{seoResult.avgHeadingCount.toFixed(1)}개</p>
+                    </div>
+                  </div>
+
+                  {seoResult.recommendedKeywords && seoResult.recommendedKeywords.length > 0 && (
+                    <div>
+                      <p className="text-[11px] font-medium text-at-text-secondary mb-1">추천 키워드 (자동 반영)</p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {seoResult.recommendedKeywords.slice(0, 8).map((kw) => (
+                          <span key={kw} className="inline-flex px-2 py-0.5 text-[11px] rounded-full bg-indigo-50 text-indigo-700 border border-indigo-100">
+                            {kw}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={applySeoRecommendations}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-emerald-600 text-white hover:bg-emerald-700 transition-colors"
+                    >
+                      권장값을 글 길이/이미지에 적용
+                    </button>
+                    <span className="text-[11px] text-at-text-weak">
+                      → 글자수 {Math.max(1000, Math.round(seoResult.avgBodyLength / 100) * 100).toLocaleString()}자, 이미지 {Math.min(5, Math.max(0, Math.round(seoResult.avgImageCount)))}장
+                    </span>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* 목표 글자수 입력 */}
+            <div className="mt-4">
+              <label className="block text-sm font-medium text-at-text-secondary mb-1.5">
+                목표 글자수
+                {seoResult && (
+                  <span className="ml-2 text-[11px] text-at-text-weak">
+                    (경쟁 평균 {seoResult.avgBodyLength.toLocaleString()}자)
+                  </span>
+                )}
+              </label>
+              <div className="flex items-center gap-3">
+                <input
+                  type="range"
+                  min={1000}
+                  max={3500}
+                  step={100}
+                  value={targetWordCount}
+                  onChange={(e) => setTargetWordCount(Number(e.target.value))}
+                  className="flex-1 h-2 accent-at-accent cursor-pointer"
+                />
+                <input
+                  type="number"
+                  min={1000}
+                  max={5000}
+                  step={100}
+                  value={targetWordCount}
+                  onChange={(e) => {
+                    const v = Number(e.target.value)
+                    if (Number.isFinite(v)) setTargetWordCount(Math.max(500, Math.min(5000, v)))
+                  }}
+                  className="w-24 px-2 py-1.5 border border-at-border rounded-lg text-sm focus:ring-2 focus:ring-at-accent focus:border-at-accent"
+                />
+                <span className="text-xs text-at-text-weak">자</span>
+              </div>
+              <p className="text-[11px] text-at-text-weak mt-1">
+                권장 1,500~2,500자. SEO 분석 결과의 평균 글자수에 맞추면 상위 노출 가능성이 높아집니다.
+              </p>
+            </div>
           </fieldset>
         </section>
       )}
@@ -542,7 +703,14 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
           <SectionHeader number={3} title="이미지 옵션" icon={PaintBrushIcon} iconColor="text-emerald-600" iconBg="bg-emerald-50" />
           <fieldset disabled={isGenerating} className={`space-y-5 transition-opacity ${isGenerating ? 'opacity-60' : ''}`}>
             <div>
-              <label className="block text-sm font-medium text-at-text-secondary mb-2">이미지 개수</label>
+              <label className="block text-sm font-medium text-at-text-secondary mb-2">
+                이미지 개수
+                {seoResult && (
+                  <span className="ml-2 text-[11px] text-at-text-weak">
+                    (경쟁 평균 {seoResult.avgImageCount.toFixed(1)}장)
+                  </span>
+                )}
+              </label>
               <div className="flex items-center gap-2 flex-wrap">
                 {[0, 1, 2, 3, 4, 5].map((n) => (
                   <button key={n} type="button" onClick={() => setImageCount(n)}

--- a/dental-clinic-manager/src/contexts/AIGenerationContext.tsx
+++ b/dental-clinic-manager/src/contexts/AIGenerationContext.tsx
@@ -21,6 +21,8 @@ interface GenerationOptions {
   imageStyle: string
   imageVisualStyle: string
   imageCount: number
+  /** 사용자가 정한 목표 본문 길이(자). 미지정 시 서버에서 기본값 사용. */
+  targetWordCount?: number
   referenceImageBase64?: string
   clinical?: {
     procedureType: string
@@ -106,6 +108,7 @@ export function AIGenerationProvider({ children }: { children: ReactNode }) {
             imageStyle: options.imageStyle,
             imageVisualStyle: options.imageVisualStyle,
             imageCount: options.imageCount,
+            ...(options.targetWordCount ? { targetWordCount: options.targetWordCount } : {}),
             ...(options.imageStyle === 'use_own_image' && options.referenceImageBase64
               ? { referenceImageBase64: options.referenceImageBase64 }
               : {}),

--- a/dental-clinic-manager/src/lib/marketing/content-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/content-generator.ts
@@ -24,6 +24,16 @@ const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
 });
 
+// ─── 사용자 지정 글자수 지시문 (없으면 기본 1,500자~) ───
+
+function buildLengthInstruction(targetWordCount?: number): string {
+  if (!targetWordCount || targetWordCount < 800) return '';
+  // ±10% 허용 범위로 안내 (SEO 분석 평균값 적용 시 너무 빡빡한 제약 방지)
+  const minLen = Math.round(targetWordCount * 0.9);
+  const maxLen = Math.round(targetWordCount * 1.15);
+  return `\n\n## 본문 길이 목표 (필수)\n사용자가 SEO 분석 결과를 바탕으로 본문 길이를 직접 지정했습니다. 공백을 제외한 본문 글자수가 약 ${targetWordCount.toLocaleString()}자(허용 범위: ${minLen.toLocaleString()}~${maxLen.toLocaleString()}자)가 되도록 작성하세요. 본문이 부족하면 핵심 내용을 풀어쓰거나 사례·수치를 추가하고, 과도하면 중복되는 설명을 정리하세요.`;
+}
+
 // ─── 메인 생성 함수 ───
 
 export async function generateContent(
@@ -99,7 +109,7 @@ export async function generateContent(
       : '',
     // 공지글 변수
     ...options.notice?.templateData,
-  }) + imageStyleInstruction + seoSection;
+  }) + imageStyleInstruction + seoSection + buildLengthInstruction(options.targetWordCount);
 
   // 4. Claude API 호출 (임상 사진이 있으면 멀티모달)
   const callStart = Date.now();
@@ -199,8 +209,15 @@ export async function generateContent(
   }
 
   // 8. 글자수 부족 시 재생성 (1회)
-  if (!validation.bodyLengthPassed) {
+  // 사용자가 targetWordCount를 지정했으면 그 값을, 아니면 기본 1,000자 기준으로 재시도 임계 적용
+  const minTarget = options.targetWordCount && options.targetWordCount >= 800
+    ? Math.round(options.targetWordCount * 0.9)
+    : 1000;
+  if (parsed.wordCount < minTarget) {
     const retryStart = Date.now();
+    const retryGoal = options.targetWordCount && options.targetWordCount >= 800
+      ? `${options.targetWordCount.toLocaleString()}자(최소 ${minTarget.toLocaleString()}자)`
+      : '1,000자 이상';
     const retryResponse = await anthropic.messages.create({
       model: 'claude-sonnet-4-6',
       max_tokens: 4096,
@@ -215,7 +232,7 @@ export async function generateContent(
         },
         {
           role: 'user',
-          content: `글자수가 ${parsed.wordCount}자로 부족합니다. 1,000자 이상으로 내용을 보강하여 다시 작성해주세요. 기존 구조와 [IMAGE:] 마커는 유지해주세요.`,
+          content: `글자수가 ${parsed.wordCount}자로 부족합니다. ${retryGoal}으로 내용을 보강하여 다시 작성해주세요. 기존 구조와 [IMAGE:] 마커는 유지해주세요.`,
         },
       ],
       system: systemPrompt,

--- a/dental-clinic-manager/src/types/marketing.ts
+++ b/dental-clinic-manager/src/types/marketing.ts
@@ -235,6 +235,8 @@ export interface ContentGenerateOptions {
   imageStyle?: ImageStyleOption;
   imageVisualStyle?: ImageVisualStyle;
   imageCount?: number;
+  /** 사용자가 SEO 분석 결과를 보고 직접 정한 목표 본문 길이(자). 미지정 시 기본 1500자. */
+  targetWordCount?: number;
   referenceImageBase64?: string;
   schedule: {
     publishAt?: string;


### PR DESCRIPTION
## 배경

기존에 SEO 분석은 글 생성 중 백그라운드에서만 실행되어 사용자가 **경쟁 글의 평균 글자수·이미지 수를 미리 확인할 수 없었습니다**. 글 길이 또한 사용자가 지정할 수 없어 SEO 평균과 무관한 고정 1,000자 기준으로 생성되었습니다.

## 변경

### 신규 API [api/marketing/seo/preview](src/app/api/marketing/seo/preview/route.ts)
- \`POST { keyword }\` → \`SeoKeywordMiningResult\` 반환
- 24h 내 완료 분석 즉시 반환, 진행 중이면 5초 간격 12회 폴링 (최대 60초)
- 폴링 끝까지 미완료 시 \`202\` status로 진행 중 안내

### UI ([NewPostForm](src/components/marketing/NewPostForm.tsx), [posts/new 페이지](src/app/dashboard/marketing/posts/new/page.tsx))
- 품질 옵션 섹션에 **\"경쟁 글 분석 미리보기\"** 카드 추가
- 키워드 입력 후 \"분석 실행\" 버튼 클릭 → 평균 글자수/이미지/소제목/추천 키워드 시각화
- **\"권장값을 글 길이/이미지에 적용\"** 버튼: imageCount + targetWordCount 자동 설정
- **목표 글자수 슬라이더 + 숫자 입력** (1,000~5,000자, 100단위)
- 이미지 개수 라벨에 경쟁 평균 표시

### 서버 로직 ([content-generator](src/lib/marketing/content-generator.ts), [generate route](src/app/api/marketing/generate/route.ts))
- \`ContentGenerateOptions.targetWordCount\` 추가, generate API에서 수신
- \`buildLengthInstruction\` 헬퍼: \`targetWordCount\` 지정 시 ±10~15% 범위 지시문을 시스템 프롬프트에 주입
- 글자수 부족 시 재시도 임계값을 사용자 지정값 기준으로 동적 조정

## Test plan

- [x] TypeScript 타입 체크 통과
- [x] dev 서버에서 \"경쟁 글 분석 미리보기\" 카드, 분석 실행 버튼, 슬라이더, 숫자 입력 모두 정상 표시
- [x] 키워드 미입력 시 분석 실행 버튼 disabled, 입력 시 활성화 확인
- [x] \`/api/marketing/seo/preview\` 폴링 응답 형식 확인 (202 진행 중 / 200 완료)
- [ ] 운영 배포 후 SEO 워커가 새 키워드 분석을 완료하고 결과가 카드에 표시되는지 확인
- [ ] \"권장값 적용\" 버튼이 imageCount/targetWordCount를 정확히 설정하는지 확인
- [ ] targetWordCount 지정 후 생성된 글이 ±10~15% 범위 내로 작성되는지 확인

## 회귀 위험

- \`targetWordCount\` 미지정 시 기존 동작 유지 (기본 1,000자 임계)
- SEO 분석 미실행 시 \`useSeoAnalysis=false\` 유지 (백그라운드 분석 영향 없음)
- 추천 키워드는 \`useSeoAnalysis\` 활성화 시에만 프롬프트에 자동 반영
- 새 \`/api/marketing/seo/preview\` 엔드포인트는 별도 라우트로 기존 \`/api/seo/analyze\`에 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)