### PR TITLE
feat(marketing): SEO 분석 진행률 실시간 표시 + stale 잡 자동 재큐잉

### DIFF
--- a/dental-clinic-manager/src/app/api/marketing/seo/preview/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/seo/preview/route.ts
@@ -5,16 +5,169 @@ import { extractKeywordsFromPosts } from '@/lib/marketing/seo-text-miner';
 import type { SeoKeywordMiningResult } from '@/types/marketing';
 
 // 글 작성 전 SEO 분석 미리보기
-// - 워커가 이미 분석한 결과(24h 캐시)가 있으면 즉시 반환
-// - 없으면 seo_jobs 등록 후 최대 60초 폴링 (워커가 분석 중이면 inProgress 응답)
-// - 결과는 SeoKeywordMiningResult 형식 (avgBodyLength/avgImageCount 등)으로 반환
+// - POST: 즉시 응답 (캐시 결과 또는 큐 상태). stale 잡(5분+ running)은 자동 fail 처리 후 재큐잉
+// - GET: 클라이언트가 폴링하며 status / progress / data를 받아 진행률 UI를 그림
 
-export const maxDuration = 90;
+export const maxDuration = 30;
+
+// 5분 이상 running 상태로 멈춰있으면 stale로 간주 (워커 비정상 종료 추정)
+const STALE_RUNNING_MS = 5 * 60 * 1000;
+
+interface JobRow {
+  id: string;
+  status: string;
+  started_at: string | null;
+  created_at: string;
+  error_message: string | null;
+}
 
 interface AnalysisRow {
   id: string;
   status: string;
   summary: { textMining?: SeoKeywordMiningResult } | null;
+}
+
+type PreviewStatus = 'completed' | 'pending' | 'running' | 'failed';
+
+interface PreviewResponse {
+  status: PreviewStatus;
+  /** 0~100, 상태별 추정 진행률 */
+  progress: number;
+  /** 사용자에게 보여줄 단계 설명 */
+  step: string;
+  /** completed일 때만 채워짐 */
+  data?: SeoKeywordMiningResult;
+  /** 실패 시 사유 */
+  error?: string;
+  jobId?: string;
+}
+
+/** running 잡의 경과 시간으로 progress / step 추정 */
+function estimateRunningProgress(startedAt: string | null): { progress: number; step: string } {
+  if (!startedAt) return { progress: 15, step: '워커가 분석 작업을 시작하고 있습니다...' };
+  const elapsed = Date.now() - new Date(startedAt).getTime();
+  if (elapsed < 15_000) return { progress: 25, step: '네이버 상위 노출 글을 수집 중입니다...' };
+  if (elapsed < 45_000) return { progress: 50, step: '경쟁 글 본문을 분석 중입니다...' };
+  if (elapsed < 90_000) return { progress: 75, step: '핵심 키워드와 글 구조를 추출 중입니다...' };
+  return { progress: 90, step: '거의 다 끝났습니다. 마무리 중...' };
+}
+
+/** 캐시된 완료 분석을 SeoKeywordMiningResult로 변환 (없으면 on-the-fly 계산) */
+async function buildResultFromAnalysis(admin: ReturnType<typeof getSupabaseAdmin>, analysis: AnalysisRow, keyword: string): Promise<SeoKeywordMiningResult | null> {
+  if (!admin) return null;
+  if (analysis.summary?.textMining) return analysis.summary.textMining;
+  const { data: posts } = await admin
+    .from('seo_analyzed_posts')
+    .select('body_text, title, tags, body_length, image_count, heading_count, keyword_count')
+    .eq('analysis_id', analysis.id)
+    .order('rank', { ascending: true });
+  if (!posts || posts.length === 0) return null;
+  return extractKeywordsFromPosts(posts, keyword);
+}
+
+/** 키워드의 현재 상태 조사 — POST/GET 공용 핵심 로직 */
+async function resolvePreviewState(
+  admin: ReturnType<typeof getSupabaseAdmin>,
+  keyword: string,
+  options: { autoRequeue: boolean; userId?: string }
+): Promise<PreviewResponse> {
+  if (!admin) return { status: 'failed', progress: 0, step: '서버 초기화 실패', error: 'Admin 클라이언트 사용 불가' };
+
+  const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  // 1) 24h 내 완료된 분석 우선 확인
+  const { data: completed } = await admin
+    .from('seo_keyword_analyses')
+    .select('id, status, summary')
+    .eq('keyword', keyword)
+    .eq('status', 'completed')
+    .gte('created_at', oneDayAgo)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  const completedAnalysis: AnalysisRow | null = (completed?.[0] as AnalysisRow) || null;
+  if (completedAnalysis) {
+    const data = await buildResultFromAnalysis(admin, completedAnalysis, keyword);
+    if (data) {
+      return { status: 'completed', progress: 100, step: '분석 완료', data };
+    }
+  }
+
+  // 2) 24h 내 가장 최근 잡 확인
+  const { data: jobs } = await admin
+    .from('seo_jobs')
+    .select('id, status, started_at, created_at, error_message')
+    .eq('job_type', 'keyword_analysis')
+    .filter('params->>keyword', 'eq', keyword)
+    .gte('created_at', oneDayAgo)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  const latestJob = (jobs?.[0] as JobRow | undefined) || null;
+
+  // 2-1) running 잡이 있는 경우
+  if (latestJob && latestJob.status === 'running') {
+    const startedAt = latestJob.started_at || latestJob.created_at;
+    const elapsed = Date.now() - new Date(startedAt).getTime();
+    const isStale = elapsed > STALE_RUNNING_MS;
+
+    if (isStale && options.autoRequeue) {
+      // stale 잡을 failed로 마킹하고 새 잡 생성
+      await admin
+        .from('seo_jobs')
+        .update({
+          status: 'failed',
+          completed_at: new Date().toISOString(),
+          error_message: latestJob.error_message || 'Worker timeout — auto-failed by preview API',
+        })
+        .eq('id', latestJob.id);
+      // fallthrough → 새 잡 생성 단계로
+    } else if (!isStale) {
+      const { progress, step } = estimateRunningProgress(latestJob.started_at);
+      return { status: 'running', progress, step, jobId: latestJob.id };
+    } else {
+      // stale인데 autoRequeue 비활성 (GET 호출) → running으로 그대로 반환하되 step에 안내
+      return {
+        status: 'running',
+        progress: 90,
+        step: '분석이 오래 걸리고 있습니다. 잠시 후 자동으로 재시도됩니다.',
+        jobId: latestJob.id,
+      };
+    }
+  }
+
+  // 2-2) pending 잡이 있는 경우 (워커가 아직 픽업 안 함)
+  if (latestJob && latestJob.status === 'pending') {
+    return { status: 'pending', progress: 10, step: '워커가 잡을 픽업하기를 대기 중...', jobId: latestJob.id };
+  }
+
+  // 2-3) 가장 최근 잡이 failed면 새로 큐잉 시도
+  // 2-4) 잡이 없거나 모두 종료된 상태면 새 잡 생성
+
+  // 3) autoRequeue=true (POST)인 경우 새 잡 생성
+  if (options.autoRequeue) {
+    if (!options.userId) return { status: 'failed', progress: 0, step: '권한 없음', error: '인증 필요' };
+    const { data: newJob, error: insertErr } = await admin
+      .from('seo_jobs')
+      .insert({
+        job_type: 'keyword_analysis',
+        status: 'pending',
+        params: { keyword },
+        created_by: options.userId,
+      })
+      .select('id')
+      .single();
+    if (insertErr || !newJob) {
+      return { status: 'failed', progress: 0, step: '잡 생성 실패', error: insertErr?.message || 'unknown' };
+    }
+    return { status: 'pending', progress: 10, step: '워커에 분석 요청을 등록했습니다...', jobId: newJob.id };
+  }
+
+  // 4) autoRequeue=false (GET) — 잡 자체가 없는 상태
+  if (latestJob && latestJob.status === 'failed') {
+    return { status: 'failed', progress: 0, step: '분석에 실패했습니다.', error: latestJob.error_message || '워커 오류', jobId: latestJob.id };
+  }
+  return { status: 'failed', progress: 0, step: '분석 잡이 없습니다.', error: 'no active job' };
 }
 
 export async function POST(request: NextRequest) {
@@ -32,106 +185,41 @@ export async function POST(request: NextRequest) {
     }
 
     const admin = getSupabaseAdmin();
-    if (!admin) {
-      return NextResponse.json({ error: 'Admin 클라이언트 초기화 실패' }, { status: 500 });
-    }
+    if (!admin) return NextResponse.json({ error: 'Admin 클라이언트 초기화 실패' }, { status: 500 });
 
-    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-
-    // 1) 24시간 내 완료된 분석 우선 조회
-    const { data: completed } = await admin
-      .from('seo_keyword_analyses')
-      .select('id, status, summary')
-      .eq('keyword', keyword)
-      .eq('status', 'completed')
-      .gte('created_at', oneDayAgo)
-      .order('created_at', { ascending: false })
-      .limit(1);
-
-    let analysis: AnalysisRow | null = (completed?.[0] as AnalysisRow) || null;
-
-    // 2) 진행 중인 분석 조회
-    if (!analysis) {
-      const { data: inProgress } = await admin
-        .from('seo_keyword_analyses')
-        .select('id, status, summary')
-        .eq('keyword', keyword)
-        .gte('created_at', oneDayAgo)
-        .in('status', ['pending', 'collecting', 'analyzing_quantitative', 'analyzing_qualitative'])
-        .order('created_at', { ascending: false })
-        .limit(1);
-      analysis = (inProgress?.[0] as AnalysisRow) || null;
-    }
-
-    // 3) 둘 다 없으면 새 잡 생성
-    if (!analysis) {
-      const { error: jobError } = await admin
-        .from('seo_jobs')
-        .insert({
-          job_type: 'keyword_analysis',
-          status: 'pending',
-          params: { keyword },
-          created_by: user.id,
-        });
-      if (jobError) {
-        return NextResponse.json({ error: `잡 생성 실패: ${jobError.message}` }, { status: 500 });
-      }
-    }
-
-    // 4) 최대 60초간 5초 간격 폴링 (워커가 SEO 워커인 경우 시간 소요)
-    const POLL_MAX = 12;
-    const POLL_INTERVAL_MS = 5000;
-    for (let i = 0; i < POLL_MAX; i++) {
-      const { data: check } = await admin
-        .from('seo_keyword_analyses')
-        .select('id, status, summary')
-        .eq('keyword', keyword)
-        .gte('created_at', oneDayAgo)
-        .order('created_at', { ascending: false })
-        .limit(1);
-      const row = (check?.[0] as AnalysisRow | undefined);
-      if (row?.status === 'completed') {
-        analysis = row;
-        break;
-      }
-      if (row?.status === 'failed') {
-        return NextResponse.json({ error: '분석 작업이 실패했습니다.', status: 'failed' }, { status: 502 });
-      }
-      // 아직 진행중 → 대기
-      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-    }
-
-    if (!analysis || analysis.status !== 'completed') {
-      return NextResponse.json(
-        { status: 'pending', message: '분석이 진행 중입니다. 잠시 후 다시 시도해주세요.' },
-        { status: 202 }
-      );
-    }
-
-    // 5) 캐시된 textMining 우선 사용, 없으면 on-the-fly 계산
-    let textMining: SeoKeywordMiningResult | null = analysis.summary?.textMining || null;
-    if (!textMining) {
-      const { data: posts } = await admin
-        .from('seo_analyzed_posts')
-        .select('body_text, title, tags, body_length, image_count, heading_count, keyword_count')
-        .eq('analysis_id', analysis.id)
-        .order('rank', { ascending: true });
-      if (posts && posts.length > 0) {
-        textMining = extractKeywordsFromPosts(posts, keyword);
-      }
-    }
-
-    if (!textMining) {
-      return NextResponse.json({ error: '분석 결과를 추출할 수 없습니다.' }, { status: 500 });
-    }
-
-    return NextResponse.json({
-      status: 'completed',
-      analysisId: analysis.id,
-      data: textMining,
-    });
+    const result = await resolvePreviewState(admin, keyword, { autoRequeue: true, userId: user.id });
+    // completed면 200, 그 외(진행 중)는 202, 실패면 502
+    const httpStatus = result.status === 'completed' ? 200 : result.status === 'failed' ? 502 : 202;
+    return NextResponse.json(result, { status: httpStatus });
   } catch (err) {
-    console.error('[SEO Preview] Error:', err);
+    console.error('[SEO Preview POST] Error:', err);
+    return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const keyword = (searchParams.get('keyword') || '').trim();
+    if (!keyword) {
+      return NextResponse.json({ error: '키워드 파라미터가 필요합니다.' }, { status: 400 });
+    }
+
+    const admin = getSupabaseAdmin();
+    if (!admin) return NextResponse.json({ error: 'Admin 클라이언트 초기화 실패' }, { status: 500 });
+
+    // GET은 stale 잡을 자동 재큐잉하지 않음 (사용자 행동 없이 reqeue 방지)
+    const result = await resolvePreviewState(admin, keyword, { autoRequeue: false });
+    const httpStatus = result.status === 'completed' ? 200 : result.status === 'failed' ? 502 : 202;
+    return NextResponse.json(result, { status: httpStatus });
+  } catch (err) {
+    console.error('[SEO Preview GET] Error:', err);
     return NextResponse.json({ error: '서버 오류가 발생했습니다.' }, { status: 500 });
   }
 }

