### PR TITLE
feat(permissions): 근로계약서 권한 세분화 (본인 기본 + 전체 위임)

### DIFF
--- a/dental-clinic-manager/src/components/Contract/ContractDetail.tsx
+++ b/dental-clinic-manager/src/components/Contract/ContractDetail.tsx
@@ -17,6 +17,7 @@ import { formatResidentNumber, maskResidentNumber } from '@/utils/residentNumber
 import { decryptResidentNumber } from '@/utils/encryptionUtils'
 import { collectSignatureMetadata } from '@/utils/documentLegalUtils'
 import { appConfirm, appAlert, appPrompt } from '@/components/ui/AppDialog'
+import { usePermissions } from '@/hooks/usePermissions'
 
 interface ContractDetailProps {
   contractId: string
@@ -25,6 +26,7 @@ interface ContractDetailProps {
 
 export default function ContractDetail({ contractId, currentUser }: ContractDetailProps) {
   const router = useRouter()
+  const { hasPermission } = usePermissions()
   const [contract, setContract] = useState<EmploymentContract | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -57,6 +59,13 @@ export default function ContractDetail({ contractId, currentUser }: ContractDeta
       if (response.error) {
         setError(response.error)
       } else if (response.data) {
+        // 본인이 아닌 계약서는 contract_view_all 권한 필요
+        const isOwnContract = response.data.employee_user_id === currentUser.id
+        if (!isOwnContract && !hasPermission('contract_view_all')) {
+          setError('해당 근로계약서를 조회할 권한이 없습니다.')
+          return
+        }
+
         setContract(response.data)
 
         // 주민번호 복호화

--- a/dental-clinic-manager/src/components/Contract/ContractList.tsx
+++ b/dental-clinic-manager/src/components/Contract/ContractList.tsx
@@ -14,6 +14,7 @@ import type { UserProfile } from '@/contexts/AuthContext'
 import { checkSecuritySession, setSecuritySession } from '@/lib/securitySession'
 import PasswordVerificationModal from '@/components/Security/PasswordVerificationModal'
 import { appAlert } from '@/components/ui/AppDialog'
+import { usePermissions } from '@/hooks/usePermissions'
 
 interface ContractListProps {
   currentUser: UserProfile
@@ -38,11 +39,12 @@ const STATUS_COLORS: Record<ContractStatus, string> = {
 
 export default function ContractList({ currentUser, clinicId }: ContractListProps) {
   const router = useRouter()
+  const { hasPermission } = usePermissions()
   const [contracts, setContracts] = useState<EmploymentContract[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  // 대표원장만 전체 계약서 조회, 나머지는 본인 계약서만
-  const isFullAccessRole = currentUser.role === 'owner'
+  // 전체 직원 계약서 조회 권한이 있으면 전체 조회, 아니면 본인 계약서만
+  const isFullAccessRole = hasPermission('contract_view_all')
   const [filters, setFilters] = useState<ContractListFilters>({
     status: undefined,
     employee_user_id: isFullAccessRole ? undefined : currentUser.id,

--- a/dental-clinic-manager/src/hooks/usePermissions.ts
+++ b/dental-clinic-manager/src/hooks/usePermissions.ts
@@ -20,6 +20,10 @@ const NEW_FEATURE_PREFIXES = [
   'investment_',
 ] as const
 
+// 신규로 추가된 개별 권한(prefix 보충 대상이 아닌 단독 권한)
+// 기존 그룹에 추가된 권한이라 prefix 보충에서 누락되므로, 직급 기본값에서 직접 보충
+const NEW_INDIVIDUAL_PERMISSIONS: Permission[] = ['contract_view_all']
+
 export function usePermissions() {
   const { user } = useAuth()
   const [permissions, setPermissions] = useState<Set<Permission>>(new Set())
@@ -50,6 +54,13 @@ export function usePermissions() {
         if (!hasFeaturePerms) {
           const featureDefaults = roleDefaults.filter(p => p.startsWith(prefix))
           userPermissions.push(...featureDefaults)
+        }
+      }
+
+      // 단독 신규 권한 보충 (기존 그룹에 추가된 권한)
+      for (const perm of NEW_INDIVIDUAL_PERMISSIONS) {
+        if (!userPermissions.includes(perm) && roleDefaults.includes(perm)) {
+          userPermissions.push(perm)
         }
       }
     } else {

--- a/dental-clinic-manager/src/types/permissions.ts
+++ b/dental-clinic-manager/src/types/permissions.ts
@@ -22,7 +22,8 @@ export type Permission =
   | 'protocol_history_view'  // 프로토콜 히스토리 조회
   | 'protocol_category_manage' // 프로토콜 카테고리 관리
   // 근로계약서 관리 권한
-  | 'contract_view'          // 계약서 조회
+  | 'contract_view'          // 본인 근로계약서 조회 (모든 직원 기본 보유)
+  | 'contract_view_all'      // 전체 직원 근로계약서 조회 (대표원장이 위임 가능)
   | 'contract_create'        // 계약서 생성
   | 'contract_edit'          // 계약서 수정
   | 'contract_delete'        // 계약서 삭제
@@ -107,7 +108,7 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     'protocol_view', 'protocol_create', 'protocol_edit', 'protocol_delete',
     'protocol_version_restore', 'protocol_history_view', 'protocol_category_manage',
     // 근로계약서 관리 (모든 권한)
-    'contract_view', 'contract_create', 'contract_edit', 'contract_delete', 'contract_template_manage',
+    'contract_view', 'contract_view_all', 'contract_create', 'contract_edit', 'contract_delete', 'contract_template_manage',
     // 출퇴근 관리 (모든 권한)
     'attendance_check_in', 'attendance_view_own', 'attendance_view_all', 'attendance_manage',
     'attendance_stats_view', 'schedule_view_own', 'schedule_view_all', 'schedule_manage',
@@ -318,6 +319,7 @@ export const PERMISSION_GROUPS = {
   ],
   '근로계약서': [
     { key: 'contract_view', label: '본인 근로계약서 조회' },
+    { key: 'contract_view_all', label: '전체 직원 근로계약서 조회' },
     { key: 'contract_create', label: '계약서 생성' },
     { key: 'contract_edit', label: '계약서 수정' },
     { key: 'contract_delete', label: '계약서 삭제' },
@@ -434,7 +436,8 @@ export const PERMISSION_DESCRIPTIONS: Record<Permission, string> = {
   'protocol_history_view': '프로토콜 변경 히스토리를 조회할 수 있습니다.',
   'protocol_category_manage': '프로토콜 카테고리를 관리할 수 있습니다.',
   // 근로계약서 관리 권한 설명
-  'contract_view': '본인의 근로계약서를 조회할 수 있습니다. (대표원장/실장은 전체 조회)',
+  'contract_view': '본인의 근로계약서를 조회할 수 있습니다. (모든 직원 기본 보유)',
+  'contract_view_all': '전체 직원의 근로계약서를 조회할 수 있습니다. (대표원장이 위임)',
   'contract_create': '새로운 근로계약서를 생성할 수 있습니다.',
   'contract_edit': '근로계약서를 수정할 수 있습니다.',
   'contract_delete': '근로계약서를 삭제할 수 있습니다.',


### PR DESCRIPTION
## Summary
- \`contract_view_all\` 신규 권한 추가: 전체 직원 근로계약서 조회 권한
- 모든 직급의 기본 권한에 \`contract_view\`(본인 조회) 보장 (이미 포함되어 있음)
- 대표원장만 \`contract_view_all\` 기본 보유 → 실장/부원장 등은 권한 위임 UI에서 토글로 부여 가능
- ContractList의 \`role === 'owner'\` 분기를 \`hasPermission('contract_view_all')\`로 전환
- ContractDetail에 본인 외 계약서 직접 접근 시 권한 체크 추가 (URL 직접 진입 차단)

## Test plan
- [ ] 일반 직원 계정: 본인 계약서만 목록에 노출되는지 확인
- [ ] 실장 계정 (기본): 본인 계약서만 노출 (\`contract_view_all\` 미부여 상태)
- [ ] 대표원장이 실장에게 \`contract_view_all\` 권한 부여 후 → 실장 목록에서 전체 직원 계약서 노출
- [ ] 권한 없는 계정이 다른 직원 계약서 URL 직접 접근 시 권한 없음 메시지 표시
- [ ] 대표원장은 변경 후에도 동일하게 전체 계약서 조회 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)