### PR TITLE
fix(types): notification.ts monthly_report_ready 타입 누락 보완 (Vercel 빌드 실패 핫픽스)

### DIFF
--- a/dental-clinic-manager/src/types/notification.ts
+++ b/dental-clinic-manager/src/types/notification.ts
@@ -315,6 +315,7 @@ export type UserNotificationType =
   | 'system'                      // 시스템 알림
   | 'subscription_upgrade_required'  // 구독 업그레이드 필요 (원장에게)
   | 'subscription_payment_succeeded' // 결제 성공 후 대기자 승인 안내 (원장에게)
+  | 'monthly_report_ready'           // 월간 성과 보고서 생성 완료 (대표원장/실장에게)
 
 // 사용자 알림 타입 라벨
 export const USER_NOTIFICATION_TYPE_LABELS: Record<UserNotificationType, string> = {
@@ -341,7 +342,8 @@ export const USER_NOTIFICATION_TYPE_LABELS: Record<UserNotificationType, string>
   important: '중요 알림',
   system: '시스템 알림',
   subscription_upgrade_required: '구독 업그레이드 필요',
-  subscription_payment_succeeded: '결제 완료 · 승인 대기'
+  subscription_payment_succeeded: '결제 완료 · 승인 대기',
+  monthly_report_ready: '월간 성과 보고서'
 }
 
 // 사용자 알림 아이콘 매핑
@@ -369,7 +371,8 @@ export const USER_NOTIFICATION_TYPE_ICONS: Record<UserNotificationType, string> 
   important: 'exclamation-circle',
   system: 'bell',
   subscription_upgrade_required: 'alert-circle',
-  subscription_payment_succeeded: 'credit-card'
+  subscription_payment_succeeded: 'credit-card',
+  monthly_report_ready: 'file-bar-chart-2'
 }
 
 // 사용자 알림 색상 매핑
@@ -397,7 +400,8 @@ export const USER_NOTIFICATION_TYPE_COLORS: Record<UserNotificationType, { icon:
   important: { icon: 'text-red-500', bg: 'bg-red-50', text: 'text-red-700' },
   system: { icon: 'text-blue-500', bg: 'bg-blue-50', text: 'text-blue-700' },
   subscription_upgrade_required: { icon: 'text-amber-500', bg: 'bg-amber-50', text: 'text-amber-700' },
-  subscription_payment_succeeded: { icon: 'text-emerald-500', bg: 'bg-emerald-50', text: 'text-emerald-700' }
+  subscription_payment_succeeded: { icon: 'text-emerald-500', bg: 'bg-emerald-50', text: 'text-emerald-700' },
+  monthly_report_ready: { icon: 'text-indigo-500', bg: 'bg-indigo-50', text: 'text-indigo-700' }
 }
 
 // 사용자 알림 인터페이스


### PR DESCRIPTION
## 문제

Vercel production 빌드 (PR #401, #402 머지 후)가 다음 타입 에러로 실패:

\`\`\`
./src/components/Layout/UserNotificationDropdown.tsx:54:3
Type error: Object literal may only specify known properties, and
'monthly_report_ready' does not exist in type
'Record<UserNotificationType, ComponentType<{ className?: string | undefined; }>>'
\`\`\`

## 원인

PR #401(\`smart-money fix\`)에 부가 수정으로 \`UserNotificationDropdown.tsx\`의 \`NotificationTypeIcons\`에 \`monthly_report_ready: DocumentTextIcon\` 매핑을 추가. 그러나 type 정의(\`UserNotificationType\` union 등)는 develop 브랜치에 별개로 있는 monthly-report 기능 commit에만 존재 — main 브랜치엔 type 정의 없이 매핑만 들어가서 \"unknown property\" 에러 발생.

## 수정

\`src/types/notification.ts\`의 4개 정의에 \`monthly_report_ready\` 추가:
- \`UserNotificationType\` union
- \`USER_NOTIFICATION_TYPE_LABELS\` Record
- \`USER_NOTIFICATION_TYPE_ICONS\` Record  
- \`USER_NOTIFICATION_TYPE_COLORS\` Record

라벨/아이콘/색상 값은 develop 브랜치의 monthly-report 기능 commit과 동일하게 적용 (\"월간 성과 보고서\" / \"file-bar-chart-2\" / indigo).

## 검증

- \`npm run build\` 통과 (clean rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)