### PR TITLE
fix(css): 테이블 버튼 글자색 + feat(leave): 연차 수정 페이지 재설계

### DIFF
--- a/dental-clinic-manager/src/app/globals.css
+++ b/dental-clinic-manager/src/app/globals.css
@@ -53,8 +53,15 @@ table th,
 table td,
 table tbody,
 table thead {
-  color: #000000 !important;
-  -webkit-text-fill-color: #000000 !important;
+  color: #000000;
+  -webkit-text-fill-color: #000000;
+}
+
+/* 테이블 안의 버튼/링크는 디자인 시스템 색상(text-white 등)을 그대로 사용 */
+table button,
+table a {
+  color: revert;
+  -webkit-text-fill-color: currentColor;
 }
 
 /* placeholder 스타일 */

--- a/dental-clinic-manager/src/components/Leave/LeaveManagement.tsx
+++ b/dental-clinic-manager/src/components/Leave/LeaveManagement.tsx
@@ -26,7 +26,7 @@ import type { EmployeeLeaveBalance, LeaveType, LeaveTypeCode } from '@/types/lea
 import { LEAVE_STATUS_NAMES, LEAVE_STATUS_COLORS, LEAVE_TYPE_NAMES } from '@/types/leave'
 import LeaveRequestForm from './LeaveRequestForm'
 import LeaveApprovalList from './LeaveApprovalList'
-import LeaveAdminInput from './LeaveAdminInput'
+import LeaveEditPanel from './edit/LeaveEditPanel'
 import LeavePolicySettings from './LeavePolicySettings'
 import ClinicHolidayManager from './ClinicHolidayManager'
 import Toast from '@/components/ui/Toast'
@@ -241,7 +241,7 @@ export default function LeaveManagement({ currentUser, initialSubtab }: LeaveMan
     { id: 'request', label: '연차 신청', icon: Plus, show: hasPermission('leave_request_create') },
     { id: 'approval', label: '승인 대기', icon: Clock, badge: pendingCount, show: canApprove },
     { id: 'all', label: '전체 현황', icon: Users, show: canViewAll },
-    { id: 'admin', label: '연차 관리', icon: FileText, show: canManageBalance },
+    { id: 'admin', label: '연차 수정', icon: FileText, show: canManageBalance },
     { id: 'holiday', label: '휴무일 관리', icon: Building2, show: currentUser.role === 'owner' },
     { id: 'policy', label: '정책 설정', icon: Settings, show: canManagePolicy },
   ].filter(tab => tab.show)
@@ -406,12 +406,11 @@ export default function LeaveManagement({ currentUser, initialSubtab }: LeaveMan
         </div>
       )}
 
-      {/* 연차 관리 탭 (소진 연차 입력) */}
+      {/* 연차 수정 탭 (추가/차감 + 승인된 연차 수정) */}
       {activeTab === 'admin' && canManageBalance && (
-        <LeaveAdminInput
-          year={new Date().getFullYear()}
+        <LeaveEditPanel
           leaveTypes={leaveTypes}
-          onSuccess={handleApprovalSuccess}
+          onSuccess={() => fetchInitialData(false)}
         />
       )}
 

