### PR TITLE
feat: 대시보드 병원 일정 위젯 + 연차 휴무일 차감 수정

### DIFF
--- a/dental-clinic-manager/docs/superpowers/plans/2026-04-29-dashboard-schedule-widget.md
+++ b/dental-clinic-manager/docs/superpowers/plans/2026-04-29-dashboard-schedule-widget.md
@@ -1,0 +1,1588 @@
+# 대시보드 병원 일정 위젯 — 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 대시보드 홈에 오늘/주간/월간 탭을 가진 "병원 일정" 위젯을 추가하여, 게시판의 일정·휴무 공지와 병원·법정 공휴일을 한곳에서 확인할 수 있게 한다.
+
+**Architecture:** 새 컴포넌트 `src/components/Dashboard/ScheduleWidget/`을 만들어 `DashboardHome.tsx`의 좌측 메인 칼럼 최상단에 삽입한다. 데이터는 `useScheduleData` 훅 내부에서 `announcementService` + `holidayService`를 병렬 호출 → 정규화 머지 → 정렬한다. 본문 미리보기는 새 메서드 `getAnnouncementPreview`(조회수 미증가)로 lazy 로드하며, XSS 방어는 기존 `sanitizeHtml` 유틸을 재사용한다.
+
+**Tech Stack:** Next.js 15 / React 19 / TypeScript / Tailwind / shadcn(Card, Dialog) / lucide-react / Supabase / DOMPurify(`@/utils/sanitize`).
+
+**Spec:** [docs/superpowers/specs/2026-04-29-dashboard-schedule-widget-design.md](../specs/2026-04-29-dashboard-schedule-widget-design.md)
+
+---
+
+## File Structure
+
+**New files:**
+- `src/components/Dashboard/ScheduleWidget/index.tsx` — 메인 카드 + 탭 컨테이너
+- `src/components/Dashboard/ScheduleWidget/types.ts` — 정규화 타입 (`ScheduleEvent`, `ViewType`, `ScheduleBadgeKind`)
+- `src/components/Dashboard/ScheduleWidget/scheduleParser.ts` — 본문 날짜 추출 (pure)
+- `src/components/Dashboard/ScheduleWidget/useScheduleData.ts` — 3개 소스 병렬 페치 + 머지 + 정렬
+- `src/components/Dashboard/ScheduleWidget/ScheduleItem.tsx` — 한 줄 일정 표시
+- `src/components/Dashboard/ScheduleWidget/ScheduleDateGroup.tsx` — 날짜별 그룹 헤더 + 항목들
+- `src/components/Dashboard/ScheduleWidget/TodayView.tsx` — 오늘 탭 콘텐츠
+- `src/components/Dashboard/ScheduleWidget/WeekView.tsx` — 주간 탭 콘텐츠
+- `src/components/Dashboard/ScheduleWidget/MonthView.tsx` — 월간 탭 콘텐츠
+- `src/components/Dashboard/ScheduleWidget/ScheduleDetailModal.tsx` — 클릭 시 본문 미리보기
+
+**Modified files:**
+- `src/lib/bulletinService.ts` — `getAnnouncementPreview(id)` 메서드 추가 (조회수 미증가 버전)
+- `src/components/Dashboard/DashboardHome.tsx` — 좌측 메인 칼럼 최상단(오늘의 현황 위)에 `<ScheduleWidget />` 삽입
+
+---
+
+## Conventions
+
+- 파일 인용: `src/...` 절대 경로
+- 빌드 명령: `npm run build` (앱 루트 `dental-clinic-manager/dental-clinic-manager/`)
+- 개발 서버: `npm run dev`
+- 테스트 계정: `whitedc0902@gmail.com` / `ghkdgmltn81!`
+- Git: 각 task 완료마다 develop 브랜치에 커밋 (push는 모든 task 끝낸 후 한 번)
+- TDD가 가능한 환경이 아니므로(테스트 프레임워크 미설치) 각 task는 "코드 작성 → 빌드 검증 → 커밋" 사이클로 진행한다. 단위 검증이 필요한 순수함수(`scheduleParser`)는 Task 13의 통합 검증에서 동작 확인으로 갈음한다.
+
+---
+
+## Task 1: announcementService에 미리보기용 조회 메서드 추가
+
+**Why:** 기존 `getAnnouncement(id)`는 자동으로 조회수 증가 RPC(`increment_announcement_view_count`)를 호출한다. spec에 따르면 미리보기 모달은 조회수를 늘리지 말아야 하므로, 별도 메서드가 필요하다.
+
+**Files:**
+- Modify: `src/lib/bulletinService.ts` (announcementService 객체 안, `getAnnouncement` 바로 아래에 추가)
+
+- [ ] **Step 1: 메서드 추가**
+
+`src/lib/bulletinService.ts`의 `announcementService = {` 블록 안, `getAnnouncement` 메서드 정의 직후에 다음을 추가한다 (line 200 직후, `createAnnouncement` 직전):
+
+```typescript
+  /**
+   * 공지사항 상세 조회 — 조회수 미증가 (대시보드 미리보기용)
+   */
+  async getAnnouncementPreview(id: string): Promise<{ data: Announcement | null; error: string | null }> {
+    try {
+      const supabase = await ensureConnection()
+      if (!supabase) throw new Error('Database connection failed')
+
+      const { data, error } = await (supabase as any)
+        .from('announcements')
+        .select('*')
+        .eq('id', id)
+        .single()
+
+      if (error) throw error
+
+      // author 이름 조회 (조회수 증가 RPC는 호출하지 않음)
+      const nameMap = await getUserNames(supabase, [data.author_id])
+
+      return {
+        data: {
+          ...data,
+          author_name: nameMap[data.author_id] || '알 수 없음',
+        },
+        error: null,
+      }
+    } catch (error) {
+      console.error('[announcementService.getAnnouncementPreview] Error:', error)
+      return { data: null, error: extractErrorMessage(error) }
+    }
+  },
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+cd dental-clinic-manager && npm run build
+```
+
+Expected: 빌드 성공 (타입 에러 없음)
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/lib/bulletinService.ts
+git commit -m "feat(bulletin): add getAnnouncementPreview for view-count-safe lookup"
+```
+
+---
+
+## Task 2: 정규화 타입 정의
+
+**Files:**
+- Create: `src/components/Dashboard/ScheduleWidget/types.ts`
+
+- [ ] **Step 1: 디렉토리 생성**
+
+```bash
+mkdir -p src/components/Dashboard/ScheduleWidget
+```
+
+- [ ] **Step 2: types.ts 작성**
+
+`src/components/Dashboard/ScheduleWidget/types.ts`:
+
+```typescript
+export type ViewType = 'today' | 'week' | 'month'
+
+export type ScheduleSource = 'announcement' | 'clinic_holiday' | 'public_holiday'
+
+export type ScheduleBadgeKind = 'clinic_holiday' | 'public_holiday' | 'schedule' | 'holiday_announcement'
+
+export interface ScheduleEvent {
+  id: string
+  source: ScheduleSource
+  startDate: string
+  endDate: string
+  title: string
+  badgeKind: ScheduleBadgeKind
+  isPinned?: boolean
+  isImportant?: boolean
+  announcementId?: string
+}
+
+export interface DateRange {
+  start: string
+  end: string
+}
+```
+
+- [ ] **Step 3: 빌드 검증**
+
+```bash
+cd dental-clinic-manager && npm run build
+```
+
+Expected: 성공
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/components/Dashboard/ScheduleWidget/types.ts
+git commit -m "feat(schedule-widget): define ScheduleEvent normalized types"
+```
+
+---
+
+## Task 3: 본문 날짜 추출 유틸 (scheduleParser)
+
+**Why:** 공지사항의 `start_date`/`end_date`가 비어 있을 때 본문(`content`) 첫 매치에서 한국식·기간 표현 날짜를 추출한다.
+
+**Files:**
+- Create: `src/components/Dashboard/ScheduleWidget/scheduleParser.ts`
+
+- [ ] **Step 1: scheduleParser.ts 작성**
+
+```typescript
+/**
+ * 공지사항 본문에서 날짜/기간을 추출하는 순수 유틸.
+ * - start_date/end_date가 비어 있는 공지에 한해 호출.
+ * - 본문의 "첫 매치"만 반환 (다중 날짜 언급 시 가장 앞 매치를 일정 시작으로 간주).
+ * - 연도 생략 시 currentYear 기본; 추출 결과가 currentDate 기준 6개월 이전이면 다음 해로 보정.
+ */
+
+export interface ParsedRange {
+  startDate: string
+  endDate: string
+}
+
+const RE_FULL_DATE = /(\d{4})[-./년]\s?(\d{1,2})[-./월]\s?(\d{1,2})\s?일?/
+const RE_SHORT_DATE = /(\d{1,2})\s?월\s?(\d{1,2})\s?일/
+const RE_RANGE_SEPARATOR = /^\s*[~\-–]\s*/
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+function buildIso(year: number, month: number, day: number): string | null {
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null
+  const d = new Date(`${year}-${pad2(month)}-${pad2(day)}T00:00:00`)
+  if (
+    d.getFullYear() !== year ||
+    d.getMonth() !== month - 1 ||
+    d.getDate() !== day
+  ) {
+    return null
+  }
+  return `${year}-${pad2(month)}-${pad2(day)}`
+}
+
+interface RawDate {
+  year?: number
+  month: number
+  day: number
+}
+
+interface MatchResult {
+  raw: RawDate
+  matchStartAbs: number
+  matchEndAbs: number
+}
+
+function matchSingleAt(text: string, fromIndex: number): MatchResult | null {
+  const slice = text.slice(fromIndex)
+  const fullMatch = slice.match(RE_FULL_DATE)
+  const shortMatch = slice.match(RE_SHORT_DATE)
+
+  const candidates: Array<{ idx: number; len: number; raw: RawDate }> = []
+  if (fullMatch && fullMatch.index !== undefined) {
+    candidates.push({
+      idx: fullMatch.index,
+      len: fullMatch[0].length,
+      raw: {
+        year: parseInt(fullMatch[1], 10),
+        month: parseInt(fullMatch[2], 10),
+        day: parseInt(fullMatch[3], 10),
+      },
+    })
+  }
+  if (shortMatch && shortMatch.index !== undefined) {
+    candidates.push({
+      idx: shortMatch.index,
+      len: shortMatch[0].length,
+      raw: {
+        month: parseInt(shortMatch[1], 10),
+        day: parseInt(shortMatch[2], 10),
+      },
+    })
+  }
+  if (candidates.length === 0) return null
+  candidates.sort((a, b) => a.idx - b.idx)
+  const chosen = candidates[0]
+  return {
+    raw: chosen.raw,
+    matchStartAbs: fromIndex + chosen.idx,
+    matchEndAbs: fromIndex + chosen.idx + chosen.len,
+  }
+}
+
+function resolveYear(raw: RawDate, today: Date): number {
+  if (raw.year !== undefined) return raw.year
+  const currentYear = today.getFullYear()
+  const candidate = buildIso(currentYear, raw.month, raw.day)
+  if (!candidate) return currentYear
+  const candidateDate = new Date(`${candidate}T00:00:00`)
+  const sixMonthsAgo = new Date(today)
+  sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6)
+  if (candidateDate < sixMonthsAgo) return currentYear + 1
+  return currentYear
+}
+
+/**
+ * content에서 첫 매치를 추출한다.
+ * 기간 표현(`A ~ B`)이면 startDate, endDate 모두 반환.
+ * 단일이면 startDate === endDate.
+ * 추출 실패 시 null.
+ */
+export function extractDateRangeFromContent(content: string, today: Date = new Date()): ParsedRange | null {
+  if (!content) return null
+  const text = content.replace(/<[^>]*>/g, ' ').replace(/&nbsp;/g, ' ')
+
+  const first = matchSingleAt(text, 0)
+  if (!first) return null
+
+  const startYear = resolveYear(first.raw, today)
+  const startIso = buildIso(startYear, first.raw.month, first.raw.day)
+  if (!startIso) return null
+
+  const remainder = text.slice(first.matchEndAbs)
+  const sepMatch = remainder.match(RE_RANGE_SEPARATOR)
+  if (sepMatch) {
+    const afterSep = first.matchEndAbs + sepMatch[0].length
+    const second = matchSingleAt(text, afterSep)
+    if (second && second.matchStartAbs === afterSep) {
+      const endYear = second.raw.year ?? startYear
+      const endIso = buildIso(endYear, second.raw.month, second.raw.day)
+      if (endIso && endIso >= startIso) {
+        return { startDate: startIso, endDate: endIso }
+      }
+    }
+  }
+
+  return { startDate: startIso, endDate: startIso }
+}
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+cd dental-clinic-manager && npm run build
+```
+
+Expected: 성공
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Dashboard/ScheduleWidget/scheduleParser.ts
+git commit -m "feat(schedule-widget): add scheduleParser for content-based date extraction"
+```
+
+---
+
+## Task 4: 데이터 페치 훅 (useScheduleData)
+
+**Files:**
+- Create: `src/components/Dashboard/ScheduleWidget/useScheduleData.ts`
+
+- [ ] **Step 1: useScheduleData.ts 작성**
+
+```typescript
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { announcementService } from '@/lib/bulletinService'
+import {
+  getKoreanPublicHolidays,
+  getClinicDesignatedHolidays,
+  getClinicHolidaySettings,
+} from '@/lib/holidayService'
+import type { Announcement } from '@/types/bulletin'
+import type { ScheduleEvent, ViewType, DateRange, ScheduleBadgeKind } from './types'
+import { extractDateRangeFromContent } from './scheduleParser'
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+function formatLocalDate(d: Date): string {
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`
+}
+
+export function getRangeForView(viewType: ViewType, anchor: Date): DateRange {
+  const today = new Date(anchor)
+  today.setHours(0, 0, 0, 0)
+
+  if (viewType === 'today') {
+    const iso = formatLocalDate(today)
+    return { start: iso, end: iso }
+  }
+
+  if (viewType === 'week') {
+    const dayOfWeek = today.getDay() // 0=일, 1=월
+    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek
+    const monday = new Date(today)
+    monday.setDate(today.getDate() + mondayOffset)
+    const sunday = new Date(monday)
+    sunday.setDate(monday.getDate() + 6)
+    return { start: formatLocalDate(monday), end: formatLocalDate(sunday) }
+  }
+
+  // month
+  const first = new Date(today.getFullYear(), today.getMonth(), 1)
+  const last = new Date(today.getFullYear(), today.getMonth() + 1, 0)
+  return { start: formatLocalDate(first), end: formatLocalDate(last) }
+}
+
+function rangeOverlaps(rangeStart: string, rangeEnd: string, eventStart: string, eventEnd: string): boolean {
+  return eventStart <= rangeEnd && eventEnd >= rangeStart
+}
+
+function announcementBadge(category: Announcement['category']): ScheduleBadgeKind {
+  if (category === 'holiday') return 'holiday_announcement'
+  return 'schedule'
+}
+
+function priorityWeight(ev: ScheduleEvent): number {
+  // 0: 휴무, 1: 중요/고정, 2: 일반
+  if (
+    ev.source === 'clinic_holiday' ||
+    ev.source === 'public_holiday' ||
+    ev.badgeKind === 'holiday_announcement'
+  ) return 0
+  if (ev.isPinned || ev.isImportant) return 1
+  return 2
+}
+
+function sortEvents(events: ScheduleEvent[]): ScheduleEvent[] {
+  return [...events].sort((a, b) => {
+    if (a.startDate !== b.startDate) return a.startDate.localeCompare(b.startDate)
+    const pa = priorityWeight(a)
+    const pb = priorityWeight(b)
+    if (pa !== pb) return pa - pb
+    return a.title.localeCompare(b.title, 'ko')
+  })
+}
+
+function dedupeByDateAndTitle(events: ScheduleEvent[]): ScheduleEvent[] {
+  const seen = new Set<string>()
+  const result: ScheduleEvent[] = []
+  for (const ev of events) {
+    const key = `${ev.startDate}|${ev.endDate}|${ev.title}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(ev)
+  }
+  return result
+}
+
+interface UseScheduleDataResult {
+  events: ScheduleEvent[]
+  loading: boolean
+  error: string | null
+  range: DateRange
+}
+
+export function useScheduleData(
+  clinicId: string | null,
+  viewType: ViewType,
+  anchor: Date
+): UseScheduleDataResult {
+  const range = useMemo(() => getRangeForView(viewType, anchor), [viewType, anchor])
+  const [events, setEvents] = useState<ScheduleEvent[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    if (!clinicId) {
+      setEvents([])
+      setLoading(false)
+      setError(null)
+      return
+    }
+
+    const controller = new AbortController()
+    abortRef.current?.abort()
+    abortRef.current = controller
+
+    const today = new Date()
+
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const startYear = parseInt(range.start.substring(0, 4), 10)
+        const endYear = parseInt(range.end.substring(0, 4), 10)
+
+        const [annResult, settingsResult, designatedResults] = await Promise.all([
+          announcementService.getAnnouncements({ limit: 200 }),
+          getClinicHolidaySettings(clinicId!),
+          (async () => {
+            const out: Array<{ date: string; description: string | null }> = []
+            for (let y = startYear; y <= endYear; y++) {
+              const r = await getClinicDesignatedHolidays(clinicId!, y)
+              if (r.success && r.holidays) out.push(...r.holidays)
+            }
+            return out
+          })(),
+        ])
+
+        if (controller.signal.aborted) return
+
+        const settings = settingsResult.success ? settingsResult.settings : undefined
+
+        // 1) 공지사항 → 정규화
+        const annEvents: ScheduleEvent[] = []
+        const announcements = annResult.data || []
+        for (const a of announcements) {
+          if (a.category !== 'schedule' && a.category !== 'holiday') continue
+
+          let startDate = a.start_date || ''
+          let endDate = a.end_date || a.start_date || ''
+          if (!startDate) {
+            const parsed = extractDateRangeFromContent(a.content || '', today)
+            if (!parsed) continue
+            startDate = parsed.startDate
+            endDate = parsed.endDate
+          }
+
+          if (!rangeOverlaps(range.start, range.end, startDate, endDate)) continue
+
+          annEvents.push({
+            id: `announcement-${a.id}`,
+            source: 'announcement',
+            startDate,
+            endDate,
+            title: a.title,
+            badgeKind: announcementBadge(a.category),
+            isPinned: a.is_pinned,
+            isImportant: a.is_important,
+            announcementId: a.id,
+          })
+        }
+
+        // 2) 병원 지정 휴무일 → 윈도우 내 필터
+        const clinicHolidayEvents: ScheduleEvent[] = []
+        for (const h of designatedResults) {
+          if (h.date < range.start || h.date > range.end) continue
+          clinicHolidayEvents.push({
+            id: `clinic-${h.date}`,
+            source: 'clinic_holiday',
+            startDate: h.date,
+            endDate: h.date,
+            title: h.description || '병원 휴무',
+            badgeKind: 'clinic_holiday',
+          })
+        }
+
+        // 3) 법정 공휴일 → 설정에 따라 포함
+        const publicHolidayEvents: ScheduleEvent[] = []
+        if (settings?.use_public_holidays) {
+          const includeSubstitute = settings.use_substitute_holidays
+          for (let y = startYear; y <= endYear; y++) {
+            const yearHolidays = getKoreanPublicHolidays(y, includeSubstitute)
+            for (const h of yearHolidays) {
+              if (h.date < range.start || h.date > range.end) continue
+              publicHolidayEvents.push({
+                id: `public-${h.date}-${h.name}`,
+                source: 'public_holiday',
+                startDate: h.date,
+                endDate: h.date,
+                title: h.name,
+                badgeKind: 'public_holiday',
+              })
+            }
+          }
+        }
+
+        const merged = sortEvents(
+          dedupeByDateAndTitle([...annEvents, ...clinicHolidayEvents, ...publicHolidayEvents])
+        )
+
+        if (!controller.signal.aborted) {
+          setEvents(merged)
+        }
+      } catch (e: any) {
+        if (!controller.signal.aborted) {
+          console.warn('[useScheduleData] load failed:', e)
+          setError(e?.message || 'load failed')
+          setEvents([])
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    load()
+    return () => controller.abort()
+  }, [clinicId, range.start, range.end])
+
+  return { events, loading, error, range }
+}
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+cd dental-clinic-manager && npm run build
+```
+
+Expected: 성공
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Dashboard/ScheduleWidget/useScheduleData.ts
+git commit -m "feat(schedule-widget): add useScheduleData hook for parallel fetch+merge"
+```
+
+---
+
+## Task 5: ScheduleItem 컴포넌트
+
+**Files:**
+- Create: `src/components/Dashboard/ScheduleWidget/ScheduleItem.tsx`
+
+- [ ] **Step 1: ScheduleItem.tsx 작성**
+
+```typescript
+'use client'
+
+import React from 'react'
+import { Pin, Star } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { ScheduleEvent, ScheduleBadgeKind } from './types'
+
+interface BadgeStyle {
+  label: string
+  className: string
+}
+
+const BADGE_STYLES: Record<ScheduleBadgeKind, BadgeStyle> = {
+  clinic_holiday: { label: '휴무', className: 'bg-red-50 text-red-700' },
+  public_holiday: { label: '공휴일', className: 'bg-amber-50 text-amber-700' },
+  schedule: { label: '일정', className: 'bg-at-accent-tag text-at-accent' },
+  holiday_announcement: { label: '휴무공지', className: 'bg-red-50 text-red-700' },
+}
+
+function formatRangeSuffix(startDate: string, endDate: string): string {
+  if (startDate === endDate) return ''
+  const [, sm, sd] = startDate.split('-')
+  const [, em, ed] = endDate.split('-')
+  return ` (${parseInt(sm, 10)}.${parseInt(sd, 10)}~${parseInt(em, 10)}.${parseInt(ed, 10)})`
+}
+
+interface ScheduleItemProps {
+  event: ScheduleEvent
+  onClick?: (event: ScheduleEvent) => void
+}
+
+export default function ScheduleItem({ event, onClick }: ScheduleItemProps) {
+  const badge = BADGE_STYLES[event.badgeKind]
+  const isClickable = event.source === 'announcement' && !!onClick
+  const suffix = formatRangeSuffix(event.startDate, event.endDate)
+
+  return (
+    <button
+      type="button"
+      onClick={isClickable ? () => onClick!(event) : undefined}
+      disabled={!isClickable}
+      aria-label={`${badge.label} 일정: ${event.title}`}
+      className={cn(
+        'flex items-center gap-2 w-full px-2 py-1.5 rounded-lg text-left',
+        isClickable
+          ? 'cursor-pointer hover:bg-at-surface-hover'
+          : 'cursor-default'
+      )}
+    >
+      <span
+        className={cn(
+          'shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium tracking-[0.07px]',
+          badge.className
+        )}
+      >
+        {badge.label}
+      </span>
+      <span className="flex-1 text-sm text-at-text truncate tracking-[0.08px]">
+        {event.title}
+        {suffix && <span className="text-at-text-weak">{suffix}</span>}
+      </span>
+      {event.isPinned && <Pin className="w-3.5 h-3.5 text-at-accent shrink-0" />}
+      {event.isImportant && <Star className="w-3.5 h-3.5 text-amber-400 fill-amber-400 shrink-0" />}
+    </button>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+cd dental-clinic-manager && npm run build
+```
+
+Expected: 성공
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Dashboard/ScheduleWidget/ScheduleItem.tsx
+git commit -m "feat(schedule-widget): add ScheduleItem row component with badges"
+```
+
+---
+
+## Task 6: ScheduleDateGroup 컴포넌트 (주간/월간 그룹 헤더)
+
+**Files:**
+- Create: `src/components/Dashboard/ScheduleWidget/ScheduleDateGroup.tsx`
+
+- [ ] **Step 1: ScheduleDateGroup.tsx 작성**
+
+```typescript
+'use client'
+
+import React from 'react'
+import { cn } from '@/lib/utils'
+import type { ScheduleEvent } from './types'
+import ScheduleItem from './ScheduleItem'
+
+const DOW_LABELS = ['일', '월', '화', '수', '목', '금', '토']
+
+function formatGroupHeader(dateIso: string): { label: string; dayOfWeek: number } {
+  const d = new Date(`${dateIso}T12:00:00`)
+  const month = d.getMonth() + 1
+  const day = d.getDate()
+  const dow = d.getDay()
+  return {
+    label: `${String(month).padStart(2, '0')}.${String(day).padStart(2, '0')} (${DOW_LABELS[dow]})`,
+    dayOfWeek: dow,
+  }
+}
+
+interface ScheduleDateGroupProps {
+  date: string
+  events: ScheduleEvent[]
+  todayIso: string
+  onItemClick: (event: ScheduleEvent) => void
+}
+
+export default function ScheduleDateGroup({ date, events, todayIso, onItemClick }: ScheduleDateGroupProps) {
+  const { label, dayOfWeek } = formatGroupHeader(date)
+  const isToday = date === todayIso
+  const isWeekend = dayOfWeek === 0 || dayOfWeek === 6
+
+  return (
+    <div className="space-y-1">
+      <div
+        className={cn(
+          'text-xs font-semibold tracking-[0.07px] flex items-center gap-2 px-2',
+          isToday ? 'text-at-accent' : isWeekend ? 'text-red-600' : 'text-at-text'
+        )}
+      >
+        <span>{label}</span>
+        {isToday && <span className="w-1.5 h-1.5 rounded-full bg-at-accent" />}
+      </div>
+      <div className="space-y-0.5">
+        {events.map(ev => (
+          <ScheduleItem key={ev.id} event={ev} onClick={onItemClick} />
+        ))}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+cd dental-clinic-manager && npm run build
+```
+
+Expected: 성공
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Dashboard/ScheduleWidget/ScheduleDateGroup.tsx
+git commit -m "feat(schedule-widget): add ScheduleDateGroup for week/month grouping"
+```
+
+---
+
+## Task 7: TodayView 컴포넌트
+
+**Files:**
+- Create: `src/components/Dashboard/ScheduleWidget/TodayView.tsx`
+
+- [ ] **Step 1: TodayView.tsx 작성**
+
+```typescript
+'use client'
+
+import React from 'react'
+import { Building2, CalendarOff } from 'lucide-react'
+import type { ScheduleEvent } from './types'
+import ScheduleItem from './ScheduleItem'
+
+interface TodayViewProps {
+  events: ScheduleEvent[]
+  loading: boolean
+  todayIso: string
+  onItemClick: (event: ScheduleEvent) => void
+}
+
+function isHolidayEvent(ev: ScheduleEvent): boolean {
+  return (
+    ev.source === 'clinic_holiday' ||
+    ev.source === 'public_holiday' ||
+    ev.badgeKind === 'holiday_announcement'
+  )
+}
+
+export default function TodayView({ events, loading, todayIso, onItemClick }: TodayViewProps) {
+  if (loading) {
+    return (
+      <div className="flex justify-center py-6">
+        <div className="w-6 h-6 border-4 border-at-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  // 오늘에 해당하는 휴무 (range가 today만 포함하는 단일일)
+  const todayHoliday = events.find(
+    ev => isHolidayEvent(ev) && ev.startDate <= todayIso && ev.endDate >= todayIso
+  )
+
+  const otherEvents = events.filter(ev => !(todayHoliday && ev.id === todayHoliday.id))
+
+  if (events.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-6 text-at-text-secondary gap-2">
+        <CalendarOff className="w-8 h-8 text-at-text-weak" />
+        <p className="text-sm tracking-[0.08px]">오늘 등록된 일정이 없습니다</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {todayHoliday && (
+        <div className="flex items-center gap-2 bg-red-50 border-l-4 border-red-500 text-red-700 px-4 py-3 rounded-lg">
+          <Building2 className="w-4 h-4 shrink-0" />
+          <span className="text-sm font-semibold tracking-[0.08px]">
+            오늘 휴무 — {todayHoliday.title}
+          </span>
+        </div>
+      )}
+      <div className="space-y-0.5">
+        {otherEvents.map(ev => (
+          <ScheduleItem key={ev.id} event={ev} onClick={onItemClick} />
+        ))}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+cd dental-clinic-manager && npm run build
+```
+
+Expected: 성공
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Dashboard/ScheduleWidget/TodayView.tsx
+git commit -m "feat(schedule-widget): add TodayView with holiday banner"
+```
+
+---
+
+## Task 8: WeekView 컴포넌트
+
+**Files:**
+- Create: `src/components/Dashboard/ScheduleWidget/WeekView.tsx`
+
+- [ ] **Step 1: WeekView.tsx 작성**
+
+```typescript
+'use client'
+
+import React, { useMemo } from 'react'
+import { CalendarOff } from 'lucide-react'
+import type { ScheduleEvent } from './types'
+import ScheduleDateGroup from './ScheduleDateGroup'
+
+interface WeekViewProps {
+  events: ScheduleEvent[]
+  loading: boolean
+  todayIso: string
+  onItemClick: (event: ScheduleEvent) => void
+}
+
+function expandEventToDates(ev: ScheduleEvent): string[] {
+  const dates: string[] = []
+  const start = new Date(`${ev.startDate}T00:00:00`)
+  const end = new Date(`${ev.endDate}T00:00:00`)
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    const y = d.getFullYear()
+    const m = String(d.getMonth() + 1).padStart(2, '0')
+    const dy = String(d.getDate()).padStart(2, '0')
+    dates.push(`${y}-${m}-${dy}`)
+  }
+  return dates
+}
+
+function groupByDate(events: ScheduleEvent[]): Map<string, ScheduleEvent[]> {
+  const map = new Map<string, ScheduleEvent[]>()
+  for (const ev of events) {
+    const dates = expandEventToDates(ev)
+    for (const d of dates) {
+      const list = map.get(d) || []
+      list.push(ev)
+      map.set(d, list)
+    }
+  }
+  return map
+}
+
+export default function WeekView({ events, loading, todayIso, onItemClick }: WeekViewProps) {
+  const groups = useMemo(() => groupByDate(events), [events])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-6">
+        <div className="w-6 h-6 border-4 border-at-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  if (groups.size === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-6 text-at-text-secondary gap-2">
+        <CalendarOff className="w-8 h-8 text-at-text-weak" />
+        <p className="text-sm tracking-[0.08px]">이번 주 등록된 일정이 없습니다</p>
+      </div>
+    )
+  }
+
+  const sortedDates = Array.from(groups.keys()).sort()
+
+  return (
+    <div className="space-y-3">
+      {sortedDates.map(date => (
+        <ScheduleDateGroup
+          key={date}
+          date={date}
+          events={groups.get(date)!}
+          todayIso={todayIso}
+          onItemClick={onItemClick}
+        />
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+cd dental-clinic-manager && npm run build
+```
+
+Expected: 성공
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Dashboard/ScheduleWidget/WeekView.tsx
+git commit -m "feat(schedule-widget): add WeekView with per-day grouping"
+```
+
+---
+
+## Task 9: MonthView 컴포넌트
+
+**Files:**
+- Create: `src/components/Dashboard/ScheduleWidget/MonthView.tsx`
+
+- [ ] **Step 1: MonthView.tsx 작성**
+
+```typescript
+'use client'
+
+import React, { useMemo } from 'react'
+import { CalendarOff } from 'lucide-react'
+import type { ScheduleEvent } from './types'
+import ScheduleDateGroup from './ScheduleDateGroup'
+
+interface MonthViewProps {
+  events: ScheduleEvent[]
+  loading: boolean
+  todayIso: string
+  onItemClick: (event: ScheduleEvent) => void
+}
+
+function expandEventToDates(ev: ScheduleEvent): string[] {
+  const dates: string[] = []
+  const start = new Date(`${ev.startDate}T00:00:00`)
+  const end = new Date(`${ev.endDate}T00:00:00`)
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    const y = d.getFullYear()
+    const m = String(d.getMonth() + 1).padStart(2, '0')
+    const dy = String(d.getDate()).padStart(2, '0')
+    dates.push(`${y}-${m}-${dy}`)
+  }
+  return dates
+}
+
+function groupByDate(events: ScheduleEvent[]): Map<string, ScheduleEvent[]> {
+  const map = new Map<string, ScheduleEvent[]>()
+  for (const ev of events) {
+    const dates = expandEventToDates(ev)
+    for (const d of dates) {
+      const list = map.get(d) || []
+      list.push(ev)
+      map.set(d, list)
+    }
+  }
+  return map
+}
+
+export default function MonthView({ events, loading, todayIso, onItemClick }: MonthViewProps) {
+  const groups = useMemo(() => groupByDate(events), [events])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-6">
+        <div className="w-6 h-6 border-4 border-at-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  if (groups.size === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-6 text-at-text-secondary gap-2">
+        <CalendarOff className="w-8 h-8 text-at-text-weak" />
+        <p className="text-sm tracking-[0.08px]">이번 달 등록된 일정이 없습니다</p>
+      </div>
+    )
+  }
+
+  const sortedDates = Array.from(groups.keys()).sort()
+
+  return (
+    <div className="space-y-3 max-h-[480px] overflow-y-auto pr-1">
+      {sortedDates.map(date => (
+        <ScheduleDateGroup
+          key={date}
+          date={date}
+          events={groups.get(date)!}
+          todayIso={todayIso}
+          onItemClick={onItemClick}
+        />
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+cd dental-clinic-manager && npm run build
+```
+
+Expected: 성공
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Dashboard/ScheduleWidget/MonthView.tsx
+git commit -m "feat(schedule-widget): add MonthView with scrollable per-day list"
+```
+
+---
+
+## Task 10: ScheduleDetailModal 컴포넌트
+
+**Why:** 공지사항 미리보기 모달. 본문 sanitize 렌더링은 기존 [src/components/Bulletin/AnnouncementDetail.tsx](../../../src/components/Bulletin/AnnouncementDetail.tsx) line 131~134의 패턴을 그대로 동일하게 사용한다 (즉, `sanitizeHtml`로 처리한 HTML을 동일한 방식으로 prop에 주입). 새로운 sanitize 로직은 추가하지 않는다.
+
+**Files:**
+- Create: `src/components/Dashboard/ScheduleWidget/ScheduleDetailModal.tsx`
+- Reference (필독): `src/components/Bulletin/AnnouncementDetail.tsx` line 131~134 (sanitize 사용 패턴)
+
+- [ ] **Step 1: 참조 패턴 확인**
+
+먼저 `src/components/Bulletin/AnnouncementDetail.tsx`의 line 131~134를 직접 열어 본문 렌더링 코드를 확인한다. 그 정확히 같은 JSX 구조 (`className="prose prose-sm max-w-none text-at-text-secondary whitespace-pre-wrap"`와 sanitize된 HTML 주입)를 모달의 본문 영역에서 그대로 복사해서 사용해야 한다.
+
+- [ ] **Step 2: ScheduleDetailModal.tsx 작성 — 본문 영역을 제외한 골격**
+
+다음 코드를 작성하되, `// PASTE_BODY_RENDER_HERE` 주석 위치에는 Step 1에서 확인한 정확한 4줄 패턴을 그대로 복사 붙여넣기 한다 (className과 sanitizeHtml 호출 인자만 `detail.content || ''`으로 맞춤).
+
+```typescript
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/Button'
+import { CalendarRange, UserCircle2, Pin, Star } from 'lucide-react'
+import { announcementService } from '@/lib/bulletinService'
+import type { Announcement } from '@/types/bulletin'
+import { sanitizeHtml } from '@/utils/sanitize'
+import type { ScheduleEvent } from './types'
+import { cn } from '@/lib/utils'
+
+interface ScheduleDetailModalProps {
+  event: ScheduleEvent | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function formatDateRangeLabel(startDate: string, endDate: string): string {
+  if (startDate === endDate) return startDate.replace(/-/g, '.')
+  return `${startDate.replace(/-/g, '.')} ~ ${endDate.replace(/-/g, '.')}`
+}
+
+function formatCreatedAt(iso: string | undefined): string {
+  if (!iso) return ''
+  try {
+    const d = new Date(iso)
+    const m = String(d.getMonth() + 1).padStart(2, '0')
+    const day = String(d.getDate()).padStart(2, '0')
+    return `${m}.${day} 작성`
+  } catch {
+    return ''
+  }
+}
+
+export default function ScheduleDetailModal({ event, open, onOpenChange }: ScheduleDetailModalProps) {
+  const router = useRouter()
+  const [detail, setDetail] = useState<Announcement | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open || !event?.announcementId) {
+      setDetail(null)
+      setError(null)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    announcementService
+      .getAnnouncementPreview(event.announcementId)
+      .then(result => {
+        if (cancelled) return
+        if (result.error || !result.data) {
+          setError(result.error || '본문을 불러올 수 없습니다')
+          setDetail(null)
+        } else {
+          setDetail(result.data)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [open, event?.announcementId])
+
+  const handleNavigate = () => {
+    if (!event?.announcementId) return
+    onOpenChange(false)
+    router.push(`/dashboard/bulletin?id=${event.announcementId}`)
+  }
+
+  const badgeLabel = event?.badgeKind === 'holiday_announcement' ? '휴무공지' : '일정'
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-base text-at-text">
+            <span className="px-1.5 py-0.5 rounded bg-at-accent-tag text-at-accent text-xs font-medium">
+              {badgeLabel}
+            </span>
+            <span className="flex-1 truncate">{event?.title}</span>
+            {event?.isPinned && <Pin className="w-4 h-4 text-at-accent shrink-0" />}
+            {event?.isImportant && <Star className="w-4 h-4 text-amber-400 fill-amber-400 shrink-0" />}
+          </DialogTitle>
+          <DialogDescription asChild>
+            <div className="flex flex-wrap items-center gap-3 text-xs text-at-text-secondary mt-1">
+              <span className="flex items-center gap-1">
+                <CalendarRange className="w-3.5 h-3.5" />
+                {event && formatDateRangeLabel(event.startDate, event.endDate)}
+              </span>
+              {detail?.author_name && (
+                <span className="flex items-center gap-1">
+                  <UserCircle2 className="w-3.5 h-3.5" />
+                  {detail.author_name}
+                </span>
+              )}
+              {detail?.created_at && (
+                <span>· {formatCreatedAt(detail.created_at)}</span>
+              )}
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className={cn('mt-2 max-h-[60vh] overflow-y-auto', loading && 'opacity-60')}>
+          {loading && (
+            <div className="space-y-2 py-4">
+              <div className="h-4 bg-at-surface-alt rounded animate-pulse" />
+              <div className="h-4 bg-at-surface-alt rounded animate-pulse w-5/6" />
+              <div className="h-4 bg-at-surface-alt rounded animate-pulse w-4/6" />
+            </div>
+          )}
+          {!loading && error && (
+            <p className="text-sm text-at-error py-4 text-center">{error}</p>
+          )}
+          {!loading && detail && (
+            // PASTE_BODY_RENDER_HERE — AnnouncementDetail.tsx:131-134 동일 패턴 복사
+            // (sanitizeHtml(detail.content || '')로 인자만 변경)
+            null
+          )}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            닫기
+          </Button>
+          <Button onClick={handleNavigate} disabled={!event?.announcementId}>
+            게시판에서 보기 →
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Step 3: PASTE_BODY_RENDER_HERE 자리에 sanitize 본문 렌더 4줄 삽입**
+
+`src/components/Bulletin/AnnouncementDetail.tsx`의 line 131~134에서 본문 렌더링 4줄(div + className + sanitize HTML 주입 prop)을 그대로 복사하여, 위 골격의 `// PASTE_BODY_RENDER_HERE` 주석과 그 아래의 `null` 식을 대체한다. `sanitizeHtml` 인자만 `detail.content || ''`로 맞춘다.
+
+이 단계 완료 후 파일에 plain `null` 표현식이 남아 있으면 안 된다.
+
+- [ ] **Step 4: 빌드 검증**
+
+```bash
+cd dental-clinic-manager && npm run build
+```
+
+Expected: 성공. 만약 `Dialog`/`DialogHeader`/`DialogFooter`/`DialogDescription` 중 일부가 export되지 않았다면 `src/components/ui/dialog.tsx`를 열어 정확한 export 이름을 확인하고 import를 조정한다.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/components/Dashboard/ScheduleWidget/ScheduleDetailModal.tsx
+git commit -m "feat(schedule-widget): add ScheduleDetailModal with sanitized preview"
+```
+
+---
+
+## Task 11: ScheduleWidget 메인 (탭 컨테이너)
+
+**Files:**
+- Create: `src/components/Dashboard/ScheduleWidget/index.tsx`
+
+- [ ] **Step 1: index.tsx 작성**
+
+```typescript
+'use client'
+
+import React, { useMemo, useState } from 'react'
+import { Calendar } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useAuth } from '@/contexts/AuthContext'
+import { cn } from '@/lib/utils'
+import type { ScheduleEvent, ViewType } from './types'
+import { useScheduleData } from './useScheduleData'
+import TodayView from './TodayView'
+import WeekView from './WeekView'
+import MonthView from './MonthView'
+import ScheduleDetailModal from './ScheduleDetailModal'
+
+const TAB_LABELS: Array<{ key: ViewType; label: string; shortLabel: string }> = [
+  { key: 'today', label: '오늘', shortLabel: '오늘' },
+  { key: 'week', label: '이번 주', shortLabel: '주간' },
+  { key: 'month', label: '이번 달', shortLabel: '월간' },
+]
+
+function todayIsoSeoul(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date())
+}
+
+export default function ScheduleWidget() {
+  const { user } = useAuth()
+  const [activeTab, setActiveTab] = useState<ViewType>('today')
+  const [modalEvent, setModalEvent] = useState<ScheduleEvent | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
+
+  const todayIso = useMemo(() => todayIsoSeoul(), [])
+  const anchorDate = useMemo(() => new Date(`${todayIso}T00:00:00`), [todayIso])
+
+  const { events, loading } = useScheduleData(user?.clinic_id ?? null, activeTab, anchorDate)
+
+  const handleItemClick = (ev: ScheduleEvent) => {
+    if (ev.source !== 'announcement' || !ev.announcementId) return
+    setModalEvent(ev)
+    setModalOpen(true)
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="flex items-center gap-2 text-sm font-semibold text-at-text tracking-[0.08px]">
+            <Calendar className="w-4 h-4 text-at-accent" />
+            병원 일정
+          </CardTitle>
+          <div
+            role="tablist"
+            aria-label="기간 선택"
+            className="flex items-center gap-1 bg-at-surface-alt rounded-xl p-1"
+          >
+            {TAB_LABELS.map(tab => (
+              <button
+                key={tab.key}
+                role="tab"
+                aria-selected={activeTab === tab.key}
+                onClick={() => setActiveTab(tab.key)}
+                className={cn(
+                  'px-3 py-1 rounded-lg text-xs font-medium transition-colors tracking-[0.07px]',
+                  activeTab === tab.key
+                    ? 'bg-at-accent text-white shadow-sm'
+                    : 'text-at-text-secondary hover:bg-at-surface-hover'
+                )}
+              >
+                <span className="hidden sm:inline">{tab.label}</span>
+                <span className="sm:hidden">{tab.shortLabel}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {activeTab === 'today' && (
+          <TodayView events={events} loading={loading} todayIso={todayIso} onItemClick={handleItemClick} />
+        )}
+        {activeTab === 'week' && (
+          <WeekView events={events} loading={loading} todayIso={todayIso} onItemClick={handleItemClick} />
+        )}
+        {activeTab === 'month' && (
+          <MonthView events={events} loading={loading} todayIso={todayIso} onItemClick={handleItemClick} />
+        )}
+      </CardContent>
+      <ScheduleDetailModal event={modalEvent} open={modalOpen} onOpenChange={setModalOpen} />
+    </Card>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+cd dental-clinic-manager && npm run build
+```
+
+Expected: 성공
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Dashboard/ScheduleWidget/index.tsx
+git commit -m "feat(schedule-widget): add main tabbed container with modal wiring"
+```
+
+---
+
+## Task 12: DashboardHome에 위젯 통합
+
+**Why:** 사용자 합의(Q1 — 상단 첫 줄). 좌측 메인 칼럼의 최상단(`오늘의 현황` 위)에 삽입한다.
+
+**Files:**
+- Modify: `src/components/Dashboard/DashboardHome.tsx`
+
+- [ ] **Step 1: import 추가**
+
+`src/components/Dashboard/DashboardHome.tsx`의 import 섹션 (약 line 29 `import MyTasksSection from './MyTasksSection'` 바로 아래)에 추가:
+
+```typescript
+import ScheduleWidget from './ScheduleWidget'
+```
+
+- [ ] **Step 2: 위젯 삽입**
+
+`src/components/Dashboard/DashboardHome.tsx`에서 좌측 메인 칼럼(`<div className="flex-1 space-y-4 sm:space-y-5">`, line 554) 안의 첫 번째 자식인 `{/* 오늘의 현황 */}` 주석 바로 위에 다음을 삽입:
+
+```tsx
+            {/* 병원 일정 */}
+            <ScheduleWidget />
+
+```
+
+즉 변경 후 구조:
+
+```tsx
+          {/* 왼쪽: 메인 콘텐츠 */}
+          <div className="flex-1 space-y-4 sm:space-y-5">
+            {/* 병원 일정 */}
+            <ScheduleWidget />
+
+            {/* 오늘의 현황 */}
+            <div>
+              ...
+```
+
+기존 위젯들의 코드/스타일은 절대 변경하지 않는다.
+
+- [ ] **Step 3: 빌드 검증**
+
+```bash
+cd dental-clinic-manager && npm run build
+```
+
+Expected: 성공
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/components/Dashboard/DashboardHome.tsx
+git commit -m "feat(dashboard): mount ScheduleWidget at top of main column"
+```
+
+---
+
+## Task 13: 통합 검증 (Chrome DevTools MCP)
+
+**Why:** CLAUDE.md의 "구현-테스트-수정-푸시 사이클" 규칙. 빌드만 통과해서는 안 되며 실제 기능을 브라우저에서 확인해야 한다.
+
+**Files:** (검증만, 수정 없음)
+
+- [ ] **Step 1: dev 서버 시작 (백그라운드)**
+
+```bash
+cd dental-clinic-manager && npm run dev
+```
+
+서버가 `http://localhost:3000`에서 응답하는지 확인.
+
+- [ ] **Step 2: Chrome DevTools MCP — 로그인**
+
+`mcp__chrome-devtools__navigate_page`로 `http://localhost:3000`로 이동, 테스트 계정(`whitedc0902@gmail.com` / `ghkdgmltn81!`)으로 로그인.
+
+- [ ] **Step 3: 대시보드 위젯 표시 확인**
+
+`mcp__chrome-devtools__take_snapshot`으로 대시보드 화면 캡처. 다음을 검증:
+
+- [ ] 좌측 메인 칼럼 최상단에 "병원 일정" 카드가 보인다
+- [ ] 카드 헤더에 `Calendar` 아이콘 + "병원 일정" 텍스트 + 탭 3개(`오늘 / 이번 주 / 이번 달`)가 보인다
+- [ ] 활성 탭이 `오늘`이고 강조 스타일이 적용되어 있다
+- [ ] 데이터가 있으면 일정 항목이 보이고, 없으면 빈 상태 메시지("오늘 등록된 일정이 없습니다")가 보인다
+
+- [ ] **Step 4: 탭 전환 동작 확인**
+
+`mcp__chrome-devtools__click`으로 "이번 주" 탭 클릭 → snapshot. 다음을 검증:
+
+- [ ] "이번 주" 탭이 활성화된다
+- [ ] 콘텐츠 영역이 주간 뷰(날짜 그룹 리스트)로 전환된다
+- [ ] 오늘 날짜 그룹 헤더가 액센트 색상이다
+- [ ] 토/일 그룹 헤더가 빨간색이다 (해당 날짜 일정이 있는 경우)
+
+"이번 달" 탭 클릭 → 월간 뷰로 전환. 동일한 그룹 형식 + 스크롤 가능 여부 확인.
+
+- [ ] **Step 5: 모달 동작 확인**
+
+`오늘` 또는 `주간` 탭에서 공지사항 항목(배지가 `일정` 또는 `휴무공지`)을 클릭 → snapshot. 다음을 검증:
+
+- [ ] Dialog 모달이 열린다
+- [ ] 제목, 기간, 작성자/작성일이 표시된다
+- [ ] 본문이 sanitize된 HTML로 렌더링된다 (`<script>` 등이 실행되지 않음)
+- [ ] 페치 중 스켈레톤이 잠시 보였다 사라진다
+- [ ] "닫기" 버튼 클릭 → 모달 닫힘
+- [ ] "게시판에서 보기" 버튼 클릭 → `/dashboard/bulletin?id=...`로 라우팅
+
+- [ ] **Step 6: 휴무일 클릭 비활성 확인**
+
+휴무일 항목(배지 `휴무` 또는 `공휴일`)을 클릭 시도. 모달이 열리지 않고 hover/click 효과가 없어야 한다.
+
+- [ ] **Step 7: 콘솔 에러 + 조회수 미증가 확인**
+
+`mcp__chrome-devtools__list_console_messages` (types: error)로 콘솔 에러 0건임을 확인.
+
+`mcp__chrome-devtools__list_network_requests`로 다음을 확인:
+
+- [ ] `announcements` 테이블 쿼리가 발생함
+- [ ] `clinic_holidays` 테이블 쿼리가 발생함
+- [ ] `clinic_holiday_settings` 쿼리가 발생함
+- [ ] 모달 열 때 `announcements` SELECT는 발생하지만, `increment_announcement_view_count` RPC는 호출되지 않음 (게시판 페이지로 이동했을 때만 호출)
+
+- [ ] **Step 8: 실패 시 대응**
+
+위 검증 중 실패 항목이 있으면:
+1. 콘솔 에러/네트워크 응답에서 원인 파악
+2. 해당 task의 코드를 수정
+3. dev 서버 재시작 (필요 시) → Step 2부터 재실행
+4. 정상 동작 확인까지 반복
+
+CLAUDE.md 규칙에 따라 실패한 채로 두지 말고 반드시 성공할 때까지 수정-검증을 반복한다.
+
+---
+
+## Task 14: 모든 커밋 검토 + 최종 푸시
+
+- [ ] **Step 1: 변경 사항 검토**
+
+```bash
+git log develop..HEAD --oneline
+```
+
+Expected: Task 1~12 각각의 커밋이 모두 보인다.
+
+```bash
+git diff origin/develop..HEAD --stat
+```
+
+Expected: 새 파일 10개(ScheduleWidget/* + index.tsx) + bulletinService.ts + DashboardHome.tsx만 변경되어 있다.
+
+- [ ] **Step 2: 최종 빌드 + lint**
+
+```bash
+cd dental-clinic-manager && npm run build && npm run lint
+```
+
+Expected: 모두 성공. 경고가 있으면 ScheduleWidget 관련만 수정 (다른 기존 경고는 손대지 않음).
+
+- [ ] **Step 3: develop 브랜치에 푸시**
+
+```bash
+git push origin develop
+```
+
+푸시 실패 시 `git pull --rebase origin develop` 후 재시도. CLAUDE.md 규칙에 따라 성공할 때까지 반복.
+
+- [ ] **Step 4: 작업 로그 기록 (선택)**
+
+`.claude/WORK_LOG.md`가 존재하면 다음 형식으로 기록:
+
+```markdown
+## 2026-04-29 [기능 개발] 대시보드 병원 일정 위젯
+
+**키워드:** #dashboard #schedule #bulletin #holiday
+
+### 📋 작업 내용
+- 대시보드 홈 좌측 메인 칼럼 최상단에 "병원 일정" 카드 위젯 추가
+- 오늘/주간/월간 3개 탭 + 공지사항(schedule/holiday) + 병원 휴무일 + 법정 공휴일 통합 표시
+- 본문 날짜 추출(scheduleParser) 지원
+- 공지사항 클릭 → 본문 미리보기 모달 (조회수 미증가)
+
+### ✅ 해결 방법
+- announcementService에 getAnnouncementPreview 메서드 추가
+- ScheduleWidget 디렉토리에 10개 컴포넌트/유틸 분리
+
+### 🧪 테스트 결과
+- 빌드 성공, lint 통과
+- Chrome DevTools MCP로 탭 전환/모달/라우팅 동작 검증
+- 콘솔 에러 0건, 미리보기 모달은 조회수 증가 RPC 미호출 확인
+
+---
+```
+
+---
+
+## Self-Review 체크리스트
+
+작성 후 다음을 확인:
+
+1. **Spec coverage**
+   - [x] §2 위치: Task 12에서 DashboardHome 좌측 메인 칼럼 최상단 삽입
+   - [x] §3 컴포넌트 구조: Task 2~11에서 모든 파일 생성
+   - [x] §4.1 데이터 소스 3종: Task 4 useScheduleData
+   - [x] §4.2 본문 날짜 추출: Task 3 scheduleParser
+   - [x] §4.3 정규화 타입: Task 2 types.ts
+   - [x] §4.4 조회 범위: Task 4의 getRangeForView
+   - [x] §4.5 정렬 규칙: Task 4의 sortEvents
+   - [x] §4.6 페치 전략: Task 4의 AbortController + Promise.all
+   - [x] §5.1 카드 헤더 + 탭: Task 11 index.tsx
+   - [x] §5.2 오늘 탭 + 휴무 배너: Task 7 TodayView
+   - [x] §5.3 주간 탭: Task 8 WeekView
+   - [x] §5.4 월간 탭 (스크롤): Task 9 MonthView
+   - [x] §5.5 ScheduleItem (배지 4종): Task 5
+   - [x] §6 모달 (sanitize, 조회수 미증가, 라우팅): Task 1 + Task 10
+   - [x] §7 디자인 토큰: 모든 컴포넌트가 at-* 토큰 사용
+   - [x] §8 엣지 케이스: useScheduleData에서 dedupe + 에러 처리
+
+2. **Placeholder scan**: 모든 코드 블록은 실제 코드. Task 10 Step 3는 명시적으로 기존 파일의 4줄 패턴을 복사하라는 지시이므로 placeholder가 아니라 reference-by-pattern.
+
+3. **Type consistency**:
+   - `ScheduleEvent` 필드명 (id, source, startDate, endDate, title, badgeKind, isPinned, isImportant, announcementId)이 Task 2~11 전체에서 일관됨.
+   - `ViewType`이 `'today' | 'week' | 'month'`로 일관.
+   - 메서드명 `getAnnouncementPreview`가 Task 1과 Task 10에서 동일.
+
+4. **Ambiguity**:
+   - 본문 첫 매치만 사용하는 규칙 명시
+   - 조회수 증가 회피를 위한 별도 메서드 분리
+   - clinic_holidays 테이블이 기간형이지만 `getClinicDesignatedHolidays`가 이미 펼쳐 반환하는 것을 그대로 사용

--- a/dental-clinic-manager/docs/superpowers/specs/2026-04-29-dashboard-schedule-widget-design.md
+++ b/dental-clinic-manager/docs/superpowers/specs/2026-04-29-dashboard-schedule-widget-design.md
@@ -1,0 +1,286 @@
+# 대시보드 병원 일정 위젯 — 설계 문서
+
+**작성일**: 2026-04-29
+**상태**: 승인 대기
+**대상**: `src/components/Dashboard/DashboardHome.tsx`
+
+---
+
+## 1. 목적
+
+서비스 접속 직후 보이는 대시보드 홈에 "병원 일정" 위젯을 추가한다. 사용자가 대시보드를 떠나지 않고도 병원 게시판의 일정/휴무 공지와 휴무일(병원·법정 공휴일)을 오늘/주간/월간 단위로 한눈에 확인할 수 있도록 한다.
+
+---
+
+## 2. 위치 및 컨테이너
+
+- 진입 컴포넌트: `src/components/Dashboard/DashboardHome.tsx`
+- 배치: 대시보드 **상단 첫 번째 줄**, 기존 "오늘 보고서 요약" 카드 **옆**
+- 기존 위젯의 props/로직/스타일은 일절 변경하지 않는다 (기존 기능 보호 원칙)
+- 반응형 그리드: 모바일 1열, 태블릿 2열, 데스크톱 3열 — 기존 그리드 규약 그대로 사용
+
+---
+
+## 3. 컴포넌트 구조
+
+```
+src/components/Dashboard/ScheduleWidget/
+  index.tsx                  ← 메인 카드 (탭 컨테이너)
+  TodayView.tsx              ← 오늘 탭 콘텐츠
+  WeekView.tsx               ← 주간 탭 콘텐츠
+  MonthView.tsx              ← 월간 탭 콘텐츠
+  ScheduleItem.tsx           ← 일정 1줄 표시 (3개 뷰에서 재사용)
+  ScheduleDetailModal.tsx    ← 공지사항 클릭 시 본문 미리보기
+  useScheduleData.ts         ← 데이터 페치/통합 훅
+  scheduleParser.ts          ← 본문 날짜 추출 순수함수 (단위 테스트 가능)
+```
+
+각 단위의 책임:
+
+| 파일 | 책임 | 의존성 |
+|---|---|---|
+| `index.tsx` | 카드/탭 컨테이너, 탭 상태 관리 | shadcn `Card`, `Tabs` |
+| `TodayView` / `WeekView` / `MonthView` | 뷰별 레이아웃 (휴무 배너, 그룹핑 등) | `useScheduleData`, `ScheduleItem` |
+| `ScheduleItem` | 한 줄 일정 표시 + 클릭 핸들 | 디자인 토큰 |
+| `ScheduleDetailModal` | 공지 본문 lazy 로드 + 게시판 이동 | shadcn `Dialog`, `bulletinService`, `sanitizeHtml` |
+| `useScheduleData` | 3개 소스 병렬 페치 → 정규화 머지 → 정렬 | `bulletinService`, `holidayService`, supabase 클라이언트 |
+| `scheduleParser` | content에서 날짜/기간 추출 | (없음, pure) |
+
+---
+
+## 4. 데이터 통합
+
+### 4.1 소스
+
+1. **공지사항** (`bulletinService`)
+   - 조건: `category in ('schedule', 'holiday')`
+   - 범위: `[start_date, end_date]`이 조회 윈도우와 겹치는 모든 공지
+   - `start_date`/`end_date`가 비어있는 공지는 `content`에서 날짜 추출 시도 (4.2 참조)
+2. **병원 휴무일** (`clinic_holidays` 테이블)
+   - `holiday_date`이 조회 윈도우 범위 내
+3. **법정 공휴일** (`holidayService.getPublicHolidays(year)`)
+   - 병원 설정 `clinic_holiday_settings.use_public_holidays === true`인 경우에만 포함
+   - 대체공휴일은 `use_substitute_holidays === true`일 때만 포함
+
+### 4.2 본문 날짜 추출 (`scheduleParser.ts`)
+
+`start_date`/`end_date`가 채워진 공지는 그 값을 우선 사용한다. 비어 있을 때만 본문에서 추출한다.
+
+지원 패턴 (단일):
+- `YYYY-MM-DD`, `YYYY.MM.DD`, `YYYY/MM/DD`
+- `YYYY년 M월 D일`, `M월 D일` (연도 생략 시 추론, 아래 참조)
+
+지원 패턴 (기간):
+- 위 표현 + (` ~ ` | ` - ` | ` ~`) + 위 표현
+  예: `4월 30일 ~ 5월 2일`, `2026-04-30 ~ 2026-05-02`
+
+연도 생략 시 처리:
+- 기본: 현재 연도
+- 단, 추출된 날짜가 오늘 기준 6개월 이전이면 다음 해로 보정 (연말~연초 케이스 자연스럽게 처리)
+
+추출은 본문의 첫 매치만 사용한다 (다중 날짜 언급 시 가장 앞 날짜를 일정 시작으로 본다). 추출 실패한 공지는 위젯에 표시하지 않는다 (조용히 누락).
+
+### 4.3 정규화 타입
+
+```typescript
+type ScheduleEvent = {
+  id: string                                  // 고유키 (source-id 조합)
+  source: 'announcement' | 'clinic_holiday' | 'public_holiday'
+  startDate: string                           // YYYY-MM-DD
+  endDate: string                             // 단일일은 startDate와 동일
+  title: string
+  category: 'schedule' | 'holiday' | 'public_holiday'
+  isPinned?: boolean                          // 공지사항만
+  isImportant?: boolean                       // 공지사항만
+  announcementId?: string                     // 모달 페치용 (announcement일 때)
+}
+```
+
+### 4.4 조회 범위 계산
+
+| 탭 | 시작 | 끝 |
+|---|---|---|
+| 오늘 | `today` | `today` |
+| 주간 | `startOfWeek(today, { weekStartsOn: 1 })` (월) | `endOfWeek(today, { weekStartsOn: 1 })` (일) |
+| 월간 | `startOfMonth(today)` | `endOfMonth(today)` |
+
+`date-fns`는 프로젝트에 이미 설치되어 있는지 확인 후 사용. 없으면 표준 `Date` API로 직접 계산.
+
+### 4.5 정렬 규칙
+
+1. `startDate` 오름차순
+2. 같은 날짜 내 우선순위:
+   - 휴무일 (`clinic_holiday`, `public_holiday`, `category=holiday`인 announcement)
+   - 중요/고정 공지 (`isImportant || isPinned`)
+   - 일반 일정
+3. 같은 우선순위 내에서는 `title` 가나다순
+
+### 4.6 페치 전략
+
+- `useScheduleData(viewType, anchorDate)` 훅 내부에서 3개 소스 `Promise.all` 병렬
+- 같은 위젯 라이프타임 동안 중복 페치 방지 (탭 전환 시 데이터 캐시 또는 viewType별 결과 메모이제이션)
+- 에러 발생 시 빈 배열 반환 + `console.warn` (위젯이 대시보드 전체를 깨뜨리지 않도록)
+- AbortController로 페치 중 언마운트 시 취소
+
+---
+
+## 5. UI 레이아웃
+
+### 5.1 카드 헤더 (모든 탭 공통)
+
+```
+┌────────────────────────────────────────────┐
+│  📅 병원 일정                               │
+│  [ 오늘 ]  [ 이번 주 ]  [ 이번 달 ]         │
+└────────────────────────────────────────────┘
+```
+
+- 카드: shadcn `<Card>` (`rounded-2xl shadow-at-card`)
+- 탭: shadcn `<Tabs>` 또는 동일한 스타일의 segment 토글 (모바일 텍스트: `오늘 / 주간 / 월간`)
+
+### 5.2 오늘 탭 (TodayView)
+
+- 해당일이 휴무(병원/법정/휴무공지)인 경우 카드 콘텐츠 최상단에 **휴무 배너**:
+  ```
+  🏥 오늘 휴무 — {휴무명}
+  ```
+  스타일: `bg-red-50 border-l-4 border-red-500 text-red-700 px-4 py-3 rounded-lg`
+- 배너 아래 일정 리스트 (`ScheduleItem` 반복)
+- 빈 상태: lucide `<CalendarOff>` 아이콘 + "오늘 등록된 일정이 없습니다"
+
+### 5.3 주간 탭 (WeekView)
+
+- 월~일 7일을 날짜별 그룹핑
+- 일정 없는 날은 그룹 자체 생략 (밀도 유지)
+- 그룹 헤더: `04.29 (수)` — 오늘은 `text-at-accent`, 토/일은 `text-red-600`
+- 빈 상태: "이번 주 등록된 일정이 없습니다"
+
+### 5.4 월간 탭 (MonthView)
+
+- 주간과 동일한 그룹 형식 (날짜별 그룹 + 항목들)
+- 범위만 1일~말일로 확장
+- 항목 수가 많을 수 있어 카드 내부 스크롤: `max-h-[480px] overflow-y-auto`
+- 빈 상태: "이번 달 등록된 일정이 없습니다"
+
+### 5.5 ScheduleItem
+
+```
+[휴무]   신정 연휴                    📌
+[일정]   2026 봄 직원 워크샵 (4.30~5.2)  ⭐
+[공휴일] 어린이날
+```
+
+- 좌측 배지 (4가지):
+
+| 종류 | 라벨 | 배경 | 글자색 |
+|---|---|---|---|
+| `clinic_holiday` | `휴무` | `bg-red-50` | `text-red-700` |
+| `public_holiday` | `공휴일` | `bg-amber-50` | `text-amber-700` |
+| announcement (`category=schedule`) | `일정` | `bg-at-accent-tag` | `text-at-accent` |
+| announcement (`category=holiday`) | `휴무공지` | `bg-red-50` | `text-red-700` |
+
+- 우측 표식: `isPinned`이면 `<Pin>`, `isImportant`이면 `<Star>` (fill amber-400)
+- 기간 일정은 제목 끝에 `(M.D~M.D)` 표기
+- announcement source일 때만 `cursor-pointer hover:bg-at-surface-hover`. 휴무일은 `cursor-default`
+
+---
+
+## 6. 상호작용 — 모달 (ScheduleDetailModal)
+
+공지사항 클릭 시에만 열림. 휴무일·법정 공휴일은 클릭 비활성.
+
+### 6.1 모달 구조
+
+```
+┌─ Dialog ─────────────────────────────────┐
+│ 📌 [일정] 2026 봄 직원 워크샵          ✕ │
+├──────────────────────────────────────────┤
+│ 📅 2026.04.30 ~ 2026.05.02              │
+│ ✍️ 작성자: 홍길동 · 04.20 작성            │
+├──────────────────────────────────────────┤
+│ [본문 HTML 렌더링, max-h-[60vh] 스크롤]  │
+├──────────────────────────────────────────┤
+│        [ 닫기 ]   [ 게시판에서 보기 → ] │
+└──────────────────────────────────────────┘
+```
+
+### 6.2 동작
+
+- 본문은 `bulletinService.getAnnouncement(id)`로 lazy 페치 (모달 오픈 시점)
+- 페치 중 스켈레톤
+- 본문 렌더링: TipTap이 HTML로 저장하므로 **`@/utils/sanitize`의 `sanitizeHtml(content)`로 sanitize 후** Tailwind `prose` 클래스 적용. (XSS 방어 — 이미 프로젝트의 `AnnouncementDetail.tsx` 등에서 사용 중인 동일 유틸을 그대로 재사용한다. 신규 sanitization 로직을 추가하지 않는다.)
+- "게시판에서 보기" → `/dashboard/bulletin?id={announcementId}`로 라우팅
+- ESC / 배경 클릭 / X 버튼 닫기 (shadcn 기본)
+- **조회수는 증가시키지 않는다** (게시판으로 진입 시에만 카운트되는 기존 흐름 유지)
+
+### 6.3 접근성
+
+- 모달 열림 시 닫기 버튼에 자동 포커스
+- Tab 순서: 닫기 → 게시판으로 이동
+- 배지에 `aria-label` (예: "휴무 일정", "중요 공지")
+
+---
+
+## 7. 디자인 시스템 적용
+
+기존 `--at-*` CSS 변수와 shadcn 컴포넌트를 그대로 사용한다.
+
+### 7.1 토큰
+
+- 카드: `<Card>` (`rounded-2xl`, `shadow-at-card`)
+- 액센트: `--at-accent` (#1b61c9), `--at-accent-tag` (#e8f0fe)
+- 텍스트: `--at-text-primary`, `--at-text-secondary`, `--at-text-weak`
+- 표면: `--at-surface`, `--at-surface-hover`
+- 휴무 강조: `red-50` / `red-500` / `red-700` (Tailwind 기본)
+- 공휴일 강조: `amber-50` / `amber-700` (Tailwind 기본)
+
+### 7.2 아이콘 (lucide-react)
+
+- 카드 제목: `<Calendar>`
+- 중요: `<Star>` (fill amber-400)
+- 고정: `<Pin>`
+- 빈 상태: `<CalendarOff>`
+- 모달 메타: `<CalendarRange>`, `<UserCircle2>`
+- 휴무 배너: `<Building2>` 또는 `<Ban>`
+
+### 7.3 반응형
+
+- 모바일 (`< 768px`): 카드 1열, 탭 텍스트 축약 (`오늘 / 주간 / 월간`)
+- 태블릿+: 다른 위젯과 같은 폭
+
+---
+
+## 8. 에러 / 엣지 케이스
+
+| 케이스 | 처리 |
+|---|---|
+| 공지 본문 날짜 추출 실패 | 위젯에서 누락 (콘솔에 debug 로그) |
+| 휴무 설정 조회 실패 | 법정 공휴일 표시 안 함 (병원·공지 휴무는 그대로) |
+| 모달 본문 페치 실패 | 모달 내 에러 메시지 + "게시판에서 보기" 버튼은 활성 유지 |
+| 같은 날짜에 동일 항목 중복 (휴무공지+병원휴무) | `(date, title)`로 dedupe |
+| 기간이 조회 윈도우 일부만 겹치는 경우 | 그대로 표시, 제목에 전체 기간 노출 |
+| 클리닉 ID 미확인 (인증 직후) | 빈 상태 표시, 컨텍스트가 채워지면 자동 재페치 |
+
+---
+
+## 9. 비범위 (Out of Scope)
+
+- 일정 등록/수정 UI (게시판에서 함)
+- 캘린더 그리드 뷰 (날짜 그룹 리스트로 충분)
+- 일정 알림/푸시
+- 휴무일 데이터 편집 (마스터 페이지에서 별도 관리)
+- general 카테고리 공지사항 (일정성이 아니므로)
+
+---
+
+## 10. 검증 계획
+
+1. `npm run build` 통과
+2. Chrome DevTools MCP로 테스트 계정(`whitedc0902@gmail.com`) 로그인 후:
+   - 오늘 / 주간 / 월간 탭 전환 동작 확인
+   - 공지사항 항목 클릭 → 모달 본문 정상 표시 (sanitize 적용 확인) → "게시판에서 보기" 라우팅 확인
+   - 휴무일 항목 클릭 비활성 확인
+   - 빈 상태 메시지 표시 확인 (필요 시 임시로 데이터 비우고 검증)
+3. `scheduleParser` 단위 테스트 (가능한 경우):
+   - 단일 날짜 패턴 5종, 기간 패턴 4종, 연도 생략 보정, 추출 실패 케이스
+4. 콘솔 에러 0건 확인

--- a/dental-clinic-manager/docs/superpowers/specs/2026-04-29-rl-trading-design.md
+++ b/dental-clinic-manager/docs/superpowers/specs/2026-04-29-rl-trading-design.md
@@ -1,0 +1,546 @@
+# 강화학습(RL) 기반 적응형 트레이딩 모델 통합 — Phase 1
+
+작성일: 2026-04-29
+대상 시장: 미국 주식 (Phase 1)
+운용 단위: Portfolio (Dow 30 등) + Single-asset (Phase 1은 Portfolio만 자동매매까지 완성)
+
+---
+
+## 1. Context
+
+기존 자동매매는 룰 기반(지표 + 조건 트리)만 지원한다. 강화학습 기반 적응형 트레이딩 모델을 새로운 전략 타입으로 추가해, 시장 데이터에 학습된 정책이 직접 매수/매도 결정을 내릴 수 있게 한다.
+
+**Phase 1은 의도적으로 좁다:**
+- 미국 주식 시장만 (KIS 해외주식 인프라 재사용)
+- FinRL/Stable-Baselines3 **공식 사전학습 모델 로드**가 출발점 (자체 학습 파이프라인은 Phase 2)
+- 일봉(1d) **재교형** 1회/일이 결정 주기 (분봉/실시간 추론은 Phase 2)
+- **Portfolio 운용 단위**가 자동매매 완성 대상. Single-asset 추상화는 등록만 가능, 자동매매 자체 학습 모델 등록 후로 미룸
+
+**왜 좁히는가:**
+- FinRL 사전학습 모델은 대부분 Dow 30 portfolio · 일봉 구조. 분포 변화(distribution shift)·state space 불일치를 피하려면 학습 시점 환경에 맞춰 운영해야 한다.
+- 일봉 재교형은 KIS API 호출이 하루 몇 번에 그쳐 운영 부담이 작고, 미국 시장 마감 후 충분한 데이터 안정화 시간을 확보할 수 있다.
+- 사용자가 "Paper·Live 모두 자동 가능"을 선택했지만, Phase 1 안전망(default level=1, kill switch, 신뢰도 임계, 일일 손실 한도, idempotency)을 강제로 포함한다.
+
+---
+
+## 2. 시스템 아키텍처
+
+```
+┌─ Next.js 메인 앱 ────────┐    ┌─ trading-worker (기존 + 확장) ──┐
+│  /investment/rl-models   │    │  signalProcessor.ts (기존)       │
+│  /investment/strategy/*  │    │  + dailyRebalanceJob.ts (신규)   │
+│  /api/investment/*       │    │  KIS 미국주식 WS/REST            │
+└──────────┬───────────────┘    └─────────┬───────────────────────┘
+           │                               │ HTTP (localhost:8001)
+           │                               ▼
+           │                    ┌─ rl-inference-server (신규) ─────┐
+           │                    │  Python 3.11 + FastAPI           │
+           │                    │  + PyTorch + stable-baselines3   │
+           │                    │  + finrl (필요 모듈만)           │
+           │                    │  POST /predict, /backtest        │
+           │                    │  ckpt LRU + state schema 검증    │
+           │                    └──────────────────────────────────┘
+           ▼
+┌─ Supabase ───────────────┐
+│  rl_models (신규)         │
+│  rl_inference_logs (신규) │
+│  investment_strategies    │
+│   (strategy_type 확장)    │
+└──────────────────────────┘
+```
+
+**프로세스 토폴로지:**
+- 메인 앱: 기존 그대로 (Vercel 또는 자체 호스팅)
+- trading-worker: 기존 PM2 프로세스
+- rl-inference-server: 별도 PM2 프로세스 (`pm2 start ecosystem.config.js --only rl-inference`)
+- 모두 동일 머신(Mac mini M4) 위에서 동작 가정. 통신은 localhost only (외부 노출 금지).
+
+---
+
+## 3. 데이터 모델
+
+### 3.1 신규 테이블: `rl_models`
+
+```sql
+CREATE TABLE rl_models (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+
+  name TEXT NOT NULL,
+  description TEXT,
+  source TEXT NOT NULL CHECK (source IN ('finrl_pretrained','sb3_pretrained','custom')),
+  algorithm TEXT NOT NULL,  -- 'PPO' | 'A2C' | 'TD3' | 'DDPG' | 'DQN' | 'SAC'
+  kind TEXT NOT NULL CHECK (kind IN ('portfolio','single_asset')),
+  market TEXT NOT NULL DEFAULT 'US',
+  timeframe TEXT NOT NULL DEFAULT '1d',
+
+  universe JSONB,                    -- portfolio: ['AAPL','MSFT',...], single: NULL
+  input_features JSONB NOT NULL,     -- ['open','high','low','close','volume','rsi_14',...]
+  state_window INT NOT NULL DEFAULT 60,  -- 모델이 요구하는 과거 봉 수
+  output_shape JSONB NOT NULL,       -- {type:'continuous'|'discrete', dim:30}
+
+  checkpoint_url TEXT,               -- HuggingFace/GitHub 다운로드 URL
+  checkpoint_path TEXT,              -- 서버 로컬 경로 (다운로드 후)
+  checkpoint_sha256 TEXT,            -- 무결성 검증용
+
+  min_confidence NUMERIC(3,2) DEFAULT 0.60,  -- 자동매매 차단 임계값
+
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','downloading','ready','failed','archived')),
+  metrics JSONB,                     -- {sharpe, max_dd, win_rate, ...}
+  failure_reason TEXT,
+
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_rl_models_clinic ON rl_models(clinic_id);
+CREATE INDEX idx_rl_models_status ON rl_models(status);
+```
+
+### 3.2 `investment_strategies` 확장
+
+```sql
+ALTER TABLE investment_strategies
+  ADD COLUMN strategy_type TEXT NOT NULL DEFAULT 'rule'
+    CHECK (strategy_type IN ('rule','rl_portfolio','rl_single')),
+  ADD COLUMN rl_model_id UUID REFERENCES rl_models(id) ON DELETE SET NULL;
+
+-- RL 전략은 반드시 모델 연결되어야 함
+ALTER TABLE investment_strategies
+  ADD CONSTRAINT rl_strategy_requires_model
+  CHECK (strategy_type = 'rule' OR rl_model_id IS NOT NULL);
+```
+
+### 3.3 신규 테이블: `rl_inference_logs`
+
+```sql
+CREATE TABLE rl_inference_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  strategy_id UUID NOT NULL REFERENCES investment_strategies(id) ON DELETE CASCADE,
+  rl_model_id UUID NOT NULL REFERENCES rl_models(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL,
+
+  trade_date DATE NOT NULL,                  -- 결정이 적용될 거래일 (ET 기준)
+  state_hash TEXT NOT NULL,                  -- 입력 state SHA256 — 재현성
+
+  output JSONB NOT NULL,                     -- {action|weights, confidence, reasoning?}
+  confidence NUMERIC(4,3),                   -- 추출된 평균 신뢰도 (정렬/필터용)
+  decision TEXT NOT NULL CHECK (decision IN ('order','hold','blocked_low_confidence','blocked_kill_switch','error')),
+  blocked_reason TEXT,
+
+  latency_ms INT,
+  error_message TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+
+  UNIQUE (strategy_id, trade_date)           -- idempotency: 하루 1회만
+);
+
+CREATE INDEX idx_rl_logs_strategy_date ON rl_inference_logs(strategy_id, trade_date DESC);
+CREATE INDEX idx_rl_logs_user_date ON rl_inference_logs(user_id, trade_date DESC);
+```
+
+### 3.4 `user_investment_settings` 확장 (kill switch)
+
+```sql
+ALTER TABLE user_investment_settings
+  ADD COLUMN rl_paused_at TIMESTAMPTZ,        -- NULL=활성, 시각=일시정지 시점
+  ADD COLUMN rl_paused_reason TEXT;
+```
+
+### 3.5 RLS 정책
+- 모든 신규 테이블: 본인 clinic_id 기준 read, 본인 user_id 기준 write
+- `rl_inference_logs`: 시스템(서비스 키)만 INSERT, 사용자는 본인 것 read만
+
+---
+
+## 4. 핵심 컴포넌트
+
+### 4.1 `rl-inference-server/` (신규 Python 프로젝트)
+
+위치: `/Users/hhs/Project/dental-clinic-manager/rl-inference-server/`
+
+```
+rl-inference-server/
+├── pyproject.toml          # 또는 requirements.txt
+├── ecosystem.config.js     # PM2 설정 (또는 trading-worker와 통합)
+├── src/
+│   ├── main.py             # FastAPI 앱 + 라우트
+│   ├── config.py           # 환경변수 로딩 (PORT, MODEL_DIR, ...)
+│   ├── model_registry.py   # ckpt 다운로드/캐시/로드 (LRU 2개)
+│   ├── schemas.py          # Pydantic: PredictRequest/Response, BacktestRequest/Response
+│   ├── inference/
+│   │   ├── portfolio.py    # PortfolioInferenceEngine
+│   │   └── single.py       # SingleAssetInferenceEngine
+│   ├── adapters/
+│   │   ├── finrl.py        # FinRL ckpt → 표준 인터페이스
+│   │   └── sb3.py          # stable-baselines3 ckpt → 표준 인터페이스
+│   └── utils/
+│       ├── state_builder.py
+│       └── feature_engineering.py
+└── tests/
+    ├── test_predict.py
+    └── test_backtest.py
+```
+
+**핵심 의존성:**
+- `fastapi`, `uvicorn[standard]`, `pydantic>=2`
+- `torch>=2.2` (CPU 빌드도 충분 — 일봉 추론은 빠름)
+- `stable-baselines3>=2.3` (PPO/A2C/TD3/DQN/SAC 로드)
+- `finrl` (선택 — Dow 30 환경 정의 등 필요한 부분만)
+- `numpy`, `pandas`
+- `httpx` (테스트용)
+- `pytest`, `pytest-asyncio`
+
+**API:**
+
+```
+GET  /health                       → {status, loaded_models, uptime}
+POST /models/download              → {model_id, checkpoint_url, sha256?}
+                                    응답: {status: 'downloading'|'ready', path}
+POST /predict                      → 본문 아래 참조
+POST /backtest                     → ohlcv 기간 시뮬레이션
+```
+
+**`/predict` 요청 스키마:**
+```ts
+{
+  model_id: string,                // rl_models.id (서버는 실제 ckpt만 읽음)
+  checkpoint_path: string,         // 로컬 절대 경로
+  algorithm: 'PPO'|'A2C'|...,
+  kind: 'portfolio'|'single_asset',
+  state_window: number,            // 60
+  input_features: string[],
+  ohlcv: {                         // universe별 OHLCV (portfolio 기준)
+    [ticker: string]: Array<{date, open, high, low, close, volume}>
+  },
+  indicators?: {[ticker: string]: {[name: string]: number[]}},
+  current_positions?: {[ticker: string]: {qty: number, avg_price: number}},
+}
+```
+
+**`/predict` 응답 스키마:**
+```ts
+// portfolio:
+{
+  kind: 'portfolio',
+  weights: {[ticker: string]: number},   // 합 ≈ 1
+  confidence: number,                    // 0~1, 모델 출력 분포 기반 (예: softmax 최대값)
+  raw_action: number[],                  // 디버깅용
+  metadata: {model_id, latency_ms, ts}
+}
+
+// single_asset:
+{
+  kind: 'single_asset',
+  action: 'buy'|'sell'|'hold',
+  size_hint?: number,                    // 0~1 (자본 비율)
+  confidence: number,
+  metadata: {...}
+}
+```
+
+**`confidence` 계산 규칙 (어댑터별):**
+- PPO/A2C 등 stochastic policy: `mean(softmax(logits))의 최대 확률` 또는 분산 기반 1 − std/std_max
+- DQN: `softmax(q_values)`의 최대값
+- continuous (TD3/DDPG/SAC): 분산 기반 신뢰도. **모델별 어댑터에 명시적 함수로 구현, 가짜 1.0 금지**
+
+**모델 캐시:**
+- 메모리: 최근 사용 모델 2개 LRU (가벼운 설정 — 메모리 절약)
+- 디스크: 다운로드한 ckpt는 영구 (`MODEL_DIR/<sha256>/`)
+- 로딩 실패는 `rl_models.status='failed'`로 마킹 (서버가 직접 DB 호출하지 않고, 응답으로 실패 보고 → 트레이딩 워커가 갱신)
+
+**보안:**
+- 서버는 localhost(127.0.0.1)만 바인드
+- API 키 인증 헤더(`X-RL-API-KEY`) 환경변수 검증
+- 외부 인터넷 접근은 모델 다운로드 시점만 (HuggingFace/GitHub URL whitelist)
+
+### 4.2 `trading-worker/` 확장
+
+위치: `/Users/hhs/Project/dental-clinic-manager/trading-worker/`
+
+**신규 모듈:**
+
+```
+trading-worker/src/
+├── dailyRebalanceJob.ts       # 신규 — 일봉 마감 후 RL 추론
+├── rlInferenceClient.ts       # 신규 — fetch /predict, 타임아웃 5s, 재시도 0회
+└── (기존 모듈 그대로)
+```
+
+**`dailyRebalanceJob.ts` 흐름:**
+
+```ts
+// node-cron: '0 7 * * 2-6' KST (월~금 ET 마감 다음날 새벽). DST는 검토 후 결정.
+async function runDailyRebalance() {
+  const date = todayInET();
+  const strategies = await fetchActiveRLStrategies();   // strategy_type LIKE 'rl_%'
+  for (const s of strategies) {
+    try {
+      const skipped = await checkIdempotency(s.id, date);
+      if (skipped) continue;
+      const killSwitch = await checkKillSwitch(s.user_id);
+      if (killSwitch) {
+        await logInference(s, date, {decision: 'blocked_kill_switch'});
+        continue;
+      }
+      const state = await buildState(s);                // OHLCV + 지표
+      const result = await rlInferenceClient.predict(s, state);
+      if (result.confidence < s.model.min_confidence) {
+        await logInference(s, date, {decision: 'blocked_low_confidence', output: result});
+        await notifyTelegram(s.user_id, `[RL] ${s.name}: 신뢰도 ${result.confidence} 낮아 hold`);
+        continue;
+      }
+      const orders = computeOrders(s, result);          // portfolio diff or buy/sell
+      if (s.automation_level === 1) {
+        await notifyTelegram(s.user_id, formatSignalAlert(s, result, orders));
+        await logInference(s, date, {decision: 'order', output: result, orders});
+      } else {
+        for (const o of orders) await executeAutoOrder(o);   // 기존 함수 재사용
+        await logInference(s, date, {decision: 'order', output: result, orders});
+      }
+    } catch (err) {
+      await logInference(s, date, {decision: 'error', error_message: err.message});
+      await notifyTelegram(s.user_id, `[RL] ${s.name} 추론 실패: ${err.message}`);
+    }
+  }
+}
+```
+
+**state 구성:**
+- 모델의 `input_features` + `state_window` 따라 다름
+- portfolio: universe 모든 종목의 OHLCV `state_window` 봉 + 모델이 요구한 지표
+- 지표 계산은 메인 앱의 `indicatorEngine.ts`와 동일한 결과를 내야 함 (서버 사이드 검증 — Python에서 동일 산출 가능한지 어댑터에서 보장하거나, trading-worker가 계산 후 보냄)
+
+**Phase 1 결정**: trading-worker가 OHLCV + 기존 indicator 계산 결과를 보내고, rl-inference-server는 받은 그대로 모델에 입력. 지표 산출 정합성을 서버에서 다시 검증하지 않음. (피처 누락은 응답 schema 검증에서 거부)
+
+**universe / input_features / state_window 정의:**
+- 자동 추출하지 않음. **모델 등록 시 사용자가 명시적으로 입력** (사전학습 모델 README/공식 문서 참조)
+- 검증: rl-inference-server `/models/download` 시 ckpt 로드 후 dummy state로 forward pass 1회 → 입출력 형상이 사용자 입력과 일치하는지 확인. 불일치 시 `status='failed'`
+
+### 4.3 메인 앱 (Next.js)
+
+**신규 페이지:**
+
+| 경로 | 역할 |
+|---|---|
+| `/investment/rl-models` | 사전학습 모델 라이브러리 (목록/추가/다운로드/메트릭/활성화) |
+| `/investment/rl-models/[id]` | 모델 상세 (학습 정보, 추론 로그, 백테스트) |
+| `/investment/strategy/new?type=rl_portfolio` | RL 전략 생성 폼 |
+
+**기존 페이지 변경:**
+- `/investment/strategy`: 카드/리스트에 strategy_type 배지 표시 (Rule / RL Portfolio / RL Single)
+- `/investment/strategy/[id]/monitor` (있으면): 추론 로그 섹션 추가
+
+**신규 API 라우트:**
+
+| 경로 | 역할 |
+|---|---|
+| `POST /api/investment/rl-models` | 모델 등록 (URL/sha256 받아서 rl-inference-server로 download 위임) |
+| `GET /api/investment/rl-models` | 목록 |
+| `DELETE /api/investment/rl-models/[id]` | archive (참조 전략 비활성화 후) |
+| `POST /api/investment/rl-models/[id]/backtest` | rl-inference-server `/backtest` 위임 |
+| `POST /api/investment/rl-pause` | kill switch 토글 |
+
+**Phase 1 UI 디자인 컨벤션:**
+- 기존 AT Tokens/디자인 시스템 그대로 (`bg-at-accent`, `rounded-xl`, ...)
+- RL 자동매매 활성화 화면에는 빨간 경고 배너 + paper credential 권장 표시
+- automation_level 변경은 confirmation modal (현재 잔여 잔고/일일 손실 한도 명시)
+
+### 4.4 안전 가드 (강제)
+
+| 가드 | 구현 위치 | 행동 |
+|---|---|---|
+| **default automation_level=1** | API `POST /api/investment/strategies` (RL 타입) | 명시 안 하면 1 강제 |
+| **min_confidence** | dailyRebalanceJob | 임계 미달 → hold + 알림 |
+| **kill switch** | dailyRebalanceJob → checkKillSwitch | `rl_paused_at IS NOT NULL`이면 skip |
+| **daily_loss_limit** | 기존 `riskGuard.checkDailyLossLimit` | 기존 로직 그대로 |
+| **idempotency** | `rl_inference_logs (strategy_id, trade_date)` UNIQUE | 두 번째 추론 시도는 차단 |
+| **추론 타임아웃** | rlInferenceClient | 5s, 재시도 0회, 실패 시 hold |
+| **paper 권장** | UI 배지 + 첫 활성화 confirmation | 사용자 인지 강제 |
+| **emergency-stop 호환** | 기존 `/api/investment/emergency-stop` | RL 전략도 함께 비활성화 |
+
+---
+
+## 5. 일봉 재교형 흐름 상세
+
+```
+[ET 16:00 미장 마감 = KST 06:00]
+        │
+        │ +1h 안정화 (KIS 일봉 데이터 + 보조지표)
+        ▼
+[KST 07:00] dailyRebalanceJob.run()
+        │
+        ▼
+   1. 활성 RL 전략 N개 조회 (is_active=true AND strategy_type LIKE 'rl_%')
+        │
+        ▼ for each strategy
+   2. checkIdempotency(strategy_id, date)
+        │ (rl_inference_logs UNIQUE)
+        ▼
+   3. checkKillSwitch(user_id)
+        │ (rl_paused_at)
+        ▼
+   4. buildState(strategy) — universe OHLCV `state_window` + 지표
+        │
+        ▼
+   5. rlInferenceClient.predict() ──────HTTP──────▶ rl-inference-server /predict
+        │                                              │
+        │                                              ▼
+        │                                          ckpt 로드 + 추론 (~수백 ms)
+        │                                              │
+        │ ◀────────── {weights/action, confidence} ────┘
+        ▼
+   6. confidence < min_confidence?
+        │ Yes → log(blocked_low_confidence) + Telegram 알림
+        │ No  → 7
+        ▼
+   7. computeOrders(strategy, result)
+        │ portfolio: 현재 포지션 vs 목표 weights → diff 주문 목록
+        │ single: action(buy|sell) → 주문 1개
+        ▼
+   8. automation_level=1?
+        │ Yes → Telegram 알림 + log(order, orders=[]?) — 사용자 수동 승인
+        │ No  → for o in orders: executeAutoOrder(o) (기존 함수)
+        ▼
+   9. log(order, output, orders) + Telegram 요약 보고
+```
+
+**시간대 처리:**
+- cron은 KST 기준이지만 trade_date는 ET 기준 ISO date. 실패 시 재시작 가능하도록 `trade_date`는 명시적으로 계산.
+- DST: 미국 EDT/EST 전환 시 cron 시간 자동 조정 안 됨. Phase 1은 KST 07:00 고정 → 늦어도 1시간 마진.
+
+---
+
+## 6. 테스트 전략
+
+### 6.1 rl-inference-server (Python)
+- 단위(`pytest`):
+  - `model_registry`: 다운로드 mock(httpx_mock) + 캐시 LRU
+  - `adapters/sb3`: 실제 가벼운 PPO ckpt 로드 후 입력 → 출력 형상 검증
+  - `inference/portfolio`: 가짜 ckpt + 더미 OHLCV → 합 ≈ 1
+- integration: FastAPI TestClient + 실제 PPO Dow 30 ckpt 1개로 `/predict` 호출
+- 회귀: 동일 state → 동일 weights (deterministic 모드)
+
+### 6.2 trading-worker (TypeScript)
+- 단위(`vitest`):
+  - `dailyRebalanceJob`: fetch + supabase 모두 mock, 시나리오별 분기 (kill switch on, 신뢰도 미달, 정상, 추론 실패, idempotency 적용)
+  - `rlInferenceClient`: 타임아웃, 5xx, 응답 스키마 검증
+
+### 6.3 메인 앱 (Next.js)
+- API 단위: rl-models CRUD, 권한, RLS 가정
+- UI: 새 페이지 렌더링 smoke test (Vitest + RTL)
+
+### 6.4 E2E (수동 시나리오)
+1. 사전학습 PPO Dow 30 ckpt 다운로드 → status=ready
+2. 전략 생성(automation_level=1, paper credential 연결)
+3. cron 트리거 강제 호출 → Telegram 알림 수신
+4. automation_level=2로 변경 → confirmation 모달 통과
+5. 다음 cron 시각에 paper 계좌로 자동 주문 발생
+6. kill switch ON → 다음 cron skip
+7. emergency-stop → 모든 RL 전략 비활성
+
+---
+
+## 7. 모니터링 & 알림
+
+| 신호 | 채널 | 트리거 |
+|---|---|---|
+| 일일 추론 시작/종료 요약 | Telegram | dailyRebalanceJob 끝 |
+| 추론 실패 (5xx, timeout) | Telegram + `investment_audit_logs` | rlInferenceClient catch |
+| 신뢰도 임계 미달 | Telegram (low priority) | dailyRebalanceJob |
+| 자동 주문 체결/실패 | Telegram (기존) | 기존 orderExecutor |
+| 모델 다운로드 실패 | UI + Telegram | model_registry |
+
+---
+
+## 8. Phase 1 범위
+
+### 포함 (IN)
+- DB 마이그레이션: `rl_models`, `rl_inference_logs`, `investment_strategies` 확장, `user_investment_settings.rl_paused_at`
+- `rl-inference-server` 골격 (Python FastAPI + PyTorch + sb3) + 어댑터 2개(sb3, finrl 환경 1개)
+- FinRL PPO Dow 30 ckpt 1개 등록 시나리오 (실증)
+- `trading-worker`: `dailyRebalanceJob` + `rlInferenceClient`
+- 메인 앱: `/investment/rl-models` + 전략 생성에 `rl_portfolio` 옵션
+- 모든 안전 가드 (default level=1, kill switch, min_confidence, idempotency, 타임아웃)
+- 테스트 (단위/integration)
+- 운영 가이드 문서 (모델 등록 절차, kill switch 사용법, 트러블슈팅)
+
+### 제외 (OUT — Phase 2 이후)
+- 단일 종목 RL 자동매매 (등록은 가능, 실행 분기는 todo로 표시)
+- 분봉/실시간 RL
+- 자체 학습 파이프라인 (학습용 환경, 데이터 수집 자동화, 실험 추적)
+- 코인 거래소 어댑터 (업비트/바이낸스)
+- 한국 주식 RL
+- ONNX export / Node.js 직접 추론 최적화
+- 멀티 GPU / 분산 추론
+
+---
+
+## 9. 핵심 파일 경로 (참조)
+
+**기존 (수정 대상):**
+- [trading-worker/src/index.ts](trading-worker/src/index.ts) — dailyRebalanceJob 등록
+- [trading-worker/src/orderExecutor.ts](trading-worker/src/orderExecutor.ts) — 재사용
+- [trading-worker/src/riskGuard.ts](trading-worker/src/riskGuard.ts) — 재사용
+- [trading-worker/src/telegramNotifier.ts](trading-worker/src/telegramNotifier.ts) — 재사용
+- [src/app/api/investment/strategies/route.ts](dental-clinic-manager/src/app/api/investment/strategies/route.ts) — strategy_type 분기 추가
+- [src/app/investment/strategy/page.tsx](dental-clinic-manager/src/app/investment/strategy/page.tsx) — 배지 추가
+- [src/types/investment.ts](dental-clinic-manager/src/types/investment.ts) — 타입 확장
+
+**신규:**
+- `rl-inference-server/` (전체)
+- [trading-worker/src/dailyRebalanceJob.ts](trading-worker/src/dailyRebalanceJob.ts)
+- [trading-worker/src/rlInferenceClient.ts](trading-worker/src/rlInferenceClient.ts)
+- `supabase/migrations/<YYYYMMDD>_rl_trading.sql` (구현 시점 날짜로 명명)
+- [src/app/investment/rl-models/page.tsx](dental-clinic-manager/src/app/investment/rl-models/page.tsx) (외 다수)
+- [src/app/api/investment/rl-models/route.ts](dental-clinic-manager/src/app/api/investment/rl-models/route.ts) (외 다수)
+
+---
+
+## 10. 검증 (구현 완료 후 어떻게 동작 확인하는가)
+
+1. **DB 마이그레이션 적용**: `mcp__supabase__apply_migration`으로 적용. 모든 신규 테이블/제약/RLS 검증.
+2. **rl-inference-server 기동**: `pm2 start` → `/health` 200 응답.
+3. **모델 등록 시나리오**:
+   - UI에서 PPO Dow 30 ckpt URL 입력 → status가 downloading→ready로 전이
+   - rl_models row, checkpoint_path 채워짐
+4. **전략 생성 시나리오**:
+   - `/investment/strategy/new?type=rl_portfolio` → 모델 선택 → automation_level=1로 저장 (default)
+   - investment_strategies row 생성, strategy_type='rl_portfolio', rl_model_id 채워짐
+5. **dailyRebalanceJob 강제 실행** (수동 트리거):
+   - 활성 RL 전략 1개 → /predict 호출 → rl_inference_logs INSERT → Telegram 알림 수신
+   - 같은 trade_date로 재실행 → idempotency로 skip
+6. **kill switch**:
+   - UI에서 RL 일시정지 ON → 다음 실행에서 `blocked_kill_switch` 로그
+7. **automation_level=2로 변경 후 paper credential**:
+   - confirmation 모달 통과
+   - 다음 실행에서 KIS 모의투자 계좌에 자동 주문 (executeAutoOrder)
+   - trade_orders row + Telegram 체결 알림
+8. **emergency-stop**:
+   - 모든 RL 전략 is_active=false 전환
+
+---
+
+## 11. 의존성 / 운영 노트
+
+- **Python 환경**: `pyproject.toml` 또는 `requirements.txt` + `python -m venv`. PyTorch CPU 빌드 권장 (Mac mini M4 기준 일봉 추론은 충분)
+- **PM2 ecosystem**: trading-worker와 rl-inference-server가 동시 기동/재시작
+- **로그**: 두 워커 모두 pino 또는 structlog → 동일 로그 디렉터리
+- **모델 저장소**: 로컬 `MODEL_DIR=/Users/hhs/.../models/`. 디스크 사용량 모니터링 (디폴트 모델 수십 MB ~ 수백 MB)
+- **백업**: 모델 ckpt는 url + sha256 기록되어 있으므로 재다운로드 가능. DB 백업이 일차 진실원
+
+---
+
+## 12. 위험 요인과 대응
+
+| 위험 | 대응 |
+|---|---|
+| 사전학습 모델의 분포 변화로 부적절한 신호 | min_confidence + kill switch + paper credential 권장 |
+| 추론 서버 다운 시 자동매매 정지 | 5s 타임아웃 + hold 처리, Telegram 즉시 알림 |
+| 사용자가 무모하게 level=2로 변경 | confirmation 모달 + paper 권장 배지 + daily_loss_limit 강제 |
+| 동시성: 같은 전략에 cron 중첩 실행 | rl_inference_logs UNIQUE + cron 락 (PM2 + flock 단일 인스턴스) |
+| FinRL ckpt 형식 비호환 | 어댑터 단위 테스트 + 실패 시 status='failed' + UI에 명확한 에러 |
+| 모델 산출 weight 합이 1 아님 | rl-inference-server에서 normalize + warning 로그 |
+| 신뢰도 산출 어댑터 부재 (continuous policy) | 어댑터별 명시적 `compute_confidence` 함수, 가짜 1.0 금지 |

--- a/dental-clinic-manager/src/app/dashboard/bulletin/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/bulletin/page.tsx
@@ -99,7 +99,12 @@ export default function BulletinPage() {
           </div>
         ) : (
           <>
-            {activeTab === 'announcements' && <AnnouncementList canCreate={isAdmin} />}
+            {activeTab === 'announcements' && (
+              <AnnouncementList
+                canCreate={isAdmin}
+                initialAnnouncementId={searchParams.get('id')}
+              />
+            )}
             {activeTab === 'documents' && <DocumentList canCreate={isAdmin} />}
           </>
         )}

--- a/dental-clinic-manager/src/components/Bulletin/AnnouncementList.tsx
+++ b/dental-clinic-manager/src/components/Bulletin/AnnouncementList.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
 import {
   Megaphone,
   Pin,
@@ -20,9 +21,11 @@ import { appConfirm, appAlert } from '@/components/ui/AppDialog'
 
 interface AnnouncementListProps {
   canCreate?: boolean
+  initialAnnouncementId?: string | null
 }
 
-export default function AnnouncementList({ canCreate = false }: AnnouncementListProps) {
+export default function AnnouncementList({ canCreate = false, initialAnnouncementId }: AnnouncementListProps) {
+  const router = useRouter()
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -58,6 +61,21 @@ export default function AnnouncementList({ canCreate = false }: AnnouncementList
   useEffect(() => {
     fetchAnnouncements()
   }, [fetchAnnouncements])
+
+  // initialAnnouncementId가 있으면 마운트 시 1회 자동 오픈 + URL에서 id 제거
+  useEffect(() => {
+    if (!initialAnnouncementId) return
+    let cancelled = false
+    announcementService.getAnnouncement(initialAnnouncementId).then(({ data }) => {
+      if (!cancelled && data) setSelectedAnnouncement(data)
+    })
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href)
+      url.searchParams.delete('id')
+      router.replace(url.pathname + url.search, { scroll: false })
+    }
+    return () => { cancelled = true }
+  }, [initialAnnouncementId, router])
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault()

--- a/dental-clinic-manager/src/components/Dashboard/DashboardHome.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/DashboardHome.tsx
@@ -27,6 +27,7 @@ import {
   Users,
 } from 'lucide-react'
 import MyTasksSection from './MyTasksSection'
+import ScheduleWidget from './ScheduleWidget'
 
 // 날씨 아이콘 매핑
 const weatherIcons: Record<string, React.ReactNode> = {
@@ -552,6 +553,9 @@ export default function DashboardHome() {
       <div className="flex flex-col lg:flex-row gap-4 sm:gap-6">
           {/* 왼쪽: 메인 콘텐츠 */}
           <div className="flex-1 space-y-4 sm:space-y-5">
+            {/* 병원 일정 */}
+            <ScheduleWidget />
+
             {/* 오늘의 현황 */}
             <div>
               <h3 className="text-sm font-semibold text-at-text mb-3 tracking-[0.08px] flex items-center gap-2">

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/MonthView.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/MonthView.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import React, { useMemo } from 'react'
+import { CalendarOff } from 'lucide-react'
+import type { ScheduleEvent } from './types'
+import ScheduleDateGroup from './ScheduleDateGroup'
+
+interface MonthViewProps {
+  events: ScheduleEvent[]
+  loading: boolean
+  todayIso: string
+  onItemClick: (event: ScheduleEvent) => void
+}
+
+function expandEventToDates(ev: ScheduleEvent): string[] {
+  const dates: string[] = []
+  const start = new Date(`${ev.startDate}T00:00:00`)
+  const end = new Date(`${ev.endDate}T00:00:00`)
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    const y = d.getFullYear()
+    const m = String(d.getMonth() + 1).padStart(2, '0')
+    const dy = String(d.getDate()).padStart(2, '0')
+    dates.push(`${y}-${m}-${dy}`)
+  }
+  return dates
+}
+
+function groupByDate(events: ScheduleEvent[]): Map<string, ScheduleEvent[]> {
+  const map = new Map<string, ScheduleEvent[]>()
+  for (const ev of events) {
+    const dates = expandEventToDates(ev)
+    for (const d of dates) {
+      const list = map.get(d) || []
+      list.push(ev)
+      map.set(d, list)
+    }
+  }
+  return map
+}
+
+export default function MonthView({ events, loading, todayIso, onItemClick }: MonthViewProps) {
+  const groups = useMemo(() => groupByDate(events), [events])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-6">
+        <div className="w-6 h-6 border-4 border-at-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  if (groups.size === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-6 text-at-text-secondary gap-2">
+        <CalendarOff className="w-8 h-8 text-at-text-weak" />
+        <p className="text-sm tracking-[0.08px]">이번 달 등록된 일정이 없습니다</p>
+      </div>
+    )
+  }
+
+  const sortedDates = Array.from(groups.keys()).sort()
+
+  return (
+    <div className="space-y-3 max-h-[480px] overflow-y-auto pr-1">
+      {sortedDates.map(date => (
+        <ScheduleDateGroup
+          key={date}
+          date={date}
+          events={groups.get(date)!}
+          todayIso={todayIso}
+          onItemClick={onItemClick}
+        />
+      ))}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/ScheduleDateGroup.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/ScheduleDateGroup.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import React from 'react'
+import { cn } from '@/lib/utils'
+import type { ScheduleEvent } from './types'
+import ScheduleItem from './ScheduleItem'
+
+const DOW_LABELS = ['일', '월', '화', '수', '목', '금', '토']
+
+function formatGroupHeader(dateIso: string): { label: string; dayOfWeek: number } {
+  const d = new Date(`${dateIso}T12:00:00`)
+  const month = d.getMonth() + 1
+  const day = d.getDate()
+  const dow = d.getDay()
+  return {
+    label: `${String(month).padStart(2, '0')}.${String(day).padStart(2, '0')} (${DOW_LABELS[dow]})`,
+    dayOfWeek: dow,
+  }
+}
+
+interface ScheduleDateGroupProps {
+  date: string
+  events: ScheduleEvent[]
+  todayIso: string
+  onItemClick: (event: ScheduleEvent) => void
+}
+
+export default function ScheduleDateGroup({ date, events, todayIso, onItemClick }: ScheduleDateGroupProps) {
+  const { label, dayOfWeek } = formatGroupHeader(date)
+  const isToday = date === todayIso
+  const isWeekend = dayOfWeek === 0 || dayOfWeek === 6
+
+  return (
+    <div className="space-y-1">
+      <div
+        className={cn(
+          'text-xs font-semibold tracking-[0.07px] flex items-center gap-2 px-2',
+          isToday ? 'text-at-accent' : isWeekend ? 'text-red-600' : 'text-at-text'
+        )}
+      >
+        <span>{label}</span>
+        {isToday && <span className="w-1.5 h-1.5 rounded-full bg-at-accent" />}
+      </div>
+      <div className="space-y-0.5">
+        {events.map(ev => (
+          <ScheduleItem key={ev.id} event={ev} onClick={onItemClick} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/ScheduleDetailModal.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/ScheduleDetailModal.tsx
@@ -90,7 +90,7 @@ export default function ScheduleDetailModal({ event, open, onOpenChange }: Sched
       <DialogContent className="max-w-2xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-base text-at-text">
-            <span className="px-1.5 py-0.5 rounded bg-at-accent-tag text-at-accent text-xs font-medium">
+            <span className="px-1.5 py-0.5 rounded bg-at-tag text-at-accent text-xs font-medium">
               {badgeLabel}
             </span>
             <span className="flex-1 truncate">{event?.title}</span>

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/ScheduleDetailModal.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/ScheduleDetailModal.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/Button'
+import { CalendarRange, UserCircle2, Pin, Star } from 'lucide-react'
+import { announcementService } from '@/lib/bulletinService'
+import type { Announcement } from '@/types/bulletin'
+import { sanitizeHtml } from '@/utils/sanitize'
+import type { ScheduleEvent } from './types'
+import { cn } from '@/lib/utils'
+
+interface ScheduleDetailModalProps {
+  event: ScheduleEvent | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function formatDateRangeLabel(startDate: string, endDate: string): string {
+  if (startDate === endDate) return startDate.replace(/-/g, '.')
+  return `${startDate.replace(/-/g, '.')} ~ ${endDate.replace(/-/g, '.')}`
+}
+
+function formatCreatedAt(iso: string | undefined): string {
+  if (!iso) return ''
+  try {
+    const d = new Date(iso)
+    const m = String(d.getMonth() + 1).padStart(2, '0')
+    const day = String(d.getDate()).padStart(2, '0')
+    return `${m}.${day} 작성`
+  } catch {
+    return ''
+  }
+}
+
+export default function ScheduleDetailModal({ event, open, onOpenChange }: ScheduleDetailModalProps) {
+  const router = useRouter()
+  const [detail, setDetail] = useState<Announcement | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open || !event?.announcementId) {
+      setDetail(null)
+      setError(null)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    announcementService
+      .getAnnouncementPreview(event.announcementId)
+      .then(result => {
+        if (cancelled) return
+        if (result.error || !result.data) {
+          setError(result.error || '본문을 불러올 수 없습니다')
+          setDetail(null)
+        } else {
+          setDetail(result.data)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [open, event?.announcementId])
+
+  const handleNavigate = () => {
+    if (!event?.announcementId) return
+    onOpenChange(false)
+    router.push(`/dashboard/bulletin?id=${event.announcementId}`)
+  }
+
+  const badgeLabel = event?.badgeKind === 'holiday_announcement' ? '휴무공지' : '일정'
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-base text-at-text">
+            <span className="px-1.5 py-0.5 rounded bg-at-accent-tag text-at-accent text-xs font-medium">
+              {badgeLabel}
+            </span>
+            <span className="flex-1 truncate">{event?.title}</span>
+            {event?.isPinned && <Pin className="w-4 h-4 text-at-accent shrink-0" />}
+            {event?.isImportant && <Star className="w-4 h-4 text-amber-400 fill-amber-400 shrink-0" />}
+          </DialogTitle>
+          <DialogDescription asChild>
+            <div className="flex flex-wrap items-center gap-3 text-xs text-at-text-secondary mt-1">
+              <span className="flex items-center gap-1">
+                <CalendarRange className="w-3.5 h-3.5" />
+                {event && formatDateRangeLabel(event.startDate, event.endDate)}
+              </span>
+              {detail?.author_name && (
+                <span className="flex items-center gap-1">
+                  <UserCircle2 className="w-3.5 h-3.5" />
+                  {detail.author_name}
+                </span>
+              )}
+              {detail?.created_at && (
+                <span>· {formatCreatedAt(detail.created_at)}</span>
+              )}
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className={cn('mt-2 max-h-[60vh] overflow-y-auto', loading && 'opacity-60')}>
+          {loading && (
+            <div className="space-y-2 py-4">
+              <div className="h-4 bg-at-surface-alt rounded animate-pulse" />
+              <div className="h-4 bg-at-surface-alt rounded animate-pulse w-5/6" />
+              <div className="h-4 bg-at-surface-alt rounded animate-pulse w-4/6" />
+            </div>
+          )}
+          {!loading && error && (
+            <p className="text-sm text-at-error py-4 text-center">{error}</p>
+          )}
+          {!loading && detail && (
+            <div
+              className="prose prose-sm max-w-none text-at-text-secondary whitespace-pre-wrap"
+              dangerouslySetInnerHTML={{ __html: sanitizeHtml(detail.content || '') }}
+            />
+          )}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            닫기
+          </Button>
+          <Button onClick={handleNavigate} disabled={!event?.announcementId}>
+            게시판에서 보기 →
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/ScheduleItem.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/ScheduleItem.tsx
@@ -13,7 +13,7 @@ interface BadgeStyle {
 const BADGE_STYLES: Record<ScheduleBadgeKind, BadgeStyle> = {
   clinic_holiday: { label: '휴무', className: 'bg-red-50 text-red-700' },
   public_holiday: { label: '공휴일', className: 'bg-amber-50 text-amber-700' },
-  schedule: { label: '일정', className: 'bg-at-accent-tag text-at-accent' },
+  schedule: { label: '일정', className: 'bg-at-tag text-at-accent' },
   holiday_announcement: { label: '휴무공지', className: 'bg-red-50 text-red-700' },
 }
 

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/ScheduleItem.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/ScheduleItem.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import React from 'react'
+import { Pin, Star } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { ScheduleEvent, ScheduleBadgeKind } from './types'
+
+interface BadgeStyle {
+  label: string
+  className: string
+}
+
+const BADGE_STYLES: Record<ScheduleBadgeKind, BadgeStyle> = {
+  clinic_holiday: { label: '휴무', className: 'bg-red-50 text-red-700' },
+  public_holiday: { label: '공휴일', className: 'bg-amber-50 text-amber-700' },
+  schedule: { label: '일정', className: 'bg-at-accent-tag text-at-accent' },
+  holiday_announcement: { label: '휴무공지', className: 'bg-red-50 text-red-700' },
+}
+
+function formatRangeSuffix(startDate: string, endDate: string): string {
+  if (startDate === endDate) return ''
+  const [, sm, sd] = startDate.split('-')
+  const [, em, ed] = endDate.split('-')
+  return ` (${parseInt(sm, 10)}.${parseInt(sd, 10)}~${parseInt(em, 10)}.${parseInt(ed, 10)})`
+}
+
+interface ScheduleItemProps {
+  event: ScheduleEvent
+  onClick?: (event: ScheduleEvent) => void
+}
+
+export default function ScheduleItem({ event, onClick }: ScheduleItemProps) {
+  const badge = BADGE_STYLES[event.badgeKind]
+  const isClickable = event.source === 'announcement' && !!onClick
+  const suffix = formatRangeSuffix(event.startDate, event.endDate)
+
+  return (
+    <button
+      type="button"
+      onClick={isClickable ? () => onClick!(event) : undefined}
+      disabled={!isClickable}
+      aria-label={`${badge.label} 일정: ${event.title}`}
+      className={cn(
+        'flex items-center gap-2 w-full px-2 py-1.5 rounded-lg text-left',
+        isClickable
+          ? 'cursor-pointer hover:bg-at-surface-hover'
+          : 'cursor-default'
+      )}
+    >
+      <span
+        className={cn(
+          'shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium tracking-[0.07px]',
+          badge.className
+        )}
+      >
+        {badge.label}
+      </span>
+      <span className="flex-1 text-sm text-at-text truncate tracking-[0.08px]">
+        {event.title}
+        {suffix && <span className="text-at-text-weak">{suffix}</span>}
+      </span>
+      {event.isPinned && <Pin className="w-3.5 h-3.5 text-at-accent shrink-0" />}
+      {event.isImportant && <Star className="w-3.5 h-3.5 text-amber-400 fill-amber-400 shrink-0" />}
+    </button>
+  )
+}

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/TodayView.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/TodayView.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import React from 'react'
+import { Building2, CalendarOff } from 'lucide-react'
+import type { ScheduleEvent } from './types'
+import ScheduleItem from './ScheduleItem'
+
+interface TodayViewProps {
+  events: ScheduleEvent[]
+  loading: boolean
+  todayIso: string
+  onItemClick: (event: ScheduleEvent) => void
+}
+
+function isHolidayEvent(ev: ScheduleEvent): boolean {
+  return (
+    ev.source === 'clinic_holiday' ||
+    ev.source === 'public_holiday' ||
+    ev.badgeKind === 'holiday_announcement'
+  )
+}
+
+export default function TodayView({ events, loading, todayIso, onItemClick }: TodayViewProps) {
+  if (loading) {
+    return (
+      <div className="flex justify-center py-6">
+        <div className="w-6 h-6 border-4 border-at-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  // 오늘에 해당하는 휴무 (range가 today만 포함하는 단일일)
+  const todayHoliday = events.find(
+    ev => isHolidayEvent(ev) && ev.startDate <= todayIso && ev.endDate >= todayIso
+  )
+
+  const otherEvents = events.filter(ev => !(todayHoliday && ev.id === todayHoliday.id))
+
+  if (events.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-6 text-at-text-secondary gap-2">
+        <CalendarOff className="w-8 h-8 text-at-text-weak" />
+        <p className="text-sm tracking-[0.08px]">오늘 등록된 일정이 없습니다</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {todayHoliday && (
+        <div className="flex items-center gap-2 bg-red-50 border-l-4 border-red-500 text-red-700 px-4 py-3 rounded-lg">
+          <Building2 className="w-4 h-4 shrink-0" />
+          <span className="text-sm font-semibold tracking-[0.08px]">
+            오늘 휴무 — {todayHoliday.title}
+          </span>
+        </div>
+      )}
+      <div className="space-y-0.5">
+        {otherEvents.map(ev => (
+          <ScheduleItem key={ev.id} event={ev} onClick={onItemClick} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/WeekView.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/WeekView.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import React, { useMemo } from 'react'
+import { CalendarOff } from 'lucide-react'
+import type { ScheduleEvent } from './types'
+import ScheduleDateGroup from './ScheduleDateGroup'
+
+interface WeekViewProps {
+  events: ScheduleEvent[]
+  loading: boolean
+  todayIso: string
+  onItemClick: (event: ScheduleEvent) => void
+}
+
+function expandEventToDates(ev: ScheduleEvent): string[] {
+  const dates: string[] = []
+  const start = new Date(`${ev.startDate}T00:00:00`)
+  const end = new Date(`${ev.endDate}T00:00:00`)
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    const y = d.getFullYear()
+    const m = String(d.getMonth() + 1).padStart(2, '0')
+    const dy = String(d.getDate()).padStart(2, '0')
+    dates.push(`${y}-${m}-${dy}`)
+  }
+  return dates
+}
+
+function groupByDate(events: ScheduleEvent[]): Map<string, ScheduleEvent[]> {
+  const map = new Map<string, ScheduleEvent[]>()
+  for (const ev of events) {
+    const dates = expandEventToDates(ev)
+    for (const d of dates) {
+      const list = map.get(d) || []
+      list.push(ev)
+      map.set(d, list)
+    }
+  }
+  return map
+}
+
+export default function WeekView({ events, loading, todayIso, onItemClick }: WeekViewProps) {
+  const groups = useMemo(() => groupByDate(events), [events])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-6">
+        <div className="w-6 h-6 border-4 border-at-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  if (groups.size === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-6 text-at-text-secondary gap-2">
+        <CalendarOff className="w-8 h-8 text-at-text-weak" />
+        <p className="text-sm tracking-[0.08px]">이번 주 등록된 일정이 없습니다</p>
+      </div>
+    )
+  }
+
+  const sortedDates = Array.from(groups.keys()).sort()
+
+  return (
+    <div className="space-y-3">
+      {sortedDates.map(date => (
+        <ScheduleDateGroup
+          key={date}
+          date={date}
+          events={groups.get(date)!}
+          todayIso={todayIso}
+          onItemClick={onItemClick}
+        />
+      ))}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/index.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/index.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import React, { useMemo, useState } from 'react'
+import { Calendar } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useAuth } from '@/contexts/AuthContext'
+import { cn } from '@/lib/utils'
+import type { ScheduleEvent, ViewType } from './types'
+import { useScheduleData } from './useScheduleData'
+import TodayView from './TodayView'
+import WeekView from './WeekView'
+import MonthView from './MonthView'
+import ScheduleDetailModal from './ScheduleDetailModal'
+
+const TAB_LABELS: Array<{ key: ViewType; label: string; shortLabel: string }> = [
+  { key: 'today', label: '오늘', shortLabel: '오늘' },
+  { key: 'week', label: '이번 주', shortLabel: '주간' },
+  { key: 'month', label: '이번 달', shortLabel: '월간' },
+]
+
+function todayIsoSeoul(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date())
+}
+
+export default function ScheduleWidget() {
+  const { user } = useAuth()
+  const [activeTab, setActiveTab] = useState<ViewType>('today')
+  const [modalEvent, setModalEvent] = useState<ScheduleEvent | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
+
+  const todayIso = useMemo(() => todayIsoSeoul(), [])
+  const anchorDate = useMemo(() => new Date(`${todayIso}T00:00:00`), [todayIso])
+
+  const { events, loading } = useScheduleData(user?.clinic_id ?? null, activeTab, anchorDate)
+
+  const handleItemClick = (ev: ScheduleEvent) => {
+    if (ev.source !== 'announcement' || !ev.announcementId) return
+    setModalEvent(ev)
+    setModalOpen(true)
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="flex items-center gap-2 text-sm font-semibold text-at-text tracking-[0.08px]">
+            <Calendar className="w-4 h-4 text-at-accent" />
+            병원 일정
+          </CardTitle>
+          <div
+            role="tablist"
+            aria-label="기간 선택"
+            className="flex items-center gap-1 bg-at-surface-alt rounded-xl p-1"
+          >
+            {TAB_LABELS.map(tab => (
+              <button
+                key={tab.key}
+                role="tab"
+                aria-selected={activeTab === tab.key}
+                onClick={() => setActiveTab(tab.key)}
+                className={cn(
+                  'px-3 py-1 rounded-lg text-xs font-medium transition-colors tracking-[0.07px]',
+                  activeTab === tab.key
+                    ? 'bg-at-accent text-white shadow-sm'
+                    : 'text-at-text-secondary hover:bg-at-surface-hover'
+                )}
+              >
+                <span className="hidden sm:inline">{tab.label}</span>
+                <span className="sm:hidden">{tab.shortLabel}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {activeTab === 'today' && (
+          <TodayView events={events} loading={loading} todayIso={todayIso} onItemClick={handleItemClick} />
+        )}
+        {activeTab === 'week' && (
+          <WeekView events={events} loading={loading} todayIso={todayIso} onItemClick={handleItemClick} />
+        )}
+        {activeTab === 'month' && (
+          <MonthView events={events} loading={loading} todayIso={todayIso} onItemClick={handleItemClick} />
+        )}
+      </CardContent>
+      <ScheduleDetailModal event={modalEvent} open={modalOpen} onOpenChange={setModalOpen} />
+    </Card>
+  )
+}

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/scheduleParser.ts
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/scheduleParser.ts
@@ -1,0 +1,127 @@
+/**
+ * 공지사항 본문에서 날짜/기간을 추출하는 순수 유틸.
+ * - start_date/end_date가 비어 있는 공지에 한해 호출.
+ * - 본문의 "첫 매치"만 반환 (다중 날짜 언급 시 가장 앞 매치를 일정 시작으로 간주).
+ * - 연도 생략 시 currentYear 기본; 추출 결과가 currentDate 기준 6개월 이전이면 다음 해로 보정.
+ */
+
+export interface ParsedRange {
+  startDate: string
+  endDate: string
+}
+
+const RE_FULL_DATE = /(\d{4})[-./년]\s?(\d{1,2})[-./월]\s?(\d{1,2})\s?일?/
+const RE_SHORT_DATE = /(\d{1,2})\s?월\s?(\d{1,2})\s?일/
+const RE_RANGE_SEPARATOR = /^\s*[~\-–]\s*/
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+function buildIso(year: number, month: number, day: number): string | null {
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null
+  const d = new Date(`${year}-${pad2(month)}-${pad2(day)}T00:00:00`)
+  if (
+    d.getFullYear() !== year ||
+    d.getMonth() !== month - 1 ||
+    d.getDate() !== day
+  ) {
+    return null
+  }
+  return `${year}-${pad2(month)}-${pad2(day)}`
+}
+
+interface RawDate {
+  year?: number
+  month: number
+  day: number
+}
+
+interface MatchResult {
+  raw: RawDate
+  matchStartAbs: number
+  matchEndAbs: number
+}
+
+function matchSingleAt(text: string, fromIndex: number): MatchResult | null {
+  const slice = text.slice(fromIndex)
+  const fullMatch = slice.match(RE_FULL_DATE)
+  const shortMatch = slice.match(RE_SHORT_DATE)
+
+  const candidates: Array<{ idx: number; len: number; raw: RawDate }> = []
+  if (fullMatch && fullMatch.index !== undefined) {
+    candidates.push({
+      idx: fullMatch.index,
+      len: fullMatch[0].length,
+      raw: {
+        year: parseInt(fullMatch[1], 10),
+        month: parseInt(fullMatch[2], 10),
+        day: parseInt(fullMatch[3], 10),
+      },
+    })
+  }
+  if (shortMatch && shortMatch.index !== undefined) {
+    candidates.push({
+      idx: shortMatch.index,
+      len: shortMatch[0].length,
+      raw: {
+        month: parseInt(shortMatch[1], 10),
+        day: parseInt(shortMatch[2], 10),
+      },
+    })
+  }
+  if (candidates.length === 0) return null
+  candidates.sort((a, b) => a.idx - b.idx)
+  const chosen = candidates[0]
+  return {
+    raw: chosen.raw,
+    matchStartAbs: fromIndex + chosen.idx,
+    matchEndAbs: fromIndex + chosen.idx + chosen.len,
+  }
+}
+
+function resolveYear(raw: RawDate, today: Date): number {
+  if (raw.year !== undefined) return raw.year
+  const currentYear = today.getFullYear()
+  const candidate = buildIso(currentYear, raw.month, raw.day)
+  if (!candidate) return currentYear
+  const candidateDate = new Date(`${candidate}T00:00:00`)
+  const sixMonthsAgo = new Date(today)
+  sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6)
+  if (candidateDate < sixMonthsAgo) return currentYear + 1
+  return currentYear
+}
+
+/**
+ * content에서 첫 매치를 추출한다.
+ * 기간 표현(`A ~ B`)이면 startDate, endDate 모두 반환.
+ * 단일이면 startDate === endDate.
+ * 추출 실패 시 null.
+ */
+export function extractDateRangeFromContent(content: string, today: Date = new Date()): ParsedRange | null {
+  if (!content) return null
+  const text = content.replace(/<[^>]*>/g, ' ').replace(/&nbsp;/g, ' ')
+
+  const first = matchSingleAt(text, 0)
+  if (!first) return null
+
+  const startYear = resolveYear(first.raw, today)
+  const startIso = buildIso(startYear, first.raw.month, first.raw.day)
+  if (!startIso) return null
+
+  const remainder = text.slice(first.matchEndAbs)
+  const sepMatch = remainder.match(RE_RANGE_SEPARATOR)
+  if (sepMatch) {
+    const afterSep = first.matchEndAbs + sepMatch[0].length
+    const second = matchSingleAt(text, afterSep)
+    if (second && second.matchStartAbs === afterSep) {
+      const endYear = second.raw.year ?? startYear
+      const endIso = buildIso(endYear, second.raw.month, second.raw.day)
+      if (endIso && endIso >= startIso) {
+        return { startDate: startIso, endDate: endIso }
+      }
+    }
+  }
+
+  return { startDate: startIso, endDate: startIso }
+}

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/types.ts
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/types.ts
@@ -1,0 +1,22 @@
+export type ViewType = 'today' | 'week' | 'month'
+
+export type ScheduleSource = 'announcement' | 'clinic_holiday' | 'public_holiday'
+
+export type ScheduleBadgeKind = 'clinic_holiday' | 'public_holiday' | 'schedule' | 'holiday_announcement'
+
+export interface ScheduleEvent {
+  id: string
+  source: ScheduleSource
+  startDate: string
+  endDate: string
+  title: string
+  badgeKind: ScheduleBadgeKind
+  isPinned?: boolean
+  isImportant?: boolean
+  announcementId?: string
+}
+
+export interface DateRange {
+  start: string
+  end: string
+}

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/useScheduleData.ts
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/useScheduleData.ts
@@ -1,0 +1,234 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { announcementService } from '@/lib/bulletinService'
+import {
+  getKoreanPublicHolidays,
+  getClinicDesignatedHolidays,
+  getClinicHolidaySettings,
+} from '@/lib/holidayService'
+import type { Announcement } from '@/types/bulletin'
+import type { ScheduleEvent, ViewType, DateRange, ScheduleBadgeKind } from './types'
+import { extractDateRangeFromContent } from './scheduleParser'
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+function formatLocalDate(d: Date): string {
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`
+}
+
+export function getRangeForView(viewType: ViewType, anchor: Date): DateRange {
+  const today = new Date(anchor)
+  today.setHours(0, 0, 0, 0)
+
+  if (viewType === 'today') {
+    const iso = formatLocalDate(today)
+    return { start: iso, end: iso }
+  }
+
+  if (viewType === 'week') {
+    const dayOfWeek = today.getDay() // 0=일, 1=월
+    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek
+    const monday = new Date(today)
+    monday.setDate(today.getDate() + mondayOffset)
+    const sunday = new Date(monday)
+    sunday.setDate(monday.getDate() + 6)
+    return { start: formatLocalDate(monday), end: formatLocalDate(sunday) }
+  }
+
+  // month
+  const first = new Date(today.getFullYear(), today.getMonth(), 1)
+  const last = new Date(today.getFullYear(), today.getMonth() + 1, 0)
+  return { start: formatLocalDate(first), end: formatLocalDate(last) }
+}
+
+function rangeOverlaps(rangeStart: string, rangeEnd: string, eventStart: string, eventEnd: string): boolean {
+  return eventStart <= rangeEnd && eventEnd >= rangeStart
+}
+
+function announcementBadge(category: Announcement['category']): ScheduleBadgeKind {
+  if (category === 'holiday') return 'holiday_announcement'
+  return 'schedule'
+}
+
+function priorityWeight(ev: ScheduleEvent): number {
+  // 0: 휴무, 1: 중요/고정, 2: 일반
+  if (
+    ev.source === 'clinic_holiday' ||
+    ev.source === 'public_holiday' ||
+    ev.badgeKind === 'holiday_announcement'
+  ) return 0
+  if (ev.isPinned || ev.isImportant) return 1
+  return 2
+}
+
+function sortEvents(events: ScheduleEvent[]): ScheduleEvent[] {
+  return [...events].sort((a, b) => {
+    if (a.startDate !== b.startDate) return a.startDate.localeCompare(b.startDate)
+    const pa = priorityWeight(a)
+    const pb = priorityWeight(b)
+    if (pa !== pb) return pa - pb
+    return a.title.localeCompare(b.title, 'ko')
+  })
+}
+
+function dedupeByDateAndTitle(events: ScheduleEvent[]): ScheduleEvent[] {
+  const seen = new Set<string>()
+  const result: ScheduleEvent[] = []
+  for (const ev of events) {
+    const key = `${ev.startDate}|${ev.endDate}|${ev.title}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(ev)
+  }
+  return result
+}
+
+interface UseScheduleDataResult {
+  events: ScheduleEvent[]
+  loading: boolean
+  error: string | null
+  range: DateRange
+}
+
+export function useScheduleData(
+  clinicId: string | null,
+  viewType: ViewType,
+  anchor: Date
+): UseScheduleDataResult {
+  const range = useMemo(() => getRangeForView(viewType, anchor), [viewType, anchor])
+  const [events, setEvents] = useState<ScheduleEvent[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    if (!clinicId) {
+      setEvents([])
+      setLoading(false)
+      setError(null)
+      return
+    }
+
+    const controller = new AbortController()
+    abortRef.current?.abort()
+    abortRef.current = controller
+
+    const today = new Date()
+
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const startYear = parseInt(range.start.substring(0, 4), 10)
+        const endYear = parseInt(range.end.substring(0, 4), 10)
+
+        const [annResult, settingsResult, designatedResults] = await Promise.all([
+          announcementService.getAnnouncements({ limit: 200 }),
+          getClinicHolidaySettings(clinicId!),
+          (async () => {
+            const out: Array<{ date: string; description: string | null }> = []
+            for (let y = startYear; y <= endYear; y++) {
+              const r = await getClinicDesignatedHolidays(clinicId!, y)
+              if (r.success && r.holidays) out.push(...r.holidays)
+            }
+            return out
+          })(),
+        ])
+
+        if (controller.signal.aborted) return
+
+        const settings = settingsResult.success ? settingsResult.settings : undefined
+
+        // 1) 공지사항 → 정규화
+        const annEvents: ScheduleEvent[] = []
+        const announcements = annResult.data || []
+        for (const a of announcements) {
+          if (a.category !== 'schedule' && a.category !== 'holiday') continue
+
+          let startDate = a.start_date || ''
+          let endDate = a.end_date || a.start_date || ''
+          if (!startDate) {
+            const parsed = extractDateRangeFromContent(a.content || '', today)
+            if (!parsed) continue
+            startDate = parsed.startDate
+            endDate = parsed.endDate
+          }
+
+          if (!rangeOverlaps(range.start, range.end, startDate, endDate)) continue
+
+          annEvents.push({
+            id: `announcement-${a.id}`,
+            source: 'announcement',
+            startDate,
+            endDate,
+            title: a.title,
+            badgeKind: announcementBadge(a.category),
+            isPinned: a.is_pinned,
+            isImportant: a.is_important,
+            announcementId: a.id,
+          })
+        }
+
+        // 2) 병원 지정 휴무일 → 윈도우 내 필터
+        const clinicHolidayEvents: ScheduleEvent[] = []
+        for (const h of designatedResults) {
+          if (h.date < range.start || h.date > range.end) continue
+          clinicHolidayEvents.push({
+            id: `clinic-${h.date}`,
+            source: 'clinic_holiday',
+            startDate: h.date,
+            endDate: h.date,
+            title: h.description || '병원 휴무',
+            badgeKind: 'clinic_holiday',
+          })
+        }
+
+        // 3) 법정 공휴일 → 설정에 따라 포함
+        const publicHolidayEvents: ScheduleEvent[] = []
+        if (settings?.use_public_holidays) {
+          const includeSubstitute = settings.use_substitute_holidays
+          for (let y = startYear; y <= endYear; y++) {
+            const yearHolidays = getKoreanPublicHolidays(y, includeSubstitute)
+            for (const h of yearHolidays) {
+              if (h.date < range.start || h.date > range.end) continue
+              publicHolidayEvents.push({
+                id: `public-${h.date}-${h.name}`,
+                source: 'public_holiday',
+                startDate: h.date,
+                endDate: h.date,
+                title: h.name,
+                badgeKind: 'public_holiday',
+              })
+            }
+          }
+        }
+
+        const merged = sortEvents(
+          dedupeByDateAndTitle([...annEvents, ...clinicHolidayEvents, ...publicHolidayEvents])
+        )
+
+        if (!controller.signal.aborted) {
+          setEvents(merged)
+        }
+      } catch (e: any) {
+        if (!controller.signal.aborted) {
+          console.warn('[useScheduleData] load failed:', e)
+          setError(e?.message || 'load failed')
+          setEvents([])
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    load()
+    return () => controller.abort()
+  }, [clinicId, range.start, range.end])
+
+  return { events, loading, error, range }
+}

--- a/dental-clinic-manager/src/lib/bulletinService.ts
+++ b/dental-clinic-manager/src/lib/bulletinService.ts
@@ -200,6 +200,38 @@ export const announcementService = {
   },
 
   /**
+   * 공지사항 상세 조회 — 조회수 미증가 (대시보드 미리보기용)
+   */
+  async getAnnouncementPreview(id: string): Promise<{ data: Announcement | null; error: string | null }> {
+    try {
+      const supabase = await ensureConnection()
+      if (!supabase) throw new Error('Database connection failed')
+
+      const { data, error } = await (supabase as any)
+        .from('announcements')
+        .select('*')
+        .eq('id', id)
+        .single()
+
+      if (error) throw error
+
+      // author 이름 조회 (조회수 증가 RPC는 호출하지 않음)
+      const nameMap = await getUserNames(supabase, [data.author_id])
+
+      return {
+        data: {
+          ...data,
+          author_name: nameMap[data.author_id] || '알 수 없음',
+        },
+        error: null,
+      }
+    } catch (error) {
+      console.error('[announcementService.getAnnouncementPreview] Error:', error)
+      return { data: null, error: extractErrorMessage(error) }
+    }
+  },
+
+  /**
    * 공지사항 생성
    */
   async createAnnouncement(input: CreateAnnouncementDto): Promise<{ data: Announcement | null; error: string | null }> {

--- a/dental-clinic-manager/src/lib/leaveService.ts
+++ b/dental-clinic-manager/src/lib/leaveService.ts
@@ -2231,10 +2231,10 @@ export const leaveService = {
         throw new Error('연차 차감 대상이 아닌 휴무일입니다.')
       }
 
-      // 적용 대상 직원 조회
+      // 적용 대상 직원 조회 (hire_date, created_at 포함 - 입사일 기준 연차 기간 계산용)
       let staffQuery = (supabase as any)
         .from('users')
-        .select('id, name, role')
+        .select('id, name, role, hire_date, created_at')
         .eq('clinic_id', user.clinic_id)
         .eq('status', 'active')
 
@@ -2249,12 +2249,33 @@ export const leaveService = {
       )
 
       const deductDays = holiday.deduct_days ?? holiday.total_days
-      const year = new Date(holiday.start_date).getFullYear()
+      const holidayStartDate = new Date(holiday.start_date)
       let appliedCount = 0
+      const skippedBeforeHire: string[] = []
 
-      // 각 직원에게 연차 차감 적용
+      // 각 직원에게 연차 차감 적용 (직원별 입사일 기준 연차 기간으로 year 계산)
       for (const staff of targetStaff) {
-        // 연차 조정 추가
+        // 입사일 기준 (없으면 created_at fallback - update_leave_balance/initializeBalance와 일관)
+        const hireDate = staff.hire_date ? new Date(staff.hire_date) : new Date(staff.created_at)
+
+        // 휴가 시작일이 입사일 이전이면 차감 대상 아님 → skip
+        if (holidayStartDate < hireDate) {
+          skippedBeforeHire.push(staff.name)
+          continue
+        }
+
+        // 직원별 입사일 기준 연차 기간 계산 (휴가일이 어느 연차 기간에 속하는지)
+        // calculateLeavePeriod은 referenceDate 기준 현재 기간을 반환하므로 holidayStartDate를 referenceDate로 사용
+        let periodYear: number
+        try {
+          const period = calculateLeavePeriod(hireDate, holidayStartDate)
+          periodYear = new Date(period.startDate).getFullYear()
+        } catch {
+          // 계산 실패 시 캘린더 연도 fallback
+          periodYear = holidayStartDate.getFullYear()
+        }
+
+        // 연차 조정 추가 (initializeBalance가 .eq('year', periodYear)로 조회하므로 일관 유지)
         const { data: adjustment, error: adjError } = await (supabase as any)
           .from('leave_adjustments')
           .insert({
@@ -2262,7 +2283,7 @@ export const leaveService = {
             clinic_id: user.clinic_id,
             adjustment_type: 'deduct',
             days: deductDays,
-            year,
+            year: periodYear,
             reason: `[병원휴무] ${holiday.holiday_name} (${holiday.start_date} ~ ${holiday.end_date})`,
             use_date: holiday.start_date,
             adjusted_by: user.id,
@@ -2270,25 +2291,39 @@ export const leaveService = {
           .select()
           .single()
 
-        if (adjError) {
-          console.error(`Error applying to ${staff.name}:`, adjError)
+        if (adjError || !adjustment?.id) {
+          console.error(`[applyHolidayToLeave] Failed to insert adjustment for ${staff.name}:`, adjError)
           continue
         }
 
-        // 적용 기록 저장
-        await (supabase as any)
+        // 적용 기록 저장 (leave_adjustment_id가 유효할 때만)
+        const { error: hlaError } = await (supabase as any)
           .from('holiday_leave_applications')
           .insert({
             clinic_holiday_id: holidayId,
             user_id: staff.id,
             clinic_id: user.clinic_id,
             deducted_days: deductDays,
-            year,
+            year: periodYear,
             leave_adjustment_id: adjustment.id,
             applied_by: user.id,
           })
 
+        if (hlaError) {
+          // application 기록 실패 시 leave_adjustments도 롤백 (정합성 유지)
+          console.error(`[applyHolidayToLeave] Failed to record application for ${staff.name}:`, hlaError)
+          await (supabase as any)
+            .from('leave_adjustments')
+            .delete()
+            .eq('id', adjustment.id)
+          continue
+        }
+
         appliedCount++
+      }
+
+      if (skippedBeforeHire.length > 0) {
+        console.log(`[applyHolidayToLeave] 입사일 이전이라 차감 제외된 직원: ${skippedBeforeHire.join(', ')}`)
       }
 
       // 휴무일 적용 완료 표시


### PR DESCRIPTION
## Summary

- **대시보드 병원 일정 위젯** 신규 추가 (오늘/이번주/이번달 탭, 게시판 일정 자동 추출)
- **연차 휴무일 차감** 버그 수정 (year 불일치 + 입사 전 적용)
- 게시판 `?id=` 자동 오픈 지원 (위젯에서 진입)

## 주요 변경사항

### 대시보드 일정 위젯 (`src/components/Dashboard/ScheduleWidget/`)
- `ScheduleItem`, `ScheduleDateGroup`, `TodayView`, `WeekView`, `MonthView` 등 분리 컴포넌트
- `useScheduleData` 훅으로 병렬 fetch + 정규화
- `scheduleParser`로 게시판 본문에서 날짜 자동 추출
- `ScheduleDetailModal`로 sanitized preview 표시
- 메인 컬럼 상단에 마운트

### 게시판 (`src/components/Bulletin/`, `src/lib/bulletinService.ts`)
- `?id=` 쿼리 파라미터로 특정 공지 자동 오픈
- `getAnnouncementPreview`: 조회수 증가 없이 미리보기용 lookup

### 연차 (`src/lib/leaveService.ts`)
- 병원 휴무일 차감 시 year 불일치 버그 수정
- 입사 전 휴무일이 차감되던 문제 수정

## Test plan
- [x] tsc --noEmit 통과
- [ ] 대시보드 위젯 오늘/주/월 탭 전환 확인
- [ ] 게시판 일정에서 위젯 진입 시 모달 정상 표시
- [ ] 연차 신청 시 휴무일이 정확히 제외되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)