--- a/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
@@ -30,12 +30,12 @@ import {
   type PlatformOptions,
   type ImageStyleOption,
   type ImageVisualStyle,
-  type SeoKeywordMiningResult,
 } from '@/types/marketing'
 import dynamic from 'next/dynamic'
 import { useAIGeneration, type GeneratedResultType } from '@/contexts/AIGenerationContext'
 import { requireWorker } from '@/hooks/useWorkerGuard'
 import { usePremiumFeatures } from '@/hooks/usePremiumFeatures'
+import { useSeoPreview } from '@/hooks/useSeoPreview'
 
 const ContentEditor = dynamic(() => import('@/components/marketing/ContentEditor'), { ssr: false })
 
@@ -85,10 +85,8 @@ export default function NewMarketingPostPage() {
   const [imageCount, setImageCount] = useState(3)
   const [targetWordCount, setTargetWordCount] = useState<number>(1500)
   const [useSeoAnalysis, setUseSeoAnalysis] = useState(false)
-  const [seoAnalyzing, setSeoAnalyzing] = useState(false)
-  const [seoResult, setSeoResult] = useState<SeoKeywordMiningResult | null>(null)
-  const [seoError, setSeoError] = useState<string>('')
-  const [seoAppliedKeyword, setSeoAppliedKeyword] = useState<string>('')
+  const seoPreview = useSeoPreview()
+  const seoResult = seoPreview.result
   const [referenceImageBase64, setReferenceImageBase64] = useState<string>('')
   const [referenceImagePreview, setReferenceImagePreview] = useState<string>('')
 
@@ -131,36 +129,11 @@ export default function NewMarketingPostPage() {
   }
 
   // ── SEO 분석 미리보기 ──
-  const runSeoPreview = async () => {
-    if (!keyword.trim()) {
-      setSeoError('키워드를 먼저 입력해주세요.')
-      return
-    }
-    setSeoAnalyzing(true)
-    setSeoError('')
-    setSeoResult(null)
-    try {
-      const res = await fetch('/api/marketing/seo/preview', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ keyword: keyword.trim() }),
-      })
-      const json = await res.json()
-      if (res.status === 202) {
-        setSeoError(json.message || '분석이 진행 중입니다. 1~2분 후 다시 시도해주세요.')
-      } else if (!res.ok) {
-        setSeoError(json.error || 'SEO 분석에 실패했습니다.')
-      } else {
-        setSeoResult(json.data as SeoKeywordMiningResult)
-        setSeoAppliedKeyword(keyword.trim())
-        setUseSeoAnalysis(true)
-      }
-    } catch (err) {
-      setSeoError(err instanceof Error ? err.message : '네트워크 오류')
-    } finally {
-      setSeoAnalyzing(false)
-    }
-  }
+  const runSeoPreview = useCallback(() => {
+    if (!keyword.trim()) return
+    setUseSeoAnalysis(true)
+    seoPreview.start(keyword)
+  }, [keyword, seoPreview])
 
   const applySeoRecommendations = () => {
     if (!seoResult) return
@@ -413,19 +386,38 @@ export default function NewMarketingPostPage() {
               <button
                 type="button"
                 onClick={runSeoPreview}
-                disabled={seoAnalyzing || !keyword.trim() || isFormDisabled}
+                disabled={seoPreview.isBusy || !keyword.trim() || isFormDisabled}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 disabled:bg-at-border disabled:cursor-not-allowed transition-colors"
                 title={!keyword.trim() ? '키워드를 먼저 입력해주세요' : 'SEO 분석을 실행하여 상위 노출 글의 권장값을 확인합니다'}
               >
-                {seoAnalyzing ? '분석 중...' : (seoResult ? '다시 분석' : '분석 실행')}
+                {seoPreview.isBusy ? '분석 중...' : (seoResult ? '다시 분석' : '분석 실행')}
               </button>
             </div>
 
-            {seoError && <p className="text-xs text-at-error">{seoError}</p>}
+            {/* 진행률 바 (분석 중) */}
+            {seoPreview.isBusy && (
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between text-[11px]">
+                  <span className="text-at-text-secondary">{seoPreview.step || '분석 중...'}</span>
+                  <span className="font-semibold text-indigo-600">{seoPreview.progress}%</span>
+                </div>
+                <div className="relative h-2 bg-at-border rounded-full overflow-hidden">
+                  <div
+                    className="absolute inset-y-0 left-0 bg-gradient-to-r from-indigo-500 to-purple-500 rounded-full transition-all duration-500 ease-out"
+                    style={{ width: `${seoPreview.progress}%` }}
+                  />
+                </div>
+                <p className="text-[10px] text-at-text-weak">분석은 보통 30초~1분 정도 걸리며, 페이지를 떠나지 않으셔도 됩니다.</p>
+              </div>
+            )}
+
+            {seoPreview.status === 'failed' && seoPreview.error && (
+              <p className="text-xs text-at-error">{seoPreview.error}</p>
+            )}
 
             {seoResult && (
               <div className="space-y-3">
-                <p className="text-[11px] text-at-text-weak">키워드 “{seoAppliedKeyword}” 상위 노출 글 분석 결과</p>
+                <p className="text-[11px] text-at-text-weak">키워드 “{seoPreview.appliedKeyword}” 상위 노출 글 분석 결과</p>
                 <div className="grid grid-cols-3 gap-2">
                   <div className="rounded-lg bg-white border border-at-border p-2.5">
                     <p className="text-[10px] text-at-text-weak">평균 글자수</p>

--- a/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
+++ b/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
@@ -29,7 +29,6 @@ import {
   type ImageVisualStyle,
   type PlatformContent,
   type ClinicalPhotoInput,
-  type SeoKeywordMiningResult,
 } from '@/types/marketing'
 import dynamic from 'next/dynamic'
 import ScheduleModal from '@/components/marketing/ScheduleModal'
@@ -37,6 +36,7 @@ import ImageEditModal from '@/components/marketing/ImageEditModal'
 import ClinicalForm, { type ClinicalFormData } from '@/components/marketing/clinical/ClinicalForm'
 import ClinicalPhotoEditor from '@/components/marketing/clinical/ClinicalPhotoEditor'
 import { useAIGeneration, type GeneratedResultType } from '@/contexts/AIGenerationContext'
+import { useSeoPreview } from '@/hooks/useSeoPreview'
 
 const ContentEditor = dynamic(() => import('@/components/marketing/ContentEditor'), { ssr: false })
 
@@ -88,11 +88,9 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
   const [imageVisualStyle, setImageVisualStyle] = useState<ImageVisualStyle>('realistic')
   const [imageCount, setImageCount] = useState(3)
   const [targetWordCount, setTargetWordCount] = useState<number>(1500)
-  // ── SEO 분석 미리보기 상태 ──
-  const [seoAnalyzing, setSeoAnalyzing] = useState(false)
-  const [seoResult, setSeoResult] = useState<SeoKeywordMiningResult | null>(null)
-  const [seoError, setSeoError] = useState<string>('')
-  const [seoAppliedKeyword, setSeoAppliedKeyword] = useState<string>('')
+  // ── SEO 분석 미리보기 ──
+  const seoPreview = useSeoPreview()
+  const seoResult = seoPreview.result
   const [referenceImageBase64, setReferenceImageBase64] = useState<string>('')
   const [referenceImagePreview, setReferenceImagePreview] = useState<string>('')
   const [clinicalData, setClinicalData] = useState<ClinicalFormData | null>(null)
@@ -147,37 +145,11 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
   }
 
   // ── SEO 분석 미리보기 ──
-  const runSeoPreview = async () => {
-    if (!keyword.trim()) {
-      setSeoError('키워드를 먼저 입력해주세요.')
-      return
-    }
-    setSeoAnalyzing(true)
-    setSeoError('')
-    setSeoResult(null)
-    try {
-      const res = await fetch('/api/marketing/seo/preview', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ keyword: keyword.trim() }),
-      })
-      const json = await res.json()
-      if (res.status === 202) {
-        setSeoError(json.message || '분석이 진행 중입니다. 1~2분 후 다시 시도해주세요.')
-      } else if (!res.ok) {
-        setSeoError(json.error || 'SEO 분석에 실패했습니다.')
-      } else {
-        setSeoResult(json.data as SeoKeywordMiningResult)
-        setSeoAppliedKeyword(keyword.trim())
-        // 분석 결과를 글 생성 시 자동 반영하도록 useSeoAnalysis 자동 활성화
-        setUseSeoAnalysis(true)
-      }
-    } catch (err) {
-      setSeoError(err instanceof Error ? err.message : '네트워크 오류')
-    } finally {
-      setSeoAnalyzing(false)
-    }
-  }
+  const runSeoPreview = useCallback(() => {
+    if (!keyword.trim()) return
+    setUseSeoAnalysis(true)
+    seoPreview.start(keyword)
+  }, [keyword, seoPreview])
 
   // 분석 결과의 권장값을 imageCount/targetWordCount에 적용
   const applySeoRecommendations = () => {
@@ -594,22 +566,39 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
                 <button
                   type="button"
                   onClick={runSeoPreview}
-                  disabled={seoAnalyzing || !keyword.trim()}
+                  disabled={seoPreview.isBusy || !keyword.trim()}
                   className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 disabled:bg-at-border disabled:cursor-not-allowed transition-colors"
                   title={!keyword.trim() ? '키워드를 먼저 입력해주세요' : 'SEO 분석을 실행하여 상위 노출 글의 권장값을 확인합니다'}
                 >
-                  {seoAnalyzing ? '분석 중...' : (seoResult ? '다시 분석' : '분석 실행')}
+                  {seoPreview.isBusy ? '분석 중...' : (seoResult ? '다시 분석' : '분석 실행')}
                 </button>
               </div>
 
-              {seoError && (
-                <p className="text-xs text-at-error">{seoError}</p>
+              {/* 진행률 바 (분석 중) */}
+              {seoPreview.isBusy && (
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between text-[11px]">
+                    <span className="text-at-text-secondary">{seoPreview.step || '분석 중...'}</span>
+                    <span className="font-semibold text-indigo-600">{seoPreview.progress}%</span>
+                  </div>
+                  <div className="relative h-2 bg-at-border rounded-full overflow-hidden">
+                    <div
+                      className="absolute inset-y-0 left-0 bg-gradient-to-r from-indigo-500 to-purple-500 rounded-full transition-all duration-500 ease-out"
+                      style={{ width: `${seoPreview.progress}%` }}
+                    />
+                  </div>
+                  <p className="text-[10px] text-at-text-weak">분석은 보통 30초~1분 정도 걸리며, 페이지를 떠나지 않으셔도 됩니다.</p>
+                </div>
+              )}
+
+              {seoPreview.status === 'failed' && seoPreview.error && (
+                <p className="text-xs text-at-error">{seoPreview.error}</p>
               )}
 
               {seoResult && (
                 <div className="space-y-3">
                   <p className="text-[11px] text-at-text-weak">
-                    키워드 “{seoAppliedKeyword}” 상위 노출 글 분석 결과
+                    키워드 “{seoPreview.appliedKeyword}” 상위 노출 글 분석 결과
                   </p>
                   <div className="grid grid-cols-3 gap-2">
                     <div className="rounded-lg bg-white border border-at-border p-2.5">

--- a/dental-clinic-manager/src/hooks/useSeoPreview.ts
+++ b/dental-clinic-manager/src/hooks/useSeoPreview.ts
@@ -1,0 +1,165 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { SeoKeywordMiningResult } from '@/types/marketing'
+
+export type SeoPreviewStatus = 'idle' | 'completed' | 'pending' | 'running' | 'failed'
+
+interface PreviewApiResponse {
+  status: 'completed' | 'pending' | 'running' | 'failed'
+  progress: number
+  step: string
+  data?: SeoKeywordMiningResult
+  error?: string
+  jobId?: string
+}
+
+interface UseSeoPreviewState {
+  status: SeoPreviewStatus
+  progress: number
+  step: string
+  error: string
+  result: SeoKeywordMiningResult | null
+  appliedKeyword: string
+}
+
+interface UseSeoPreviewReturn extends UseSeoPreviewState {
+  /** "분석 실행" 액션 — POST로 큐잉 + 폴링 시작 */
+  start: (keyword: string) => Promise<void>
+  /** 폴링/상태 초기화 (모달 닫을 때 등) */
+  reset: () => void
+  /** 분석 진행 중인지 (UI에서 입력 비활성화 등에 사용) */
+  isBusy: boolean
+}
+
+const POLL_INTERVAL_MS = 3000
+const POLL_MAX_DURATION_MS = 5 * 60 * 1000 // 5분
+
+/**
+ * SEO 분석 미리보기 폴링 훅
+ * - start(keyword) 호출 → POST로 잡 등록 → GET 폴링으로 진행률 갱신
+ * - 완료/실패 시 polling 중단
+ */
+export function useSeoPreview(): UseSeoPreviewReturn {
+  const [state, setState] = useState<UseSeoPreviewState>({
+    status: 'idle',
+    progress: 0,
+    step: '',
+    error: '',
+    result: null,
+    appliedKeyword: '',
+  })
+
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pollDeadlineRef = useRef<number>(0)
+  const activeKeywordRef = useRef<string>('')
+  const cancelledRef = useRef<boolean>(false)
+
+  const stopPolling = useCallback(() => {
+    if (pollTimerRef.current) {
+      clearTimeout(pollTimerRef.current)
+      pollTimerRef.current = null
+    }
+  }, [])
+
+  const reset = useCallback(() => {
+    cancelledRef.current = true
+    stopPolling()
+    activeKeywordRef.current = ''
+    setState({ status: 'idle', progress: 0, step: '', error: '', result: null, appliedKeyword: '' })
+  }, [stopPolling])
+
+  // 컴포넌트 unmount 시 polling 정리
+  useEffect(() => {
+    return () => {
+      cancelledRef.current = true
+      stopPolling()
+    }
+  }, [stopPolling])
+
+  const applyResponse = useCallback((keyword: string, body: PreviewApiResponse) => {
+    if (cancelledRef.current || activeKeywordRef.current !== keyword) return
+    setState((prev) => ({
+      ...prev,
+      status: body.status,
+      progress: body.progress,
+      step: body.step,
+      error: body.error || '',
+      result: body.status === 'completed' ? (body.data || prev.result) : prev.result,
+      appliedKeyword: keyword,
+    }))
+  }, [])
+
+  const pollOnce = useCallback(async (keyword: string) => {
+    try {
+      const res = await fetch(`/api/marketing/seo/preview?keyword=${encodeURIComponent(keyword)}`)
+      const body: PreviewApiResponse = await res.json()
+      applyResponse(keyword, body)
+      if (body.status === 'completed' || body.status === 'failed') {
+        stopPolling()
+        return
+      }
+    } catch (err) {
+      // 일시적 네트워크 오류는 계속 폴링
+      console.warn('[SeoPreview] poll error:', err)
+    }
+    // 마감 시간 초과 시 중단
+    if (Date.now() > pollDeadlineRef.current) {
+      stopPolling()
+      setState((prev) => ({
+        ...prev,
+        status: 'failed',
+        error: '분석 시간이 너무 오래 걸려 중단했습니다. 잠시 후 다시 시도해주세요.',
+      }))
+      return
+    }
+    // 다음 폴링 예약
+    pollTimerRef.current = setTimeout(() => {
+      if (!cancelledRef.current && activeKeywordRef.current === keyword) {
+        pollOnce(keyword)
+      }
+    }, POLL_INTERVAL_MS)
+  }, [applyResponse, stopPolling])
+
+  const start = useCallback(async (keyword: string) => {
+    const trimmed = keyword.trim()
+    if (!trimmed) return
+
+    cancelledRef.current = false
+    stopPolling()
+    activeKeywordRef.current = trimmed
+    pollDeadlineRef.current = Date.now() + POLL_MAX_DURATION_MS
+    setState({ status: 'pending', progress: 5, step: '분석을 요청하고 있습니다...', error: '', result: null, appliedKeyword: trimmed })
+
+    try {
+      const res = await fetch('/api/marketing/seo/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ keyword: trimmed }),
+      })
+      const body: PreviewApiResponse = await res.json()
+      applyResponse(trimmed, body)
+
+      if (body.status === 'completed' || body.status === 'failed') {
+        return
+      }
+
+      // 폴링 시작
+      pollTimerRef.current = setTimeout(() => {
+        if (!cancelledRef.current && activeKeywordRef.current === trimmed) {
+          pollOnce(trimmed)
+        }
+      }, POLL_INTERVAL_MS)
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        status: 'failed',
+        error: err instanceof Error ? err.message : '네트워크 오류',
+      }))
+    }
+  }, [applyResponse, pollOnce, stopPolling])
+
+  const isBusy = state.status === 'pending' || state.status === 'running'
+
+  return { ...state, start, reset, isBusy }
+}


### PR DESCRIPTION
## 배경

사용자가 \"분석 실행\" 버튼 클릭 시 60초 폴링 후 \"분석이 진행 중입니다. 잠시 후 다시 시도해주세요.\" 메시지만 반환되어 진행 상황을 볼 수 없었습니다.

DB 진단 결과: **워커가 비정상 종료되어 'running' 상태로 멈춘 stale 잡이 8개** (4/23~4/28) 누적되어 있었으며, 마지막 정상 완료된 \`seo_keyword_analyses\`는 **4월 10일**. 기존 API는 stale 잡을 무한히 따라가서 영원히 진행 중 응답을 반환했습니다.

## 변경

### API 재설계 [api/marketing/seo/preview](src/app/api/marketing/seo/preview/route.ts)
- **POST**: 즉시 응답 (서버 폴링 제거)
  - 24h 캐시된 완료 분석 있으면 즉시 결과
  - **5분 이상 running인 stale 잡은 'failed'로 마킹 후 새 잡 자동 생성**
  - 활성 running/pending 잡은 status + 추정 progress 반환
- **GET**: 클라이언트 폴링용 — keyword 파라미터로 현재 status 조회
- 응답 형식: \`{ status, progress(0~100), step(설명), data?, error?, jobId? }\`
- running 시 \`started_at\` 경과시간으로 progress 추정 (15s→25%, 45s→50%, 90s→75%)

### 신규 hook [hooks/useSeoPreview](src/hooks/useSeoPreview.ts)
- \`start(keyword)\` → POST 큐잉 → 3초 간격 GET 폴링 (최대 5분)
- 완료/실패 시 폴링 자동 중단
- 컴포넌트 unmount 시 정리

### UI ([NewPostForm](src/components/marketing/NewPostForm.tsx), [posts/new 페이지](src/app/dashboard/marketing/posts/new/page.tsx))
- 분석 카드에 **진행률 바 + 단계 설명 + 퍼센트** 표시
- 단계 예: \"워커가 잡을 픽업하기를 대기 중...\" 10%, \"네이버 상위 노출 글을 수집 중입니다...\" 25%, \"경쟁 글 본문을 분석 중...\" 50%
- 분석 중 안내문 (\"페이지를 떠나지 않으셔도 됩니다\")
- 실패 시 에러 메시지 표시
- 기존 결과 카드/권장값 적용 버튼은 유지

### DB 정리
- 5분 이상 running으로 멈춰있던 stale 잡 8개를 'failed'로 정리

## Test plan

- [x] DB 진단: stale running 잡 8개 확인 → 정리
- [x] TypeScript 타입 체크 통과
- [x] dev 서버에서 \"분석 실행\" 클릭 시 즉시 진행률 바 표시 확인
- [x] 새 잡(\"스케일링 주의사항\") 정상 생성 + 워커가 21초 만에 'running' 진입 확인
- [x] 진행률 \"10% — 워커가 잡을 픽업하기를 대기 중...\" 표시 확인
- [ ] 운영 배포 후 워커가 새 키워드 분석을 완료하고 결과 카드까지 자동 전환되는지 확인
- [ ] 분석 도중 워커 사망 시 5분 후 자동으로 새 잡 큐잉되는지 확인

## 회귀 위험

- POST 응답 status가 변경됨 (이전 200/202/502, 현재 동일하나 body 형식 확장)
- 기존 한 번에 결과 받기를 기대하던 호출자는 \`status === 'completed'\` 체크 필요 — 우리 hook이 이를 처리
- GET은 신규 — 기존 코드에 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)