--- a/dental-clinic-manager/src/components/Leave/edit/AdjustmentsTable.tsx
+++ b/dental-clinic-manager/src/components/Leave/edit/AdjustmentsTable.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+import { FileText, Pencil, Trash2 } from 'lucide-react'
+import type { LeaveAdjustment, LeaveAdjustmentType } from '@/types/leave'
+
+type AdjustmentRow = LeaveAdjustment & {
+  leave_types?: { name: string; code: string } | null
+  adjusted_by_user?: { name: string } | null
+}
+
+interface AdjustmentsTableProps {
+  adjustments: Array<AdjustmentRow>
+  onEdit: (adjustment: any) => void
+  onDelete: (adjustment: any) => Promise<void>
+}
+
+const isSystemGenerated = (reason: string): boolean =>
+  reason.startsWith('[병원휴무]') || reason.startsWith('[법정공휴일]')
+
+const formatKoreanDate = (value?: string | null): string => {
+  if (!value) return '-'
+  try {
+    const d = new Date(value)
+    if (Number.isNaN(d.getTime())) return '-'
+    const y = d.getFullYear()
+    const m = String(d.getMonth() + 1).padStart(2, '0')
+    const day = String(d.getDate()).padStart(2, '0')
+    return `${y}.${m}.${day}`
+  } catch {
+    return '-'
+  }
+}
+
+interface TypeBadgeStyle {
+  className: string
+  label: string
+}
+
+const getTypeBadge = (type: LeaveAdjustmentType): TypeBadgeStyle => {
+  switch (type) {
+    case 'add':
+      return {
+        className:
+          'inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-at-success-bg text-at-success',
+        label: '추가',
+      }
+    case 'deduct':
+      return {
+        className:
+          'inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-at-error-bg text-at-error',
+        label: '차감',
+      }
+    case 'set':
+    default:
+      return {
+        className:
+          'inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-at-surface-alt text-at-text-secondary',
+        label: '설정',
+      }
+  }
+}
+
+export default function AdjustmentsTable({
+  adjustments,
+  onEdit,
+  onDelete,
+}: AdjustmentsTableProps) {
+  if (!adjustments || adjustments.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <FileText
+          className="w-10 h-10 text-at-text-weak mx-auto mb-2"
+          aria-hidden="true"
+        />
+        <p className="text-sm text-at-text-secondary">수동 조정 내역이 없습니다</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-[720px] w-full text-sm">
+        <thead className="bg-at-surface-alt">
+          <tr>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              적용일
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              유형
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              일수
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              종류
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              사유
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              등록자
+            </th>
+            <th className="px-3 py-2 text-right text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              작업
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-at-border">
+          {adjustments.map((adj) => {
+            const badge = getTypeBadge(adj.adjustment_type)
+            const reason = adj.reason ?? ''
+            const isSystem = isSystemGenerated(reason)
+            const typeName = adj.leave_types?.name ?? '-'
+            const registrant = adj.adjusted_by_user?.name ?? '-'
+            const days =
+              typeof adj.days === 'number' ? adj.days : Number(adj.days ?? 0)
+
+            return (
+              <tr key={adj.id} className="hover:bg-at-surface-alt">
+                <td className="px-3 py-2 text-at-text whitespace-nowrap">
+                  {formatKoreanDate(adj.use_date)}
+                </td>
+                <td className="px-3 py-2 whitespace-nowrap">
+                  <span className={badge.className}>{badge.label}</span>
+                </td>
+                <td className="px-3 py-2 text-at-text whitespace-nowrap">
+                  {days.toFixed(1)}일
+                </td>
+                <td className="px-3 py-2 text-at-text whitespace-nowrap">
+                  {typeName}
+                </td>
+                <td className="px-3 py-2 text-at-text-secondary">
+                  <div className="flex items-center gap-2">
+                    <div
+                      className="truncate max-w-[200px]"
+                      title={reason || undefined}
+                    >
+                      {reason || '-'}
+                    </div>
+                    {isSystem && (
+                      <span className="inline-flex shrink-0 px-2 py-0.5 text-xs font-medium rounded-full bg-at-surface-alt text-at-text-secondary">
+                        시스템
+                      </span>
+                    )}
+                  </div>
+                </td>
+                <td className="px-3 py-2 whitespace-nowrap">
+                  <div className="text-at-text">{registrant}</div>
+                  <div className="text-xs text-at-text-weak">
+                    {formatKoreanDate(adj.adjusted_at ?? adj.created_at)}
+                  </div>
+                </td>
+                <td className="px-3 py-2">
+                  <div className="flex justify-end gap-1">
+                    <button
+                      type="button"
+                      onClick={() => onEdit(adj)}
+                      disabled={isSystem}
+                      className={[
+                        'p-1.5 rounded-xl transition-colors',
+                        isSystem
+                          ? 'opacity-30 cursor-not-allowed text-at-text-secondary'
+                          : 'hover:bg-at-accent-light text-at-text-secondary hover:text-at-accent',
+                      ].join(' ')}
+                      aria-label="수정"
+                      title={
+                        isSystem
+                          ? '시스템 자동 생성 항목은 수정/삭제할 수 없습니다'
+                          : '수정'
+                      }
+                    >
+                      <Pencil className="w-4 h-4" aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (isSystem) return
+                        void onDelete(adj)
+                      }}
+                      disabled={isSystem}
+                      className={[
+                        'p-1.5 rounded-xl transition-colors',
+                        isSystem
+                          ? 'opacity-30 cursor-not-allowed text-at-text-secondary'
+                          : 'hover:bg-at-error-bg text-at-text-secondary hover:text-at-error',
+                      ].join(' ')}
+                      aria-label="삭제"
+                      title={
+                        isSystem
+                          ? '시스템 자동 생성 항목은 수정/삭제할 수 없습니다'
+                          : '삭제'
+                      }
+                    >
+                      <Trash2 className="w-4 h-4" aria-hidden="true" />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Leave/edit/ApprovedRequestsTable.tsx
+++ b/dental-clinic-manager/src/components/Leave/edit/ApprovedRequestsTable.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { Calendar, Pencil, Trash2 } from 'lucide-react'
+
+interface ApprovedRequestsTableProps {
+  requests: Array<any>
+  onEdit: (request: any) => void
+  onDelete: (request: any) => Promise<void>
+}
+
+const formatKoreanDate = (value?: string | null): string => {
+  if (!value) return '-'
+  try {
+    const d = new Date(value)
+    if (Number.isNaN(d.getTime())) return '-'
+    const y = d.getFullYear()
+    const m = String(d.getMonth() + 1).padStart(2, '0')
+    const day = String(d.getDate()).padStart(2, '0')
+    return `${y}.${m}.${day}`
+  } catch {
+    return '-'
+  }
+}
+
+const formatHalfDayType = (halfDayType?: string | null): string => {
+  if (halfDayType === 'AM') return '오전'
+  if (halfDayType === 'PM') return '오후'
+  return '-'
+}
+
+export default function ApprovedRequestsTable({
+  requests,
+  onEdit,
+  onDelete,
+}: ApprovedRequestsTableProps) {
+  if (!requests || requests.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <Calendar
+          className="w-10 h-10 text-at-text-weak mx-auto mb-2"
+          aria-hidden="true"
+        />
+        <p className="text-sm text-at-text-secondary">승인된 연차가 없습니다</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-[720px] w-full text-sm">
+        <thead className="bg-at-surface-alt">
+          <tr>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              시작일
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              종료일
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              종류
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              일수
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              반차
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              사유
+            </th>
+            <th className="px-3 py-2 text-right text-xs font-medium text-at-text-weak uppercase tracking-wider">
+              작업
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-at-border">
+          {requests.map((req) => {
+            const reason = req.reason ?? ''
+            const typeName = req.leave_types?.name ?? '-'
+            const totalDays =
+              typeof req.total_days === 'number' ? req.total_days : Number(req.total_days ?? 0)
+
+            return (
+              <tr key={req.id} className="hover:bg-at-surface-alt">
+                <td className="px-3 py-2 text-at-text whitespace-nowrap">
+                  {formatKoreanDate(req.start_date)}
+                </td>
+                <td className="px-3 py-2 text-at-text whitespace-nowrap">
+                  {formatKoreanDate(req.end_date)}
+                </td>
+                <td className="px-3 py-2 text-at-text whitespace-nowrap">{typeName}</td>
+                <td className="px-3 py-2 text-at-text whitespace-nowrap">
+                  {totalDays.toFixed(1)}일
+                </td>
+                <td className="px-3 py-2 text-at-text whitespace-nowrap">
+                  {formatHalfDayType(req.half_day_type)}
+                </td>
+                <td className="px-3 py-2 text-at-text-secondary">
+                  <div
+                    className="truncate max-w-[200px]"
+                    title={reason || undefined}
+                  >
+                    {reason || '-'}
+                  </div>
+                </td>
+                <td className="px-3 py-2">
+                  <div className="flex justify-end gap-1">
+                    <button
+                      type="button"
+                      onClick={() => onEdit(req)}
+                      className="p-1.5 rounded-xl hover:bg-at-accent-light text-at-text-secondary hover:text-at-accent transition-colors"
+                      aria-label="수정"
+                      title="수정"
+                    >
+                      <Pencil className="w-4 h-4" aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void onDelete(req)
+                      }}
+                      className="p-1.5 rounded-xl hover:bg-at-error-bg text-at-text-secondary hover:text-at-error transition-colors"
+                      aria-label="삭제"
+                      title="삭제"
+                    >
+                      <Trash2 className="w-4 h-4" aria-hidden="true" />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Leave/edit/EmployeeSelector.tsx
+++ b/dental-clinic-manager/src/components/Leave/edit/EmployeeSelector.tsx
@@ -1,0 +1,183 @@
+'use client'
+
+import { useMemo, useRef, useState, type KeyboardEvent } from 'react'
+import { Search, Users } from 'lucide-react'
+
+interface EmployeeSelectorProps {
+  staff: Array<{ id: string; name: string; role: string; hire_date?: string | null }>
+  balances: Array<{
+    user_id: string
+    remaining_days: number
+    total_days: number
+    used_days: number
+  }>
+  selectedUserId: string | null
+  onSelect: (userId: string) => void
+}
+
+const ROLE_LABELS: Record<string, string> = {
+  owner: '원장',
+  vice_director: '부원장',
+  manager: '실장',
+  team_leader: '진료팀장',
+  staff: '직원',
+}
+
+interface EmployeeRow {
+  id: string
+  name: string
+  role: string
+  hire_date?: string | null
+  remaining_days: number
+  total_days: number
+  used_days: number
+}
+
+const getRemainingTextClass = (remaining: number): string => {
+  if (remaining < 0) return 'text-at-error'
+  if (remaining <= 3) return 'text-at-warning'
+  return 'text-at-accent'
+}
+
+export default function EmployeeSelector({
+  staff,
+  balances,
+  selectedUserId,
+  onSelect,
+}: EmployeeSelectorProps) {
+  const [query, setQuery] = useState('')
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const balanceMap = useMemo(() => {
+    const m = new Map<
+      string,
+      { remaining_days: number; total_days: number; used_days: number }
+    >()
+    for (const b of balances) {
+      m.set(b.user_id, {
+        remaining_days: b.remaining_days,
+        total_days: b.total_days,
+        used_days: b.used_days,
+      })
+    }
+    return m
+  }, [balances])
+
+  const rows: EmployeeRow[] = useMemo(() => {
+    const trimmed = query.trim().toLowerCase()
+    return staff
+      .filter((s) => {
+        if (!trimmed) return true
+        return s.name.toLowerCase().includes(trimmed)
+      })
+      .map((s) => {
+        const b = balanceMap.get(s.id)
+        return {
+          id: s.id,
+          name: s.name,
+          role: s.role,
+          hire_date: s.hire_date,
+          remaining_days: b?.remaining_days ?? 0,
+          total_days: b?.total_days ?? 0,
+          used_days: b?.used_days ?? 0,
+        }
+      })
+  }, [staff, balanceMap, query])
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (rows.length === 0) return
+    const currentIndex = rows.findIndex((r) => r.id === selectedUserId)
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      const next = currentIndex < 0 ? 0 : Math.min(currentIndex + 1, rows.length - 1)
+      onSelect(rows[next].id)
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      const prev = currentIndex < 0 ? 0 : Math.max(currentIndex - 1, 0)
+      onSelect(rows[prev].id)
+    } else if (e.key === 'Enter') {
+      if (currentIndex < 0 && rows.length > 0) {
+        e.preventDefault()
+        onSelect(rows[0].id)
+      }
+    }
+  }
+
+  return (
+    <div className="bg-white border border-at-border rounded-xl overflow-hidden">
+      <div className="p-3 border-b border-at-border">
+        <div className="relative">
+          <Search
+            className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-at-text-weak pointer-events-none"
+            aria-hidden="true"
+          />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="직원 검색..."
+            className="w-full pl-9 pr-3 py-2 text-sm border border-at-border rounded-xl focus:outline-none focus:ring-2 focus:ring-at-accent text-at-text bg-white"
+            aria-label="직원 검색"
+          />
+        </div>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <Users className="w-10 h-10 text-at-text-weak mb-2" aria-hidden="true" />
+          <p className="text-sm text-at-text-secondary">검색 결과가 없습니다</p>
+        </div>
+      ) : (
+        <div
+          ref={listRef}
+          className="max-h-[600px] overflow-y-auto"
+          onKeyDown={handleKeyDown}
+          role="listbox"
+          aria-label="직원 목록"
+        >
+          {rows.map((row) => {
+            const isSelected = row.id === selectedUserId
+            const remainingClass = getRemainingTextClass(row.remaining_days)
+
+            return (
+              <button
+                key={row.id}
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                onClick={() => onSelect(row.id)}
+                className={[
+                  'w-full text-left px-4 py-3 border-b border-at-border last:border-0 transition-colors',
+                  'focus:outline-none focus:bg-at-surface-alt',
+                  isSelected
+                    ? 'bg-at-accent-light border-l-4 border-l-at-accent'
+                    : 'hover:bg-at-surface-alt',
+                ].join(' ')}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-semibold text-at-text truncate">
+                      {row.name}
+                    </div>
+                    <div className="text-xs text-at-text-secondary mt-0.5">
+                      {ROLE_LABELS[row.role] ?? row.role}
+                    </div>
+                  </div>
+                  <div className="text-right shrink-0">
+                    <div className={`text-sm font-semibold ${remainingClass}`}>
+                      {row.remaining_days.toFixed(1)}일
+                    </div>
+                    <div className="text-xs text-at-text-weak mt-0.5">
+                      사용 {row.used_days.toFixed(1)} / 총{' '}
+                      {row.total_days.toFixed(1)}
+                    </div>
+                  </div>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Leave/edit/EmployeeSummary.tsx
+++ b/dental-clinic-manager/src/components/Leave/edit/EmployeeSummary.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { Users } from 'lucide-react'
+
+interface EmployeeSummaryProps {
+  employee: {
+    id: string
+    name: string
+    role: string
+    hire_date?: string | null
+  } | null
+  balance: {
+    total_days: number
+    used_days: number
+    pending_days: number
+    remaining_days: number
+    family_event_days?: number
+    unpaid_days?: number
+  } | null
+  yearsOfService: number
+}
+
+const ROLE_LABELS: Record<string, string> = {
+  owner: '원장',
+  vice_director: '부원장',
+  manager: '실장',
+  team_leader: '진료팀장',
+  staff: '직원',
+}
+
+const formatHireDate = (hireDate?: string | null): string => {
+  if (!hireDate) return '입사일 미등록'
+  try {
+    const d = new Date(hireDate)
+    if (Number.isNaN(d.getTime())) return '입사일 미등록'
+    const y = d.getFullYear()
+    const m = String(d.getMonth() + 1).padStart(2, '0')
+    const day = String(d.getDate()).padStart(2, '0')
+    return `${y}.${m}.${day}`
+  } catch {
+    return '입사일 미등록'
+  }
+}
+
+const getRemainingTextClass = (remaining: number): string => {
+  if (remaining < 0) return 'text-at-error'
+  if (remaining <= 3) return 'text-at-warning'
+  return 'text-at-accent'
+}
+
+interface StatCardProps {
+  label: string
+  value: number
+  unit?: string
+  valueClassName?: string
+}
+
+const StatCard = ({ label, value, unit = '일', valueClassName }: StatCardProps) => (
+  <div className="bg-white border border-at-border rounded-xl p-4">
+    <div className="text-xs text-at-text-secondary mb-1">{label}</div>
+    <div className="flex items-baseline">
+      <span className={`text-2xl font-bold ${valueClassName ?? 'text-at-text'}`}>
+        {value.toFixed(1)}
+      </span>
+      <span className="text-sm text-at-text-secondary ml-1">{unit}</span>
+    </div>
+  </div>
+)
+
+export default function EmployeeSummary({
+  employee,
+  balance,
+  yearsOfService,
+}: EmployeeSummaryProps) {
+  if (!employee) {
+    return (
+      <div className="bg-at-surface-alt border border-at-border rounded-xl py-12 text-center">
+        <Users
+          className="w-10 h-10 text-at-text-weak mx-auto mb-2"
+          aria-hidden="true"
+        />
+        <p className="text-sm text-at-text-secondary">직원을 선택해주세요</p>
+      </div>
+    )
+  }
+
+  const total = balance?.total_days ?? 0
+  const used = balance?.used_days ?? 0
+  const pending = balance?.pending_days ?? 0
+  const remaining = balance?.remaining_days ?? 0
+  const familyEvent = balance?.family_event_days ?? 0
+  const unpaid = balance?.unpaid_days ?? 0
+
+  const roleLabel = ROLE_LABELS[employee.role] ?? employee.role
+  const remainingClass = getRemainingTextClass(remaining)
+
+  const showSpecial = familyEvent > 0 || unpaid > 0
+
+  return (
+    <div className="space-y-3">
+      <div className="bg-white border border-at-border rounded-xl px-4 py-3 flex flex-wrap items-center gap-x-3 gap-y-1">
+        <span className="text-base font-semibold text-at-text">{employee.name}</span>
+        <span className="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-at-accent-light text-at-accent">
+          {roleLabel}
+        </span>
+        <span className="text-sm text-at-text-secondary">
+          {formatHireDate(employee.hire_date)}
+        </span>
+        <span className="text-sm text-at-text-secondary">
+          {yearsOfService.toFixed(1)}년차
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <StatCard label="총 연차" value={total} />
+        <StatCard label="사용" value={used} />
+        <StatCard label="대기" value={pending} />
+        <StatCard label="잔여" value={remaining} valueClassName={remainingClass} />
+      </div>
+
+      {showSpecial && (
+        <div className="text-xs text-at-text-secondary px-1">
+          특별휴가: 경조사 {familyEvent.toFixed(1)}일 · 무급휴가 {unpaid.toFixed(1)}일
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Leave/edit/LeaveActionBar.tsx
+++ b/dental-clinic-manager/src/components/Leave/edit/LeaveActionBar.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { Plus, Minus } from 'lucide-react'
+
+interface LeaveActionBarProps {
+  disabled: boolean
+  onAdd: () => void
+  onDeduct: () => void
+}
+
+export default function LeaveActionBar({
+  disabled,
+  onAdd,
+  onDeduct,
+}: LeaveActionBarProps) {
+  return (
+    <div className="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-between bg-white border border-at-border rounded-xl p-4">
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onAdd}
+          disabled={disabled}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-at-success hover:opacity-90 text-white rounded-xl text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+          aria-label="연차 추가"
+          title="연차 추가"
+        >
+          <Plus className="w-4 h-4" aria-hidden="true" />
+          <span>연차 추가</span>
+        </button>
+        <button
+          type="button"
+          onClick={onDeduct}
+          disabled={disabled}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-at-error hover:opacity-90 text-white rounded-xl text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+          aria-label="연차 차감"
+          title="연차 차감"
+        >
+          <Minus className="w-4 h-4" aria-hidden="true" />
+          <span>연차 차감</span>
+        </button>
+      </div>
+
+      <div className="text-xs text-at-text-secondary">
+        추가는 +, 차감은 - (이미 사용한 연차도 차감으로 입력)
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Leave/edit/LeaveEditPanel.tsx
+++ b/dental-clinic-manager/src/components/Leave/edit/LeaveEditPanel.tsx
@@ -1,0 +1,418 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ArrowLeft, FileText } from 'lucide-react'
+import {
+  leaveService,
+  calculateLeavePeriod,
+  calculateYearsOfService,
+} from '@/lib/leaveService'
+import type { LeaveType } from '@/types/leave'
+import { appConfirm } from '@/components/ui/AppDialog'
+import Toast from '@/components/ui/Toast'
+import EmployeeSelector from './EmployeeSelector'
+import EmployeeSummary from './EmployeeSummary'
+import LeaveActionBar from './LeaveActionBar'
+import LeaveHistoryTabs from './LeaveHistoryTabs'
+import ApprovedRequestsTable from './ApprovedRequestsTable'
+import AdjustmentsTable from './AdjustmentsTable'
+import AdjustmentModal from './modals/AdjustmentModal'
+import EditApprovedModal from './modals/EditApprovedModal'
+import EditAdjustmentModal from './modals/EditAdjustmentModal'
+
+interface LeaveEditPanelProps {
+  leaveTypes: LeaveType[]
+  onSuccess?: () => void
+}
+
+interface StaffMember {
+  id: string
+  name: string
+  role: string
+  hire_date?: string | null
+}
+
+interface BalanceRow {
+  user_id: string
+  total_days: number
+  used_days: number
+  pending_days: number
+  remaining_days: number
+  family_event_days?: number
+  unpaid_days?: number
+}
+
+type ToastState = {
+  show: boolean
+  message: string
+  type: 'success' | 'error' | 'warning' | 'info'
+}
+
+const getCurrentYearForUser = (hireDate?: string | null): number => {
+  if (hireDate) {
+    try {
+      const period = calculateLeavePeriod(new Date(hireDate))
+      return new Date(period.startDate).getFullYear()
+    } catch {
+      return new Date().getFullYear()
+    }
+  }
+  return new Date().getFullYear()
+}
+
+export default function LeaveEditPanel({ leaveTypes, onSuccess }: LeaveEditPanelProps) {
+  const [staff, setStaff] = useState<StaffMember[]>([])
+  const [balances, setBalances] = useState<BalanceRow[]>([])
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null)
+  const [approvedRequests, setApprovedRequests] = useState<any[]>([])
+  const [adjustments, setAdjustments] = useState<any[]>([])
+  const [historyTab, setHistoryTab] = useState<'approved' | 'adjustments'>('approved')
+  const [loading, setLoading] = useState(true)
+  const [detailLoading, setDetailLoading] = useState(false)
+
+  const [adjustmentModal, setAdjustmentModal] = useState<{
+    open: boolean
+    mode: 'add' | 'deduct'
+  }>({ open: false, mode: 'add' })
+  const [editApprovedModal, setEditApprovedModal] = useState<{
+    open: boolean
+    request: any | null
+  }>({ open: false, request: null })
+  const [editAdjustmentModal, setEditAdjustmentModal] = useState<{
+    open: boolean
+    adjustment: any | null
+  }>({ open: false, adjustment: null })
+
+  const [toast, setToast] = useState<ToastState>({
+    show: false,
+    message: '',
+    type: 'success',
+  })
+
+  const showToast = useCallback(
+    (message: string, type: ToastState['type'] = 'success') => {
+      setToast({ show: true, message, type })
+    },
+    [],
+  )
+
+  const selectedEmployee = useMemo(
+    () => staff.find((s) => s.id === selectedUserId) ?? null,
+    [staff, selectedUserId],
+  )
+
+  const selectedBalance = useMemo(
+    () => balances.find((b) => b.user_id === selectedUserId) ?? null,
+    [balances, selectedUserId],
+  )
+
+  const selectedYear = useMemo(
+    () => getCurrentYearForUser(selectedEmployee?.hire_date),
+    [selectedEmployee],
+  )
+
+  const yearsOfService = useMemo(() => {
+    if (!selectedEmployee?.hire_date) return 0
+    try {
+      return calculateYearsOfService(new Date(selectedEmployee.hire_date))
+    } catch {
+      return 0
+    }
+  }, [selectedEmployee])
+
+  const loadStaffAndBalances = useCallback(async () => {
+    const currentYear = new Date().getFullYear()
+    const [staffResult, balanceResult] = await Promise.all([
+      leaveService.getStaffList(),
+      leaveService.getAllEmployeeBalances(currentYear),
+    ])
+    setStaff((staffResult.data ?? []) as StaffMember[])
+    setBalances((balanceResult.data ?? []) as BalanceRow[])
+  }, [])
+
+  const loadDetail = useCallback(async (userId: string, year: number) => {
+    setDetailLoading(true)
+    try {
+      const [requestsResult, adjustmentsResult] = await Promise.all([
+        leaveService.getAllRequests({ userId, status: 'approved' }),
+        leaveService.getAdjustments(userId, year),
+      ])
+      setApprovedRequests(requestsResult.data ?? [])
+      setAdjustments(adjustmentsResult.data ?? [])
+    } finally {
+      setDetailLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    loadStaffAndBalances().finally(() => {
+      if (!cancelled) setLoading(false)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [loadStaffAndBalances])
+
+  useEffect(() => {
+    if (!selectedUserId) {
+      setApprovedRequests([])
+      setAdjustments([])
+      return
+    }
+    loadDetail(selectedUserId, selectedYear)
+  }, [selectedUserId, selectedYear, loadDetail])
+
+  const refreshAll = useCallback(async () => {
+    await loadStaffAndBalances()
+    if (selectedUserId) {
+      await loadDetail(selectedUserId, selectedYear)
+    }
+    onSuccess?.()
+  }, [loadStaffAndBalances, loadDetail, selectedUserId, selectedYear, onSuccess])
+
+  const handleAdjustmentSuccess = useCallback(
+    async (mode: 'add' | 'deduct') => {
+      setAdjustmentModal({ open: false, mode })
+      showToast(mode === 'add' ? '연차가 추가되었습니다.' : '연차가 차감되었습니다.', 'success')
+      await refreshAll()
+    },
+    [refreshAll, showToast],
+  )
+
+  const handleEditApprovedSuccess = useCallback(async () => {
+    setEditApprovedModal({ open: false, request: null })
+    showToast('연차 신청이 수정되었습니다.', 'success')
+    await refreshAll()
+  }, [refreshAll, showToast])
+
+  const handleEditAdjustmentSuccess = useCallback(async () => {
+    setEditAdjustmentModal({ open: false, adjustment: null })
+    showToast('조정 내역이 수정되었습니다.', 'success')
+    await refreshAll()
+  }, [refreshAll, showToast])
+
+  const handleDeleteRequest = useCallback(
+    async (request: any) => {
+      const confirmed = await appConfirm({
+        title: '연차 삭제',
+        description: '이 승인된 연차를 삭제하면 잔여 연차가 복구됩니다. 계속하시겠습니까?',
+        variant: 'destructive',
+        confirmText: '삭제',
+        cancelText: '취소',
+      })
+      if (!confirmed) return
+      const result = await leaveService.deleteApprovedRequest(request.id)
+      if (result.error) {
+        showToast(result.error, 'error')
+      } else {
+        showToast('연차가 삭제되었습니다.', 'success')
+        await refreshAll()
+      }
+    },
+    [refreshAll, showToast],
+  )
+
+  const handleDeleteAdjustment = useCallback(
+    async (adjustment: any) => {
+      const confirmed = await appConfirm({
+        title: '조정 내역 삭제',
+        description: '이 조정 내역을 삭제하면 잔여 연차가 다시 계산됩니다. 계속하시겠습니까?',
+        variant: 'destructive',
+        confirmText: '삭제',
+        cancelText: '취소',
+      })
+      if (!confirmed) return
+      const result = await leaveService.deleteAdjustment(adjustment.id)
+      if (result.error) {
+        showToast(result.error, 'error')
+      } else {
+        showToast('조정 내역이 삭제되었습니다.', 'success')
+        await refreshAll()
+      }
+    },
+    [refreshAll, showToast],
+  )
+
+  if (loading && staff.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-at-accent" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center space-x-3 pb-3 border-b border-at-border">
+        <div className="flex items-center justify-center w-8 h-8 rounded-xl bg-at-accent-light text-at-accent">
+          <FileText className="w-4 h-4" aria-hidden="true" />
+        </div>
+        <div>
+          <h3 className="text-base font-semibold text-at-text">연차 수정</h3>
+          <p className="text-xs text-at-text-secondary">
+            직원을 선택해 연차를 추가/차감하거나, 이미 승인된 연차나 조정 내역을 수정할 수 있습니다.
+          </p>
+        </div>
+      </div>
+
+      {/* 모바일: 직원 선택 안 됐을 때 직원 목록만 풀스크린 */}
+      <div className="md:hidden">
+        {!selectedUserId ? (
+          <EmployeeSelector
+            staff={staff}
+            balances={balances}
+            selectedUserId={selectedUserId}
+            onSelect={setSelectedUserId}
+          />
+        ) : (
+          <div className="space-y-4">
+            <button
+              type="button"
+              onClick={() => setSelectedUserId(null)}
+              className="inline-flex items-center gap-1 text-sm font-medium text-at-accent hover:text-at-accent-hover"
+            >
+              <ArrowLeft className="w-4 h-4" aria-hidden="true" />
+              직원 목록으로
+            </button>
+            <EmployeeSummary
+              employee={selectedEmployee}
+              balance={selectedBalance}
+              yearsOfService={yearsOfService}
+            />
+            <LeaveActionBar
+              disabled={false}
+              onAdd={() => setAdjustmentModal({ open: true, mode: 'add' })}
+              onDeduct={() => setAdjustmentModal({ open: true, mode: 'deduct' })}
+            />
+            <LeaveHistoryTabs
+              approvedCount={approvedRequests.length}
+              adjustmentCount={adjustments.length}
+              activeTab={historyTab}
+              onTabChange={setHistoryTab}
+            >
+              {detailLoading ? (
+                <div className="flex items-center justify-center py-12">
+                  <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-at-accent" />
+                </div>
+              ) : historyTab === 'approved' ? (
+                <ApprovedRequestsTable
+                  requests={approvedRequests}
+                  onEdit={(request) =>
+                    setEditApprovedModal({ open: true, request })
+                  }
+                  onDelete={handleDeleteRequest}
+                />
+              ) : (
+                <AdjustmentsTable
+                  adjustments={adjustments}
+                  onEdit={(adjustment) =>
+                    setEditAdjustmentModal({ open: true, adjustment })
+                  }
+                  onDelete={handleDeleteAdjustment}
+                />
+              )}
+            </LeaveHistoryTabs>
+          </div>
+        )}
+      </div>
+
+      {/* 데스크탑: 좌우 분할 */}
+      <div className="hidden md:grid md:grid-cols-[280px_1fr] gap-4">
+        <EmployeeSelector
+          staff={staff}
+          balances={balances}
+          selectedUserId={selectedUserId}
+          onSelect={setSelectedUserId}
+        />
+
+        <div className="space-y-4">
+          <EmployeeSummary
+            employee={selectedEmployee}
+            balance={selectedBalance}
+            yearsOfService={yearsOfService}
+          />
+          {selectedEmployee && (
+            <>
+              <LeaveActionBar
+                disabled={false}
+                onAdd={() => setAdjustmentModal({ open: true, mode: 'add' })}
+                onDeduct={() => setAdjustmentModal({ open: true, mode: 'deduct' })}
+              />
+              <LeaveHistoryTabs
+                approvedCount={approvedRequests.length}
+                adjustmentCount={adjustments.length}
+                activeTab={historyTab}
+                onTabChange={setHistoryTab}
+              >
+                {detailLoading ? (
+                  <div className="flex items-center justify-center py-12">
+                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-at-accent" />
+                  </div>
+                ) : historyTab === 'approved' ? (
+                  <ApprovedRequestsTable
+                    requests={approvedRequests}
+                    onEdit={(request) =>
+                      setEditApprovedModal({ open: true, request })
+                    }
+                    onDelete={handleDeleteRequest}
+                  />
+                ) : (
+                  <AdjustmentsTable
+                    adjustments={adjustments}
+                    onEdit={(adjustment) =>
+                      setEditAdjustmentModal({ open: true, adjustment })
+                    }
+                    onDelete={handleDeleteAdjustment}
+                  />
+                )}
+              </LeaveHistoryTabs>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* 모달 */}
+      {selectedEmployee && (
+        <AdjustmentModal
+          open={adjustmentModal.open}
+          mode={adjustmentModal.mode}
+          userId={selectedEmployee.id}
+          userName={selectedEmployee.name}
+          year={selectedYear}
+          leaveTypes={leaveTypes}
+          onClose={() => setAdjustmentModal((s) => ({ ...s, open: false }))}
+          onSuccess={() => handleAdjustmentSuccess(adjustmentModal.mode)}
+        />
+      )}
+
+      {editApprovedModal.request && (
+        <EditApprovedModal
+          open={editApprovedModal.open}
+          request={editApprovedModal.request}
+          leaveTypes={leaveTypes}
+          onClose={() => setEditApprovedModal({ open: false, request: null })}
+          onSuccess={handleEditApprovedSuccess}
+        />
+      )}
+
+      {editAdjustmentModal.adjustment && (
+        <EditAdjustmentModal
+          open={editAdjustmentModal.open}
+          adjustment={editAdjustmentModal.adjustment}
+          leaveTypes={leaveTypes}
+          onClose={() => setEditAdjustmentModal({ open: false, adjustment: null })}
+          onSuccess={handleEditAdjustmentSuccess}
+        />
+      )}
+
+      <Toast
+        message={toast.message}
+        type={toast.type}
+        show={toast.show}
+        onClose={() => setToast((prev) => ({ ...prev, show: false }))}
+      />
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Leave/edit/LeaveHistoryTabs.tsx
+++ b/dental-clinic-manager/src/components/Leave/edit/LeaveHistoryTabs.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import type { ReactNode } from 'react'
+
+interface LeaveHistoryTabsProps {
+  approvedCount: number
+  adjustmentCount: number
+  activeTab: 'approved' | 'adjustments'
+  onTabChange: (tab: 'approved' | 'adjustments') => void
+  children: ReactNode
+}
+
+interface TabDef {
+  key: 'approved' | 'adjustments'
+  label: string
+  count: number
+}
+
+export default function LeaveHistoryTabs({
+  approvedCount,
+  adjustmentCount,
+  activeTab,
+  onTabChange,
+  children,
+}: LeaveHistoryTabsProps) {
+  const tabs: TabDef[] = [
+    { key: 'approved', label: '승인된 연차', count: approvedCount },
+    { key: 'adjustments', label: '수동 조정', count: adjustmentCount },
+  ]
+
+  return (
+    <div className="bg-white border border-at-border rounded-xl overflow-hidden">
+      <div
+        className="flex border-b border-at-border bg-at-surface-alt px-2"
+        role="tablist"
+      >
+        {tabs.map((tab) => {
+          const isActive = activeTab === tab.key
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => onTabChange(tab.key)}
+              className={[
+                'py-3 px-4 text-sm font-medium border-b-2 transition-colors flex items-center',
+                isActive
+                  ? 'border-at-accent text-at-accent'
+                  : 'border-transparent text-at-text-weak hover:text-at-text-secondary',
+              ].join(' ')}
+            >
+              <span>{tab.label}</span>
+              <span
+                className={[
+                  'ml-2 px-2 py-0.5 text-xs rounded-full',
+                  isActive
+                    ? 'bg-at-accent-light text-at-accent'
+                    : 'bg-at-surface-alt text-at-text-secondary',
+                ].join(' ')}
+              >
+                {tab.count}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+      <div className="p-4">{children}</div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Leave/edit/modals/AdjustmentModal.tsx
+++ b/dental-clinic-manager/src/components/Leave/edit/modals/AdjustmentModal.tsx
@@ -1,0 +1,229 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { leaveService } from '@/lib/leaveService'
+import type { LeaveType } from '@/types/leave'
+
+export interface AdjustmentModalProps {
+  open: boolean
+  mode: 'add' | 'deduct'
+  userId: string
+  userName: string
+  year: number
+  leaveTypes: LeaveType[]
+  onClose: () => void
+  onSuccess: () => void
+}
+
+export default function AdjustmentModal({
+  open,
+  mode,
+  userId,
+  userName,
+  year,
+  leaveTypes,
+  onClose,
+  onSuccess,
+}: AdjustmentModalProps) {
+  const [days, setDays] = useState<string>('')
+  const [useDate, setUseDate] = useState<string>('')
+  const [leaveTypeId, setLeaveTypeId] = useState<string>('')
+  const [reason, setReason] = useState<string>('')
+  const [error, setError] = useState<string>('')
+  const [submitting, setSubmitting] = useState<boolean>(false)
+
+  const daysRef = useRef<HTMLInputElement>(null)
+  const reasonRef = useRef<HTMLTextAreaElement>(null)
+
+  // Reset on open/mode/userId change
+  useEffect(() => {
+    if (open) {
+      setDays('')
+      setUseDate('')
+      setLeaveTypeId('')
+      setReason('')
+      setError('')
+      setSubmitting(false)
+    }
+  }, [open, mode, userId])
+
+  const isAdd = mode === 'add'
+  const title = isAdd ? '연차 추가' : '연차 차감'
+  const headerToneClass = isAdd
+    ? 'bg-at-success-bg text-at-success'
+    : 'bg-at-error-bg text-at-error'
+  const reasonPlaceholder = isAdd
+    ? '예: 보충 연차 부여, 연차 양도 등'
+    : '예: 시스템 도입 전 사용한 연차'
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    const daysNumber = Number(days)
+    if (!days || isNaN(daysNumber) || daysNumber <= 0) {
+      setError('일수를 0보다 큰 값으로 입력해주세요.')
+      daysRef.current?.focus()
+      return
+    }
+    if (!reason.trim()) {
+      setError('사유를 입력해주세요.')
+      reasonRef.current?.focus()
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const result = await leaveService.addAdjustment({
+        user_id: userId,
+        adjustment_type: mode,
+        days: daysNumber,
+        year,
+        reason: reason.trim(),
+        leave_type_id: leaveTypeId || undefined,
+        use_date: useDate || undefined,
+      })
+
+      if (!result.success) {
+        setError(result.error || '저장에 실패했습니다.')
+        setSubmitting(false)
+        return
+      }
+
+      onSuccess()
+      onClose()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '저장 중 오류가 발생했습니다.'
+      setError(message)
+      setSubmitting(false)
+    }
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && !submitting) onClose()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="bg-white rounded-2xl border border-at-border max-w-md p-0 overflow-hidden">
+        <DialogHeader className={`${headerToneClass} px-6 py-4 space-y-1`}>
+          <DialogTitle className="text-lg font-semibold">{title}</DialogTitle>
+          <DialogDescription className="text-sm opacity-80">
+            {userName} 님의 {year}년 연차를 {isAdd ? '추가' : '차감'}합니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
+          {error && (
+            <div
+              role="alert"
+              className="bg-at-error-bg border border-red-200 text-at-error rounded-xl p-3 text-sm"
+            >
+              {error}
+            </div>
+          )}
+
+          {/* 일수 */}
+          <div>
+            <label htmlFor="adj-days" className="block text-sm font-medium text-at-text mb-1.5">
+              일수 <span className="text-at-error">*</span>
+            </label>
+            <input
+              id="adj-days"
+              ref={daysRef}
+              type="number"
+              step="0.5"
+              min="0.5"
+              value={days}
+              onChange={(e) => setDays(e.target.value)}
+              placeholder="예: 1, 0.5"
+              className="w-full px-3 py-2.5 border border-at-border rounded-xl text-[16px] text-at-text focus:outline-none focus:ring-2 focus:ring-at-accent"
+              disabled={submitting}
+            />
+          </div>
+
+          {/* 사용일자 (차감 모드만) */}
+          {!isAdd && (
+            <div>
+              <label htmlFor="adj-use-date" className="block text-sm font-medium text-at-text mb-1.5">
+                사용일자
+              </label>
+              <input
+                id="adj-use-date"
+                type="date"
+                value={useDate}
+                onChange={(e) => setUseDate(e.target.value)}
+                className="w-full px-3 py-2.5 border border-at-border rounded-xl text-[16px] text-at-text focus:outline-none focus:ring-2 focus:ring-at-accent"
+                disabled={submitting}
+              />
+            </div>
+          )}
+
+          {/* 연차 종류 */}
+          <div>
+            <label htmlFor="adj-type" className="block text-sm font-medium text-at-text mb-1.5">
+              연차 종류
+            </label>
+            <select
+              id="adj-type"
+              value={leaveTypeId}
+              onChange={(e) => setLeaveTypeId(e.target.value)}
+              className="w-full px-3 py-2.5 border border-at-border rounded-xl text-[16px] text-at-text focus:outline-none focus:ring-2 focus:ring-at-accent bg-white"
+              disabled={submitting}
+            >
+              <option value="">선택 안함</option>
+              {leaveTypes.map((lt) => (
+                <option key={lt.id} value={lt.id}>
+                  {lt.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* 사유 */}
+          <div>
+            <label htmlFor="adj-reason" className="block text-sm font-medium text-at-text mb-1.5">
+              사유 <span className="text-at-error">*</span>
+            </label>
+            <textarea
+              id="adj-reason"
+              ref={reasonRef}
+              rows={3}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder={reasonPlaceholder}
+              className="w-full px-3 py-2.5 border border-at-border rounded-xl text-[16px] text-at-text focus:outline-none focus:ring-2 focus:ring-at-accent resize-none"
+              disabled={submitting}
+            />
+          </div>
+
+          <DialogFooter className="pt-2 flex flex-row justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="px-4 py-2 rounded-xl border border-at-border bg-white hover:bg-at-surface-alt text-at-text text-sm font-medium disabled:opacity-50"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="px-4 py-2 rounded-xl bg-at-accent hover:bg-at-accent-hover text-white text-sm font-medium disabled:opacity-50"
+            >
+              {submitting ? '처리 중...' : isAdd ? '추가' : '차감'}
+            </button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/dental-clinic-manager/src/components/Leave/edit/modals/EditAdjustmentModal.tsx
+++ b/dental-clinic-manager/src/components/Leave/edit/modals/EditAdjustmentModal.tsx
@@ -1,0 +1,247 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { leaveService } from '@/lib/leaveService'
+import { appAlert } from '@/components/ui/AppDialog'
+import type { LeaveType, LeaveAdjustment } from '@/types/leave'
+
+export interface EditAdjustmentModalProps {
+  open: boolean
+  adjustment: LeaveAdjustment & {
+    leave_types?: { name: string; code: string } | null
+    adjusted_by_user?: { name: string } | null
+  }
+  leaveTypes: LeaveType[]
+  onClose: () => void
+  onSuccess: () => void
+}
+
+export default function EditAdjustmentModal({
+  open,
+  adjustment,
+  leaveTypes,
+  onClose,
+  onSuccess,
+}: EditAdjustmentModalProps) {
+  const [days, setDays] = useState<string>('')
+  const [useDate, setUseDate] = useState<string>('')
+  const [leaveTypeId, setLeaveTypeId] = useState<string>('')
+  const [reason, setReason] = useState<string>('')
+  const [error, setError] = useState<string>('')
+  const [submitting, setSubmitting] = useState<boolean>(false)
+
+  const daysRef = useRef<HTMLInputElement>(null)
+  const reasonRef = useRef<HTMLTextAreaElement>(null)
+
+  const isDeduct = adjustment?.adjustment_type === 'deduct'
+  const isAdd = adjustment?.adjustment_type === 'add'
+
+  // System auto-generated guard + prefill
+  useEffect(() => {
+    if (!open || !adjustment) return
+
+    const reasonValue = adjustment.reason || ''
+    if (reasonValue.startsWith('[병원휴무]') || reasonValue.startsWith('[법정공휴일]')) {
+      // Defensive: close immediately and notify
+      onClose()
+      void appAlert('시스템 자동 생성 항목은 수정할 수 없습니다.')
+      return
+    }
+
+    setDays(
+      adjustment.days !== undefined && adjustment.days !== null
+        ? String(adjustment.days)
+        : ''
+    )
+    setUseDate(adjustment.use_date || '')
+    setLeaveTypeId(adjustment.leave_type_id || '')
+    setReason(reasonValue)
+    setError('')
+    setSubmitting(false)
+  }, [open, adjustment, onClose])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    const daysNumber = Number(days)
+    if (!days || isNaN(daysNumber) || daysNumber <= 0) {
+      setError('일수를 0보다 큰 값으로 입력해주세요.')
+      daysRef.current?.focus()
+      return
+    }
+    if (!reason.trim()) {
+      setError('사유를 입력해주세요.')
+      reasonRef.current?.focus()
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const result = await leaveService.updateAdjustment(adjustment.id, {
+        days: daysNumber,
+        reason: reason.trim(),
+        use_date: useDate || null,
+        leave_type_id: leaveTypeId || null,
+      })
+
+      if (!result.success) {
+        setError(result.error || '저장에 실패했습니다.')
+        setSubmitting(false)
+        return
+      }
+
+      onSuccess()
+      onClose()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '저장 중 오류가 발생했습니다.'
+      setError(message)
+      setSubmitting(false)
+    }
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && !submitting) onClose()
+  }
+
+  if (!adjustment) return null
+
+  const badgeClass = isAdd
+    ? 'bg-at-success-bg text-at-success'
+    : 'bg-at-error-bg text-at-error'
+  const badgeLabel = isAdd ? '추가' : isDeduct ? '차감' : '조정'
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="bg-white rounded-2xl border border-at-border max-w-md p-0 overflow-hidden">
+        <DialogHeader className="px-6 py-4 space-y-1 border-b border-at-border">
+          <DialogTitle className="text-lg font-semibold text-at-text">
+            연차 조정 수정
+          </DialogTitle>
+          <DialogDescription className="text-sm text-at-text-secondary">
+            수동으로 추가/차감된 연차 조정을 수정합니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
+          {error && (
+            <div
+              role="alert"
+              className="bg-at-error-bg border border-red-200 text-at-error rounded-xl p-3 text-sm"
+            >
+              {error}
+            </div>
+          )}
+
+          {/* 유형 (읽기 전용 배지) */}
+          <div>
+            <span className="block text-sm font-medium text-at-text mb-1.5">유형</span>
+            <span
+              className={`inline-flex items-center px-2.5 py-1 rounded-xl text-xs font-medium ${badgeClass}`}
+            >
+              {badgeLabel}
+            </span>
+          </div>
+
+          {/* 일수 */}
+          <div>
+            <label htmlFor="eadj-days" className="block text-sm font-medium text-at-text mb-1.5">
+              일수 <span className="text-at-error">*</span>
+            </label>
+            <input
+              id="eadj-days"
+              ref={daysRef}
+              type="number"
+              step="0.5"
+              min="0.5"
+              value={days}
+              onChange={(e) => setDays(e.target.value)}
+              className="w-full px-3 py-2.5 border border-at-border rounded-xl text-[16px] text-at-text focus:outline-none focus:ring-2 focus:ring-at-accent"
+              disabled={submitting}
+            />
+          </div>
+
+          {/* 사용일자 (차감일 때만) */}
+          {isDeduct && (
+            <div>
+              <label htmlFor="eadj-use-date" className="block text-sm font-medium text-at-text mb-1.5">
+                사용일자
+              </label>
+              <input
+                id="eadj-use-date"
+                type="date"
+                value={useDate}
+                onChange={(e) => setUseDate(e.target.value)}
+                className="w-full px-3 py-2.5 border border-at-border rounded-xl text-[16px] text-at-text focus:outline-none focus:ring-2 focus:ring-at-accent"
+                disabled={submitting}
+              />
+            </div>
+          )}
+
+          {/* 연차 종류 */}
+          <div>
+            <label htmlFor="eadj-type" className="block text-sm font-medium text-at-text mb-1.5">
+              연차 종류
+            </label>
+            <select
+              id="eadj-type"
+              value={leaveTypeId}
+              onChange={(e) => setLeaveTypeId(e.target.value)}
+              className="w-full px-3 py-2.5 border border-at-border rounded-xl text-[16px] text-at-text focus:outline-none focus:ring-2 focus:ring-at-accent bg-white"
+              disabled={submitting}
+            >
+              <option value="">선택 안함</option>
+              {leaveTypes.map((lt) => (
+                <option key={lt.id} value={lt.id}>
+                  {lt.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* 사유 */}
+          <div>
+            <label htmlFor="eadj-reason" className="block text-sm font-medium text-at-text mb-1.5">
+              사유 <span className="text-at-error">*</span>
+            </label>
+            <textarea
+              id="eadj-reason"
+              ref={reasonRef}
+              rows={3}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className="w-full px-3 py-2.5 border border-at-border rounded-xl text-[16px] text-at-text focus:outline-none focus:ring-2 focus:ring-at-accent resize-none"
+              disabled={submitting}
+            />
+          </div>
+
+          <DialogFooter className="pt-2 flex flex-row justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="px-4 py-2 rounded-xl border border-at-border bg-white hover:bg-at-surface-alt text-at-text text-sm font-medium disabled:opacity-50"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="px-4 py-2 rounded-xl bg-at-accent hover:bg-at-accent-hover text-white text-sm font-medium disabled:opacity-50"
+            >
+              {submitting ? '처리 중...' : '저장'}
+            </button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/dental-clinic-manager/src/components/Leave/edit/modals/EditApprovedModal.tsx
+++ b/dental-clinic-manager/src/components/Leave/edit/modals/EditApprovedModal.tsx
@@ -1,0 +1,385 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { leaveService } from '@/lib/leaveService'
+import { appConfirm } from '@/components/ui/AppDialog'
+import type { LeaveType, HalfDayType } from '@/types/leave'
+
+export interface EditApprovedModalProps {
+  open: boolean
+  request: any
+  leaveTypes: LeaveType[]
+  onClose: () => void
+  onSuccess: () => void
+}
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+function diffInDays(start: string, end: string): number {
+  if (!start || !end) return 0
+  const s = new Date(start).getTime()
+  const e = new Date(end).getTime()
+  if (isNaN(s) || isNaN(e) || e < s) return 0
+  return Math.max(1, Math.floor((e - s) / ONE_DAY_MS) + 1)
+}
+
+export default function EditApprovedModal({
+  open,
+  request,
+  leaveTypes,
+  onClose,
+  onSuccess,
+}: EditApprovedModalProps) {
+  const [startDate, setStartDate] = useState<string>('')
+  const [endDate, setEndDate] = useState<string>('')
+  const [leaveTypeId, setLeaveTypeId] = useState<string>('')
+  const [totalDays, setTotalDays] = useState<string>('')
+  const [halfDayType, setHalfDayType] = useState<'' | HalfDayType>('')
+  const [reason, setReason] = useState<string>('')
+  const [autoCalc, setAutoCalc] = useState<boolean>(true)
+
+  const [error, setError] = useState<string>('')
+  const [submitting, setSubmitting] = useState<boolean>(false)
+  const [deleting, setDeleting] = useState<boolean>(false)
+
+  const startRef = useRef<HTMLInputElement>(null)
+  const endRef = useRef<HTMLInputElement>(null)
+  const daysRef = useRef<HTMLInputElement>(null)
+  const reasonRef = useRef<HTMLTextAreaElement>(null)
+
+  // Prefill on open / request change
+  useEffect(() => {
+    if (!open || !request) return
+    setStartDate(request.start_date || '')
+    setEndDate(request.end_date || '')
+    setLeaveTypeId(request.leave_type_id || '')
+    setTotalDays(
+      request.total_days !== undefined && request.total_days !== null
+        ? String(request.total_days)
+        : ''
+    )
+    const hdt = request.half_day_type
+    setHalfDayType(hdt === 'AM' || hdt === 'PM' ? hdt : '')
+    setReason(request.reason || '')
+    setAutoCalc(true)
+    setError('')
+    setSubmitting(false)
+    setDeleting(false)
+  }, [open, request])
+
+  // Auto re-calc when start/end/halfDay changes (only if autoCalc is true)
+  useEffect(() => {
+    if (!autoCalc) return
+    if (!startDate || !endDate) return
+    if (halfDayType && startDate === endDate) {
+      setTotalDays('0.5')
+    } else {
+      const days = diffInDays(startDate, endDate)
+      if (days > 0) setTotalDays(String(days))
+    }
+  }, [startDate, endDate, halfDayType, autoCalc])
+
+  const halfDayEnabled = startDate === endDate && Number(totalDays) === 0.5
+  const halfDayCanToggle = startDate && endDate && startDate === endDate
+
+  const handleDaysChange = (value: string) => {
+    setAutoCalc(false)
+    setTotalDays(value)
+  }
+
+  const handleHalfDayChange = (val: '' | HalfDayType) => {
+    setHalfDayType(val)
+    // when user explicitly toggles half-day, allow auto-calc to apply 0.5
+    if (val) {
+      setAutoCalc(true)
+    }
+  }
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    if (!startDate) {
+      setError('시작일을 입력해주세요.')
+      startRef.current?.focus()
+      return
+    }
+    if (!endDate) {
+      setError('종료일을 입력해주세요.')
+      endRef.current?.focus()
+      return
+    }
+    if (new Date(endDate) < new Date(startDate)) {
+      setError('종료일은 시작일 이후여야 합니다.')
+      endRef.current?.focus()
+      return
+    }
+    const daysNumber = Number(totalDays)
+    if (!totalDays || isNaN(daysNumber) || daysNumber <= 0) {
+      setError('일수를 0보다 큰 값으로 입력해주세요.')
+      daysRef.current?.focus()
+      return
+    }
+    if (!leaveTypeId) {
+      setError('연차 종류를 선택해주세요.')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const result = await leaveService.updateApprovedRequest(request.id, {
+        start_date: startDate,
+        end_date: endDate,
+        leave_type_id: leaveTypeId,
+        total_days: daysNumber,
+        half_day_type: halfDayType ? halfDayType : null,
+        reason: reason.trim(),
+      })
+
+      if (!result.success) {
+        setError(result.error || '저장에 실패했습니다.')
+        setSubmitting(false)
+        return
+      }
+
+      onSuccess()
+      onClose()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '저장 중 오류가 발생했습니다.'
+      setError(message)
+      setSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    setError('')
+    const confirmed = await appConfirm({
+      title: '연차 삭제',
+      description: '승인된 연차를 삭제하면 잔여 연차가 복구됩니다. 계속하시겠습니까?',
+      variant: 'destructive',
+      confirmText: '삭제',
+    })
+    if (!confirmed) return
+
+    setDeleting(true)
+    try {
+      const result = await leaveService.deleteApprovedRequest(request.id)
+      if (!result.success) {
+        setError(result.error || '삭제에 실패했습니다.')
+        setDeleting(false)
+        return
+      }
+      onSuccess()
+      onClose()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '삭제 중 오류가 발생했습니다.'
+      setError(message)
+      setDeleting(false)
+    }
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && !submitting && !deleting) onClose()
+  }
+
+  if (!request) return null
+
+  const userName = request.users?.name || '직원'
+  const busy = submitting || deleting
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="bg-white rounded-2xl border border-at-border max-w-md p-0 overflow-hidden">
+        <DialogHeader className="px-6 py-4 space-y-1 border-b border-at-border">
+          <DialogTitle className="text-lg font-semibold text-at-text">승인된 연차 수정</DialogTitle>
+          <DialogDescription className="text-sm text-at-text-secondary">
+            {userName} 님의 승인된 연차를 수정합니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSave} className="px-6 py-5 space-y-4">
+          {error && (
+            <div
+              role="alert"
+              className="bg-at-error-bg border border-red-200 text-at-error rounded-xl p-3 text-sm"
+            >
+              {error}
+            </div>
+          )}
+
+          {/* 시작일 / 종료일 */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label htmlFor="ea-start" className="block text-sm font-medium text-at-text mb-1.5">
+                시작일 <span className="text-at-error">*</span>
+              </label>
+              <input
+                id="ea-start"
+                ref={startRef}
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                className="w-full px-3 py-2.5 border border-at-border rounded-xl text-[16px] text-at-text focus:outline-none focus:ring-2 focus:ring-at-accent"
+                disabled={busy}
+              />
+            </div>
+            <div>
+              <label htmlFor="ea-end" className="block text-sm font-medium text-at-text mb-1.5">
+                종료일 <span className="text-at-error">*</span>
+              </label>
+              <input
+                id="ea-end"
+                ref={endRef}
+                type="date"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                className="w-full px-3 py-2.5 border border-at-border rounded-xl text-[16px] text-at-text focus:outline-none focus:ring-2 focus:ring-at-accent"
+                disabled={busy}
+              />
+            </div>
+          </div>
+
+          {/* 연차 종류 */}
+          <div>
+            <label htmlFor="ea-type" className="block text-sm font-medium text-at-text mb-1.5">
+              연차 종류 <span className="text-at-error">*</span>
+            </label>
+            <select
+              id="ea-type"
+              value={leaveTypeId}
+              onChange={(e) => setLeaveTypeId(e.target.value)}
+              className="w-full px-3 py-2.5 border border-at-border rounded-xl text-[16px] text-at-text focus:outline-none focus:ring-2 focus:ring-at-accent bg-white"
+              disabled={busy}
+            >
+              <option value="">선택해주세요</option>
+              {leaveTypes.map((lt) => (
+                <option key={lt.id} value={lt.id}>
+                  {lt.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* 일수 */}
+          <div>
+            <label htmlFor="ea-days" className="block text-sm font-medium text-at-text mb-1.5">
+              일수 <span className="text-at-error">*</span>
+            </label>
+            <input
+              id="ea-days"
+              ref={daysRef}
+              type="number"
+              step="0.5"
+              min="0.5"
+              value={totalDays}
+              onChange={(e) => handleDaysChange(e.target.value)}
+              className="w-full px-3 py-2.5 border border-at-border rounded-xl text-[16px] text-at-text focus:outline-none focus:ring-2 focus:ring-at-accent"
+              disabled={busy}
+            />
+            {!autoCalc && (
+              <p className="mt-1 text-xs text-at-text-weak">
+                수동 입력됨 · 시작일/종료일 변경 시 자동 재계산되지 않습니다.
+              </p>
+            )}
+          </div>
+
+          {/* 반차 타입 */}
+          <div>
+            <span className="block text-sm font-medium text-at-text mb-1.5">반차 타입</span>
+            <div className="flex items-center gap-3">
+              {([
+                { value: '', label: '없음' },
+                { value: 'AM', label: '오전' },
+                { value: 'PM', label: '오후' },
+              ] as const).map((opt) => {
+                const disabled =
+                  busy ||
+                  (opt.value !== '' && !halfDayCanToggle)
+                return (
+                  <label
+                    key={opt.value || 'none'}
+                    className={`inline-flex items-center gap-1.5 text-sm ${
+                      disabled ? 'text-at-text-weak cursor-not-allowed' : 'text-at-text cursor-pointer'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="ea-half-day"
+                      value={opt.value}
+                      checked={halfDayType === opt.value}
+                      onChange={() => handleHalfDayChange(opt.value)}
+                      disabled={disabled}
+                      className="accent-at-accent"
+                    />
+                    {opt.label}
+                  </label>
+                )
+              })}
+            </div>
+            {!halfDayCanToggle && (
+              <p className="mt-1 text-xs text-at-text-weak">
+                반차는 시작일과 종료일이 같을 때만 선택할 수 있습니다.
+              </p>
+            )}
+          </div>
+
+          {/* 사유 */}
+          <div>
+            <label htmlFor="ea-reason" className="block text-sm font-medium text-at-text mb-1.5">
+              사유
+            </label>
+            <textarea
+              id="ea-reason"
+              ref={reasonRef}
+              rows={2}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className="w-full px-3 py-2.5 border border-at-border rounded-xl text-[16px] text-at-text focus:outline-none focus:ring-2 focus:ring-at-accent resize-none"
+              disabled={busy}
+            />
+          </div>
+
+          <DialogFooter className="pt-2 flex flex-row sm:justify-between items-center gap-2">
+            {/* 좌측: 삭제 */}
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={busy}
+              aria-label="이 연차 삭제"
+              className="text-at-error hover:bg-at-error-bg rounded-xl px-3 py-2 text-sm font-medium disabled:opacity-50"
+            >
+              {deleting ? '삭제 중...' : '삭제'}
+            </button>
+
+            {/* 우측: 취소 / 저장 */}
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={busy}
+                className="px-4 py-2 rounded-xl border border-at-border bg-white hover:bg-at-surface-alt text-at-text text-sm font-medium disabled:opacity-50"
+              >
+                취소
+              </button>
+              <button
+                type="submit"
+                disabled={busy}
+                className="px-4 py-2 rounded-xl bg-at-accent hover:bg-at-accent-hover text-white text-sm font-medium disabled:opacity-50"
+              >
+                {submitting ? '처리 중...' : '저장'}
+              </button>
+            </div>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/dental-clinic-manager/src/lib/leaveService.ts
+++ b/dental-clinic-manager/src/lib/leaveService.ts
@@ -1810,6 +1810,69 @@ export const leaveService = {
   },
 
   /**
+   * 연차 조정 수정 (관리자용)
+   * leave_adjustments 레코드의 일수/사유/사용일자 수정 후 잔여 연차 재계산
+   */
+  async updateAdjustment(
+    adjustmentId: string,
+    updates: {
+      days?: number
+      reason?: string
+      use_date?: string | null
+      leave_type_id?: string | null
+    }
+  ): Promise<{ success: boolean; error: string | null }> {
+    try {
+      const supabase = await ensureConnection()
+      if (!supabase) throw new Error('Database connection failed')
+
+      const user = getCurrentUser()
+      if (!user) throw new Error('User not found')
+
+      if (user.role !== 'owner' && user.role !== 'manager') {
+        throw new Error('권한이 없습니다.')
+      }
+
+      const { data: existing, error: fetchError } = await (supabase as any)
+        .from('leave_adjustments')
+        .select('user_id, year, reason')
+        .eq('id', adjustmentId)
+        .single()
+
+      if (fetchError) throw fetchError
+      if (!existing) throw new Error('조정 내역을 찾을 수 없습니다.')
+
+      // 시스템 자동 생성 항목은 수정 금지 (UI에서도 차단하지만 방어적으로 한 번 더)
+      const reason: string = existing.reason || ''
+      if (reason.startsWith('[병원휴무]') || reason.startsWith('[법정공휴일]')) {
+        throw new Error('시스템에서 자동 생성된 조정 내역은 수정할 수 없습니다.')
+      }
+
+      const updateData: Record<string, unknown> = {
+        updated_at: new Date().toISOString(),
+      }
+      if (typeof updates.days === 'number') updateData.days = updates.days
+      if (typeof updates.reason === 'string') updateData.reason = updates.reason
+      if (updates.use_date !== undefined) updateData.use_date = updates.use_date
+      if (updates.leave_type_id !== undefined) updateData.leave_type_id = updates.leave_type_id
+
+      const { error } = await (supabase as any)
+        .from('leave_adjustments')
+        .update(updateData)
+        .eq('id', adjustmentId)
+
+      if (error) throw error
+
+      await this.initializeBalance(existing.user_id, existing.year)
+
+      return { success: true, error: null }
+    } catch (error) {
+      console.error('[leaveService.updateAdjustment] Error:', error)
+      return { success: false, error: extractErrorMessage(error) }
+    }
+  },
+
+  /**
    * 조정 삭제
    */
   async deleteAdjustment(adjustmentId: string): Promise<{ success: boolean; error: string | null }> {

--- a/dental-clinic-manager/src/types/leave.ts
+++ b/dental-clinic-manager/src/types/leave.ts
@@ -552,6 +552,58 @@ export interface LeaveConflictCheck {
 }
 
 /**
+ * 수동 연차 조정
+ * Leave Adjustment (관리자가 수동으로 추가/차감하는 기록)
+ */
+export interface LeaveAdjustment {
+  id: string;
+  user_id: string;
+  clinic_id: string;
+
+  adjustment_type: LeaveAdjustmentType; // 'deduct' | 'add' | 'set'
+  days: number; // 조정 일수
+  year: number; // 입사일 기준 연차 기간의 시작 연도
+
+  reason: string; // 조정 사유 (시스템 생성: '[병원휴무]', '[법정공휴일]' prefix)
+  leave_type_id?: string | null;
+  use_date?: string | null; // 차감일 때의 사용 일자
+
+  adjusted_by: string; // 조정한 관리자 ID
+  adjusted_at: string;
+
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * 연차 조정 유형
+ */
+export type LeaveAdjustmentType = 'deduct' | 'add' | 'set';
+
+/**
+ * 연차 조정 입력 DTO
+ */
+export interface LeaveAdjustmentInput {
+  user_id: string;
+  adjustment_type: LeaveAdjustmentType;
+  days: number;
+  year: number;
+  reason: string;
+  leave_type_id?: string;
+  use_date?: string;
+}
+
+/**
+ * 연차 조정 수정 DTO
+ */
+export interface LeaveAdjustmentUpdateInput {
+  days?: number;
+  reason?: string;
+  use_date?: string | null;
+  leave_type_id?: string | null;
+}
+
+/**
  * 연차 종류 한글 매핑
  */
 export const LEAVE_TYPE_NAMES: Record<LeaveTypeCode, string> = {


### PR DESCRIPTION
## Summary

- **fix(css)**: 테이블 셀 글자 강제 검정 글로벌 규칙(`!important`)이 디자인 시스템의 버튼 글자색(`text-white`)을 덮어쓰던 문제 해결. 요일별 스케줄 저장 버튼이 흰색이 아닌 검정으로 보이던 회귀 픽스
- **feat(leave)**: 연차 수정 페이지를 단일 화면 통합 + 모달 구조로 재설계 (직원 선택, 요약, 조정 테이블, 승인 이력, 편집 모달 등 분리된 컴포넌트로 구조화)

## Test plan

- [ ] 근무 관리 → 요일별 스케줄 → 직원 행에서 "수정" 클릭 → 저장 버튼 글자가 흰색으로 보이는지 확인
- [ ] 다른 테이블 안의 버튼들도 디자인 시스템 색상이 정상 적용되는지 확인 (회귀 없음)
- [ ] 연차 관리 → 수정 페이지에서 직원 선택, 조정 추가/편집/삭제, 승인 이력 편집 정상 동작
- [ ] 모바일 뷰포트에서 모달 레이아웃 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)