### PR TITLE
fix(monthly-report): 과거 매출 12개월 추이 표시 — backfill 범위 24개월

### DIFF
--- a/dental-clinic-manager/src/app/api/dentweb/request-revenue-sync/route.ts
+++ b/dental-clinic-manager/src/app/api/dentweb/request-revenue-sync/route.ts
@@ -6,12 +6,13 @@ const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
 
 /**
  * POST: 특정 월 또는 전체 과거 데이터 수입 동기화 요청
- * - mode: 'single' (단일 월) 또는 'backfill' (올해 전체 + 전년도 최근 3개월)
+ * - mode: 'single' (단일 월) 또는 'backfill' (직전 N개월, default 24)
+ * - months_back: backfill 모드에서 직전 몇 개월을 채울지 (1~48, default 24)
  */
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { clinic_id, mode, year, month } = body
+    const { clinic_id, mode, year, month, months_back } = body
 
     if (!clinic_id) {
       return NextResponse.json({ success: false, error: 'clinic_id가 필요합니다.' }, { status: 400 })
@@ -36,17 +37,16 @@ export async function POST(request: NextRequest) {
     let newMonths: Array<{ year: number; month: number }> = []
 
     if (mode === 'backfill') {
-      // 올해 1월~현재월 + 전년도 10~12월
+      // 직전 N개월 (default 24, 최대 48) — 월간 보고서 12개월 윈도우 + 여유분
+      const requestedBack = Number.isFinite(Number(months_back)) ? parseInt(months_back) : 24
+      const monthsBack = Math.max(1, Math.min(48, requestedBack))
       const now = new Date()
-      const currentYear = now.getFullYear()
-      const currentMonth = now.getMonth() + 1
-
-      for (let m = 1; m <= currentMonth; m++) {
-        newMonths.push({ year: currentYear, month: m })
+      for (let i = monthsBack; i >= 1; i--) {
+        const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
+        newMonths.push({ year: d.getFullYear(), month: d.getMonth() + 1 })
       }
-      for (let m = 10; m <= 12; m++) {
-        newMonths.push({ year: currentYear - 1, month: m })
-      }
+      // 현재월도 포함 (덴트웹 워커가 진행 중인 월의 누적 매출 갱신)
+      newMonths.push({ year: now.getFullYear(), month: now.getMonth() + 1 })
     } else {
       // 단일 월
       if (!year || !month) {

--- a/dental-clinic-manager/src/components/MonthlyReport/MonthlyReportContainer.tsx
+++ b/dental-clinic-manager/src/components/MonthlyReport/MonthlyReportContainer.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/contexts/AuthContext'
 import { usePermissions } from '@/hooks/usePermissions'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/Button'
-import { ChevronLeft, ChevronRight, RefreshCw, FileBarChart2 } from 'lucide-react'
+import { ChevronLeft, ChevronRight, RefreshCw, FileBarChart2, Download } from 'lucide-react'
 import type { MonthlyReport } from '@/types/monthlyReport'
 import SummaryCards from './SummaryCards'
 import RevenueTrendChart from './RevenueTrendChart'
@@ -33,6 +33,8 @@ export default function MonthlyReportContainer() {
   const [error, setError] = useState<string | null>(null)
   const [regenerating, setRegenerating] = useState(false)
   const [accessDenied, setAccessDenied] = useState(false)
+  const [backfillLoading, setBackfillLoading] = useState(false)
+  const [backfillMessage, setBackfillMessage] = useState<string | null>(null)
 
   const queryYear = searchParams?.get('year')
   const queryMonth = searchParams?.get('month')
@@ -137,6 +139,35 @@ export default function MonthlyReportContainer() {
     }
   }
 
+  const handleBackfillRevenue = async () => {
+    if (!user?.clinic_id) return
+    setBackfillLoading(true)
+    setBackfillMessage(null)
+    setError(null)
+    try {
+      const res = await fetch('/api/dentweb/request-revenue-sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clinic_id: user.clinic_id, mode: 'backfill', months_back: 24 }),
+      })
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok || !json.success) {
+        throw new Error(json?.error ?? '동기화 요청 실패')
+      }
+      const added = json?.data?.added_count ?? 0
+      const total = json?.data?.total_pending ?? 0
+      setBackfillMessage(
+        added > 0
+          ? `과거 ${added}개월 동기화 요청 등록 완료 (대기 중 ${total}건). 워커가 처리하면 데이터가 채워집니다. 잠시 후 "재생성" 버튼을 눌러 반영하세요.`
+          : '추가로 동기화할 과거 월이 없습니다 (이미 데이터가 있거나 요청이 등록되어 있습니다).',
+      )
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '동기화 요청 중 오류 발생')
+    } finally {
+      setBackfillLoading(false)
+    }
+  }
+
   const navigateMonth = (delta: number) => {
     if (!report) return
     let y = report.year
@@ -224,6 +255,18 @@ export default function MonthlyReportContainer() {
               </Button>
             </div>
           )}
+          {canManage && (
+            <Button
+              variant="outline"
+              onClick={handleBackfillRevenue}
+              disabled={backfillLoading}
+              className="gap-2"
+              title="덴트웹의 과거 24개월 매출을 다시 가져옵니다 (이미 있는 월은 건너뜀)"
+            >
+              <Download className={`w-4 h-4 ${backfillLoading ? 'animate-pulse' : ''}`} />
+              과거 매출 가져오기
+            </Button>
+          )}
           {canManage && report && (
             <Button
               variant="outline"
@@ -237,6 +280,15 @@ export default function MonthlyReportContainer() {
           )}
         </div>
       </div>
+
+      {/* 동기화 요청 안내 */}
+      {backfillMessage && (
+        <Card>
+          <CardContent className="p-4 text-sm text-indigo-700 bg-indigo-50 border-l-4 border-indigo-300 rounded-xl">
+            {backfillMessage}
+          </CardContent>
+        </Card>
+      )}
 
       {/* 에러 표시 */}
       {error && (


### PR DESCRIPTION
## 문제

월간 성과 보고서의 **매출 추이 차트에서 12개월 중 절반 이상이 비어있는** 현상.
예: 4월 기준 윈도우는 \`2025-05 ~ 2026-04\`인데 \`2025-12\` 이전이 모두 0으로 표시.

## 근본 원인

\`request-revenue-sync\` API의 \`backfill\` 모드가 *"올해 1월~현재월 + 전년도 10~12월"* 로 좁게 한정.
- 4월 호출: pending에 \`2026-01~04\` + \`2025-10~12\` (총 7개월)
- **누락**: \`2025-05~2025-09\` (5개월) → 워커가 영원히 가져오지 않음

## 수정

1. **backfill 범위 24개월로 확장** — 월간 보고서 12개월 윈도우 + 여유분
2. **months_back 파라미터 지원** (1~48, default 24) — 사용자 정의 가능
3. **월간 보고서 페이지에 "과거 매출 가져오기" 버튼 추가** — owner/master_admin만 노출, 워커 동기화 안내 메시지

## 사용자 동작

1. \`/dashboard/monthly-report\` 접속 → "과거 매출 가져오기" 클릭
2. pending에 누락 월이 추가되면 "X개월 동기화 요청 등록 완료" 메시지 표시
3. Electron 워커가 덴트웹에서 그 월 매출을 가져와 \`revenue_records\`에 채움
4. "재생성" 버튼으로 보고서 갱신 → 12개월 모두 표시됨

## 검증
- \`npm run build\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)