### PR TITLE
fix(marketing): SEO 분석 대기 시간 연장 및 stale 잡 자동 정리

### DIFF
--- a/dental-clinic-manager/src/app/api/marketing/seo/preview/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/seo/preview/route.ts
@@ -10,8 +10,9 @@ import type { SeoKeywordMiningResult } from '@/types/marketing';
 
 export const maxDuration = 30;
 
-// 5분 이상 running 상태로 멈춰있으면 stale로 간주 (워커 비정상 종료 추정)
-const STALE_RUNNING_MS = 5 * 60 * 1000;
+// 7분 이상 running 상태로 멈춰있으면 stale로 간주 (워커 비정상 종료 추정)
+// 워커가 네이버 상위 5개 글을 스크래핑하는 데 5~6분이 걸릴 수 있어 5분은 너무 짧음
+const STALE_RUNNING_MS = 7 * 60 * 1000;
 
 interface JobRow {
   id: string;
@@ -126,11 +127,21 @@ async function resolvePreviewState(
       const { progress, step } = estimateRunningProgress(latestJob.started_at);
       return { status: 'running', progress, step, jobId: latestJob.id };
     } else {
-      // stale인데 autoRequeue 비활성 (GET 호출) → running으로 그대로 반환하되 step에 안내
+      // stale인데 autoRequeue 비활성 (GET 호출) → 무한 running 방지를 위해 failed 마킹만 (재큐잉 X)
+      // 사용자가 다시 분석 실행 시 새 잡이 생성됨
+      await admin
+        .from('seo_jobs')
+        .update({
+          status: 'failed',
+          completed_at: new Date().toISOString(),
+          error_message: latestJob.error_message || '워커 응답 없음 — 자동 종료',
+        })
+        .eq('id', latestJob.id);
       return {
-        status: 'running',
-        progress: 90,
-        step: '분석이 오래 걸리고 있습니다. 잠시 후 자동으로 재시도됩니다.',
+        status: 'failed',
+        progress: 0,
+        step: '분석이 시간 내에 완료되지 못했습니다.',
+        error: '워커 응답이 지연되어 분석을 중단했습니다. 다시 시도해주세요.',
         jobId: latestJob.id,
       };
     }

--- a/dental-clinic-manager/src/contexts/SeoPreviewContext.tsx
+++ b/dental-clinic-manager/src/contexts/SeoPreviewContext.tsx
@@ -35,7 +35,9 @@ interface SeoPreviewContextType extends SeoPreviewState {
 const SeoPreviewContext = createContext<SeoPreviewContextType | null>(null)
 
 const POLL_INTERVAL_MS = 3000
-const POLL_MAX_DURATION_MS = 5 * 60 * 1000
+// 워커가 네이버 상위 5개 글을 모두 스크래핑하는 데 시간이 오래 걸리므로
+// 클라이언트 폴링 데드라인은 워커 stale 임계값(7분)보다 충분히 큰 15분으로 설정
+const POLL_MAX_DURATION_MS = 15 * 60 * 1000
 
 const STORAGE_KEY = 'seo-preview-state-v1'
 
@@ -139,12 +141,15 @@ export function SeoPreviewProvider({ children }: { children: ReactNode }) {
       console.warn('[SeoPreview] poll error:', err)
     }
     if (Date.now() > pollDeadlineRef.current) {
+      // 클라이언트 폴링 데드라인 만료 (15분).
+      // 일반적으로는 서버 STALE(7분) 처리로 더 빨리 'failed' 응답을 받지만,
+      // 그 응답조차 도달하지 못한 극단적 경우의 안전장치.
       stopPolling()
       setState((prev) => {
         const next: SeoPreviewState = {
           ...prev,
           status: 'failed',
-          error: '분석 시간이 너무 오래 걸려 중단했습니다. 잠시 후 다시 시도해주세요.',
+          error: '분석이 예상보다 오래 걸려 중단했습니다. 잠시 후 다시 시도해주세요.',
         }
         persistFullState(next, pollDeadlineRef.current)
         return next


### PR DESCRIPTION
## Summary
- 사용자가 \"분석시간이 너무 오래 걸려 중단했습니다\" 메시지를 빠르게 보던 문제 해결
- 클라이언트 폴링 데드라인 5분 → 15분, 서버 STALE 임계값 5분 → 7분
- GET 폴링에서 stale 잡 자동 fail 마킹하여 무한 running 방지

## 근본 원인
워커가 네이버 상위 5개 글을 스크래핑하는 데 5~6분이 걸릴 수 있는데, 클라이언트 폴링 데드라인이 5분으로 짧아 워커가 끝내기 전에 사용자에게 \"중단됐다\" 메시지가 표시됨. 또한 워커가 hang된 경우 GET 폴링에서 자동 정리하지 않아 무한히 running 상태로 보임.

## 변경 파일
- `src/contexts/SeoPreviewContext.tsx`: POLL_MAX_DURATION_MS 5분 → 15분, deadline 만료 메시지 개선
- `src/app/api/marketing/seo/preview/route.ts`: STALE_RUNNING_MS 5분 → 7분, GET 폴링에서도 stale 자동 fail 마킹

## Test plan
- [x] `npm run build` 통과
- [x] /dashboard/marketing/posts/new 접속 → 분석 실행 → progress UI 표시
- [x] /dashboard 등 다른 페이지 이동 → floating panel 정상 표시 (5%→25%→75%→90%)
- [x] 최소화 토글 정상 동작
- [x] sessionStorage에 남은 stale 'failed' 메시지가 닫기 후 사라짐
- [x] 7분 stale 임계값 도달 시 자동 fail 처리되며 명확한 에러 메시지 표시
- [x] Stale 잡 3건(스케일링 주의사항/잠실 임플란트/천호역 임플란트) DB 정리 완료

## 후속 작업
- 워커 자체의 robustness 개선(전체 잡 처리 timeout, 각 글 처리 timeout) — 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)