### PR TITLE
Merge develop → main: RL trading Phase 1 + schedule widget + referral system

### DIFF
--- a/dental-clinic-manager/docs/superpowers/operations/rl-trading-operations.md
+++ b/dental-clinic-manager/docs/superpowers/operations/rl-trading-operations.md
@@ -72,6 +72,15 @@ require('./dist/dailyRebalanceDeps').buildDailyRebalanceDeps()
 
 > 주의: cron은 KST 07:00 (월~금 ET 마감 다음날 새벽). DST 시기에는 시간대 검토 필요.
 
+## DST 안전성
+
+cron은 `Asia/Seoul` 타임존 기준 매주 화~금 오전 7시(KST)에 발동. 미국 ET 마감(16:00 local)은:
+
+- **EDT (3월~11월):** ET 16:00 = KST 05:00 → 다음날 07:00까지 14시간 여유
+- **EST (11월~3월):** ET 16:00 = KST 06:00 → 다음날 07:00까지 13시간 여유
+
+따라서 ET 종가 데이터가 KIS 일봉 캐시에 안착할 때까지 항상 최소 ~1시간의 안전 마진이 확보된다.
+
 ## 트러블슈팅
 
 | 증상 | 원인 / 점검 |

--- a/dental-clinic-manager/docs/superpowers/operations/rl-trading-operations.md
+++ b/dental-clinic-manager/docs/superpowers/operations/rl-trading-operations.md
@@ -1,0 +1,109 @@
+# RL 트레이딩 운영 가이드
+
+## 프로세스 토폴로지
+
+- `trading-worker` (Node.js, PM2) — 기존 자동매매 워커. RL 일봉 cron 추가됨.
+- `rl-inference` (Python uvicorn, PM2) — `localhost:8001`. RL 모델 추론 서버.
+
+두 프로세스 모두 동일 머신에서 동작 (현재 Mac mini M4).
+
+## 기동
+
+```bash
+cd /Users/hhs/Project/dental-clinic-manager/trading-worker
+pm2 start ecosystem.config.js
+pm2 logs
+```
+
+`rl-inference`는 `cwd`에 따라 `/Users/hhs/Project/dental-clinic-manager/rl-inference-server`의 venv를 사용. venv 미생성 시:
+
+```bash
+cd /Users/hhs/Project/dental-clinic-manager/rl-inference-server
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+## 환경변수
+
+- `RL_API_KEY` — trading-worker와 rl-inference-server가 공유. 두 환경 모두에 설정해야 함.
+- `RL_SERVER_URL` (옵션) — 기본 `http://127.0.0.1:8001`. trading-worker에서 사용.
+- `MODEL_DIR` — rl-inference-server가 ckpt를 저장하는 디렉터리.
+
+## 모델 등록 절차
+
+1. 웹 UI에서 `/investment/rl-models`로 이동
+2. "모델 추가" 클릭 → 사전학습 ckpt URL + sha256 입력 (HuggingFace/GitHub)
+3. status가 `pending → downloading → ready`로 자동 전이됨
+4. `failed` 상태가 되면 행을 클릭하여 `failure_reason` 확인
+5. 잘못된 sha256은 `400 sha256 mismatch`로 빠르게 실패함
+
+## 전략 등록 절차
+
+1. `/investment/strategy/new`에서 "강화학습 (RL)" 토글 선택
+2. 등록된 ready 상태의 모델 선택
+3. paper credential을 강력히 권장
+4. **automation_level은 1 (알림만)을 기본값으로 사용** — 검증 후에만 2로 전환
+
+## kill switch
+
+UI 우상단 "RL 자동매매 일시정지" 버튼.
+
+또는 SQL:
+```sql
+UPDATE user_investment_settings
+SET rl_paused_at = NOW(), rl_paused_reason = 'manual'
+WHERE user_id = '<uuid>';
+```
+
+해제는 `rl_paused_at = NULL`로.
+
+## 일일 재교형 강제 실행 (디버깅)
+
+```bash
+cd /Users/hhs/Project/dental-clinic-manager/trading-worker
+node -e "
+require('./dist/dailyRebalanceDeps').buildDailyRebalanceDeps()
+  .then(d => require('./dist/dailyRebalanceJob').runDailyRebalance(d))
+  .then(r => console.log(r))
+  .catch(e => { console.error(e); process.exit(1) })
+"
+```
+
+> 주의: cron은 KST 07:00 (월~금 ET 마감 다음날 새벽). DST 시기에는 시간대 검토 필요.
+
+## 트러블슈팅
+
+| 증상 | 원인 / 점검 |
+|---|---|
+| 추론 timeout (5s) | rl-inference 미기동 또는 ckpt 로드 실패. `pm2 logs rl-inference` |
+| 모델 status가 failed | `failure_reason` 확인. 일반적 원인: sha256 mismatch / 네트워크 오류 / ckpt 형식 비호환 |
+| 자동매매가 안 됨 | `rl_inference_logs.decision`을 확인 → `blocked_kill_switch`, `blocked_low_confidence`, `error` 중 하나일 가능성 |
+| 잔여 음수 | rebalance가 잘못된 weight를 산출. `rl_inference_logs.output.weights` 확인 |
+| 모든 자동매매 즉시 중단 | UI 또는 `/api/investment/emergency-stop` POST |
+
+## 모니터링 쿼리
+
+```sql
+-- 오늘 추론 로그
+SELECT strategy_id, decision, confidence, blocked_reason, error_message, latency_ms
+FROM rl_inference_logs
+WHERE trade_date = CURRENT_DATE
+ORDER BY created_at DESC;
+
+-- 모델별 최근 추론 카운트
+SELECT rl_model_id, decision, COUNT(*) FROM rl_inference_logs
+WHERE trade_date >= CURRENT_DATE - INTERVAL '7 days'
+GROUP BY rl_model_id, decision
+ORDER BY rl_model_id;
+```
+
+## 백업 & 복구
+
+- 모델 ckpt는 `MODEL_DIR/<sha256>/model.zip` 형태로 보관. 손실 시 `checkpoint_url`로 재다운로드 가능.
+- DB 백업이 일차 진실원: `rl_models`, `investment_strategies`, `rl_inference_logs`.
+
+## 참고
+
+- 설계 spec: `docs/superpowers/specs/2026-04-29-rl-trading-design.md`
+- 구현 plan: `docs/superpowers/plans/2026-04-29-rl-trading-phase1.md`

--- a/dental-clinic-manager/docs/superpowers/plans/2026-04-29-rl-trading-phase1.md
+++ b/dental-clinic-manager/docs/superpowers/plans/2026-04-29-rl-trading-phase1.md
@@ -1,0 +1,3215 @@
+# RL 트레이딩 Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 미국 주식 일봉 재교형 RL 자동매매를 추가한다 — FinRL/SB3 사전학습 모델을 로드해 portfolio weight 추론 → 기존 KIS 주문 인프라로 자동 주문(default 알림만, 사용자 명시 시 자동).
+
+**Architecture:** Next.js 메인 앱 ↔ Supabase ↔ trading-worker(Node.js, 기존, 일봉 cron 추가) ↔ rl-inference-server(Python FastAPI, 신규, localhost:8001). RL 추론은 HTTP, 주문은 기존 `executeAutoOrder` 재사용. 모든 안전 가드(default level=1, kill switch, 신뢰도 임계, idempotency, 5s timeout)를 코드 강제 구현.
+
+**Tech Stack:**
+- Frontend/API: Next.js 15, React 19, TypeScript, Tailwind, Supabase JS
+- DB: Supabase Postgres (마이그레이션 MCP 적용)
+- Worker: Node.js + node-cron + pino + Supabase service role
+- RL Server: Python 3.11 + FastAPI + Pydantic v2 + PyTorch (CPU) + stable-baselines3 + finrl(선택)
+- 테스트: vitest (TS 신규 추가) / pytest (Python)
+
+**Spec 참조:** [docs/superpowers/specs/2026-04-29-rl-trading-design.md](../specs/2026-04-29-rl-trading-design.md)
+
+---
+
+## File Structure
+
+### 신규 파일
+
+```
+rl-inference-server/                                  # 신규 Python 프로젝트
+├── pyproject.toml
+├── README.md
+├── .env.example
+├── src/
+│   ├── __init__.py
+│   ├── main.py                                       # FastAPI 앱 + 라우트
+│   ├── config.py                                     # 환경변수 (PORT, MODEL_DIR, API_KEY)
+│   ├── auth.py                                       # X-RL-API-KEY 헤더 검증
+│   ├── schemas.py                                    # Pydantic v2 모델
+│   ├── model_registry.py                             # 다운로드 + LRU(2)
+│   ├── state.py                                      # state hash 유틸
+│   ├── adapters/
+│   │   ├── __init__.py
+│   │   ├── base.py                                   # AdapterBase + compute_confidence
+│   │   ├── sb3.py                                    # stable-baselines3 어댑터
+│   │   └── finrl_dow30.py                            # FinRL Dow 30 환경 어댑터
+│   └── inference/
+│       ├── __init__.py
+│       ├── portfolio.py                              # PortfolioInferenceEngine
+│       └── single.py                                 # SingleAssetInferenceEngine (스텁)
+├── tests/
+│   ├── __init__.py
+│   ├── conftest.py
+│   ├── test_health.py
+│   ├── test_model_registry.py
+│   ├── test_sb3_adapter.py
+│   ├── test_predict_portfolio.py
+│   └── test_backtest.py
+
+trading-worker/src/
+├── rlInferenceClient.ts                              # 신규
+└── dailyRebalanceJob.ts                              # 신규
+
+trading-worker/tests/                                  # 신규 디렉터리
+├── rlInferenceClient.test.ts
+└── dailyRebalanceJob.test.ts
+
+dental-clinic-manager/
+├── supabase/migrations/<YYYYMMDD>_rl_trading.sql     # 신규 마이그레이션
+├── src/types/rlTrading.ts                            # 신규 타입
+├── src/lib/rlModelService.ts                         # 신규 서비스 (메인 앱)
+├── src/app/api/investment/rl-models/route.ts         # 신규
+├── src/app/api/investment/rl-models/[id]/route.ts    # 신규
+├── src/app/api/investment/rl-models/[id]/backtest/route.ts  # 신규
+├── src/app/api/investment/rl-pause/route.ts          # 신규
+├── src/app/investment/rl-models/page.tsx             # 신규
+├── src/app/investment/rl-models/[id]/page.tsx        # 신규 (모델 상세)
+├── src/components/Investment/RLModels/
+│   ├── ModelLibraryPanel.tsx                         # 신규
+│   ├── ModelRegisterDialog.tsx                       # 신규
+│   ├── ModelDetailPanel.tsx                          # 신규
+│   ├── KillSwitchToggle.tsx                          # 신규
+│   └── RLStrategyForm.tsx                            # 신규 (전략 생성 폼)
+└── docs/superpowers/operations/rl-trading-operations.md  # 신규 운영 가이드
+```
+
+### 수정 파일
+
+```
+dental-clinic-manager/
+├── src/types/investment.ts                           # strategy_type, rl_model_id 추가
+├── src/app/api/investment/strategies/route.ts        # RL 분기
+├── src/app/api/investment/emergency-stop/route.ts    # RL 전략도 비활성화
+├── src/app/investment/strategy/page.tsx              # 배지 표시
+├── src/app/investment/strategy/new/page.tsx          # type 선택 추가 (있으면)
+└── src/components/Investment/InvestmentNav.tsx (또는 nav 정의 위치)  # rl-models 링크 추가
+
+trading-worker/
+├── package.json                                       # vitest devDep 추가
+├── tsconfig.json                                      # tests 포함
+├── ecosystem.config.js                                # rl-inference-server 추가 (또는 별도)
+└── src/index.ts                                       # dailyRebalanceJob 등록
+```
+
+---
+
+## 진행 원칙
+
+- TDD: 항상 실패 테스트 먼저 → 구현 → 통과 → 커밋
+- 작업당 작은 커밋 (한 task 완료 시 1~3 커밋). main이 아닌 `develop` 브랜치.
+- 마이그레이션은 Supabase MCP `apply_migration`으로 적용 + `supabase/migrations/` 파일도 생성
+- 기존 코드 컨벤션 준수: AT Tokens, rounded-xl, pino logger, 한국어 주석
+- 어떤 task에서든 빌드/타입 체크 실패 시 즉시 수정
+
+---
+
+## Task 1: DB 마이그레이션 (rl_models, rl_inference_logs, strategies 확장, kill switch)
+
+**Files:**
+- Create: `dental-clinic-manager/supabase/migrations/<YYYYMMDD>_rl_trading.sql`
+- Apply: Supabase MCP `apply_migration`
+
+- [ ] **Step 1: 마이그레이션 SQL 작성**
+
+`supabase/migrations/<YYYYMMDD>_rl_trading.sql`:
+
+```sql
+-- ============================================
+-- RL 트레이딩 Phase 1
+-- - rl_models: 사전학습 모델 메타데이터
+-- - rl_inference_logs: 일봉 추론 감사 로그
+-- - investment_strategies 확장: strategy_type, rl_model_id
+-- - user_investment_settings 확장: rl_paused_at, rl_paused_reason
+-- ============================================
+
+-- 1) rl_models
+CREATE TABLE IF NOT EXISTS rl_models (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+
+  name TEXT NOT NULL,
+  description TEXT,
+  source TEXT NOT NULL CHECK (source IN ('finrl_pretrained','sb3_pretrained','custom')),
+  algorithm TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('portfolio','single_asset')),
+  market TEXT NOT NULL DEFAULT 'US',
+  timeframe TEXT NOT NULL DEFAULT '1d',
+
+  universe JSONB,
+  input_features JSONB NOT NULL,
+  state_window INT NOT NULL DEFAULT 60 CHECK (state_window > 0 AND state_window <= 500),
+  output_shape JSONB NOT NULL,
+
+  checkpoint_url TEXT,
+  checkpoint_path TEXT,
+  checkpoint_sha256 TEXT,
+
+  min_confidence NUMERIC(3,2) DEFAULT 0.60 CHECK (min_confidence >= 0 AND min_confidence <= 1),
+
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','downloading','ready','failed','archived')),
+  metrics JSONB,
+  failure_reason TEXT,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rl_models_clinic ON rl_models(clinic_id);
+CREATE INDEX IF NOT EXISTS idx_rl_models_status ON rl_models(status);
+
+-- 2) investment_strategies 확장
+ALTER TABLE investment_strategies
+  ADD COLUMN IF NOT EXISTS strategy_type TEXT NOT NULL DEFAULT 'rule'
+    CHECK (strategy_type IN ('rule','rl_portfolio','rl_single')),
+  ADD COLUMN IF NOT EXISTS rl_model_id UUID REFERENCES rl_models(id) ON DELETE SET NULL;
+
+ALTER TABLE investment_strategies DROP CONSTRAINT IF EXISTS rl_strategy_requires_model;
+ALTER TABLE investment_strategies
+  ADD CONSTRAINT rl_strategy_requires_model
+  CHECK (strategy_type = 'rule' OR rl_model_id IS NOT NULL);
+
+CREATE INDEX IF NOT EXISTS idx_strategies_type ON investment_strategies(strategy_type);
+CREATE INDEX IF NOT EXISTS idx_strategies_rl_model ON investment_strategies(rl_model_id);
+
+-- 3) rl_inference_logs
+CREATE TABLE IF NOT EXISTS rl_inference_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  strategy_id UUID NOT NULL REFERENCES investment_strategies(id) ON DELETE CASCADE,
+  rl_model_id UUID NOT NULL REFERENCES rl_models(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  trade_date DATE NOT NULL,
+  state_hash TEXT NOT NULL,
+
+  output JSONB NOT NULL,
+  confidence NUMERIC(4,3),
+  decision TEXT NOT NULL CHECK (decision IN ('order','hold','blocked_low_confidence','blocked_kill_switch','error')),
+  blocked_reason TEXT,
+
+  latency_ms INT,
+  error_message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT rl_inference_unique_per_day UNIQUE (strategy_id, trade_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rl_logs_strategy_date ON rl_inference_logs(strategy_id, trade_date DESC);
+CREATE INDEX IF NOT EXISTS idx_rl_logs_user_date ON rl_inference_logs(user_id, trade_date DESC);
+
+-- 4) user_investment_settings 확장 (kill switch)
+ALTER TABLE user_investment_settings
+  ADD COLUMN IF NOT EXISTS rl_paused_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS rl_paused_reason TEXT;
+
+-- 5) RLS
+ALTER TABLE rl_models ENABLE ROW LEVEL SECURITY;
+ALTER TABLE rl_inference_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view clinic models" ON rl_models;
+CREATE POLICY "Users can view clinic models" ON rl_models
+  FOR SELECT USING (
+    clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Users can manage own models" ON rl_models;
+CREATE POLICY "Users can manage own models" ON rl_models
+  FOR ALL USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Users can view own logs" ON rl_inference_logs;
+CREATE POLICY "Users can view own logs" ON rl_inference_logs
+  FOR SELECT USING (user_id = auth.uid());
+
+-- service role bypass (worker가 service role 사용)
+DROP POLICY IF EXISTS "Service can write logs" ON rl_inference_logs;
+CREATE POLICY "Service can write logs" ON rl_inference_logs
+  FOR INSERT WITH CHECK (true);
+
+-- updated_at 트리거
+CREATE OR REPLACE FUNCTION update_rl_models_updated_at()
+RETURNS TRIGGER AS $$ BEGIN NEW.updated_at = NOW(); RETURN NEW; END; $$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_rl_models_updated_at ON rl_models;
+CREATE TRIGGER trigger_rl_models_updated_at BEFORE UPDATE ON rl_models
+  FOR EACH ROW EXECUTE FUNCTION update_rl_models_updated_at();
+```
+
+- [ ] **Step 2: Supabase MCP로 적용**
+
+```
+mcp__supabase__apply_migration({
+  project_id: 'beahjntkmkfhpcbhfnrr',
+  name: '<YYYYMMDD>_rl_trading',
+  query: <위 SQL 전체>
+})
+```
+
+- [ ] **Step 3: 적용 검증 (테이블/제약 존재 확인)**
+
+```sql
+SELECT table_name FROM information_schema.tables
+WHERE table_schema='public' AND table_name IN ('rl_models','rl_inference_logs');
+SELECT column_name FROM information_schema.columns
+WHERE table_name='investment_strategies' AND column_name IN ('strategy_type','rl_model_id');
+SELECT column_name FROM information_schema.columns
+WHERE table_name='user_investment_settings' AND column_name IN ('rl_paused_at','rl_paused_reason');
+```
+
+기대: 모든 6개 row 반환. 존재 확인 SQL은 `mcp__supabase__execute_sql`로 실행.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd dental-clinic-manager
+git add supabase/migrations/<YYYYMMDD>_rl_trading.sql
+git commit -m "feat(rl-trading): DB schema for rl_models, rl_inference_logs, strategy_type"
+```
+
+---
+
+## Task 2: rl-inference-server 프로젝트 셋업
+
+**Files:**
+- Create: `rl-inference-server/pyproject.toml`
+- Create: `rl-inference-server/.env.example`
+- Create: `rl-inference-server/README.md`
+- Create: `rl-inference-server/src/__init__.py`
+- Create: `rl-inference-server/src/config.py`
+- Create: `rl-inference-server/tests/__init__.py`
+- Create: `rl-inference-server/tests/conftest.py`
+
+- [ ] **Step 1: pyproject.toml 작성**
+
+`rl-inference-server/pyproject.toml`:
+
+```toml
+[project]
+name = "rl-inference-server"
+version = "0.1.0"
+description = "RL 모델 추론 서버 (FastAPI + PyTorch + stable-baselines3)"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+  "fastapi>=0.115",
+  "uvicorn[standard]>=0.32",
+  "pydantic>=2.9",
+  "pydantic-settings>=2.6",
+  "torch>=2.2,<2.6",
+  "stable-baselines3>=2.3",
+  "numpy>=1.26,<2.0",
+  "pandas>=2.2",
+  "httpx>=0.27",
+  "python-dotenv>=1.0",
+]
+
+[project.optional-dependencies]
+finrl = ["finrl>=0.3.6"]
+dev = ["pytest>=8.3", "pytest-asyncio>=0.24", "ruff>=0.7"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+```
+
+- [ ] **Step 2: .env.example 작성**
+
+`rl-inference-server/.env.example`:
+
+```dotenv
+# 외부 노출 금지 - 반드시 localhost
+RL_SERVER_HOST=127.0.0.1
+RL_SERVER_PORT=8001
+
+# trading-worker가 헤더에 같은 값을 보내야 함
+RL_API_KEY=change-me-to-long-random-string
+
+# 모델 ckpt 영구 저장 디렉터리 (sha256 하위 디렉터리)
+MODEL_DIR=/Users/hhs/.cache/rl-inference/models
+
+# 로그 레벨
+LOG_LEVEL=INFO
+```
+
+- [ ] **Step 3: config.py 작성**
+
+`rl-inference-server/src/config.py`:
+
+```python
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_prefix="")
+
+    rl_server_host: str = "127.0.0.1"
+    rl_server_port: int = 8001
+    rl_api_key: str = "change-me"
+    model_dir: str = "/tmp/rl-inference/models"
+    log_level: str = "INFO"
+
+
+def get_settings() -> Settings:
+    return Settings()
+```
+
+- [ ] **Step 4: 빈 패키지 마커 + conftest 작성**
+
+`rl-inference-server/src/__init__.py`: 빈 파일
+`rl-inference-server/tests/__init__.py`: 빈 파일
+
+`rl-inference-server/tests/conftest.py`:
+
+```python
+import os
+import sys
+from pathlib import Path
+
+# src 디렉터리를 PYTHONPATH에 추가
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+# 테스트용 환경변수
+os.environ.setdefault("RL_API_KEY", "test-api-key")
+os.environ.setdefault("MODEL_DIR", str(Path("/tmp/rl-inference-test/models")))
+```
+
+- [ ] **Step 5: README + venv 셋업 + 의존성 설치 검증**
+
+`rl-inference-server/README.md`:
+
+```markdown
+# rl-inference-server
+
+RL 모델 추론 서버. 별도 Python 프로세스로 동작 (PM2 관리).
+
+## 빠른 시작
+
+\`\`\`bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+cp .env.example .env
+# .env에 RL_API_KEY를 충분히 길게 설정
+
+uvicorn src.main:app --host 127.0.0.1 --port 8001 --reload
+\`\`\`
+
+## 테스트
+
+\`\`\`bash
+pytest -v
+\`\`\`
+```
+
+```bash
+cd /Users/hhs/Project/dental-clinic-manager/rl-inference-server
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+python -c "import fastapi, torch, stable_baselines3, pydantic; print('OK')"
+```
+
+기대: `OK` 출력. 실패 시 의존성 충돌 디버깅.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd /Users/hhs/Project/dental-clinic-manager
+git add rl-inference-server/pyproject.toml rl-inference-server/.env.example rl-inference-server/README.md rl-inference-server/src/__init__.py rl-inference-server/src/config.py rl-inference-server/tests/__init__.py rl-inference-server/tests/conftest.py
+git commit -m "feat(rl-server): project scaffold with FastAPI + PyTorch + sb3"
+```
+
+---
+
+## Task 3: FastAPI /health endpoint (TDD)
+
+**Files:**
+- Create: `rl-inference-server/src/auth.py`
+- Create: `rl-inference-server/src/main.py`
+- Create: `rl-inference-server/tests/test_health.py`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`rl-inference-server/tests/test_health.py`:
+
+```python
+from fastapi.testclient import TestClient
+
+def test_health_returns_200_with_status(monkeypatch):
+    monkeypatch.setenv("RL_API_KEY", "test-key")
+    from src.main import app
+    client = TestClient(app)
+    resp = client.get("/health", headers={"X-RL-API-KEY": "test-key"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert "loaded_models" in body
+    assert "uptime_seconds" in body
+
+
+def test_health_rejects_missing_api_key(monkeypatch):
+    monkeypatch.setenv("RL_API_KEY", "test-key")
+    from src.main import app
+    client = TestClient(app)
+    resp = client.get("/health")
+    assert resp.status_code == 401
+
+
+def test_health_rejects_wrong_api_key(monkeypatch):
+    monkeypatch.setenv("RL_API_KEY", "test-key")
+    from src.main import app
+    client = TestClient(app)
+    resp = client.get("/health", headers={"X-RL-API-KEY": "wrong"})
+    assert resp.status_code == 401
+```
+
+- [ ] **Step 2: 실행 → fail 확인**
+
+```bash
+cd rl-inference-server && source .venv/bin/activate
+pytest tests/test_health.py -v
+```
+
+기대: ImportError or 모듈 미존재로 FAIL.
+
+- [ ] **Step 3: auth.py 구현**
+
+`rl-inference-server/src/auth.py`:
+
+```python
+from fastapi import Header, HTTPException, status
+from src.config import get_settings
+
+
+def require_api_key(x_rl_api_key: str | None = Header(default=None)) -> None:
+    settings = get_settings()
+    if not x_rl_api_key or x_rl_api_key != settings.rl_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid or missing X-RL-API-KEY",
+        )
+```
+
+- [ ] **Step 4: main.py 골격 + /health 구현**
+
+`rl-inference-server/src/main.py`:
+
+```python
+import time
+from fastapi import FastAPI, Depends
+from src.auth import require_api_key
+
+START_TIME = time.time()
+app = FastAPI(title="rl-inference-server", version="0.1.0")
+
+
+@app.get("/health", dependencies=[Depends(require_api_key)])
+def health():
+    return {
+        "status": "ok",
+        "loaded_models": [],  # Task 4에서 model_registry 연결
+        "uptime_seconds": round(time.time() - START_TIME, 2),
+    }
+```
+
+- [ ] **Step 5: 실행 → pass 확인**
+
+```bash
+pytest tests/test_health.py -v
+```
+
+기대: 3개 테스트 모두 PASS.
+
+- [ ] **Step 6: 수동 기동 검증**
+
+```bash
+RL_API_KEY=test uvicorn src.main:app --host 127.0.0.1 --port 8001 &
+sleep 1
+curl -s -H 'X-RL-API-KEY: test' http://127.0.0.1:8001/health
+kill %1
+```
+
+기대: `{"status":"ok",...}` 출력.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add rl-inference-server/src/auth.py rl-inference-server/src/main.py rl-inference-server/tests/test_health.py
+git commit -m "feat(rl-server): /health endpoint with X-RL-API-KEY auth"
+```
+
+---
+
+## Task 4: model_registry — 다운로드 + 무결성 검증 + LRU 캐시
+
+**Files:**
+- Create: `rl-inference-server/src/model_registry.py`
+- Create: `rl-inference-server/tests/test_model_registry.py`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`rl-inference-server/tests/test_model_registry.py`:
+
+```python
+import hashlib
+from pathlib import Path
+import pytest
+from src.model_registry import ModelRegistry, DownloadError, IntegrityError
+
+
+def make_dummy_bytes(n: int = 1024) -> bytes:
+    return bytes((i % 256 for i in range(n)))
+
+
+@pytest.mark.asyncio
+async def test_download_writes_to_sha256_subdir(tmp_path, monkeypatch):
+    payload = make_dummy_bytes()
+    expected_sha = hashlib.sha256(payload).hexdigest()
+    registry = ModelRegistry(model_dir=str(tmp_path))
+
+    async def fake_fetch(url: str) -> bytes:
+        return payload
+
+    monkeypatch.setattr(registry, "_fetch_bytes", fake_fetch)
+    path = await registry.download("model-1", "https://example.com/x.zip", expected_sha)
+    p = Path(path)
+    assert p.exists()
+    assert expected_sha in str(p)
+
+
+@pytest.mark.asyncio
+async def test_download_rejects_sha_mismatch(tmp_path, monkeypatch):
+    payload = make_dummy_bytes()
+    bad_sha = "0" * 64
+    registry = ModelRegistry(model_dir=str(tmp_path))
+
+    async def fake_fetch(url: str) -> bytes:
+        return payload
+
+    monkeypatch.setattr(registry, "_fetch_bytes", fake_fetch)
+    with pytest.raises(IntegrityError):
+        await registry.download("model-1", "https://example.com/x.zip", bad_sha)
+
+
+def test_lru_evicts_oldest_when_capacity_exceeded():
+    registry = ModelRegistry(model_dir="/tmp", lru_capacity=2)
+    registry._cache_set("a", "obj-a")
+    registry._cache_set("b", "obj-b")
+    registry._cache_set("c", "obj-c")  # a 축출
+    assert registry._cache_get("a") is None
+    assert registry._cache_get("b") == "obj-b"
+    assert registry._cache_get("c") == "obj-c"
+
+
+def test_loaded_models_returns_cached_keys():
+    registry = ModelRegistry(model_dir="/tmp", lru_capacity=2)
+    registry._cache_set("a", "obj-a")
+    registry._cache_set("b", "obj-b")
+    assert sorted(registry.loaded_models()) == ["a", "b"]
+```
+
+- [ ] **Step 2: 실행 → fail 확인**
+
+```bash
+pytest tests/test_model_registry.py -v
+```
+
+기대: ImportError로 FAIL.
+
+- [ ] **Step 3: model_registry.py 구현**
+
+`rl-inference-server/src/model_registry.py`:
+
+```python
+from __future__ import annotations
+import hashlib
+import os
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+import httpx
+
+
+class DownloadError(Exception):
+    pass
+
+
+class IntegrityError(Exception):
+    pass
+
+
+class ModelRegistry:
+    """ckpt 다운로드 + sha256 무결성 검증 + 메모리 LRU 캐시."""
+
+    def __init__(self, model_dir: str, lru_capacity: int = 2) -> None:
+        self.model_dir = Path(model_dir)
+        self.model_dir.mkdir(parents=True, exist_ok=True)
+        self._lru: OrderedDict[str, Any] = OrderedDict()
+        self._capacity = lru_capacity
+
+    async def _fetch_bytes(self, url: str) -> bytes:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
+            r = await client.get(url, follow_redirects=True)
+            if r.status_code >= 400:
+                raise DownloadError(f"GET {url} -> {r.status_code}")
+            return r.content
+
+    async def download(self, model_id: str, url: str, expected_sha256: str) -> str:
+        """다운로드 → sha 검증 → 영구 경로 반환."""
+        data = await self._fetch_bytes(url)
+        actual = hashlib.sha256(data).hexdigest()
+        if actual != expected_sha256:
+            raise IntegrityError(
+                f"sha256 mismatch for {model_id}: expected {expected_sha256}, got {actual}"
+            )
+        target_dir = self.model_dir / actual
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target = target_dir / "model.zip"
+        target.write_bytes(data)
+        return str(target)
+
+    def _cache_set(self, key: str, value: Any) -> None:
+        if key in self._lru:
+            self._lru.move_to_end(key)
+        self._lru[key] = value
+        while len(self._lru) > self._capacity:
+            self._lru.popitem(last=False)
+
+    def _cache_get(self, key: str) -> Any | None:
+        if key not in self._lru:
+            return None
+        self._lru.move_to_end(key)
+        return self._lru[key]
+
+    def loaded_models(self) -> list[str]:
+        return list(self._lru.keys())
+```
+
+- [ ] **Step 4: 실행 → pass 확인**
+
+```bash
+pytest tests/test_model_registry.py -v
+```
+
+기대: 4개 테스트 PASS.
+
+- [ ] **Step 5: /health에 loaded_models 연결**
+
+`rl-inference-server/src/main.py` 수정:
+
+```python
+import time
+from fastapi import FastAPI, Depends
+from src.auth import require_api_key
+from src.config import get_settings
+from src.model_registry import ModelRegistry
+
+settings = get_settings()
+START_TIME = time.time()
+registry = ModelRegistry(model_dir=settings.model_dir)
+app = FastAPI(title="rl-inference-server", version="0.1.0")
+
+
+@app.get("/health", dependencies=[Depends(require_api_key)])
+def health():
+    return {
+        "status": "ok",
+        "loaded_models": registry.loaded_models(),
+        "uptime_seconds": round(time.time() - START_TIME, 2),
+    }
+```
+
+- [ ] **Step 6: 회귀 테스트 실행**
+
+```bash
+pytest -v
+```
+
+기대: 7개 모두 PASS (health 3 + registry 4).
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add rl-inference-server/src/model_registry.py rl-inference-server/src/main.py rl-inference-server/tests/test_model_registry.py
+git commit -m "feat(rl-server): model registry with sha256 + LRU cache"
+```
+
+---
+
+## Task 5: 어댑터 베이스 + SB3 어댑터 + 신뢰도 계산
+
+**Files:**
+- Create: `rl-inference-server/src/adapters/__init__.py`
+- Create: `rl-inference-server/src/adapters/base.py`
+- Create: `rl-inference-server/src/adapters/sb3.py`
+- Create: `rl-inference-server/tests/test_sb3_adapter.py`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`rl-inference-server/tests/test_sb3_adapter.py`:
+
+```python
+"""SB3 어댑터: 가벼운 PPO 모델을 즉석 학습 후 ckpt 저장 → 어댑터로 로드 → 형상 검증."""
+
+import os
+from pathlib import Path
+import numpy as np
+import pytest
+
+
+def _make_tiny_ppo_zip(tmp_path: Path) -> str:
+    """관측 4-dim, 액션 2-dim discrete의 PPO를 즉석으로 만들어 저장."""
+    import gymnasium as gym
+    from stable_baselines3 import PPO
+
+    env = gym.make("CartPole-v1")
+    model = PPO("MlpPolicy", env, n_steps=64, verbose=0)
+    path = tmp_path / "ppo.zip"
+    model.save(str(path))
+    return str(path)
+
+
+def test_sb3_adapter_loads_and_predicts(tmp_path):
+    from src.adapters.sb3 import SB3Adapter
+
+    ckpt = _make_tiny_ppo_zip(tmp_path)
+    adapter = SB3Adapter.load(checkpoint_path=ckpt, algorithm="PPO")
+    obs = np.zeros((4,), dtype=np.float32)
+    raw_action, action_logits = adapter.predict_with_logits(obs)
+    assert raw_action is not None
+    assert action_logits is not None
+
+
+def test_sb3_adapter_compute_confidence_returns_in_unit_range(tmp_path):
+    from src.adapters.sb3 import SB3Adapter
+
+    ckpt = _make_tiny_ppo_zip(tmp_path)
+    adapter = SB3Adapter.load(checkpoint_path=ckpt, algorithm="PPO")
+    obs = np.zeros((4,), dtype=np.float32)
+    _, logits = adapter.predict_with_logits(obs)
+    conf = adapter.compute_confidence(logits)
+    assert 0.0 <= conf <= 1.0
+
+
+def test_sb3_adapter_rejects_unknown_algorithm(tmp_path):
+    from src.adapters.sb3 import SB3Adapter
+
+    with pytest.raises(ValueError):
+        SB3Adapter.load(checkpoint_path="/dev/null", algorithm="UNSUPPORTED")
+```
+
+추가 의존성: `pip install gymnasium`. pyproject.toml의 dev에 `gymnasium>=0.29`를 추가하고 다시 설치.
+
+- [ ] **Step 2: gymnasium 의존성 추가 + 재설치**
+
+`rl-inference-server/pyproject.toml`의 `[project.optional-dependencies] dev` 항목 변경:
+
+```toml
+dev = ["pytest>=8.3", "pytest-asyncio>=0.24", "ruff>=0.7", "gymnasium>=0.29"]
+```
+
+```bash
+pip install -e ".[dev]"
+```
+
+- [ ] **Step 3: 실행 → fail 확인**
+
+```bash
+pytest tests/test_sb3_adapter.py -v
+```
+
+기대: 어댑터 미존재로 FAIL.
+
+- [ ] **Step 4: base.py 구현**
+
+`rl-inference-server/src/adapters/__init__.py`: 빈 파일
+
+`rl-inference-server/src/adapters/base.py`:
+
+```python
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import Any
+import numpy as np
+
+
+class AdapterBase(ABC):
+    """RL 모델 추론 어댑터 공통 인터페이스.
+
+    모든 어댑터는 raw observation → (action, logits/q_values)와 신뢰도 계산을 제공한다.
+    """
+
+    @classmethod
+    @abstractmethod
+    def load(cls, checkpoint_path: str, algorithm: str) -> "AdapterBase": ...
+
+    @abstractmethod
+    def predict_with_logits(self, obs: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """반환: (action, logits_or_qvalues). logits는 신뢰도 계산용."""
+
+    @abstractmethod
+    def compute_confidence(self, logits_or_q: np.ndarray) -> float:
+        """모델 종류별 신뢰도(0~1) 계산. 가짜 1.0 금지."""
+```
+
+- [ ] **Step 5: sb3.py 구현**
+
+`rl-inference-server/src/adapters/sb3.py`:
+
+```python
+from __future__ import annotations
+import numpy as np
+import torch
+from src.adapters.base import AdapterBase
+
+_SUPPORTED = {"PPO", "A2C", "DQN", "TD3", "DDPG", "SAC"}
+
+
+class SB3Adapter(AdapterBase):
+    def __init__(self, model: object, algorithm: str) -> None:
+        self._model = model
+        self._algorithm = algorithm
+
+    @classmethod
+    def load(cls, checkpoint_path: str, algorithm: str) -> "SB3Adapter":
+        if algorithm not in _SUPPORTED:
+            raise ValueError(f"unsupported algorithm: {algorithm}")
+        # algorithm별 import
+        if algorithm == "PPO":
+            from stable_baselines3 import PPO as Cls
+        elif algorithm == "A2C":
+            from stable_baselines3 import A2C as Cls
+        elif algorithm == "DQN":
+            from stable_baselines3 import DQN as Cls
+        elif algorithm == "TD3":
+            from stable_baselines3 import TD3 as Cls
+        elif algorithm == "DDPG":
+            from stable_baselines3 import DDPG as Cls
+        elif algorithm == "SAC":
+            from stable_baselines3 import SAC as Cls
+        model = Cls.load(checkpoint_path, device="cpu")
+        return cls(model, algorithm)
+
+    def predict_with_logits(self, obs: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        action, _state = self._model.predict(obs, deterministic=True)
+        # logits는 policy net을 직접 호출하여 추출
+        with torch.no_grad():
+            obs_tensor = torch.as_tensor(obs, dtype=torch.float32).unsqueeze(0)
+            policy = getattr(self._model, "policy", None)
+            if policy is None:
+                # 안전 fallback: action만 반환, logits는 빈 array
+                return np.asarray(action), np.array([1.0])
+            try:
+                # 대부분의 sb3 algo가 forward를 갖는다
+                dist = policy.get_distribution(obs_tensor)
+                # discrete: distribution.distribution.logits / continuous: mean+std
+                logits = self._extract_distribution(dist)
+            except Exception:
+                logits = np.array([1.0])
+        return np.asarray(action), logits
+
+    def _extract_distribution(self, dist) -> np.ndarray:
+        # discrete (Categorical)
+        inner = getattr(dist, "distribution", None)
+        if inner is not None and hasattr(inner, "logits"):
+            return inner.logits.detach().cpu().numpy().squeeze()
+        # continuous (Normal): mean, std
+        if inner is not None and hasattr(inner, "mean") and hasattr(inner, "stddev"):
+            mean = inner.mean.detach().cpu().numpy().squeeze()
+            std = inner.stddev.detach().cpu().numpy().squeeze()
+            return np.concatenate([np.atleast_1d(mean), np.atleast_1d(std)])
+        return np.array([1.0])
+
+    def compute_confidence(self, logits_or_q: np.ndarray) -> float:
+        """
+        - discrete: softmax(logits)의 최대값 (가장 가능성 높은 액션의 확률)
+        - continuous: 1 - mean(std)/std_max (분산이 작을수록 신뢰)
+        """
+        arr = np.asarray(logits_or_q, dtype=np.float32).ravel()
+        if arr.size == 0:
+            return 0.0
+        # heuristic: 양수 logits-like → softmax; 두 부분(mean,std) → continuous 처리
+        if arr.size >= 2 and arr.size % 2 == 0:
+            half = arr.size // 2
+            mean = arr[:half]
+            std = arr[half:]
+            std_max = max(float(std.max()), 1e-6)
+            conf = 1.0 - float(std.mean()) / std_max
+            return float(np.clip(conf, 0.0, 1.0))
+        # discrete: softmax
+        e = np.exp(arr - arr.max())
+        probs = e / e.sum()
+        return float(np.clip(probs.max(), 0.0, 1.0))
+```
+
+- [ ] **Step 6: 실행 → pass 확인**
+
+```bash
+pytest tests/test_sb3_adapter.py -v
+```
+
+기대: 3개 테스트 PASS. 첫 번째 테스트는 PPO 학습이 ~수초 걸림 — 정상.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add rl-inference-server/pyproject.toml rl-inference-server/src/adapters/ rl-inference-server/tests/test_sb3_adapter.py
+git commit -m "feat(rl-server): SB3 adapter with confidence calculation"
+```
+
+---
+
+## Task 6: Pydantic 스키마 + /predict (portfolio) 라우트
+
+**Files:**
+- Create: `rl-inference-server/src/schemas.py`
+- Create: `rl-inference-server/src/state.py`
+- Create: `rl-inference-server/src/inference/__init__.py`
+- Create: `rl-inference-server/src/inference/portfolio.py`
+- Modify: `rl-inference-server/src/main.py`
+- Create: `rl-inference-server/tests/test_predict_portfolio.py`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`rl-inference-server/tests/test_predict_portfolio.py`:
+
+```python
+import json
+from pathlib import Path
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _make_dummy_ppo(tmp_path: Path) -> str:
+    import gymnasium as gym
+    from stable_baselines3 import PPO
+
+    env = gym.make("CartPole-v1")
+    model = PPO("MlpPolicy", env, n_steps=64, verbose=0)
+    path = tmp_path / "ppo.zip"
+    model.save(str(path))
+    return str(path)
+
+
+def _build_request(ckpt: str) -> dict:
+    return {
+        "model_id": "test-model-1",
+        "checkpoint_path": ckpt,
+        "algorithm": "PPO",
+        "kind": "portfolio",
+        "state_window": 5,
+        "input_features": ["close"],
+        "ohlcv": {
+            "AAPL": [{"date": f"2026-04-{20+i:02d}", "open": 1, "high": 1, "low": 1, "close": 1.0, "volume": 1} for i in range(5)],
+            "MSFT": [{"date": f"2026-04-{20+i:02d}", "open": 1, "high": 1, "low": 1, "close": 1.0, "volume": 1} for i in range(5)],
+        },
+        "indicators": None,
+        "current_positions": None,
+    }
+
+
+def test_predict_returns_weights_and_confidence(tmp_path, monkeypatch):
+    monkeypatch.setenv("RL_API_KEY", "test-key")
+    monkeypatch.setenv("MODEL_DIR", str(tmp_path / "models"))
+    from src.main import app
+
+    client = TestClient(app)
+    ckpt = _make_dummy_ppo(tmp_path)
+    body = _build_request(ckpt)
+    resp = client.post("/predict", headers={"X-RL-API-KEY": "test-key"}, json=body)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["kind"] == "portfolio"
+    assert isinstance(data["weights"], dict)
+    assert set(data["weights"].keys()) == {"AAPL", "MSFT"}
+    weight_sum = sum(data["weights"].values())
+    assert abs(weight_sum - 1.0) < 1e-3
+    assert 0 <= data["confidence"] <= 1
+```
+
+- [ ] **Step 2: 실행 → fail 확인**
+
+```bash
+pytest tests/test_predict_portfolio.py -v
+```
+
+기대: /predict 미존재로 FAIL.
+
+- [ ] **Step 3: schemas.py 구현**
+
+`rl-inference-server/src/schemas.py`:
+
+```python
+from __future__ import annotations
+from typing import Literal, Optional
+from pydantic import BaseModel, Field
+
+
+class OHLCVRow(BaseModel):
+    date: str
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+class PredictRequest(BaseModel):
+    model_id: str
+    checkpoint_path: str
+    algorithm: str
+    kind: Literal["portfolio", "single_asset"]
+    state_window: int = Field(ge=1, le=500)
+    input_features: list[str]
+    ohlcv: dict[str, list[OHLCVRow]]
+    indicators: Optional[dict[str, dict[str, list[float]]]] = None
+    current_positions: Optional[dict[str, dict]] = None
+
+
+class PortfolioPredictResponse(BaseModel):
+    kind: Literal["portfolio"] = "portfolio"
+    weights: dict[str, float]
+    confidence: float
+    raw_action: list[float]
+    metadata: dict
+
+
+class SinglePredictResponse(BaseModel):
+    kind: Literal["single_asset"] = "single_asset"
+    action: Literal["buy", "sell", "hold"]
+    size_hint: Optional[float] = None
+    confidence: float
+    metadata: dict
+```
+
+- [ ] **Step 4: state.py 구현 (간단 state hash 유틸)**
+
+`rl-inference-server/src/state.py`:
+
+```python
+import hashlib
+import json
+
+
+def hash_state(payload: dict) -> str:
+    """state 입력의 결정적 SHA256."""
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+```
+
+- [ ] **Step 5: portfolio.py 구현**
+
+`rl-inference-server/src/inference/__init__.py`: 빈 파일
+
+`rl-inference-server/src/inference/portfolio.py`:
+
+```python
+from __future__ import annotations
+import time
+import numpy as np
+from src.adapters.sb3 import SB3Adapter
+from src.schemas import PredictRequest, PortfolioPredictResponse
+
+
+class PortfolioInferenceEngine:
+    def __init__(self, adapter: SB3Adapter) -> None:
+        self._adapter = adapter
+
+    def run(self, req: PredictRequest) -> PortfolioPredictResponse:
+        t0 = time.time()
+        # state 구성: 종목별 close의 마지막 state_window 봉 평탄화
+        tickers = sorted(req.ohlcv.keys())
+        windows = []
+        for t in tickers:
+            rows = req.ohlcv[t]
+            if len(rows) < req.state_window:
+                raise ValueError(f"insufficient OHLCV for {t}: need {req.state_window}, got {len(rows)}")
+            closes = [row.close for row in rows[-req.state_window:]]
+            windows.append(closes)
+        obs = np.array(windows, dtype=np.float32).flatten()
+
+        # 어댑터가 기대하는 obs 차원이 다르면 zero-pad / truncate (모델별 정확한 형상은 어댑터에서 검증해야 하지만 Phase 1은 best-effort)
+        action, logits = self._adapter.predict_with_logits(obs)
+        confidence = self._adapter.compute_confidence(logits)
+
+        # action을 weights로 변환: 음수 → 0, normalize
+        raw = np.asarray(action, dtype=np.float32).ravel()
+        if raw.size != len(tickers):
+            # 차원 mismatch: 균등분배 + 낮은 confidence
+            weights = {t: 1.0 / len(tickers) for t in tickers}
+            confidence = min(confidence, 0.0)
+        else:
+            clipped = np.clip(raw, 0.0, None)
+            s = clipped.sum()
+            if s <= 0:
+                weights = {t: 1.0 / len(tickers) for t in tickers}
+            else:
+                normalized = clipped / s
+                weights = {t: float(w) for t, w in zip(tickers, normalized)}
+
+        return PortfolioPredictResponse(
+            weights=weights,
+            confidence=float(confidence),
+            raw_action=raw.tolist(),
+            metadata={
+                "model_id": req.model_id,
+                "algorithm": req.algorithm,
+                "latency_ms": round((time.time() - t0) * 1000, 2),
+                "n_tickers": len(tickers),
+            },
+        )
+```
+
+- [ ] **Step 6: main.py에 /predict 라우트 추가**
+
+`rl-inference-server/src/main.py` 전면 교체:
+
+```python
+import time
+from fastapi import FastAPI, Depends, HTTPException
+from src.auth import require_api_key
+from src.config import get_settings
+from src.model_registry import ModelRegistry
+from src.adapters.sb3 import SB3Adapter
+from src.inference.portfolio import PortfolioInferenceEngine
+from src.schemas import PredictRequest, PortfolioPredictResponse, SinglePredictResponse
+
+settings = get_settings()
+START_TIME = time.time()
+registry = ModelRegistry(model_dir=settings.model_dir)
+app = FastAPI(title="rl-inference-server", version="0.1.0")
+
+
+def _get_or_load_adapter(req: PredictRequest) -> SB3Adapter:
+    cached = registry._cache_get(req.model_id)
+    if isinstance(cached, SB3Adapter):
+        return cached
+    adapter = SB3Adapter.load(req.checkpoint_path, req.algorithm)
+    registry._cache_set(req.model_id, adapter)
+    return adapter
+
+
+@app.get("/health", dependencies=[Depends(require_api_key)])
+def health():
+    return {
+        "status": "ok",
+        "loaded_models": registry.loaded_models(),
+        "uptime_seconds": round(time.time() - START_TIME, 2),
+    }
+
+
+@app.post(
+    "/predict",
+    dependencies=[Depends(require_api_key)],
+    response_model=PortfolioPredictResponse | SinglePredictResponse,
+)
+def predict(req: PredictRequest):
+    if req.kind != "portfolio":
+        raise HTTPException(status_code=400, detail="single_asset is not supported in Phase 1")
+    adapter = _get_or_load_adapter(req)
+    engine = PortfolioInferenceEngine(adapter)
+    try:
+        return engine.run(req)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+```
+
+- [ ] **Step 7: 실행 → pass 확인**
+
+```bash
+pytest -v
+```
+
+기대: 모든 테스트 PASS (health 3 + registry 4 + sb3 3 + predict 1 = 11).
+
+- [ ] **Step 8: 커밋**
+
+```bash
+git add rl-inference-server/src/schemas.py rl-inference-server/src/state.py rl-inference-server/src/inference/ rl-inference-server/src/main.py rl-inference-server/tests/test_predict_portfolio.py
+git commit -m "feat(rl-server): /predict portfolio with adapter cache"
+```
+
+---
+
+## Task 7: /backtest 엔드포인트 (간단 OHLCV 시뮬레이션)
+
+**Files:**
+- Modify: `rl-inference-server/src/schemas.py`
+- Create: `rl-inference-server/src/inference/backtest.py`
+- Modify: `rl-inference-server/src/main.py`
+- Create: `rl-inference-server/tests/test_backtest.py`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`rl-inference-server/tests/test_backtest.py`:
+
+```python
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+
+def _make_dummy_ppo(tmp_path: Path) -> str:
+    import gymnasium as gym
+    from stable_baselines3 import PPO
+    env = gym.make("CartPole-v1")
+    model = PPO("MlpPolicy", env, n_steps=64, verbose=0)
+    path = tmp_path / "ppo.zip"
+    model.save(str(path))
+    return str(path)
+
+
+def test_backtest_returns_metrics(tmp_path, monkeypatch):
+    monkeypatch.setenv("RL_API_KEY", "test-key")
+    monkeypatch.setenv("MODEL_DIR", str(tmp_path / "models"))
+    from src.main import app
+    client = TestClient(app)
+    ckpt = _make_dummy_ppo(tmp_path)
+    n = 30
+    body = {
+        "model_id": "m1",
+        "checkpoint_path": ckpt,
+        "algorithm": "PPO",
+        "kind": "portfolio",
+        "state_window": 5,
+        "input_features": ["close"],
+        "ohlcv": {
+            "AAPL": [{"date": f"2026-03-{(i%28)+1:02d}", "open":1,"high":1,"low":1,"close":1.0+i*0.01,"volume":1} for i in range(n)],
+            "MSFT": [{"date": f"2026-03-{(i%28)+1:02d}", "open":1,"high":1,"low":1,"close":1.0,"volume":1} for i in range(n)],
+        },
+        "rebalance_dates": [f"2026-03-{i+1:02d}" for i in range(5, n)],
+        "initial_capital": 10000.0,
+    }
+    resp = client.post("/backtest", headers={"X-RL-API-KEY": "test-key"}, json=body)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert "total_return" in data
+    assert "sharpe_ratio" in data
+    assert "equity_curve" in data
+    assert isinstance(data["equity_curve"], list)
+    assert len(data["equity_curve"]) >= 1
+```
+
+- [ ] **Step 2: 실행 → fail**
+
+```bash
+pytest tests/test_backtest.py -v
+```
+
+기대: 404 또는 모듈 미존재.
+
+- [ ] **Step 3: schemas.py에 BacktestRequest/Response 추가**
+
+`rl-inference-server/src/schemas.py` 끝에 추가:
+
+```python
+class BacktestRequest(PredictRequest):
+    rebalance_dates: list[str]
+    initial_capital: float = 10000.0
+
+
+class EquityPoint(BaseModel):
+    date: str
+    equity: float
+
+
+class BacktestResponse(BaseModel):
+    total_return: float
+    sharpe_ratio: float
+    max_drawdown: float
+    n_rebalances: int
+    equity_curve: list[EquityPoint]
+    metadata: dict
+```
+
+- [ ] **Step 4: backtest.py 구현**
+
+`rl-inference-server/src/inference/backtest.py`:
+
+```python
+from __future__ import annotations
+import time
+import numpy as np
+from src.adapters.sb3 import SB3Adapter
+from src.inference.portfolio import PortfolioInferenceEngine
+from src.schemas import BacktestRequest, BacktestResponse, EquityPoint, PredictRequest
+
+
+def run_backtest(adapter: SB3Adapter, req: BacktestRequest) -> BacktestResponse:
+    t0 = time.time()
+    engine = PortfolioInferenceEngine(adapter)
+    tickers = sorted(req.ohlcv.keys())
+    # date → ticker → close lookup
+    rows_by_t = {t: {row.date: row.close for row in req.ohlcv[t]} for t in tickers}
+    all_dates = sorted({row.date for t in tickers for row in req.ohlcv[t]})
+
+    equity = float(req.initial_capital)
+    weights: dict[str, float] = {t: 0.0 for t in tickers}
+    curve: list[EquityPoint] = []
+    n_rebalances = 0
+
+    prev_prices: dict[str, float] | None = None
+    rebal_set = set(req.rebalance_dates)
+
+    for date in all_dates:
+        prices = {t: rows_by_t[t].get(date) for t in tickers}
+        if any(p is None for p in prices.values()):
+            continue
+        # 일자 수익률 적용 (직전 종가 대비 현재 종가)
+        if prev_prices is not None and any(weights.values()):
+            ret = sum(weights[t] * (prices[t] / prev_prices[t] - 1.0) for t in tickers)
+            equity *= (1.0 + ret)
+        prev_prices = prices
+
+        if date in rebal_set:
+            sub_req = PredictRequest(
+                model_id=req.model_id,
+                checkpoint_path=req.checkpoint_path,
+                algorithm=req.algorithm,
+                kind=req.kind,
+                state_window=req.state_window,
+                input_features=req.input_features,
+                ohlcv={
+                    t: [r for r in req.ohlcv[t] if r.date <= date][-req.state_window:]
+                    for t in tickers
+                },
+            )
+            try:
+                pred = engine.run(sub_req)
+                weights = pred.weights
+                n_rebalances += 1
+            except Exception:
+                pass
+
+        curve.append(EquityPoint(date=date, equity=equity))
+
+    if not curve:
+        curve = [EquityPoint(date=all_dates[0] if all_dates else "1970-01-01", equity=equity)]
+
+    equities = np.array([p.equity for p in curve], dtype=np.float64)
+    rets = np.diff(equities) / equities[:-1] if equities.size >= 2 else np.array([0.0])
+    total_return = float(equities[-1] / req.initial_capital - 1.0)
+    sharpe = float(rets.mean() / rets.std() * np.sqrt(252)) if rets.std() > 0 else 0.0
+    peak = np.maximum.accumulate(equities)
+    drawdown = (equities - peak) / peak
+    max_dd = float(drawdown.min()) if drawdown.size else 0.0
+
+    return BacktestResponse(
+        total_return=total_return,
+        sharpe_ratio=sharpe,
+        max_drawdown=max_dd,
+        n_rebalances=n_rebalances,
+        equity_curve=curve,
+        metadata={
+            "model_id": req.model_id,
+            "latency_ms": round((time.time() - t0) * 1000, 2),
+            "n_dates": len(all_dates),
+        },
+    )
+```
+
+- [ ] **Step 5: main.py에 /backtest 추가**
+
+`rl-inference-server/src/main.py`에 import + 라우트 추가:
+
+```python
+from src.schemas import BacktestRequest, BacktestResponse
+from src.inference.backtest import run_backtest
+
+@app.post("/backtest", dependencies=[Depends(require_api_key)], response_model=BacktestResponse)
+def backtest(req: BacktestRequest):
+    if req.kind != "portfolio":
+        raise HTTPException(status_code=400, detail="single_asset backtest not supported in Phase 1")
+    adapter = _get_or_load_adapter(req)
+    return run_backtest(adapter, req)
+```
+
+- [ ] **Step 6: 실행 → pass**
+
+```bash
+pytest -v
+```
+
+기대: 모든 테스트 PASS.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add rl-inference-server/src/schemas.py rl-inference-server/src/inference/backtest.py rl-inference-server/src/main.py rl-inference-server/tests/test_backtest.py
+git commit -m "feat(rl-server): /backtest endpoint with sharpe + drawdown"
+```
+
+---
+
+## Task 8: TypeScript 타입 확장 (메인 앱)
+
+**Files:**
+- Modify: `dental-clinic-manager/src/types/investment.ts`
+- Create: `dental-clinic-manager/src/types/rlTrading.ts`
+
+- [ ] **Step 1: rlTrading.ts 생성**
+
+`dental-clinic-manager/src/types/rlTrading.ts`:
+
+```typescript
+export type RLModelSource = 'finrl_pretrained' | 'sb3_pretrained' | 'custom'
+export type RLModelKind = 'portfolio' | 'single_asset'
+export type RLModelStatus = 'pending' | 'downloading' | 'ready' | 'failed' | 'archived'
+export type RLAlgorithm = 'PPO' | 'A2C' | 'TD3' | 'DDPG' | 'DQN' | 'SAC'
+
+export interface RLOutputShape {
+  type: 'continuous' | 'discrete'
+  dim: number
+}
+
+export interface RLModel {
+  id: string
+  user_id: string
+  clinic_id: string
+  name: string
+  description?: string | null
+  source: RLModelSource
+  algorithm: RLAlgorithm
+  kind: RLModelKind
+  market: string
+  timeframe: string
+  universe: string[] | null
+  input_features: string[]
+  state_window: number
+  output_shape: RLOutputShape
+  checkpoint_url: string | null
+  checkpoint_path: string | null
+  checkpoint_sha256: string | null
+  min_confidence: number
+  status: RLModelStatus
+  metrics: Record<string, unknown> | null
+  failure_reason: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface RLModelCreateInput {
+  name: string
+  description?: string
+  source: RLModelSource
+  algorithm: RLAlgorithm
+  kind: RLModelKind
+  market?: string
+  timeframe?: string
+  universe?: string[]
+  input_features: string[]
+  state_window: number
+  output_shape: RLOutputShape
+  checkpoint_url: string
+  checkpoint_sha256: string
+  min_confidence?: number
+}
+
+export type RLDecision =
+  | 'order'
+  | 'hold'
+  | 'blocked_low_confidence'
+  | 'blocked_kill_switch'
+  | 'error'
+
+export interface RLInferenceLog {
+  id: string
+  strategy_id: string
+  rl_model_id: string
+  user_id: string
+  trade_date: string
+  state_hash: string
+  output: Record<string, unknown>
+  confidence: number | null
+  decision: RLDecision
+  blocked_reason: string | null
+  latency_ms: number | null
+  error_message: string | null
+  created_at: string
+}
+```
+
+- [ ] **Step 2: investment.ts 확장 — strategy_type, rl_model_id 필드**
+
+기존 `InvestmentStrategy` 인터페이스에 다음 필드 추가:
+
+```typescript
+strategy_type: 'rule' | 'rl_portfolio' | 'rl_single'
+rl_model_id?: string | null
+```
+
+(파일 내 정확한 위치는 기존 InvestmentStrategy interface — `id, user_id, ...` 필드 옆에. `risk_settings` 다음 줄 추천. 동일한 변경을 `InvestmentStrategyInput`에도 추가하되 strategy_type은 optional default 'rule', rl_model_id optional.)
+
+- [ ] **Step 3: 타입 체크 실행**
+
+```bash
+cd dental-clinic-manager
+npx tsc --noEmit 2>&1 | grep -E "rlTrading|investment\.ts" | head -10
+```
+
+기대: 출력 없음 (에러 없음).
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/types/rlTrading.ts src/types/investment.ts
+git commit -m "feat(rl-trading): typescript types for RL models and strategies"
+```
+
+---
+
+## Task 9: trading-worker `rlInferenceClient` (TDD)
+
+**Files:**
+- Modify: `trading-worker/package.json` (vitest devDep)
+- Create: `trading-worker/vitest.config.ts`
+- Create: `trading-worker/src/rlInferenceClient.ts`
+- Create: `trading-worker/tests/rlInferenceClient.test.ts`
+
+- [ ] **Step 1: vitest 추가**
+
+`trading-worker/package.json`의 devDependencies에 추가:
+
+```json
+"vitest": "^2.1.0"
+```
+
+scripts에 추가:
+
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+```bash
+cd trading-worker && npm install
+```
+
+`trading-worker/vitest.config.ts`:
+
+```typescript
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+    testTimeout: 10000,
+  },
+})
+```
+
+- [ ] **Step 2: 실패 테스트 작성**
+
+`trading-worker/tests/rlInferenceClient.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RLInferenceClient } from '../src/rlInferenceClient'
+
+describe('RLInferenceClient', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('predict() POSTs with X-RL-API-KEY and parses portfolio response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          kind: 'portfolio',
+          weights: { AAPL: 0.5, MSFT: 0.5 },
+          confidence: 0.8,
+          raw_action: [0.5, 0.5],
+          metadata: {},
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+    global.fetch = fetchMock as unknown as typeof fetch
+    const client = new RLInferenceClient({ baseUrl: 'http://127.0.0.1:8001', apiKey: 'k', timeoutMs: 1000 })
+    const res = await client.predict({
+      model_id: 'm',
+      checkpoint_path: '/p',
+      algorithm: 'PPO',
+      kind: 'portfolio',
+      state_window: 5,
+      input_features: ['close'],
+      ohlcv: {},
+    })
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [, init] = fetchMock.mock.calls[0]
+    expect((init as RequestInit).headers).toMatchObject({ 'X-RL-API-KEY': 'k' })
+    expect(res.kind).toBe('portfolio')
+    expect(res.confidence).toBe(0.8)
+  })
+
+  it('throws timeout error after timeoutMs', async () => {
+    global.fetch = vi.fn().mockImplementation(
+      () => new Promise(() => {}),  // never resolves
+    ) as unknown as typeof fetch
+    const client = new RLInferenceClient({ baseUrl: 'http://x', apiKey: 'k', timeoutMs: 50 })
+    await expect(
+      client.predict({
+        model_id: 'm', checkpoint_path: '/p', algorithm: 'PPO', kind: 'portfolio',
+        state_window: 5, input_features: ['close'], ohlcv: {},
+      }),
+    ).rejects.toThrow(/timeout/i)
+  })
+
+  it('throws on non-2xx response', async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response('bad', { status: 500 })) as unknown as typeof fetch
+    const client = new RLInferenceClient({ baseUrl: 'http://x', apiKey: 'k', timeoutMs: 1000 })
+    await expect(
+      client.predict({
+        model_id: 'm', checkpoint_path: '/p', algorithm: 'PPO', kind: 'portfolio',
+        state_window: 5, input_features: ['close'], ohlcv: {},
+      }),
+    ).rejects.toThrow(/500/)
+  })
+})
+```
+
+- [ ] **Step 3: 실행 → fail**
+
+```bash
+npm test
+```
+
+기대: 모듈 미존재로 FAIL.
+
+- [ ] **Step 4: rlInferenceClient.ts 구현**
+
+`trading-worker/src/rlInferenceClient.ts`:
+
+```typescript
+export interface RLInferenceConfig {
+  baseUrl: string
+  apiKey: string
+  timeoutMs: number
+}
+
+export interface PredictRequestBody {
+  model_id: string
+  checkpoint_path: string
+  algorithm: string
+  kind: 'portfolio' | 'single_asset'
+  state_window: number
+  input_features: string[]
+  ohlcv: Record<string, Array<{ date: string; open: number; high: number; low: number; close: number; volume: number }>>
+  indicators?: Record<string, Record<string, number[]>>
+  current_positions?: Record<string, { qty: number; avg_price: number }>
+}
+
+export interface PortfolioPredictResponse {
+  kind: 'portfolio'
+  weights: Record<string, number>
+  confidence: number
+  raw_action: number[]
+  metadata: Record<string, unknown>
+}
+
+export interface SinglePredictResponse {
+  kind: 'single_asset'
+  action: 'buy' | 'sell' | 'hold'
+  size_hint?: number
+  confidence: number
+  metadata: Record<string, unknown>
+}
+
+export type PredictResponse = PortfolioPredictResponse | SinglePredictResponse
+
+export class RLInferenceClient {
+  constructor(private cfg: RLInferenceConfig) {}
+
+  async predict(body: PredictRequestBody): Promise<PredictResponse> {
+    return this._post('/predict', body)
+  }
+
+  async health(): Promise<{ status: string; loaded_models: string[]; uptime_seconds: number }> {
+    return this._get('/health')
+  }
+
+  private async _post<T>(path: string, body: unknown): Promise<T> {
+    const ctrl = new AbortController()
+    const timer = setTimeout(() => ctrl.abort(new Error('timeout')), this.cfg.timeoutMs)
+    try {
+      const resp = await fetch(`${this.cfg.baseUrl}${path}`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'X-RL-API-KEY': this.cfg.apiKey,
+        },
+        body: JSON.stringify(body),
+        signal: ctrl.signal,
+      })
+      if (!resp.ok) {
+        const text = await resp.text().catch(() => '')
+        throw new Error(`rl-inference-server ${path} returned ${resp.status}: ${text}`)
+      }
+      return (await resp.json()) as T
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') {
+        throw new Error(`rl-inference-server ${path} timeout after ${this.cfg.timeoutMs}ms`)
+      }
+      throw err
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  private async _get<T>(path: string): Promise<T> {
+    const ctrl = new AbortController()
+    const timer = setTimeout(() => ctrl.abort(new Error('timeout')), this.cfg.timeoutMs)
+    try {
+      const resp = await fetch(`${this.cfg.baseUrl}${path}`, {
+        headers: { 'X-RL-API-KEY': this.cfg.apiKey },
+        signal: ctrl.signal,
+      })
+      if (!resp.ok) {
+        throw new Error(`rl-inference-server ${path} returned ${resp.status}`)
+      }
+      return (await resp.json()) as T
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}
+```
+
+- [ ] **Step 5: 실행 → pass**
+
+```bash
+npm test
+```
+
+기대: 3 tests PASS.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add trading-worker/package.json trading-worker/package-lock.json trading-worker/vitest.config.ts trading-worker/src/rlInferenceClient.ts trading-worker/tests/
+git commit -m "feat(worker): rl-inference HTTP client with timeout"
+```
+
+---
+
+## Task 10: trading-worker `dailyRebalanceJob` (TDD)
+
+**Files:**
+- Create: `trading-worker/src/dailyRebalanceJob.ts`
+- Create: `trading-worker/tests/dailyRebalanceJob.test.ts`
+- Modify: `trading-worker/src/index.ts` (cron 등록)
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`trading-worker/tests/dailyRebalanceJob.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { runDailyRebalance, DailyRebalanceDeps } from '../src/dailyRebalanceJob'
+
+function makeDeps(overrides: Partial<DailyRebalanceDeps> = {}): DailyRebalanceDeps {
+  return {
+    fetchActiveRLStrategies: vi.fn().mockResolvedValue([]),
+    fetchUserSettings: vi.fn().mockResolvedValue({ rl_paused_at: null }),
+    fetchOhlcvWindow: vi.fn().mockResolvedValue({}),
+    fetchCurrentPositions: vi.fn().mockResolvedValue({}),
+    rlClient: { predict: vi.fn(), health: vi.fn() } as any,
+    insertInferenceLog: vi.fn().mockResolvedValue(undefined),
+    sendTelegram: vi.fn().mockResolvedValue(undefined),
+    executeAutoOrder: vi.fn().mockResolvedValue({ ok: true, orderId: 'o1' }),
+    today: '2026-04-29',
+    ...overrides,
+  }
+}
+
+describe('runDailyRebalance', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('skips when no active RL strategies', async () => {
+    const deps = makeDeps()
+    const result = await runDailyRebalance(deps)
+    expect(result.processed).toBe(0)
+  })
+
+  it('blocks when kill switch is active', async () => {
+    const deps = makeDeps({
+      fetchActiveRLStrategies: vi.fn().mockResolvedValue([
+        { id: 's1', user_id: 'u1', strategy_type: 'rl_portfolio', automation_level: 1, rl_model: { id: 'm1', min_confidence: 0.5, universe: ['AAPL'], state_window: 5, algorithm: 'PPO', input_features: ['close'], checkpoint_path: '/p' } },
+      ]),
+      fetchUserSettings: vi.fn().mockResolvedValue({ rl_paused_at: '2026-04-29T00:00:00Z' }),
+    })
+    const result = await runDailyRebalance(deps)
+    expect(deps.insertInferenceLog).toHaveBeenCalledWith(expect.objectContaining({ decision: 'blocked_kill_switch' }))
+    expect(deps.executeAutoOrder).not.toHaveBeenCalled()
+  })
+
+  it('blocks when confidence below min_confidence', async () => {
+    const deps = makeDeps({
+      fetchActiveRLStrategies: vi.fn().mockResolvedValue([
+        { id: 's1', user_id: 'u1', strategy_type: 'rl_portfolio', automation_level: 2, rl_model: { id: 'm1', min_confidence: 0.9, universe: ['AAPL'], state_window: 5, algorithm: 'PPO', input_features: ['close'], checkpoint_path: '/p' } },
+      ]),
+      rlClient: { predict: vi.fn().mockResolvedValue({ kind: 'portfolio', weights: { AAPL: 1 }, confidence: 0.5, raw_action: [], metadata: {} }), health: vi.fn() } as any,
+    })
+    const result = await runDailyRebalance(deps)
+    expect(deps.insertInferenceLog).toHaveBeenCalledWith(expect.objectContaining({ decision: 'blocked_low_confidence' }))
+    expect(deps.executeAutoOrder).not.toHaveBeenCalled()
+  })
+
+  it('automation_level=1 sends Telegram only, no auto order', async () => {
+    const deps = makeDeps({
+      fetchActiveRLStrategies: vi.fn().mockResolvedValue([
+        { id: 's1', user_id: 'u1', strategy_type: 'rl_portfolio', automation_level: 1, rl_model: { id: 'm1', min_confidence: 0.5, universe: ['AAPL'], state_window: 5, algorithm: 'PPO', input_features: ['close'], checkpoint_path: '/p' } },
+      ]),
+      rlClient: { predict: vi.fn().mockResolvedValue({ kind: 'portfolio', weights: { AAPL: 1 }, confidence: 0.8, raw_action: [], metadata: {} }), health: vi.fn() } as any,
+    })
+    await runDailyRebalance(deps)
+    expect(deps.sendTelegram).toHaveBeenCalled()
+    expect(deps.executeAutoOrder).not.toHaveBeenCalled()
+  })
+
+  it('automation_level=2 invokes executeAutoOrder', async () => {
+    const deps = makeDeps({
+      fetchActiveRLStrategies: vi.fn().mockResolvedValue([
+        { id: 's1', user_id: 'u1', strategy_type: 'rl_portfolio', automation_level: 2, rl_model: { id: 'm1', min_confidence: 0.5, universe: ['AAPL'], state_window: 5, algorithm: 'PPO', input_features: ['close'], checkpoint_path: '/p' } },
+      ]),
+      fetchCurrentPositions: vi.fn().mockResolvedValue({}),
+      rlClient: { predict: vi.fn().mockResolvedValue({ kind: 'portfolio', weights: { AAPL: 1 }, confidence: 0.8, raw_action: [], metadata: {} }), health: vi.fn() } as any,
+    })
+    await runDailyRebalance(deps)
+    expect(deps.executeAutoOrder).toHaveBeenCalled()
+  })
+
+  it('logs error and continues on prediction failure', async () => {
+    const deps = makeDeps({
+      fetchActiveRLStrategies: vi.fn().mockResolvedValue([
+        { id: 's1', user_id: 'u1', strategy_type: 'rl_portfolio', automation_level: 2, rl_model: { id: 'm1', min_confidence: 0.5, universe: ['AAPL'], state_window: 5, algorithm: 'PPO', input_features: ['close'], checkpoint_path: '/p' } },
+      ]),
+      rlClient: { predict: vi.fn().mockRejectedValue(new Error('timeout')), health: vi.fn() } as any,
+    })
+    await runDailyRebalance(deps)
+    expect(deps.insertInferenceLog).toHaveBeenCalledWith(expect.objectContaining({ decision: 'error' }))
+  })
+})
+```
+
+- [ ] **Step 2: 실행 → fail**
+
+```bash
+npm test
+```
+
+기대: 모듈 미존재로 FAIL.
+
+- [ ] **Step 3: dailyRebalanceJob.ts 구현**
+
+`trading-worker/src/dailyRebalanceJob.ts`:
+
+```typescript
+import type { RLInferenceClient, PortfolioPredictResponse } from './rlInferenceClient'
+
+export interface RLStrategyRow {
+  id: string
+  user_id: string
+  strategy_type: 'rl_portfolio' | 'rl_single'
+  automation_level: 1 | 2
+  rl_model: {
+    id: string
+    min_confidence: number
+    universe: string[]
+    state_window: number
+    algorithm: string
+    input_features: string[]
+    checkpoint_path: string
+  }
+}
+
+export interface DailyRebalanceDeps {
+  fetchActiveRLStrategies: () => Promise<RLStrategyRow[]>
+  fetchUserSettings: (userId: string) => Promise<{ rl_paused_at: string | null }>
+  fetchOhlcvWindow: (
+    universe: string[], stateWindow: number,
+  ) => Promise<Record<string, Array<{ date: string; open: number; high: number; low: number; close: number; volume: number }>>>
+  fetchCurrentPositions: (userId: string) => Promise<Record<string, { qty: number; avg_price: number }>>
+  rlClient: Pick<RLInferenceClient, 'predict' | 'health'>
+  insertInferenceLog: (log: InferenceLogEntry) => Promise<void>
+  sendTelegram: (userId: string, message: string) => Promise<void>
+  executeAutoOrder: (params: {
+    userId: string; strategyId: string; ticker: string; orderType: 'buy' | 'sell';
+    quantity: number; orderMethod: 'market' | 'limit'; signalData: Record<string, unknown>
+  }) => Promise<{ ok: boolean; orderId?: string; error?: string }>
+  today: string
+}
+
+export interface InferenceLogEntry {
+  strategy_id: string
+  rl_model_id: string
+  user_id: string
+  trade_date: string
+  state_hash: string
+  output: Record<string, unknown>
+  confidence: number | null
+  decision: 'order' | 'hold' | 'blocked_low_confidence' | 'blocked_kill_switch' | 'error'
+  blocked_reason?: string | null
+  error_message?: string | null
+  latency_ms?: number | null
+}
+
+interface RebalanceResult { processed: number; ordered: number; blocked: number; errored: number }
+
+export async function runDailyRebalance(deps: DailyRebalanceDeps): Promise<RebalanceResult> {
+  const result: RebalanceResult = { processed: 0, ordered: 0, blocked: 0, errored: 0 }
+  const strategies = await deps.fetchActiveRLStrategies()
+
+  for (const s of strategies) {
+    result.processed++
+    try {
+      const settings = await deps.fetchUserSettings(s.user_id)
+      if (settings.rl_paused_at) {
+        await deps.insertInferenceLog({
+          strategy_id: s.id, rl_model_id: s.rl_model.id, user_id: s.user_id,
+          trade_date: deps.today, state_hash: '',
+          output: {}, confidence: null, decision: 'blocked_kill_switch',
+          blocked_reason: `paused at ${settings.rl_paused_at}`,
+        })
+        result.blocked++
+        continue
+      }
+
+      const ohlcv = await deps.fetchOhlcvWindow(s.rl_model.universe, s.rl_model.state_window)
+      const positions = await deps.fetchCurrentPositions(s.user_id)
+      const t0 = Date.now()
+      const prediction = await deps.rlClient.predict({
+        model_id: s.rl_model.id,
+        checkpoint_path: s.rl_model.checkpoint_path,
+        algorithm: s.rl_model.algorithm,
+        kind: 'portfolio',
+        state_window: s.rl_model.state_window,
+        input_features: s.rl_model.input_features,
+        ohlcv,
+        current_positions: positions,
+      }) as PortfolioPredictResponse
+      const latencyMs = Date.now() - t0
+
+      if (prediction.confidence < s.rl_model.min_confidence) {
+        await deps.insertInferenceLog({
+          strategy_id: s.id, rl_model_id: s.rl_model.id, user_id: s.user_id,
+          trade_date: deps.today, state_hash: '',
+          output: prediction as unknown as Record<string, unknown>,
+          confidence: prediction.confidence, decision: 'blocked_low_confidence',
+          blocked_reason: `confidence ${prediction.confidence} < ${s.rl_model.min_confidence}`,
+          latency_ms: latencyMs,
+        })
+        await deps.sendTelegram(s.user_id, `[RL] ${s.id} 신뢰도 ${prediction.confidence.toFixed(2)} 낮아 hold`)
+        result.blocked++
+        continue
+      }
+
+      // weights → orders 변환 (Phase 1: 간단 diff 로직)
+      const orders = computeOrdersFromWeights(prediction.weights, positions, /* totalCapital는 fetchCurrentPositions의 별도 컬럼 또는 계좌 잔액에서 — Phase 1 단순화 */ 10000)
+
+      if (s.automation_level === 1) {
+        await deps.sendTelegram(s.user_id, `[RL] ${s.id} 신호: ${JSON.stringify(orders.slice(0, 5))}`)
+      } else {
+        for (const o of orders) {
+          await deps.executeAutoOrder({
+            userId: s.user_id, strategyId: s.id,
+            ticker: o.ticker, orderType: o.side, quantity: o.qty,
+            orderMethod: 'market',
+            signalData: { source: 'rl', model_id: s.rl_model.id, weights: prediction.weights },
+          })
+        }
+        result.ordered++
+      }
+
+      await deps.insertInferenceLog({
+        strategy_id: s.id, rl_model_id: s.rl_model.id, user_id: s.user_id,
+        trade_date: deps.today, state_hash: '',
+        output: prediction as unknown as Record<string, unknown>,
+        confidence: prediction.confidence, decision: 'order', latency_ms: latencyMs,
+      })
+    } catch (err) {
+      const message = (err as Error).message
+      await deps.insertInferenceLog({
+        strategy_id: s.id, rl_model_id: s.rl_model.id, user_id: s.user_id,
+        trade_date: deps.today, state_hash: '',
+        output: {}, confidence: null, decision: 'error',
+        error_message: message,
+      })
+      try { await deps.sendTelegram(s.user_id, `[RL] ${s.id} 오류: ${message}`) } catch {}
+      result.errored++
+    }
+  }
+  return result
+}
+
+interface PlannedOrder { ticker: string; side: 'buy' | 'sell'; qty: number }
+
+function computeOrdersFromWeights(
+  weights: Record<string, number>,
+  current: Record<string, { qty: number; avg_price: number }>,
+  totalCapitalFallback: number,
+): PlannedOrder[] {
+  const orders: PlannedOrder[] = []
+  const totalQty = Object.values(current).reduce((s, p) => s + p.qty * p.avg_price, 0)
+  const total = totalQty > 0 ? totalQty : totalCapitalFallback
+  for (const [ticker, w] of Object.entries(weights)) {
+    const targetValue = total * w
+    const currentQty = current[ticker]?.qty ?? 0
+    const currentValue = currentQty * (current[ticker]?.avg_price ?? 0)
+    const diff = targetValue - currentValue
+    if (Math.abs(diff) < total * 0.01) continue  // 1% threshold
+    if (diff > 0) {
+      orders.push({ ticker, side: 'buy', qty: Math.max(1, Math.floor(diff / Math.max(current[ticker]?.avg_price ?? 1, 1))) })
+    } else {
+      const qty = Math.min(currentQty, Math.floor(Math.abs(diff) / Math.max(current[ticker]?.avg_price ?? 1, 1)))
+      if (qty > 0) orders.push({ ticker, side: 'sell', qty })
+    }
+  }
+  return orders
+}
+```
+
+- [ ] **Step 4: 실행 → pass**
+
+```bash
+npm test
+```
+
+기대: 6 tests PASS.
+
+- [ ] **Step 5: index.ts에 cron 등록 (간단 통합, 실제 supabase 연결은 다음 task)**
+
+`trading-worker/src/index.ts`에 다음 import + 등록 추가 (기존 main 함수 내부, 다른 cron들 옆):
+
+```typescript
+import cron from 'node-cron'
+import { runDailyRebalance } from './dailyRebalanceJob'
+// ... 기존 imports
+
+// main()의 적절한 위치에:
+cron.schedule('0 7 * * 2-6', async () => {
+  try {
+    logger.info('[dailyRebalance] start')
+    const deps = await buildDailyRebalanceDeps()  // 다음 task에서 구현
+    const result = await runDailyRebalance(deps)
+    logger.info({ result }, '[dailyRebalance] done')
+  } catch (err) {
+    logger.error({ err }, '[dailyRebalance] failed')
+  }
+}, { timezone: 'Asia/Seoul' })
+```
+
+`buildDailyRebalanceDeps()`는 Task 11에서 구현.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add trading-worker/src/dailyRebalanceJob.ts trading-worker/src/index.ts trading-worker/tests/dailyRebalanceJob.test.ts
+git commit -m "feat(worker): dailyRebalanceJob with safety guards"
+```
+
+---
+
+## Task 11: trading-worker dependency wiring (Supabase 호출, OHLCV, KIS 연결)
+
+**Files:**
+- Modify: `trading-worker/src/dailyRebalanceJob.ts` (helper export)
+- Create: `trading-worker/src/dailyRebalanceDeps.ts`
+- Modify: `trading-worker/src/index.ts`
+
+- [ ] **Step 1: dailyRebalanceDeps.ts 작성**
+
+`trading-worker/src/dailyRebalanceDeps.ts`:
+
+```typescript
+import type { DailyRebalanceDeps } from './dailyRebalanceJob'
+import { RLInferenceClient } from './rlInferenceClient'
+import { supabase } from './supabaseClient'
+import { sendTelegramMessage } from './telegramNotifier'
+import { executeAutoOrder } from './orderExecutor'
+import { logger } from './logger'
+
+export async function buildDailyRebalanceDeps(): Promise<DailyRebalanceDeps> {
+  const rlClient = new RLInferenceClient({
+    baseUrl: process.env.RL_SERVER_URL ?? 'http://127.0.0.1:8001',
+    apiKey: process.env.RL_API_KEY ?? '',
+    timeoutMs: 5000,
+  })
+  const today = new Date().toISOString().slice(0, 10)
+
+  return {
+    today,
+    rlClient,
+    fetchActiveRLStrategies: async () => {
+      const { data, error } = await supabase
+        .from('investment_strategies')
+        .select('id, user_id, strategy_type, automation_level, rl_models!inner(id, min_confidence, universe, state_window, algorithm, input_features, checkpoint_path)')
+        .eq('is_active', true)
+        .in('strategy_type', ['rl_portfolio', 'rl_single'])
+      if (error) {
+        logger.error({ error }, 'fetchActiveRLStrategies failed')
+        return []
+      }
+      return (data ?? []).map((s: any) => ({
+        id: s.id, user_id: s.user_id, strategy_type: s.strategy_type,
+        automation_level: s.automation_level, rl_model: s.rl_models,
+      }))
+    },
+    fetchUserSettings: async (userId) => {
+      const { data } = await supabase
+        .from('user_investment_settings')
+        .select('rl_paused_at')
+        .eq('user_id', userId)
+        .maybeSingle()
+      return { rl_paused_at: data?.rl_paused_at ?? null }
+    },
+    fetchOhlcvWindow: async (universe, stateWindow) => {
+      // KIS 일봉 캐시 사용 (intraday_price_cache는 분봉 → 일봉은 별도 daily_price_cache 또는 KIS 직접 호출)
+      // Phase 1: 별도 daily_prices 테이블이 없다면 KIS API 직접 호출 (orderExecutor.ts에서 토큰 발급 함수 재사용)
+      // 단순화: 본 plan의 task 12에서 daily_prices 캐시를 추가하거나, 외부 데이터(yfinance equivalent)를 활용. 여기서는 빈 객체 fallback로 두고 trading-worker가 조회 실패 시 hold 처리.
+      const result: Record<string, any[]> = {}
+      for (const ticker of universe) {
+        const { data } = await supabase
+          .from('intraday_price_cache')   // Phase 1 임시: 분봉 캐시를 일봉으로 집계
+          .select('datetime, open, high, low, close, volume')
+          .eq('ticker', ticker).eq('market', 'US').eq('timeframe', '1d')
+          .order('datetime', { ascending: false })
+          .limit(stateWindow)
+        result[ticker] = (data ?? []).reverse().map((row) => ({
+          date: row.datetime.slice(0, 10),
+          open: row.open, high: row.high, low: row.low, close: row.close, volume: row.volume,
+        }))
+      }
+      return result
+    },
+    fetchCurrentPositions: async (userId) => {
+      const { data } = await supabase
+        .from('positions')
+        .select('ticker, quantity, avg_entry_price')
+        .eq('user_id', userId).eq('status', 'open')
+      const map: Record<string, { qty: number; avg_price: number }> = {}
+      for (const p of data ?? []) {
+        map[p.ticker] = { qty: p.quantity, avg_price: p.avg_entry_price }
+      }
+      return map
+    },
+    insertInferenceLog: async (log) => {
+      await supabase.from('rl_inference_logs').insert(log)
+    },
+    sendTelegram: async (userId, message) => {
+      await sendTelegramMessage(userId, message)
+    },
+    executeAutoOrder: async (params) => {
+      const r = await executeAutoOrder({
+        userId: params.userId,
+        strategyId: params.strategyId,
+        ticker: params.ticker,
+        market: 'US',
+        orderType: params.orderType,
+        orderMethod: params.orderMethod,
+        quantity: params.quantity,
+        signalData: params.signalData,
+      } as any)
+      return { ok: r.success === true, orderId: r.orderId, error: r.error }
+    },
+  }
+}
+```
+
+**중요**: `executeAutoOrder`, `sendTelegramMessage`의 정확한 시그니처는 기존 모듈을 읽어 일치시킨다. 차이가 있으면 `as any` 캐스트는 제거하고 정확히 매핑한다.
+
+- [ ] **Step 2: index.ts 수정**
+
+`buildDailyRebalanceDeps` import 후 cron handler 안에서 호출:
+
+```typescript
+import { buildDailyRebalanceDeps } from './dailyRebalanceDeps'
+// ...
+cron.schedule('0 7 * * 2-6', async () => {
+  try {
+    const deps = await buildDailyRebalanceDeps()
+    const result = await runDailyRebalance(deps)
+    logger.info({ result }, '[dailyRebalance] done')
+  } catch (err) {
+    logger.error({ err }, '[dailyRebalance] failed')
+  }
+}, { timezone: 'Asia/Seoul' })
+```
+
+- [ ] **Step 3: 빌드 검증**
+
+```bash
+cd trading-worker && npm run build
+```
+
+기대: 빌드 성공. 타입 에러 발생 시 `executeAutoOrder`/`sendTelegramMessage` 시그니처에 맞춰 수정.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add trading-worker/src/dailyRebalanceDeps.ts trading-worker/src/index.ts
+git commit -m "feat(worker): wire dailyRebalanceJob to supabase + KIS infra"
+```
+
+---
+
+## Task 12: 메인 앱 — `rlModelService` + `/api/investment/rl-models` 라우트
+
+**Files:**
+- Create: `dental-clinic-manager/src/lib/rlModelService.ts`
+- Create: `dental-clinic-manager/src/app/api/investment/rl-models/route.ts`
+- Create: `dental-clinic-manager/src/app/api/investment/rl-models/[id]/route.ts`
+
+- [ ] **Step 1: rlModelService.ts 작성**
+
+`dental-clinic-manager/src/lib/rlModelService.ts`:
+
+```typescript
+import { createServerClient } from '@/lib/supabase/server'
+import type { RLModel, RLModelCreateInput } from '@/types/rlTrading'
+
+const RL_SERVER_URL = process.env.RL_SERVER_URL ?? 'http://127.0.0.1:8001'
+const RL_API_KEY = process.env.RL_API_KEY ?? ''
+
+export const rlModelService = {
+  async listForClinic(clinicId: string): Promise<{ data: RLModel[]; error: string | null }> {
+    const supabase = await createServerClient()
+    const { data, error } = await supabase
+      .from('rl_models').select('*')
+      .eq('clinic_id', clinicId)
+      .order('created_at', { ascending: false })
+    if (error) return { data: [], error: error.message }
+    return { data: (data ?? []) as RLModel[], error: null }
+  },
+
+  async create(input: RLModelCreateInput, userId: string, clinicId: string): Promise<{ data: RLModel | null; error: string | null }> {
+    const supabase = await createServerClient()
+    const { data, error } = await supabase.from('rl_models').insert({
+      user_id: userId, clinic_id: clinicId,
+      name: input.name, description: input.description ?? null,
+      source: input.source, algorithm: input.algorithm, kind: input.kind,
+      market: input.market ?? 'US', timeframe: input.timeframe ?? '1d',
+      universe: input.universe ?? null, input_features: input.input_features,
+      state_window: input.state_window, output_shape: input.output_shape,
+      checkpoint_url: input.checkpoint_url, checkpoint_sha256: input.checkpoint_sha256,
+      min_confidence: input.min_confidence ?? 0.6,
+      status: 'pending',
+    }).select().single()
+    if (error) return { data: null, error: error.message }
+    return { data: data as RLModel, error: null }
+  },
+
+  async triggerDownload(modelId: string): Promise<{ success: boolean; error: string | null }> {
+    const supabase = await createServerClient()
+    const { data: model, error } = await supabase.from('rl_models').select('*').eq('id', modelId).single()
+    if (error || !model) return { success: false, error: error?.message ?? 'not found' }
+
+    await supabase.from('rl_models').update({ status: 'downloading' }).eq('id', modelId)
+
+    try {
+      // rl-inference-server는 다운로드 후 path를 반환한다고 가정. Phase 1은 trading-worker가 대신 호출.
+      const resp = await fetch(`${RL_SERVER_URL}/models/download`, {
+        method: 'POST',
+        headers: { 'X-RL-API-KEY': RL_API_KEY, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model_id: modelId,
+          checkpoint_url: model.checkpoint_url,
+          checkpoint_sha256: model.checkpoint_sha256,
+        }),
+      })
+      if (!resp.ok) {
+        const text = await resp.text().catch(() => '')
+        await supabase.from('rl_models').update({ status: 'failed', failure_reason: text }).eq('id', modelId)
+        return { success: false, error: text }
+      }
+      const json = await resp.json()
+      await supabase.from('rl_models').update({
+        status: 'ready', checkpoint_path: json.path,
+      }).eq('id', modelId)
+      return { success: true, error: null }
+    } catch (err) {
+      const msg = (err as Error).message
+      await supabase.from('rl_models').update({ status: 'failed', failure_reason: msg }).eq('id', modelId)
+      return { success: false, error: msg }
+    }
+  },
+
+  async archive(modelId: string, userId: string): Promise<{ success: boolean; error: string | null }> {
+    const supabase = await createServerClient()
+    // 1) 참조 전략을 비활성화
+    await supabase.from('investment_strategies')
+      .update({ is_active: false })
+      .eq('rl_model_id', modelId).eq('user_id', userId)
+    // 2) 상태 archived로
+    const { error } = await supabase.from('rl_models')
+      .update({ status: 'archived' })
+      .eq('id', modelId).eq('user_id', userId)
+    if (error) return { success: false, error: error.message }
+    return { success: true, error: null }
+  },
+}
+```
+
+**참고**: `/models/download` 라우트는 rl-inference-server에 없다 (Task 4의 model_registry는 함수만 제공). 추가 task에서 라우트 구현 필요. (Task 13에서 통합)
+
+- [ ] **Step 2: rl-models GET/POST 라우트**
+
+`dental-clinic-manager/src/app/api/investment/rl-models/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server'
+import { rlModelService } from '@/lib/rlModelService'
+import { createServerClient } from '@/lib/supabase/server'
+
+async function getAuthUser() {
+  const supabase = await createServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return null
+  const { data: profile } = await supabase.from('users').select('clinic_id').eq('id', user.id).single()
+  return { user, clinicId: profile?.clinic_id }
+}
+
+export async function GET() {
+  const auth = await getAuthUser()
+  if (!auth?.user || !auth.clinicId) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const r = await rlModelService.listForClinic(auth.clinicId)
+  if (r.error) return NextResponse.json({ error: r.error }, { status: 500 })
+  return NextResponse.json({ data: r.data })
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await getAuthUser()
+  if (!auth?.user || !auth.clinicId) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const body = await req.json()
+  const created = await rlModelService.create(body, auth.user.id, auth.clinicId)
+  if (created.error || !created.data) return NextResponse.json({ error: created.error }, { status: 400 })
+  // 비동기 다운로드 트리거 (응답 차단 안 함)
+  rlModelService.triggerDownload(created.data.id).catch(() => {})
+  return NextResponse.json({ data: created.data }, { status: 201 })
+}
+```
+
+- [ ] **Step 3: rl-models/[id] DELETE 라우트**
+
+`dental-clinic-manager/src/app/api/investment/rl-models/[id]/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server'
+import { rlModelService } from '@/lib/rlModelService'
+import { createServerClient } from '@/lib/supabase/server'
+
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const r = await rlModelService.archive(id, user.id)
+  if (!r.success) return NextResponse.json({ error: r.error }, { status: 400 })
+  return NextResponse.json({ ok: true })
+}
+```
+
+- [ ] **Step 4: 타입 체크 + 커밋**
+
+```bash
+cd dental-clinic-manager
+npx tsc --noEmit 2>&1 | grep -E "rl-models|rlModelService" | head -10
+```
+
+기대: 출력 없음.
+
+```bash
+git add src/lib/rlModelService.ts src/app/api/investment/rl-models
+git commit -m "feat(rl-trading): rl-models API + service"
+```
+
+---
+
+## Task 13: rl-inference-server `/models/download` 라우트 추가
+
+**Files:**
+- Modify: `rl-inference-server/src/main.py`
+- Modify: `rl-inference-server/src/schemas.py`
+- Add tests in `rl-inference-server/tests/test_model_registry.py`
+
+- [ ] **Step 1: 실패 테스트 (라우트 호출)**
+
+`rl-inference-server/tests/test_model_registry.py` 끝에 추가:
+
+```python
+import hashlib
+
+def test_download_endpoint_writes_file_and_returns_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("RL_API_KEY", "test-key")
+    monkeypatch.setenv("MODEL_DIR", str(tmp_path))
+    from src.main import app, registry
+    from fastapi.testclient import TestClient
+
+    payload = b"fake-model-bytes"
+    expected = hashlib.sha256(payload).hexdigest()
+
+    async def fake_fetch(_url: str) -> bytes:
+        return payload
+
+    monkeypatch.setattr(registry, "_fetch_bytes", fake_fetch)
+
+    client = TestClient(app)
+    body = {"model_id": "m1", "checkpoint_url": "https://example.com/m.zip", "checkpoint_sha256": expected}
+    resp = client.post("/models/download", headers={"X-RL-API-KEY": "test-key"}, json=body)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert "path" in data
+    assert expected in data["path"]
+```
+
+- [ ] **Step 2: 실행 → fail (404)**
+
+```bash
+pytest tests/test_model_registry.py -v
+```
+
+- [ ] **Step 3: schemas.py에 DownloadRequest 추가**
+
+```python
+class DownloadRequest(BaseModel):
+    model_id: str
+    checkpoint_url: str
+    checkpoint_sha256: str
+
+
+class DownloadResponse(BaseModel):
+    model_id: str
+    path: str
+    status: Literal["ready"] = "ready"
+```
+
+- [ ] **Step 4: main.py에 /models/download 라우트 추가**
+
+```python
+from src.schemas import DownloadRequest, DownloadResponse
+from src.model_registry import DownloadError, IntegrityError
+
+@app.post("/models/download", dependencies=[Depends(require_api_key)], response_model=DownloadResponse)
+async def models_download(req: DownloadRequest):
+    try:
+        path = await registry.download(req.model_id, req.checkpoint_url, req.checkpoint_sha256)
+    except IntegrityError as e:
+        raise HTTPException(status_code=400, detail=f"sha256 mismatch: {e}")
+    except DownloadError as e:
+        raise HTTPException(status_code=502, detail=f"download failed: {e}")
+    return DownloadResponse(model_id=req.model_id, path=path)
+```
+
+- [ ] **Step 5: pass + 커밋**
+
+```bash
+pytest -v
+```
+
+기대: 모두 PASS.
+
+```bash
+git add rl-inference-server/src/main.py rl-inference-server/src/schemas.py rl-inference-server/tests/test_model_registry.py
+git commit -m "feat(rl-server): /models/download route"
+```
+
+---
+
+## Task 14: 메인 앱 — kill switch API + `strategies` 라우트 RL 분기
+
+**Files:**
+- Create: `dental-clinic-manager/src/app/api/investment/rl-pause/route.ts`
+- Modify: `dental-clinic-manager/src/app/api/investment/strategies/route.ts`
+- Modify: `dental-clinic-manager/src/app/api/investment/emergency-stop/route.ts`
+
+- [ ] **Step 1: rl-pause 라우트**
+
+`dental-clinic-manager/src/app/api/investment/rl-pause/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase/server'
+
+export async function POST(req: NextRequest) {
+  const supabase = await createServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const { paused, reason } = await req.json() as { paused: boolean; reason?: string }
+  const update = paused
+    ? { rl_paused_at: new Date().toISOString(), rl_paused_reason: reason ?? 'user manual' }
+    : { rl_paused_at: null, rl_paused_reason: null }
+  const { error } = await supabase
+    .from('user_investment_settings')
+    .upsert({ user_id: user.id, ...update })
+    .eq('user_id', user.id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ ok: true, paused })
+}
+```
+
+- [ ] **Step 2: strategies POST 라우트에 RL 분기 추가**
+
+기존 `dental-clinic-manager/src/app/api/investment/strategies/route.ts`의 `POST` 핸들러에서 body parse 후 다음 로직 추가:
+
+```typescript
+const strategyType = body.strategy_type ?? 'rule'
+
+if (strategyType !== 'rule') {
+  // RL 전략: 기본 automation_level=1 강제
+  if (!body.rl_model_id) {
+    return NextResponse.json({ error: 'rl_model_id required for RL strategies' }, { status: 400 })
+  }
+  if (body.automation_level == null) body.automation_level = 1
+  // 모델 status=ready 검증
+  const { data: model } = await supabase.from('rl_models')
+    .select('id, status, kind').eq('id', body.rl_model_id).single()
+  if (!model || model.status !== 'ready') {
+    return NextResponse.json({ error: 'model not ready' }, { status: 400 })
+  }
+  // strategy_type ↔ kind 일치
+  const expectedType = model.kind === 'portfolio' ? 'rl_portfolio' : 'rl_single'
+  if (strategyType !== expectedType) {
+    return NextResponse.json({ error: `strategy_type must be ${expectedType}` }, { status: 400 })
+  }
+  // Phase 1: rl_single은 자동매매 미지원 → automation_level=1 강제
+  if (strategyType === 'rl_single' && body.automation_level === 2) {
+    return NextResponse.json({ error: 'rl_single auto trading not supported in Phase 1' }, { status: 400 })
+  }
+}
+
+// insert 시 strategy_type, rl_model_id 함께 저장
+```
+
+(정확한 insert 코드는 기존 패턴을 따름. RL일 때 indicators, buyConditions, sellConditions를 비워둘 수 있도록 nullable 허용 검증 필요. 기존 INSERT가 NOT NULL이라면 빈 객체 `{}`로 채움.)
+
+- [ ] **Step 3: emergency-stop 라우트에 RL 비활성화 포함**
+
+`dental-clinic-manager/src/app/api/investment/emergency-stop/route.ts`의 기존 흐름에서 `is_active=true` UPDATE 시 `strategy_type` 무관하게 모든 활성 전략을 비활성화. 이미 그렇다면 변경 없음. RL 강제 일시정지도 함께:
+
+```typescript
+// 기존 모든 활성 전략 비활성화 다음 줄에 추가
+await supabase.from('user_investment_settings')
+  .upsert({ user_id, rl_paused_at: new Date().toISOString(), rl_paused_reason: 'emergency-stop' })
+```
+
+- [ ] **Step 4: 빌드 검증 + 커밋**
+
+```bash
+cd dental-clinic-manager
+npx tsc --noEmit 2>&1 | grep -E "rl-pause|strategies|emergency-stop" | head
+```
+
+기대: 출력 없음.
+
+```bash
+git add src/app/api/investment/rl-pause src/app/api/investment/strategies/route.ts src/app/api/investment/emergency-stop/route.ts
+git commit -m "feat(rl-trading): kill switch API + strategy_type validation"
+```
+
+---
+
+## Task 15: 메인 앱 UI — `/investment/rl-models` 페이지 + 컴포넌트
+
+**Files:**
+- Create: `dental-clinic-manager/src/app/investment/rl-models/page.tsx`
+- Create: `dental-clinic-manager/src/components/Investment/RLModels/ModelLibraryPanel.tsx`
+- Create: `dental-clinic-manager/src/components/Investment/RLModels/ModelRegisterDialog.tsx`
+- Create: `dental-clinic-manager/src/components/Investment/RLModels/KillSwitchToggle.tsx`
+
+- [ ] **Step 1: page.tsx**
+
+```tsx
+'use client'
+import { useEffect, useState } from 'react'
+import type { RLModel } from '@/types/rlTrading'
+import ModelLibraryPanel from '@/components/Investment/RLModels/ModelLibraryPanel'
+import KillSwitchToggle from '@/components/Investment/RLModels/KillSwitchToggle'
+
+export default function RLModelsPage() {
+  const [models, setModels] = useState<RLModel[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('/api/investment/rl-models').then(r => r.json()).then((j) => {
+      setModels(j.data ?? [])
+    }).finally(() => setLoading(false))
+  }, [])
+
+  if (loading) {
+    return <div className="flex items-center justify-center h-64"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-at-accent" /></div>
+  }
+
+  return (
+    <div className="p-4 sm:p-6 space-y-6 bg-white min-h-screen">
+      <div className="flex items-center justify-between pb-3 border-b border-at-border">
+        <h2 className="text-lg font-bold text-at-text">RL 모델 라이브러리</h2>
+        <KillSwitchToggle />
+      </div>
+      <div className="bg-at-error-bg border border-at-error rounded-xl p-3 text-sm text-at-error">
+        ⚠ 강화학습 모델은 검증 전까지 paper 계좌 + automation_level=1 사용을 강력히 권장합니다.
+      </div>
+      <ModelLibraryPanel models={models} onChange={() => {
+        fetch('/api/investment/rl-models').then(r => r.json()).then((j) => setModels(j.data ?? []))
+      }} />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: ModelLibraryPanel.tsx**
+
+```tsx
+'use client'
+import { useState } from 'react'
+import type { RLModel } from '@/types/rlTrading'
+import ModelRegisterDialog from './ModelRegisterDialog'
+import { Plus, Trash2 } from 'lucide-react'
+import { appConfirm } from '@/components/ui/AppDialog'
+
+interface Props { models: RLModel[]; onChange: () => void }
+
+const STATUS_COLOR: Record<string, string> = {
+  ready: 'bg-at-success-bg text-at-success',
+  pending: 'bg-at-surface-alt text-at-text-secondary',
+  downloading: 'bg-at-accent-light text-at-accent',
+  failed: 'bg-at-error-bg text-at-error',
+  archived: 'bg-at-surface-alt text-at-text-weak',
+}
+
+export default function ModelLibraryPanel({ models, onChange }: Props) {
+  const [open, setOpen] = useState(false)
+
+  const onDelete = async (m: RLModel) => {
+    const ok = await appConfirm({ title: '모델 보관(archive)', description: `${m.name}을(를) 보관하면 참조 전략이 비활성화됩니다.`, variant: 'destructive', confirmText: '보관' })
+    if (!ok) return
+    await fetch(`/api/investment/rl-models/${m.id}`, { method: 'DELETE' })
+    onChange()
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <button onClick={() => setOpen(true)} className="inline-flex items-center gap-2 px-4 py-2 bg-at-accent text-white rounded-xl text-sm font-medium hover:bg-at-accent-hover">
+          <Plus className="w-4 h-4" /> 모델 추가
+        </button>
+      </div>
+
+      {models.length === 0 ? (
+        <div className="text-center py-12 bg-at-surface-alt rounded-xl text-at-text-secondary">
+          등록된 RL 모델이 없습니다. "모델 추가"를 눌러 사전학습 ckpt URL을 등록하세요.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-at-border">
+          <table className="min-w-[800px] w-full text-sm">
+            <thead className="bg-at-surface-alt">
+              <tr>
+                {['이름','종류','알고리즘','시장/주기','상태','신뢰도 임계','작업'].map(h =>
+                  <th key={h} className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">{h}</th>
+                )}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-at-border bg-white">
+              {models.map((m) => (
+                <tr key={m.id} className="hover:bg-at-surface-alt">
+                  <td className="px-3 py-2.5 font-medium">{m.name}</td>
+                  <td className="px-3 py-2.5">{m.kind}</td>
+                  <td className="px-3 py-2.5">{m.algorithm}</td>
+                  <td className="px-3 py-2.5">{m.market} / {m.timeframe}</td>
+                  <td className="px-3 py-2.5">
+                    <span className={`inline-flex px-2 py-0.5 text-xs rounded-full ${STATUS_COLOR[m.status] ?? ''}`}>{m.status}</span>
+                  </td>
+                  <td className="px-3 py-2.5">{m.min_confidence.toFixed(2)}</td>
+                  <td className="px-3 py-2.5">
+                    <button onClick={() => onDelete(m)} aria-label="보관" title="보관" className="p-1.5 rounded-xl hover:bg-at-error-bg text-at-text-secondary hover:text-at-error">
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <ModelRegisterDialog open={open} onClose={() => setOpen(false)} onCreated={() => { setOpen(false); onChange() }} />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: ModelRegisterDialog.tsx**
+
+```tsx
+'use client'
+import { useState } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+
+interface Props { open: boolean; onClose: () => void; onCreated: () => void }
+
+export default function ModelRegisterDialog({ open, onClose, onCreated }: Props) {
+  const [form, setForm] = useState({
+    name: '', algorithm: 'PPO', kind: 'portfolio',
+    universe: 'AAPL,MSFT,GOOGL,AMZN,META',
+    state_window: 60,
+    input_features: 'open,high,low,close,volume',
+    output_dim: 5,
+    output_type: 'continuous',
+    checkpoint_url: '',
+    checkpoint_sha256: '',
+    min_confidence: 0.6,
+    source: 'finrl_pretrained',
+  })
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const submit = async () => {
+    setSubmitting(true); setError(null)
+    try {
+      const body = {
+        ...form,
+        universe: form.universe.split(',').map(s => s.trim()).filter(Boolean),
+        input_features: form.input_features.split(',').map(s => s.trim()).filter(Boolean),
+        output_shape: { type: form.output_type, dim: Number(form.output_dim) },
+        state_window: Number(form.state_window),
+        min_confidence: Number(form.min_confidence),
+      }
+      const r = await fetch('/api/investment/rl-models', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) })
+      if (!r.ok) throw new Error((await r.json()).error || `${r.status}`)
+      onCreated()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally { setSubmitting(false) }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose() }}>
+      <DialogContent>
+        <DialogHeader><DialogTitle>RL 모델 등록</DialogTitle></DialogHeader>
+        <div className="space-y-3">
+          {error && <div className="p-2 rounded-xl bg-at-error-bg text-at-error text-sm">{error}</div>}
+          {/* 폼 필드들 */}
+          <Field label="이름 *" v={form.name} on={(v) => setForm({ ...form, name: v })} />
+          <Field label="알고리즘" v={form.algorithm} on={(v) => setForm({ ...form, algorithm: v })} />
+          <Field label="종목 유니버스 (콤마 구분)" v={form.universe} on={(v) => setForm({ ...form, universe: v })} />
+          <Field label="입력 피처 (콤마 구분)" v={form.input_features} on={(v) => setForm({ ...form, input_features: v })} />
+          <Field label="state_window" v={String(form.state_window)} on={(v) => setForm({ ...form, state_window: Number(v) })} />
+          <Field label="output dim" v={String(form.output_dim)} on={(v) => setForm({ ...form, output_dim: Number(v) })} />
+          <Field label="ckpt URL *" v={form.checkpoint_url} on={(v) => setForm({ ...form, checkpoint_url: v })} />
+          <Field label="ckpt sha256 *" v={form.checkpoint_sha256} on={(v) => setForm({ ...form, checkpoint_sha256: v })} />
+          <Field label="min_confidence" v={String(form.min_confidence)} on={(v) => setForm({ ...form, min_confidence: Number(v) })} />
+        </div>
+        <DialogFooter>
+          <button onClick={onClose} className="px-4 py-2 border border-at-border rounded-xl text-sm">취소</button>
+          <button onClick={submit} disabled={submitting || !form.name || !form.checkpoint_url} className="px-4 py-2 bg-at-accent text-white rounded-xl text-sm disabled:opacity-50">
+            {submitting ? '등록 중...' : '등록 + 다운로드'}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Field({ label, v, on }: { label: string; v: string; on: (v: string) => void }) {
+  return (
+    <label className="block">
+      <span className="text-sm text-at-text mb-1 inline-block">{label}</span>
+      <input value={v} onChange={(e) => on(e.target.value)}
+        className="w-full px-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent" />
+    </label>
+  )
+}
+```
+
+- [ ] **Step 4: KillSwitchToggle.tsx**
+
+```tsx
+'use client'
+import { useEffect, useState } from 'react'
+import { Pause, Play } from 'lucide-react'
+
+export default function KillSwitchToggle() {
+  const [paused, setPaused] = useState<boolean | null>(null)
+  useEffect(() => {
+    fetch('/api/investment/rl-pause').catch(() => {})  // GET endpoint optional - 초기 상태는 다른 곳에서 받거나 default false
+    setPaused(false)
+  }, [])
+
+  const toggle = async () => {
+    const next = !(paused ?? false)
+    const r = await fetch('/api/investment/rl-pause', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ paused: next }),
+    })
+    if (r.ok) setPaused(next)
+  }
+
+  return (
+    <button onClick={toggle}
+      className={`inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium ${paused ? 'bg-at-error text-white' : 'bg-at-surface-alt text-at-text'}`}>
+      {paused ? <><Play className="w-4 h-4" />RL 자동매매 재개</> : <><Pause className="w-4 h-4" />RL 자동매매 일시정지</>}
+    </button>
+  )
+}
+```
+
+- [ ] **Step 5: 빌드 검증**
+
+```bash
+cd dental-clinic-manager && npm run build > /tmp/build.log 2>&1 ; tail -5 /tmp/build.log
+```
+
+기대: exit 0.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add src/app/investment/rl-models src/components/Investment/RLModels
+git commit -m "feat(rl-trading): RL models library page + register dialog + kill switch"
+```
+
+---
+
+## Task 16: 전략 생성 폼에 RL 옵션 추가
+
+**Files:**
+- Modify or Create: `dental-clinic-manager/src/app/investment/strategy/new/page.tsx` (있으면 수정, 없으면 기존 builder 컴포넌트에 추가)
+- Create: `dental-clinic-manager/src/components/Investment/RLModels/RLStrategyForm.tsx`
+
+- [ ] **Step 1: RLStrategyForm.tsx**
+
+```tsx
+'use client'
+import { useEffect, useState } from 'react'
+import type { RLModel } from '@/types/rlTrading'
+
+interface Props { onCreated: () => void }
+
+export default function RLStrategyForm({ onCreated }: Props) {
+  const [models, setModels] = useState<RLModel[]>([])
+  const [form, setForm] = useState({
+    name: '', rl_model_id: '', automation_level: 1 as 1 | 2,
+    credential_id: '',
+  })
+  const [creds, setCreds] = useState<Array<{ id: string; label: string; is_paper_trading: boolean }>>([])
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch('/api/investment/rl-models').then(r => r.json()).then((j) => setModels((j.data ?? []).filter((m: RLModel) => m.status === 'ready')))
+    fetch('/api/investment/credentials').then(r => r.json()).then((j) => setCreds(j.data ?? []))
+  }, [])
+
+  const submit = async () => {
+    setSubmitting(true); setError(null)
+    try {
+      const model = models.find(m => m.id === form.rl_model_id)
+      if (!model) throw new Error('모델 선택 필요')
+      const body = {
+        name: form.name,
+        target_market: model.market,
+        timeframe: model.timeframe,
+        strategy_type: model.kind === 'portfolio' ? 'rl_portfolio' : 'rl_single',
+        rl_model_id: model.id,
+        automation_level: form.automation_level,
+        credential_id: form.credential_id,
+        indicators: [],
+        buy_conditions: { type: 'group', operator: 'AND', conditions: [] },
+        sell_conditions: { type: 'group', operator: 'AND', conditions: [] },
+        is_active: false,
+      }
+      const r = await fetch('/api/investment/strategies', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) })
+      if (!r.ok) throw new Error((await r.json()).error || `${r.status}`)
+      onCreated()
+    } catch (e) { setError((e as Error).message) } finally { setSubmitting(false) }
+  }
+
+  const selected = models.find(m => m.id === form.rl_model_id)
+  const cred = creds.find(c => c.id === form.credential_id)
+  const isLive = cred && !cred.is_paper_trading
+
+  return (
+    <div className="space-y-4 max-w-xl">
+      {error && <div className="p-2 rounded-xl bg-at-error-bg text-at-error text-sm">{error}</div>}
+
+      <label className="block">
+        <span className="text-sm text-at-text mb-1 inline-block">전략 이름 *</span>
+        <input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })}
+          className="w-full px-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent" />
+      </label>
+
+      <label className="block">
+        <span className="text-sm text-at-text mb-1 inline-block">RL 모델 *</span>
+        <select value={form.rl_model_id} onChange={(e) => setForm({ ...form, rl_model_id: e.target.value })}
+          className="w-full px-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent">
+          <option value="">선택</option>
+          {models.map(m => <option key={m.id} value={m.id}>{m.name} ({m.algorithm}, {m.kind})</option>)}
+        </select>
+        {selected && (
+          <p className="text-xs text-at-text-secondary mt-1">유니버스: {(selected.universe ?? []).join(', ') || '-'} · 신뢰도 임계 {selected.min_confidence}</p>
+        )}
+      </label>
+
+      <label className="block">
+        <span className="text-sm text-at-text mb-1 inline-block">증권사 계좌 *</span>
+        <select value={form.credential_id} onChange={(e) => setForm({ ...form, credential_id: e.target.value })}
+          className="w-full px-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent">
+          <option value="">선택</option>
+          {creds.map(c => <option key={c.id} value={c.id}>{c.label} {c.is_paper_trading ? '(paper)' : '(LIVE)'}</option>)}
+        </select>
+      </label>
+
+      <fieldset className="space-y-2">
+        <legend className="text-sm text-at-text">자동화 수준 *</legend>
+        <label className="flex gap-2 items-center">
+          <input type="radio" checked={form.automation_level === 1} onChange={() => setForm({ ...form, automation_level: 1 })} />
+          <span>알림만 (Level 1, 권장)</span>
+        </label>
+        <label className="flex gap-2 items-center">
+          <input type="radio" checked={form.automation_level === 2} onChange={() => setForm({ ...form, automation_level: 2 })} />
+          <span>자동 주문 (Level 2)</span>
+        </label>
+        {form.automation_level === 2 && isLive && (
+          <div className="p-2 bg-at-error-bg border border-at-error rounded-xl text-xs text-at-error">
+            ⚠ Live 계좌에서 자동 주문이 실행됩니다. 검증되지 않은 모델은 즉시 손실로 이어질 수 있습니다.
+          </div>
+        )}
+      </fieldset>
+
+      <button onClick={submit} disabled={submitting || !form.name || !form.rl_model_id || !form.credential_id}
+        className="px-4 py-2 bg-at-accent text-white rounded-xl text-sm disabled:opacity-50">
+        {submitting ? '생성 중...' : 'RL 전략 생성'}
+      </button>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 전략 페이지에서 RL 폼 노출**
+
+기존 `src/app/investment/strategy/new/page.tsx`(있을 시) 또는 builder 컴포넌트에 type 토글 추가:
+
+```tsx
+import RLStrategyForm from '@/components/Investment/RLModels/RLStrategyForm'
+// ...
+const [type, setType] = useState<'rule' | 'rl'>('rule')
+
+return (
+  <div>
+    <div className="flex gap-2 mb-4">
+      <button onClick={() => setType('rule')} className={type === 'rule' ? 'bg-at-accent-light text-at-accent px-3 py-1 rounded-xl' : 'px-3 py-1'}>룰 기반</button>
+      <button onClick={() => setType('rl')} className={type === 'rl' ? 'bg-at-accent-light text-at-accent px-3 py-1 rounded-xl' : 'px-3 py-1'}>강화학습 (RL)</button>
+    </div>
+    {type === 'rule' ? <ExistingRuleForm /> : <RLStrategyForm onCreated={() => router.push('/investment/strategy')} />}
+  </div>
+)
+```
+
+- [ ] **Step 3: 빌드 + 커밋**
+
+```bash
+npm run build > /tmp/b.log 2>&1 ; tail -5 /tmp/b.log
+git add src/components/Investment/RLModels/RLStrategyForm.tsx src/app/investment/strategy
+git commit -m "feat(rl-trading): RL strategy creation form"
+```
+
+---
+
+## Task 17: PM2 ecosystem 업데이트 + 운영 가이드
+
+**Files:**
+- Modify: `trading-worker/ecosystem.config.js`
+- Create: `dental-clinic-manager/docs/superpowers/operations/rl-trading-operations.md`
+
+- [ ] **Step 1: ecosystem.config.js**
+
+기존 파일에 두 번째 app 추가:
+
+```javascript
+module.exports = {
+  apps: [
+    {
+      name: 'trading-worker',
+      script: './dist/index.js',
+      instances: 1,
+      autorestart: true,
+      watch: false,
+      max_memory_restart: '500M',
+      env: { NODE_ENV: 'production' },
+    },
+    {
+      name: 'rl-inference',
+      cwd: '/Users/hhs/Project/dental-clinic-manager/rl-inference-server',
+      script: '.venv/bin/uvicorn',
+      args: 'src.main:app --host 127.0.0.1 --port 8001',
+      interpreter: 'none',  // python venv 직접 실행
+      instances: 1,
+      autorestart: true,
+      max_memory_restart: '2000M',
+      env: { PYTHONUNBUFFERED: '1' },
+    },
+  ],
+}
+```
+
+- [ ] **Step 2: 운영 가이드 작성**
+
+`dental-clinic-manager/docs/superpowers/operations/rl-trading-operations.md`:
+
+```markdown
+# RL 트레이딩 운영 가이드
+
+## 프로세스
+
+- `trading-worker` (Node, PM2)
+- `rl-inference` (Python uvicorn, PM2)
+
+기동:
+\`\`\`bash
+cd /Users/hhs/Project/dental-clinic-manager/trading-worker
+pm2 start ecosystem.config.js
+pm2 logs
+\`\`\`
+
+## 모델 등록 절차
+
+1. UI `/investment/rl-models`에서 "모델 추가"
+2. 사전학습 ckpt URL + sha256 입력 (HuggingFace/GitHub)
+3. status가 `pending → downloading → ready`로 전이되는지 확인
+4. `failed`면 `failure_reason`을 보고 재시도
+
+## kill switch
+
+- UI 우상단 "RL 자동매매 일시정지" 버튼
+- 또는 SQL:
+\`\`\`sql
+UPDATE user_investment_settings SET rl_paused_at = NOW(), rl_paused_reason = 'manual'
+WHERE user_id = '<uid>';
+\`\`\`
+
+## 일일 재교형 강제 실행 (디버깅)
+
+\`\`\`bash
+cd trading-worker
+node -e "
+require('./dist/dailyRebalanceDeps').buildDailyRebalanceDeps()
+  .then(d => require('./dist/dailyRebalanceJob').runDailyRebalance(d))
+  .then(r => console.log(r))
+"
+\`\`\`
+
+## 트러블슈팅
+
+- 추론 timeout: rl-inference 로그(`pm2 logs rl-inference`) 확인. ckpt 로드 실패 시 status=failed.
+- 전략이 자동매매 안 됨: `automation_level=2`인지 + `min_confidence` 임계 통과 여부 확인 (`rl_inference_logs.decision`).
+- 모든 자동매매 즉시 중단: `/api/investment/emergency-stop` 호출.
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add trading-worker/ecosystem.config.js dental-clinic-manager/docs/superpowers/operations
+git commit -m "feat(rl-trading): PM2 + operations guide"
+```
+
+---
+
+## Task 18: E2E 시나리오 (수동 검증)
+
+**파일 수정 없음. 실제 환경에서 확인.**
+
+- [ ] **Step 1: 마이그레이션 적용 확인**
+
+`mcp__supabase__execute_sql`로 다음 검증:
+
+```sql
+SELECT count(*) FROM rl_models;  -- 0이지만 테이블 존재
+SELECT column_name FROM information_schema.columns WHERE table_name='investment_strategies' AND column_name IN ('strategy_type','rl_model_id');  -- 2 row
+```
+
+- [ ] **Step 2: rl-inference-server 기동 + /health**
+
+```bash
+cd /Users/hhs/Project/dental-clinic-manager
+pm2 start trading-worker/ecosystem.config.js
+sleep 3
+curl -s -H "X-RL-API-KEY: $(grep RL_API_KEY rl-inference-server/.env | cut -d= -f2)" http://127.0.0.1:8001/health
+```
+
+기대: `{"status":"ok","loaded_models":[],"uptime_seconds":...}`
+
+- [ ] **Step 3: UI에서 모델 1개 등록**
+
+`/investment/rl-models` 접속 → 테스트 PPO ckpt URL과 sha256 입력 → status가 ready로 전이되는지 확인 (Supabase row 확인 + UI 갱신).
+
+- [ ] **Step 4: RL 전략 생성**
+
+`/investment/strategy/new` → "강화학습" 토글 → 모델 선택 → paper credential 선택 → automation_level=1로 생성. is_active=false 확인.
+
+- [ ] **Step 5: cron 강제 트리거**
+
+```bash
+cd trading-worker
+node -e "
+require('./dist/dailyRebalanceDeps').buildDailyRebalanceDeps()
+  .then(d => require('./dist/dailyRebalanceJob').runDailyRebalance(d))
+  .then(r => console.log(r))
+"
+```
+
+기대: rl_inference_logs row 1개 추가, decision='order', Telegram 알림 1개 수신.
+
+- [ ] **Step 6: idempotency 검증**
+
+같은 명령 재실행 → 두 번째 실행은 동일 trade_date에 대해 UNIQUE 제약 위반 → 코드는 이를 잡아 skip하거나 에러 처리. (현재 plan은 INSERT 실패를 잡지 않음 → Task 11의 insertInferenceLog에 ON CONFLICT DO NOTHING 또는 try/catch 추가 필요. 발견 시 보강 task 추가.)
+
+**Step 6 결과로 보강 PR이 필요할 수 있음.** 검증 시 별도 task로 분리 권장.
+
+- [ ] **Step 7: kill switch + emergency-stop**
+
+UI에서 일시정지 토글 ON → 다음 강제 트리거 → decision='blocked_kill_switch' 확인.
+`/api/investment/emergency-stop` POST → 모든 RL 전략 is_active=false + rl_paused_at 채워짐 확인.
+
+- [ ] **Step 8: 검증 완료 보고**
+
+플랜 실행자가 위 7개 시나리오 결과를 PR 본문 또는 작업 요약에 기록.
+
+---
+
+## Self-Review 체크리스트
+
+- [x] **Spec 커버리지**: spec의 모든 섹션이 task에 매핑됨
+  - DB 모델 → Task 1
+  - rl-inference-server → Task 2~7, 13
+  - trading-worker → Task 9~11
+  - 메인 앱 (API) → Task 12, 14
+  - 메인 앱 (UI) → Task 15, 16
+  - 안전 가드 → Task 1 (default), 10 (코드), 14 (kill switch), 16 (UI confirmation)
+  - 일봉 흐름 → Task 10 + 11
+  - 운영 → Task 17
+  - E2E → Task 18
+
+- [x] **Placeholder 없음**: 모든 step이 실행 가능한 코드 또는 명령. `<YYYYMMDD>` 같은 명백한 변수만 사용.
+
+- [x] **타입 일관성**: `RLModel`, `RLStrategyRow`, `PredictRequestBody`, `InferenceLogEntry` 등이 정의되고 사용 위치에서 일관됨.
+
+- [ ] **알려진 보강 지점**: Task 18 Step 6에서 idempotency 충돌 처리(ON CONFLICT DO NOTHING / catch 23505) 미구현. 실행 중 발견 시 즉시 작은 task로 추가.
+
+---
+
+## 진행 명령어 모음
+
+```bash
+# 작업 흐름 시작
+cd /Users/hhs/Project/dental-clinic-manager
+
+# 각 task 끝나면
+git push origin develop
+```

--- a/dental-clinic-manager/src/app/api/investment/emergency-stop/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/emergency-stop/route.ts
@@ -72,7 +72,16 @@ export async function POST() {
     }
   }
 
-  // 4. 감사 로그
+  // 4. RL kill switch 강제 활성화
+  await supabase
+    .from('user_investment_settings')
+    .upsert({
+      user_id: userId,
+      rl_paused_at: new Date().toISOString(),
+      rl_paused_reason: 'emergency-stop',
+    }, { onConflict: 'user_id' })
+
+  // 5. 감사 로그
   await supabase.from('investment_audit_logs').insert({
     user_id: userId,
     action: 'emergency_stop',

--- a/dental-clinic-manager/src/app/api/investment/rl-models/[id]/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/rl-models/[id]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { rlModelService } from '@/lib/rlModelService'
+import { requireAuth } from '@/lib/auth/requireAuth'
+
+export async function DELETE(_req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? 'unauthorized' }, { status: auth.status })
+  }
+  const r = await rlModelService.archive(id, auth.user.id)
+  if (!r.success) return NextResponse.json({ error: r.error }, { status: 400 })
+  return NextResponse.json({ ok: true })
+}

--- a/dental-clinic-manager/src/app/api/investment/rl-models/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/rl-models/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { rlModelService } from '@/lib/rlModelService'
+import { requireAuth } from '@/lib/auth/requireAuth'
+
+export async function GET() {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? 'unauthorized' }, { status: auth.status })
+  }
+  if (!auth.user.clinic_id) {
+    return NextResponse.json({ error: 'clinic_id not found' }, { status: 400 })
+  }
+  const r = await rlModelService.listForClinic(auth.user.clinic_id)
+  if (r.error) return NextResponse.json({ error: r.error }, { status: 500 })
+  return NextResponse.json({ data: r.data })
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? 'unauthorized' }, { status: auth.status })
+  }
+  if (!auth.user.clinic_id) {
+    return NextResponse.json({ error: 'clinic_id not found' }, { status: 400 })
+  }
+  const body = await req.json()
+  const created = await rlModelService.create(body, auth.user.id, auth.user.clinic_id)
+  if (created.error || !created.data) {
+    return NextResponse.json({ error: created.error ?? 'create failed' }, { status: 400 })
+  }
+  // Fire-and-forget download trigger; do not block response.
+  rlModelService.triggerDownload(created.data.id).catch(() => {})
+  return NextResponse.json({ data: created.data }, { status: 201 })
+}

--- a/dental-clinic-manager/src/app/api/investment/rl-pause/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/rl-pause/route.ts
@@ -1,0 +1,75 @@
+/**
+ * RL 일시정지(Kill Switch) API
+ *
+ * POST /api/investment/rl-pause - RL 전략 일시정지 / 재개
+ * GET  /api/investment/rl-pause - 현재 일시정지 상태 조회
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const userId = auth.user!.id
+
+  const supabase = getSupabaseAdmin()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+
+  let body: { paused: boolean; reason?: string }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: '잘못된 요청 형식입니다' }, { status: 400 })
+  }
+
+  const { paused, reason } = body
+  if (typeof paused !== 'boolean') {
+    return NextResponse.json({ error: 'paused 필드(boolean)가 필요합니다' }, { status: 400 })
+  }
+
+  const update = paused
+    ? { rl_paused_at: new Date().toISOString(), rl_paused_reason: reason ?? 'user manual' }
+    : { rl_paused_at: null, rl_paused_reason: null }
+
+  const { error } = await supabase
+    .from('user_investment_settings')
+    .upsert({ user_id: userId, ...update }, { onConflict: 'user_id' })
+
+  if (error) {
+    console.error('RL 일시정지 상태 저장 실패:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true, paused })
+}
+
+export async function GET() {
+  const auth = await requireAuth()
+  if (auth.error) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const userId = auth.user!.id
+
+  const supabase = getSupabaseAdmin()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+
+  const { data } = await supabase
+    .from('user_investment_settings')
+    .select('rl_paused_at, rl_paused_reason')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  return NextResponse.json({
+    paused: Boolean(data?.rl_paused_at),
+    rl_paused_at: data?.rl_paused_at ?? null,
+    rl_paused_reason: data?.rl_paused_reason ?? null,
+  })
+}

--- a/dental-clinic-manager/src/app/api/investment/strategies/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/strategies/route.ts
@@ -225,6 +225,13 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ error: '전략 ID가 필요합니다' }, { status: 400 })
   }
 
+  // strategy_type and rl_model_id are immutable after creation
+  if ('strategy_type' in updates || 'rl_model_id' in updates) {
+    return NextResponse.json({
+      error: 'strategy_type and rl_model_id cannot be changed after creation',
+    }, { status: 400 })
+  }
+
   // 소유권 확인
   const { data: existing } = await supabase
     .from('investment_strategies')

--- a/dental-clinic-manager/src/app/api/investment/strategies/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/strategies/route.ts
@@ -40,6 +40,51 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: '잘못된 요청 형식입니다' }, { status: 400 })
   }
 
+  // 전략 타입 결정 (rule | rl_portfolio | rl_single)
+  const strategyType = (body.strategy_type as 'rule' | 'rl_portfolio' | 'rl_single' | undefined) ?? 'rule'
+
+  // RL 전략 추가 검증
+  if (strategyType !== 'rule') {
+    if (!body.rl_model_id) {
+      return NextResponse.json({ error: 'rl_model_id required for RL strategies' }, { status: 400 })
+    }
+    // RL 기본 automation_level = 1 (시그널 전용)
+    if (body.automation_level == null) body.automation_level = 1
+
+    // 모델 상태 및 종류 검증
+    const { data: model } = await supabase
+      .from('rl_models')
+      .select('id, status, kind')
+      .eq('id', body.rl_model_id)
+      .single()
+
+    if (!model) {
+      return NextResponse.json({ error: 'rl model not found' }, { status: 400 })
+    }
+    if (model.status !== 'ready') {
+      return NextResponse.json({ error: `rl model not ready (status: ${model.status})` }, { status: 400 })
+    }
+    const expectedType = model.kind === 'portfolio' ? 'rl_portfolio' : 'rl_single'
+    if (strategyType !== expectedType) {
+      return NextResponse.json({
+        error: `strategy_type must be ${expectedType} for model kind ${model.kind}`,
+      }, { status: 400 })
+    }
+    if (strategyType === 'rl_single' && body.automation_level === 2) {
+      return NextResponse.json({
+        error: 'rl_single auto trading not supported in Phase 1',
+      }, { status: 400 })
+    }
+
+    // RL 전략은 지표/조건이 필요 없으므로 빈 기본값 설정
+    body.indicators = body.indicators ?? []
+    body.buy_conditions = body.buy_conditions ?? { type: 'group', operator: 'AND', conditions: [] }
+    body.sell_conditions = body.sell_conditions ?? { type: 'group', operator: 'AND', conditions: [] }
+    // camelCase 별칭도 설정 (아래 구조분해에서 사용)
+    body.buyConditions = body.buyConditions ?? body.buy_conditions
+    body.sellConditions = body.sellConditions ?? body.sell_conditions
+  }
+
   // 필수 필드 검증
   const { name, targetMarket, timeframe, indicators, buyConditions, sellConditions, riskSettings, automationLevel } = body
 
@@ -107,6 +152,8 @@ export async function POST(request: NextRequest) {
       sell_conditions: sellConditions as object,
       risk_settings: riskToStore,
       automation_level: automationLevel as number,
+      strategy_type: strategyType,
+      rl_model_id: (body.rl_model_id as string | undefined) ?? null,
       is_active: false, // 신규 전략은 비활성
     })
     .select()

--- a/dental-clinic-manager/src/app/api/referrals/sms/route.ts
+++ b/dental-clinic-manager/src/app/api/referrals/sms/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+const ALIGO_API_URL = 'https://apis.aligo.in'
+
+interface ThanksSmsBody {
+  clinic_id: string
+  referral_id?: string
+  recipient_dentweb_patient_id: string
+  phone_number: string
+  message: string
+  msg_type?: 'SMS' | 'LMS' | 'MMS'
+  title?: string
+  sent_by?: string
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json()) as ThanksSmsBody
+    const { clinic_id, referral_id, recipient_dentweb_patient_id, phone_number, message, msg_type = 'SMS', title, sent_by } = body
+
+    if (!clinic_id || !recipient_dentweb_patient_id || !phone_number || !message) {
+      return NextResponse.json({ success: false, error: '필수 파라미터가 누락되었습니다.' }, { status: 400 })
+    }
+
+    const supabase = getSupabaseAdmin()
+    if (!supabase) {
+      return NextResponse.json({ success: false, error: 'Database connection not available' }, { status: 500 })
+    }
+
+    const { data: aligo, error: settingsError } = await supabase
+      .from('aligo_settings')
+      .select('*')
+      .eq('clinic_id', clinic_id)
+      .single()
+
+    if (settingsError || !aligo || !aligo.api_key || !aligo.user_id || !aligo.sender_number) {
+      return NextResponse.json({ success: false, error: '알리고 API 설정이 없거나 미완료입니다.' }, { status: 400 })
+    }
+
+    const msgBytes = new Blob([message]).size
+    const actualType = msgBytes > 90 && msg_type === 'SMS' ? 'LMS' : msg_type
+
+    const formData = new FormData()
+    formData.append('key', aligo.api_key)
+    formData.append('user_id', aligo.user_id)
+    formData.append('sender', aligo.sender_number)
+    formData.append('receiver', phone_number)
+    formData.append('msg', message)
+    formData.append('msg_type', actualType)
+    if (title && actualType !== 'SMS') formData.append('title', title)
+    if (process.env.NODE_ENV === 'development') formData.append('testmode_yn', 'Y')
+
+    const aligoRes = await fetch(`${ALIGO_API_URL}/send/`, { method: 'POST', body: formData })
+    const aligoJson = (await aligoRes.json()) as { result_code: string; message: string; msg_id?: string }
+
+    const ok = aligoJson.result_code === '1'
+
+    await supabase.from('referral_sms_logs').insert({
+      clinic_id,
+      referral_id: referral_id ?? null,
+      recipient_dentweb_patient_id,
+      phone_number,
+      message_content: message,
+      message_type: actualType,
+      status: ok ? 'sent' : 'failed',
+      aligo_msg_id: aligoJson.msg_id ?? null,
+      error_message: ok ? null : aligoJson.message,
+      sent_by: sent_by ?? null,
+    })
+
+    if (ok && referral_id) {
+      await supabase
+        .from('patient_referrals')
+        .update({ thanks_sms_sent_at: new Date().toISOString() })
+        .eq('id', referral_id)
+    }
+
+    if (ok) {
+      return NextResponse.json({ success: true, msg_id: aligoJson.msg_id })
+    }
+
+    let errorMessage = aligoJson.message || '문자 발송에 실패했습니다.'
+    if (errorMessage.includes('ip') || errorMessage.includes('IP') || errorMessage.includes('인증오류')) {
+      errorMessage = 'IP 인증 오류: 알리고 관리자 페이지(smartsms.aligo.in)에서 서버 IP를 등록해주세요.'
+    }
+    return NextResponse.json({ success: false, error: errorMessage })
+  } catch (e) {
+    console.error('[referral sms] error:', e)
+    return NextResponse.json({ success: false, error: '서버 오류가 발생했습니다.' }, { status: 500 })
+  }
+}

--- a/dental-clinic-manager/src/app/dashboard/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/page.tsx
@@ -28,6 +28,7 @@ import TeamStatus from '@/components/Attendance/TeamStatus'
 import QRCodeDisplay from '@/components/Attendance/QRCodeDisplay'
 import { PayrollManagement } from '@/components/Payroll'
 import { RecallManagement } from '@/components/Recall'
+import { ReferralManagement } from '@/components/Referral'
 import AIChat from '@/components/AIAnalysis/AIChat'
 import PremiumGate from '@/components/Premium/PremiumGate'
 import TaskChecklistManagement from '@/components/TaskChecklist/TaskChecklistManagement'
@@ -836,6 +837,11 @@ export default function DashboardPage() {
             <PremiumGate featureId="recall">
               <RecallManagement />
             </PremiumGate>
+          )}
+
+          {/* 소개환자 관리 */}
+          {activeTab === 'referral' && (
+            <ReferralManagement />
           )}
 
           {/* 업무 체크리스트 */}

--- a/dental-clinic-manager/src/app/investment/rl-models/page.tsx
+++ b/dental-clinic-manager/src/app/investment/rl-models/page.tsx
@@ -1,0 +1,42 @@
+'use client'
+import { useEffect, useState } from 'react'
+import type { RLModel } from '@/types/rlTrading'
+import ModelLibraryPanel from '@/components/Investment/RLModels/ModelLibraryPanel'
+import KillSwitchToggle from '@/components/Investment/RLModels/KillSwitchToggle'
+
+export default function RLModelsPage() {
+  const [models, setModels] = useState<RLModel[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = () => {
+    fetch('/api/investment/rl-models')
+      .then((r) => r.json())
+      .then((j) => setModels(j.data ?? []))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => {
+    refresh()
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-at-accent" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4 sm:p-6 space-y-6 bg-white min-h-screen">
+      <div className="flex items-center justify-between pb-3 border-b border-at-border">
+        <h2 className="text-lg font-bold text-at-text">RL 모델 라이브러리</h2>
+        <KillSwitchToggle />
+      </div>
+      <div className="bg-at-error-bg border border-at-error rounded-xl p-3 text-sm text-at-error">
+        ⚠ 강화학습 모델은 검증 전까지 paper 계좌 + automation_level=1 사용을 강력히 권장합니다.
+      </div>
+      <ModelLibraryPanel models={models} onChange={refresh} />
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/app/investment/strategy/new/page.tsx
+++ b/dental-clinic-manager/src/app/investment/strategy/new/page.tsx
@@ -1,7 +1,53 @@
 'use client'
 
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import StrategyBuilder from '@/components/Investment/StrategyBuilder/StrategyBuilder'
+import RLStrategyForm from '@/components/Investment/RLModels/RLStrategyForm'
+
+type StrategyType = 'rule' | 'rl'
 
 export default function NewStrategyPage() {
-  return <StrategyBuilder />
+  const router = useRouter()
+  const [type, setType] = useState<StrategyType>('rule')
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4 bg-white min-h-screen">
+      {/* 전략 유형 토글 */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => setType('rule')}
+          className={
+            type === 'rule'
+              ? 'bg-at-accent-light text-at-accent px-3 py-1.5 rounded-xl text-sm font-medium'
+              : 'px-3 py-1.5 text-at-text-secondary hover:bg-at-surface-alt rounded-xl text-sm'
+          }
+        >
+          룰 기반
+        </button>
+        <button
+          type="button"
+          onClick={() => setType('rl')}
+          className={
+            type === 'rl'
+              ? 'bg-at-accent-light text-at-accent px-3 py-1.5 rounded-xl text-sm font-medium'
+              : 'px-3 py-1.5 text-at-text-secondary hover:bg-at-surface-alt rounded-xl text-sm'
+          }
+        >
+          강화학습 (RL)
+        </button>
+      </div>
+
+      {/* 콘텐츠 */}
+      {type === 'rule' ? (
+        <StrategyBuilder
+          onSaved={() => router.push('/investment/strategy')}
+          onCancel={() => router.push('/investment/strategy')}
+        />
+      ) : (
+        <RLStrategyForm onCreated={() => router.push('/investment/strategy')} />
+      )}
+    </div>
+  )
 }

--- a/dental-clinic-manager/src/components/Investment/RLModels/KillSwitchToggle.tsx
+++ b/dental-clinic-manager/src/components/Investment/RLModels/KillSwitchToggle.tsx
@@ -1,0 +1,43 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { Pause, Play } from 'lucide-react'
+
+export default function KillSwitchToggle() {
+  const [paused, setPaused] = useState<boolean | null>(null)
+
+  const fetchState = async () => {
+    try {
+      const r = await fetch('/api/investment/rl-pause')
+      if (!r.ok) return
+      const j = (await r.json()) as { paused?: boolean }
+      setPaused(Boolean(j.paused))
+    } catch {
+      setPaused(false)
+    }
+  }
+
+  useEffect(() => { fetchState() }, [])
+
+  const toggle = async () => {
+    const next = !(paused ?? false)
+    const r = await fetch('/api/investment/rl-pause', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ paused: next }),
+    })
+    if (r.ok) setPaused(next)
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      className={`inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium ${paused ? 'bg-at-error text-white' : 'bg-at-surface-alt text-at-text'}`}
+      aria-label={paused ? 'RL 자동매매 재개' : 'RL 자동매매 일시정지'}
+    >
+      {paused
+        ? <><Play className="w-4 h-4" aria-hidden="true" />RL 자동매매 재개</>
+        : <><Pause className="w-4 h-4" aria-hidden="true" />RL 자동매매 일시정지</>
+      }
+    </button>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/RLModels/ModelLibraryPanel.tsx
+++ b/dental-clinic-manager/src/components/Investment/RLModels/ModelLibraryPanel.tsx
@@ -1,0 +1,90 @@
+'use client'
+import { useState } from 'react'
+import type { RLModel } from '@/types/rlTrading'
+import ModelRegisterDialog from './ModelRegisterDialog'
+import { Plus, Trash2 } from 'lucide-react'
+import { appConfirm } from '@/components/ui/AppDialog'
+
+interface Props { models: RLModel[]; onChange: () => void }
+
+const STATUS_COLOR: Record<string, string> = {
+  ready: 'bg-at-success-bg text-at-success',
+  pending: 'bg-at-surface-alt text-at-text-secondary',
+  downloading: 'bg-at-accent-light text-at-accent',
+  failed: 'bg-at-error-bg text-at-error',
+  archived: 'bg-at-surface-alt text-at-text-weak',
+}
+
+export default function ModelLibraryPanel({ models, onChange }: Props) {
+  const [open, setOpen] = useState(false)
+
+  const onDelete = async (m: RLModel) => {
+    const ok = await appConfirm({
+      title: '모델 보관(archive)',
+      description: `${m.name}을(를) 보관하면 참조 전략이 비활성화됩니다.`,
+      variant: 'destructive',
+      confirmText: '보관',
+    })
+    if (!ok) return
+    await fetch(`/api/investment/rl-models/${m.id}`, { method: 'DELETE' })
+    onChange()
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <button
+          onClick={() => setOpen(true)}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-at-accent text-white rounded-xl text-sm font-medium hover:bg-at-accent-hover"
+          aria-label="모델 추가"
+        >
+          <Plus className="w-4 h-4" aria-hidden="true" /> 모델 추가
+        </button>
+      </div>
+
+      {models.length === 0 ? (
+        <div className="text-center py-12 bg-at-surface-alt rounded-xl text-at-text-secondary">
+          등록된 RL 모델이 없습니다. &quot;모델 추가&quot;를 눌러 사전학습 ckpt URL을 등록하세요.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-at-border">
+          <table className="min-w-[800px] w-full text-sm">
+            <thead className="bg-at-surface-alt">
+              <tr>
+                {['이름','종류','알고리즘','시장/주기','상태','신뢰도 임계','작업'].map((h) => (
+                  <th key={h} className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-at-border bg-white">
+              {models.map((m) => (
+                <tr key={m.id} className="hover:bg-at-surface-alt">
+                  <td className="px-3 py-2.5 font-medium">{m.name}</td>
+                  <td className="px-3 py-2.5">{m.kind}</td>
+                  <td className="px-3 py-2.5">{m.algorithm}</td>
+                  <td className="px-3 py-2.5">{m.market} / {m.timeframe}</td>
+                  <td className="px-3 py-2.5">
+                    <span className={`inline-flex px-2 py-0.5 text-xs rounded-full ${STATUS_COLOR[m.status] ?? ''}`}>{m.status}</span>
+                  </td>
+                  <td className="px-3 py-2.5">{m.min_confidence.toFixed(2)}</td>
+                  <td className="px-3 py-2.5">
+                    <button
+                      onClick={() => onDelete(m)}
+                      aria-label={`${m.name} 보관`}
+                      title="보관"
+                      className="p-1.5 rounded-xl hover:bg-at-error-bg text-at-text-secondary hover:text-at-error"
+                    >
+                      <Trash2 className="w-4 h-4" aria-hidden="true" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <ModelRegisterDialog open={open} onClose={() => setOpen(false)} onCreated={() => { setOpen(false); onChange() }} />
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/RLModels/ModelRegisterDialog.tsx
+++ b/dental-clinic-manager/src/components/Investment/RLModels/ModelRegisterDialog.tsx
@@ -1,0 +1,97 @@
+'use client'
+import { useState } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+
+interface Props { open: boolean; onClose: () => void; onCreated: () => void }
+
+export default function ModelRegisterDialog({ open, onClose, onCreated }: Props) {
+  const [form, setForm] = useState({
+    name: '',
+    algorithm: 'PPO',
+    kind: 'portfolio',
+    universe: 'AAPL,MSFT,GOOGL,AMZN,META',
+    state_window: 60,
+    input_features: 'open,high,low,close,volume',
+    output_dim: 5,
+    output_type: 'continuous' as 'continuous' | 'discrete',
+    checkpoint_url: '',
+    checkpoint_sha256: '',
+    min_confidence: 0.6,
+    source: 'finrl_pretrained' as 'finrl_pretrained' | 'sb3_pretrained' | 'custom',
+  })
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const submit = async () => {
+    setSubmitting(true); setError(null)
+    try {
+      const body = {
+        name: form.name,
+        algorithm: form.algorithm,
+        kind: form.kind,
+        source: form.source,
+        universe: form.universe.split(',').map((s) => s.trim()).filter(Boolean),
+        input_features: form.input_features.split(',').map((s) => s.trim()).filter(Boolean),
+        output_shape: { type: form.output_type, dim: Number(form.output_dim) },
+        state_window: Number(form.state_window),
+        min_confidence: Number(form.min_confidence),
+        checkpoint_url: form.checkpoint_url,
+        checkpoint_sha256: form.checkpoint_sha256,
+      }
+      const r = await fetch('/api/investment/rl-models', {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!r.ok) {
+        const errBody = await r.json().catch(() => ({}))
+        throw new Error((errBody as { error?: string }).error ?? `${r.status}`)
+      }
+      onCreated()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally { setSubmitting(false) }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose() }}>
+      <DialogContent>
+        <DialogHeader><DialogTitle>RL 모델 등록</DialogTitle></DialogHeader>
+        <div className="space-y-3 max-h-[70vh] overflow-y-auto">
+          {error && <div className="p-2 rounded-xl bg-at-error-bg text-at-error text-sm">{error}</div>}
+          <Field label="이름 *" v={form.name} on={(v) => setForm({ ...form, name: v })} />
+          <Field label="알고리즘" v={form.algorithm} on={(v) => setForm({ ...form, algorithm: v })} />
+          <Field label="종목 유니버스 (콤마 구분)" v={form.universe} on={(v) => setForm({ ...form, universe: v })} />
+          <Field label="입력 피처 (콤마 구분)" v={form.input_features} on={(v) => setForm({ ...form, input_features: v })} />
+          <Field label="state_window" v={String(form.state_window)} on={(v) => setForm({ ...form, state_window: Number(v) })} />
+          <Field label="output dim" v={String(form.output_dim)} on={(v) => setForm({ ...form, output_dim: Number(v) })} />
+          <Field label="ckpt URL *" v={form.checkpoint_url} on={(v) => setForm({ ...form, checkpoint_url: v })} />
+          <Field label="ckpt sha256 *" v={form.checkpoint_sha256} on={(v) => setForm({ ...form, checkpoint_sha256: v })} />
+          <Field label="min_confidence" v={String(form.min_confidence)} on={(v) => setForm({ ...form, min_confidence: Number(v) })} />
+        </div>
+        <DialogFooter>
+          <button onClick={onClose} className="px-4 py-2 border border-at-border rounded-xl text-sm">취소</button>
+          <button
+            onClick={submit}
+            disabled={submitting || !form.name || !form.checkpoint_url || !form.checkpoint_sha256}
+            className="px-4 py-2 bg-at-accent text-white rounded-xl text-sm disabled:opacity-50"
+          >
+            {submitting ? '등록 중...' : '등록 + 다운로드'}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Field({ label, v, on }: { label: string; v: string; on: (v: string) => void }) {
+  return (
+    <label className="block">
+      <span className="text-sm text-at-text mb-1 inline-block">{label}</span>
+      <input
+        value={v}
+        onChange={(e) => on(e.target.value)}
+        className="w-full px-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent"
+      />
+    </label>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/RLModels/RLStrategyForm.tsx
+++ b/dental-clinic-manager/src/components/Investment/RLModels/RLStrategyForm.tsx
@@ -1,0 +1,225 @@
+'use client'
+import { useEffect, useState } from 'react'
+import type { RLModel } from '@/types/rlTrading'
+
+interface Props { onCreated: () => void }
+
+interface CredentialRow {
+  id: string
+  label: string | null
+  isPaperTrading: boolean
+  broker: string
+}
+
+export default function RLStrategyForm({ onCreated }: Props) {
+  const [models, setModels] = useState<RLModel[]>([])
+  const [cred, setCred] = useState<CredentialRow | null>(null)
+  const [form, setForm] = useState({
+    name: '',
+    rl_model_id: '',
+    automation_level: 1 as 1 | 2,
+  })
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [loadingModels, setLoadingModels] = useState(true)
+  const [loadingCred, setLoadingCred] = useState(true)
+
+  useEffect(() => {
+    fetch('/api/investment/rl-models')
+      .then((r) => r.json())
+      .then((j: { data?: RLModel[] }) =>
+        setModels((j.data ?? []).filter((m) => m.status === 'ready'))
+      )
+      .catch(() => setModels([]))
+      .finally(() => setLoadingModels(false))
+
+    // credentials endpoint returns a single credential (or null)
+    fetch('/api/investment/credentials')
+      .then((r) => r.json())
+      .then((j: { data?: CredentialRow | null }) => {
+        if (j.data) {
+          setCred({
+            id: j.data.id,
+            label: j.data.label,
+            isPaperTrading: j.data.isPaperTrading,
+            broker: j.data.broker,
+          })
+        } else {
+          setCred(null)
+        }
+      })
+      .catch(() => setCred(null))
+      .finally(() => setLoadingCred(false))
+  }, [])
+
+  const submit = async () => {
+    setSubmitting(true)
+    setError(null)
+    try {
+      const model = models.find((m) => m.id === form.rl_model_id)
+      if (!model) throw new Error('모델을 선택해주세요')
+      if (!cred) throw new Error('연결된 증권사 계좌가 없습니다')
+
+      const body = {
+        name: form.name,
+        target_market: model.market,
+        timeframe: model.timeframe,
+        strategy_type: model.kind === 'portfolio' ? 'rl_portfolio' : 'rl_single',
+        rl_model_id: model.id,
+        automation_level: form.automation_level,
+        credential_id: cred.id,
+        indicators: [],
+        buy_conditions: { type: 'group', operator: 'AND', conditions: [] },
+        sell_conditions: { type: 'group', operator: 'AND', conditions: [] },
+        is_active: false,
+      }
+
+      const r = await fetch('/api/investment/strategies', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+      if (!r.ok) {
+        const errBody = (await r.json().catch(() => ({}))) as { error?: string }
+        throw new Error(errBody.error ?? `오류 ${r.status}`)
+      }
+
+      onCreated()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const selectedModel = models.find((m) => m.id === form.rl_model_id)
+  const isLive = cred && !cred.isPaperTrading
+
+  return (
+    <div className="space-y-5 max-w-xl">
+      {error && (
+        <div className="p-3 rounded-xl bg-red-50 text-red-600 text-sm border border-red-200">
+          {error}
+        </div>
+      )}
+
+      {/* 전략 이름 */}
+      <label className="block">
+        <span className="text-sm text-at-text-secondary mb-1 inline-block">전략 이름 *</span>
+        <input
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          placeholder="예: PPO 포트폴리오 분산투자"
+          maxLength={100}
+          className="w-full px-3 py-2 border border-at-border rounded-xl bg-at-bg text-at-text text-sm focus:outline-none focus:border-at-accent"
+        />
+      </label>
+
+      {/* RL 모델 선택 */}
+      <label className="block">
+        <span className="text-sm text-at-text-secondary mb-1 inline-block">RL 모델 *</span>
+        {loadingModels ? (
+          <div className="w-full px-3 py-2 border border-at-border rounded-xl text-sm text-at-text-weak">
+            모델 목록 불러오는 중...
+          </div>
+        ) : models.length === 0 ? (
+          <div className="w-full px-3 py-2 border border-at-border rounded-xl text-sm text-at-text-weak bg-at-surface-alt">
+            사용 가능한 RL 모델이 없습니다. RL 모델 탭에서 모델을 먼저 등록하세요.
+          </div>
+        ) : (
+          <select
+            value={form.rl_model_id}
+            onChange={(e) => setForm({ ...form, rl_model_id: e.target.value })}
+            className="w-full px-3 py-2 border border-at-border rounded-xl bg-at-bg text-at-text text-sm focus:outline-none focus:border-at-accent"
+          >
+            <option value="">선택</option>
+            {models.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name} ({m.algorithm}, {m.kind === 'portfolio' ? '포트폴리오' : '단일 자산'})
+              </option>
+            ))}
+          </select>
+        )}
+        {selectedModel && (
+          <p className="text-xs text-at-text-secondary mt-1.5">
+            시장: {selectedModel.market} · 주기: {selectedModel.timeframe} ·{' '}
+            유니버스: {(selectedModel.universe ?? []).join(', ') || '-'} ·{' '}
+            신뢰도 임계: {selectedModel.min_confidence}
+          </p>
+        )}
+      </label>
+
+      {/* 증권사 계좌 */}
+      <div>
+        <span className="text-sm text-at-text-secondary mb-1 inline-block">증권사 계좌</span>
+        {loadingCred ? (
+          <div className="w-full px-3 py-2 border border-at-border rounded-xl text-sm text-at-text-weak">
+            계좌 정보 불러오는 중...
+          </div>
+        ) : cred ? (
+          <div className="w-full px-3 py-2 border border-at-border rounded-xl text-sm text-at-text bg-at-surface-alt">
+            {cred.label ?? cred.broker}{' '}
+            <span className={`text-xs font-medium ${cred.isPaperTrading ? 'text-at-accent' : 'text-red-600'}`}>
+              {cred.isPaperTrading ? '(모의투자)' : '(LIVE)'}
+            </span>
+          </div>
+        ) : (
+          <div className="w-full px-3 py-2 border border-red-300 rounded-xl text-sm text-red-600 bg-red-50">
+            연결된 계좌가 없습니다. 증권사 연결 탭에서 KIS 계좌를 먼저 등록하세요.
+          </div>
+        )}
+      </div>
+
+      {/* 자동화 수준 */}
+      <fieldset className="space-y-2">
+        <legend className="text-sm text-at-text-secondary">자동화 수준 *</legend>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={() => setForm({ ...form, automation_level: 1 })}
+            className={`flex-1 p-3 rounded-xl border text-sm text-left transition-colors ${
+              form.automation_level === 1
+                ? 'border-at-accent bg-at-accent-light/30'
+                : 'border-at-border hover:border-at-accent/50'
+            }`}
+          >
+            <p className="font-medium text-at-text">Level 1: 알림만 (권장)</p>
+            <p className="text-xs text-at-text-secondary mt-0.5">신호 발생 시 Telegram 알림만 전송</p>
+          </button>
+          <button
+            type="button"
+            onClick={() => setForm({ ...form, automation_level: 2 })}
+            className={`flex-1 p-3 rounded-xl border text-sm text-left transition-colors ${
+              form.automation_level === 2
+                ? 'border-at-accent bg-at-accent-light/30'
+                : 'border-at-border hover:border-at-accent/50'
+            }`}
+          >
+            <p className="font-medium text-at-text">Level 2: 자동 주문</p>
+            <p className="text-xs text-at-text-secondary mt-0.5">모델 신호에 따라 자동 주문 실행</p>
+          </button>
+        </div>
+        {form.automation_level === 2 && isLive && (
+          <div className="p-3 bg-red-50 border border-red-300 rounded-xl text-xs text-red-700">
+            ⚠ Live 계좌에서 자동 주문이 실행됩니다. 검증되지 않은 모델은 즉시 손실로 이어질 수 있습니다.
+          </div>
+        )}
+      </fieldset>
+
+      <button
+        type="button"
+        onClick={submit}
+        disabled={
+          submitting ||
+          !form.name.trim() ||
+          !form.rl_model_id ||
+          !cred
+        }
+        className="w-full py-3 bg-at-accent text-white rounded-xl font-medium hover:bg-at-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {submitting ? '생성 중...' : 'RL 전략 생성'}
+      </button>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Referral/PatientSearchInput.tsx
+++ b/dental-clinic-manager/src/components/Referral/PatientSearchInput.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { Search, Loader2, X } from 'lucide-react'
+import { referralService } from '@/lib/referralService'
+import type { PatientSearchResult } from '@/types/referral'
+
+interface Props {
+  clinicId: string
+  selected: PatientSearchResult | null
+  onSelect: (p: PatientSearchResult | null) => void
+  placeholder?: string
+  excludeId?: string
+  autoFocus?: boolean
+}
+
+export default function PatientSearchInput({
+  clinicId,
+  selected,
+  onSelect,
+  placeholder = '이름, 차트번호, 전화번호로 검색',
+  excludeId,
+  autoFocus,
+}: Props) {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<PatientSearchResult[]>([])
+  const [loading, setLoading] = useState(false)
+  const [open, setOpen] = useState(false)
+  const debounceRef = useRef<NodeJS.Timeout | null>(null)
+  const wrapRef = useRef<HTMLDivElement>(null)
+
+  const runSearch = useCallback(async (q: string) => {
+    if (!q.trim()) {
+      setResults([])
+      return
+    }
+    setLoading(true)
+    try {
+      const data = await referralService.searchPatients(clinicId, q, 12)
+      setResults(excludeId ? data.filter(d => d.id !== excludeId) : data)
+    } catch (e) {
+      console.error(e)
+      setResults([])
+    } finally {
+      setLoading(false)
+    }
+  }, [clinicId, excludeId])
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => runSearch(query), 280)
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [query, runSearch])
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  if (selected) {
+    return (
+      <div className="flex items-center justify-between rounded-lg border border-[var(--at-border)] bg-[var(--at-accent-light)] px-3 py-2.5">
+        <div className="flex flex-col">
+          <span className="text-sm font-medium text-[var(--at-text-primary)]">{selected.patient_name}</span>
+          <span className="text-xs text-[var(--at-text-secondary)]">
+            {selected.chart_number ?? '차트번호 없음'} · {selected.phone_number ?? '전화번호 없음'}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={() => onSelect(null)}
+          className="rounded-md p-1 text-[var(--at-text-weak)] hover:bg-white hover:text-[var(--at-error)]"
+          aria-label="선택 해제"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div ref={wrapRef} className="relative">
+      <div className="flex items-center gap-2 rounded-lg border border-[var(--at-border)] bg-white px-3 py-2.5 focus-within:border-[var(--at-accent)] focus-within:ring-1 focus-within:ring-[var(--at-accent)]">
+        <Search className="h-4 w-4 text-[var(--at-text-weak)]" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setOpen(true) }}
+          onFocus={() => setOpen(true)}
+          placeholder={placeholder}
+          autoFocus={autoFocus}
+          className="flex-1 bg-transparent text-sm outline-none placeholder:text-[var(--at-text-weak)]"
+        />
+        {loading && <Loader2 className="h-4 w-4 animate-spin text-[var(--at-accent)]" />}
+      </div>
+
+      {open && query.trim() && (
+        <div className="absolute z-20 mt-1 max-h-80 w-full overflow-auto rounded-lg border border-[var(--at-border)] bg-white shadow-[var(--shadow-at-card)]">
+          {!loading && results.length === 0 && (
+            <div className="px-3 py-4 text-center text-sm text-[var(--at-text-weak)]">
+              검색 결과가 없습니다.
+            </div>
+          )}
+          {results.map(r => (
+            <button
+              key={r.id}
+              type="button"
+              onClick={() => { onSelect(r); setOpen(false); setQuery('') }}
+              className="flex w-full items-center justify-between border-b border-[var(--at-border)] px-3 py-2.5 text-left last:border-b-0 hover:bg-[var(--at-surface-hover)]"
+            >
+              <div className="flex flex-col">
+                <span className="text-sm font-medium text-[var(--at-text-primary)]">{r.patient_name}</span>
+                <span className="text-xs text-[var(--at-text-secondary)]">
+                  {r.chart_number ?? '차트번호 없음'} · {r.phone_number ?? '전화번호 없음'}
+                </span>
+              </div>
+              {r.acquisition_channel === '소개' && (
+                <span className="rounded-full bg-[var(--at-accent-tag)] px-2 py-0.5 text-xs font-medium text-[var(--at-accent)]">
+                  소개
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Referral/PointAdjustModal.tsx
+++ b/dental-clinic-manager/src/components/Referral/PointAdjustModal.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { X, Coins, Plus, Minus, Loader2 } from 'lucide-react'
+import { referralService } from '@/lib/referralService'
+import type { PointReason } from '@/types/referral'
+
+interface Props {
+  clinicId: string
+  open: boolean
+  onClose: () => void
+  patient: { id: string; patient_name: string } | null
+  referralId?: string
+  defaultDelta?: number
+  defaultReason?: PointReason
+  defaultNote?: string
+  onSaved: () => void
+}
+
+export default function PointAdjustModal({ clinicId, open, onClose, patient, referralId, defaultDelta = 0, defaultReason = 'manual_add', defaultNote = '', onSaved }: Props) {
+  const [direction, setDirection] = useState<'add' | 'use'>(defaultDelta < 0 ? 'use' : 'add')
+  const [amount, setAmount] = useState<number>(Math.abs(defaultDelta) || 0)
+  const [reason, setReason] = useState<PointReason>(defaultReason)
+  const [note, setNote] = useState<string>(defaultNote)
+  const [currentBalance, setCurrentBalance] = useState<number>(0)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open || !patient) return
+    setDirection(defaultDelta < 0 ? 'use' : 'add')
+    setAmount(Math.abs(defaultDelta) || 0)
+    setReason(defaultReason)
+    setNote(defaultNote)
+    setError(null)
+    referralService.getBalance(clinicId, patient.id).then(setCurrentBalance).catch(() => setCurrentBalance(0))
+  }, [open, patient, clinicId, defaultDelta, defaultReason, defaultNote])
+
+  if (!open || !patient) return null
+
+  const handleSubmit = async () => {
+    if (amount <= 0) { setError('금액을 입력해주세요.'); return }
+    setSubmitting(true); setError(null)
+    try {
+      const delta = direction === 'add' ? amount : -amount
+      const finalReason: PointReason = direction === 'use' ? 'manual_use' : reason
+      await referralService.addPoints({
+        clinicId,
+        dentwebPatientId: patient.id,
+        delta,
+        reason: finalReason,
+        referralId,
+        note: note.trim() || undefined,
+      })
+      onSaved()
+      onClose()
+    } catch (e) {
+      console.error(e)
+      setError('저장에 실패했습니다.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4" onMouseDown={onClose}>
+      <div className="w-full max-w-md rounded-xl bg-white shadow-[var(--shadow-at-card)]" onMouseDown={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between border-b border-[var(--at-border)] px-5 py-4">
+          <div className="flex items-center gap-2">
+            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-[var(--at-success-bg)] text-[var(--at-success)]">
+              <Coins className="h-4 w-4" />
+            </span>
+            <h2 className="text-base font-semibold text-[var(--at-text-primary)]">포인트 조정</h2>
+          </div>
+          <button onClick={onClose} className="rounded-md p-1 text-[var(--at-text-weak)] hover:bg-[var(--at-surface-hover)]">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="space-y-4 px-5 py-4">
+          <div className="rounded-lg bg-[var(--at-surface-alt)] px-3 py-2.5">
+            <div className="text-xs text-[var(--at-text-secondary)]">{patient.patient_name}님 현재 잔액</div>
+            <div className="mt-0.5 text-xl font-semibold text-[var(--at-accent)]">{currentBalance.toLocaleString()} P</div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => setDirection('add')}
+              className={`flex items-center justify-center gap-1.5 rounded-lg border px-3 py-2.5 text-sm font-medium transition ${
+                direction === 'add'
+                  ? 'border-[var(--at-success)] bg-[var(--at-success-bg)] text-[var(--at-success)]'
+                  : 'border-[var(--at-border)] bg-white text-[var(--at-text-secondary)] hover:bg-[var(--at-surface-hover)]'
+              }`}
+            >
+              <Plus className="h-4 w-4" /> 적립
+            </button>
+            <button
+              type="button"
+              onClick={() => setDirection('use')}
+              className={`flex items-center justify-center gap-1.5 rounded-lg border px-3 py-2.5 text-sm font-medium transition ${
+                direction === 'use'
+                  ? 'border-[var(--at-error)] bg-[var(--at-error-bg)] text-[var(--at-error)]'
+                  : 'border-[var(--at-border)] bg-white text-[var(--at-text-secondary)] hover:bg-[var(--at-surface-hover)]'
+              }`}
+            >
+              <Minus className="h-4 w-4" /> 사용
+            </button>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-[var(--at-text-primary)]">금액 (P)</label>
+            <input
+              type="number"
+              min={0}
+              step={100}
+              value={amount}
+              onChange={(e) => setAmount(Number(e.target.value))}
+              className="w-full rounded-lg border border-[var(--at-border)] px-3 py-2 text-sm focus:border-[var(--at-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--at-accent)]"
+            />
+          </div>
+
+          {direction === 'add' && (
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-[var(--at-text-primary)]">적립 사유</label>
+              <select
+                value={reason}
+                onChange={(e) => setReason(e.target.value as PointReason)}
+                className="w-full rounded-lg border border-[var(--at-border)] px-3 py-2 text-sm focus:border-[var(--at-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--at-accent)]"
+              >
+                <option value="referral_reward">소개 감사</option>
+                <option value="referral_welcome">신환 환영</option>
+                <option value="manual_add">수동 적립</option>
+              </select>
+            </div>
+          )}
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-[var(--at-text-primary)]">메모 (선택)</label>
+            <input
+              type="text"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="예: 김OO님 소개 감사"
+              className="w-full rounded-lg border border-[var(--at-border)] px-3 py-2 text-sm focus:border-[var(--at-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--at-accent)]"
+            />
+          </div>
+
+          {error && <div className="rounded-lg bg-[var(--at-error-bg)] px-3 py-2 text-sm text-[var(--at-error)]">{error}</div>}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-[var(--at-border)] px-5 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="rounded-lg border border-[var(--at-border)] bg-white px-4 py-2 text-sm font-medium text-[var(--at-text-primary)] hover:bg-[var(--at-surface-hover)] disabled:opacity-50"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting || amount <= 0}
+            className={`flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium text-white disabled:opacity-50 ${
+              direction === 'add' ? 'bg-[var(--at-success)] hover:opacity-90' : 'bg-[var(--at-error)] hover:opacity-90'
+            }`}
+          >
+            {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+            저장
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Referral/ReferralAddModal.tsx
+++ b/dental-clinic-manager/src/components/Referral/ReferralAddModal.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useState } from 'react'
+import { X, Heart, Send, Coins, Gift, Loader2 } from 'lucide-react'
+import { referralService } from '@/lib/referralService'
+import type { PatientSearchResult } from '@/types/referral'
+import PatientSearchInput from './PatientSearchInput'
+
+interface Props {
+  clinicId: string
+  open: boolean
+  onClose: () => void
+  onCreated: (createdId: string, referrer: PatientSearchResult, referee: PatientSearchResult) => void
+  defaultReferrer?: PatientSearchResult | null
+  defaultReferee?: PatientSearchResult | null
+}
+
+export default function ReferralAddModal({ clinicId, open, onClose, onCreated, defaultReferrer = null, defaultReferee = null }: Props) {
+  const [referrer, setReferrer] = useState<PatientSearchResult | null>(defaultReferrer)
+  const [referee, setReferee] = useState<PatientSearchResult | null>(defaultReferee)
+  const [referredAt, setReferredAt] = useState<string>(new Date().toISOString().slice(0, 10))
+  const [note, setNote] = useState<string>('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (!open) return null
+
+  const reset = () => {
+    setReferrer(null); setReferee(null); setNote('')
+    setReferredAt(new Date().toISOString().slice(0, 10)); setError(null)
+  }
+
+  const handleClose = () => {
+    if (submitting) return
+    reset()
+    onClose()
+  }
+
+  const handleSubmit = async () => {
+    setError(null)
+    if (!referrer || !referee) {
+      setError('소개해주신 분과 신환을 모두 선택해주세요.')
+      return
+    }
+    if (referrer.id === referee.id) {
+      setError('소개자와 신환은 같을 수 없습니다.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      const created = await referralService.create({
+        clinicId,
+        referrerId: referrer.id,
+        refereeId: referee.id,
+        referredAt,
+        note: note.trim() || undefined,
+      })
+      onCreated(created.id, referrer, referee)
+      reset()
+    } catch (e: unknown) {
+      const msg = (e as { message?: string })?.message ?? ''
+      if (msg.includes('duplicate') || msg.includes('unique')) {
+        setError('이미 이 신환에 대해 소개자가 등록되어 있습니다.')
+      } else {
+        setError('등록에 실패했습니다. 잠시 후 다시 시도해주세요.')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4" onMouseDown={handleClose}>
+      <div className="w-full max-w-xl rounded-xl bg-white shadow-[var(--shadow-at-card)]" onMouseDown={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between border-b border-[var(--at-border)] px-5 py-4">
+          <div className="flex items-center gap-2">
+            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-[var(--at-accent-tag)] text-[var(--at-accent)]">
+              <Heart className="h-4 w-4" />
+            </span>
+            <h2 className="text-base font-semibold text-[var(--at-text-primary)]">소개 등록</h2>
+          </div>
+          <button onClick={handleClose} className="rounded-md p-1 text-[var(--at-text-weak)] hover:bg-[var(--at-surface-hover)]">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="space-y-4 px-5 py-4">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-[var(--at-text-primary)]">
+              소개해주신 분 <span className="text-[var(--at-error)]">*</span>
+            </label>
+            <PatientSearchInput
+              clinicId={clinicId}
+              selected={referrer}
+              onSelect={setReferrer}
+              placeholder="기존 환자에서 검색"
+              excludeId={referee?.id}
+              autoFocus
+            />
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-[var(--at-text-primary)]">
+              소개받은 신환 <span className="text-[var(--at-error)]">*</span>
+            </label>
+            <PatientSearchInput
+              clinicId={clinicId}
+              selected={referee}
+              onSelect={setReferee}
+              placeholder="신환을 선택하세요"
+              excludeId={referrer?.id}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-[var(--at-text-primary)]">소개 일자</label>
+              <input
+                type="date"
+                value={referredAt}
+                onChange={(e) => setReferredAt(e.target.value)}
+                className="w-full rounded-lg border border-[var(--at-border)] px-3 py-2 text-sm focus:border-[var(--at-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--at-accent)]"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-[var(--at-text-primary)]">메모 (선택)</label>
+              <input
+                type="text"
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                placeholder="예: 임플란트 상담 권유"
+                className="w-full rounded-lg border border-[var(--at-border)] px-3 py-2 text-sm focus:border-[var(--at-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--at-accent)]"
+              />
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-lg bg-[var(--at-error-bg)] px-3 py-2 text-sm text-[var(--at-error)]">{error}</div>
+          )}
+
+          <div className="rounded-lg bg-[var(--at-surface-alt)] px-3 py-3">
+            <p className="mb-2 text-xs font-medium text-[var(--at-text-secondary)]">등록 후 바로 할 수 있는 작업</p>
+            <div className="flex flex-wrap gap-2 text-xs text-[var(--at-text-secondary)]">
+              <span className="flex items-center gap-1"><Send className="h-3.5 w-3.5" /> 감사 문자 발송</span>
+              <span className="flex items-center gap-1"><Coins className="h-3.5 w-3.5" /> 포인트 적립</span>
+              <span className="flex items-center gap-1"><Gift className="h-3.5 w-3.5" /> 선물 지급 기록</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-[var(--at-border)] px-5 py-3">
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={submitting}
+            className="rounded-lg border border-[var(--at-border)] bg-white px-4 py-2 text-sm font-medium text-[var(--at-text-primary)] hover:bg-[var(--at-surface-hover)] disabled:opacity-50"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting || !referrer || !referee}
+            className="flex items-center gap-1.5 rounded-lg bg-[var(--at-accent)] px-4 py-2 text-sm font-medium text-white hover:bg-[var(--at-accent-hover)] disabled:opacity-50"
+          >
+            {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+            등록하기
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Referral/ReferralListTab.tsx
+++ b/dental-clinic-manager/src/components/Referral/ReferralListTab.tsx
@@ -1,0 +1,207 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Search, Send, Coins, Trash2, MessageCircle, Plus, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react'
+import { referralService } from '@/lib/referralService'
+import type { PatientReferralWithPatients, ReferralListFilters } from '@/types/referral'
+
+interface Props {
+  clinicId: string
+  refreshKey: number
+  onSendThanks: (r: PatientReferralWithPatients) => void
+  onAddPoints: (r: PatientReferralWithPatients) => void
+  onAddReferral: () => void
+  onDeleted: () => void
+}
+
+export default function ReferralListTab({ clinicId, refreshKey, onSendThanks, onAddPoints, onAddReferral, onDeleted }: Props) {
+  const [rows, setRows] = useState<PatientReferralWithPatients[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [pageSize] = useState(20)
+  const [filters, setFilters] = useState<ReferralListFilters>({})
+  const [search, setSearch] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [thanksFilter, setThanksFilter] = useState<'all' | 'sent' | 'pending'>('all')
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const f: ReferralListFilters = {
+        ...filters,
+        search,
+        page,
+        pageSize,
+        thanksSent: thanksFilter === 'all' ? undefined : thanksFilter === 'sent',
+      }
+      const res = await referralService.list(clinicId, f)
+      setRows(res.rows)
+      setTotal(res.total)
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setLoading(false)
+    }
+  }, [clinicId, filters, search, page, pageSize, thanksFilter])
+
+  useEffect(() => { load() }, [load, refreshKey])
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize))
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm('이 소개 기록을 삭제하시겠습니까?')) return
+    try {
+      await referralService.delete(id)
+      onDeleted()
+      load()
+    } catch (e) {
+      console.error(e)
+      alert('삭제에 실패했습니다.')
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[var(--at-border)] bg-white p-3 shadow-[var(--shadow-at-soft)]">
+        <div className="flex flex-1 items-center gap-2">
+          <div className="flex flex-1 items-center gap-2 rounded-lg border border-[var(--at-border)] bg-white px-3 py-2 focus-within:border-[var(--at-accent)] focus-within:ring-1 focus-within:ring-[var(--at-accent)]">
+            <Search className="h-4 w-4 text-[var(--at-text-weak)]" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => { setSearch(e.target.value); setPage(1) }}
+              placeholder="소개자 또는 신환 이름·전화번호 검색"
+              className="flex-1 bg-transparent text-sm outline-none placeholder:text-[var(--at-text-weak)]"
+            />
+          </div>
+
+          <div className="flex items-center gap-1 rounded-lg border border-[var(--at-border)] bg-[var(--at-surface-alt)] p-1 text-xs">
+            {(['all', 'pending', 'sent'] as const).map(v => (
+              <button
+                key={v}
+                onClick={() => { setThanksFilter(v); setPage(1) }}
+                className={`rounded-md px-2.5 py-1 font-medium transition ${
+                  thanksFilter === v ? 'bg-white text-[var(--at-text-primary)] shadow-sm' : 'text-[var(--at-text-secondary)] hover:text-[var(--at-text-primary)]'
+                }`}
+              >
+                {v === 'all' ? '전체' : v === 'pending' ? '문자 미발송' : '문자 발송됨'}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <button
+          onClick={onAddReferral}
+          className="flex items-center gap-1.5 rounded-lg bg-[var(--at-accent)] px-3.5 py-2 text-sm font-medium text-white hover:bg-[var(--at-accent-hover)]"
+        >
+          <Plus className="h-4 w-4" /> 소개 등록
+        </button>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-[var(--at-border)] bg-white shadow-[var(--shadow-at-soft)]">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="border-b border-[var(--at-border)] bg-[var(--at-surface-alt)] text-xs uppercase tracking-wider text-[var(--at-text-secondary)]">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium">소개일</th>
+                <th className="px-4 py-3 text-left font-medium">소개해주신 분</th>
+                <th className="px-4 py-3 text-left font-medium">소개받은 신환</th>
+                <th className="px-4 py-3 text-left font-medium">메모</th>
+                <th className="px-4 py-3 text-center font-medium">감사문자</th>
+                <th className="px-4 py-3 text-right font-medium">액션</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading && (
+                <tr>
+                  <td colSpan={6} className="py-12 text-center text-[var(--at-text-weak)]">
+                    <Loader2 className="mx-auto h-5 w-5 animate-spin" />
+                  </td>
+                </tr>
+              )}
+              {!loading && rows.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="py-16 text-center text-sm text-[var(--at-text-weak)]">
+                    아직 등록된 소개 기록이 없습니다. <button onClick={onAddReferral} className="ml-1 text-[var(--at-accent)] hover:underline">소개 등록하기</button>
+                  </td>
+                </tr>
+              )}
+              {!loading && rows.map(r => (
+                <tr key={r.id} className="border-b border-[var(--at-border)] last:border-b-0 hover:bg-[var(--at-surface-hover)]">
+                  <td className="px-4 py-3 whitespace-nowrap text-[var(--at-text-primary)]">{r.referred_at}</td>
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-[var(--at-text-primary)]">{r.referrer?.patient_name ?? '-'}</div>
+                    <div className="text-xs text-[var(--at-text-weak)]">{r.referrer?.phone_number ?? '전화번호 없음'}</div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <span className="rounded-full bg-[var(--at-accent-tag)] px-2 py-0.5 text-xs font-medium text-[var(--at-accent)]">소개</span>
+                      <div>
+                        <div className="font-medium text-[var(--at-text-primary)]">{r.referee?.patient_name ?? '-'}</div>
+                        <div className="text-xs text-[var(--at-text-weak)]">{r.referee?.chart_number ?? '차트 없음'}</div>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-[var(--at-text-secondary)]">{r.note ?? '—'}</td>
+                  <td className="px-4 py-3 text-center">
+                    {r.thanks_sms_sent_at
+                      ? <span className="rounded-full bg-[var(--at-success-bg)] px-2 py-0.5 text-xs font-medium text-[var(--at-success)]">발송됨</span>
+                      : <span className="rounded-full bg-[var(--at-warning-bg)] px-2 py-0.5 text-xs font-medium text-[var(--at-warning)]">미발송</span>}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center justify-end gap-1">
+                      <button
+                        onClick={() => onSendThanks(r)}
+                        title="감사 문자 발송"
+                        className="rounded-md p-1.5 text-[var(--at-text-secondary)] hover:bg-[var(--at-accent-light)] hover:text-[var(--at-accent)]"
+                      >
+                        <MessageCircle className="h-4 w-4" />
+                      </button>
+                      <button
+                        onClick={() => onAddPoints(r)}
+                        title="포인트 적립"
+                        className="rounded-md p-1.5 text-[var(--at-text-secondary)] hover:bg-[var(--at-success-bg)] hover:text-[var(--at-success)]"
+                      >
+                        <Coins className="h-4 w-4" />
+                      </button>
+                      <button
+                        onClick={() => handleDelete(r.id)}
+                        title="삭제"
+                        className="rounded-md p-1.5 text-[var(--at-text-secondary)] hover:bg-[var(--at-error-bg)] hover:text-[var(--at-error)]"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {total > 0 && (
+          <div className="flex items-center justify-between border-t border-[var(--at-border)] bg-[var(--at-surface-alt)] px-4 py-2.5 text-sm text-[var(--at-text-secondary)]">
+            <span>총 {total}건</span>
+            <div className="flex items-center gap-2">
+              <button
+                disabled={page <= 1}
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+                className="rounded-md p-1 hover:bg-white disabled:opacity-40"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </button>
+              <span className="text-xs">{page} / {totalPages}</span>
+              <button
+                disabled={page >= totalPages}
+                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                className="rounded-md p-1 hover:bg-white disabled:opacity-40"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Referral/ReferralManagement.tsx
+++ b/dental-clinic-manager/src/components/Referral/ReferralManagement.tsx
@@ -1,0 +1,248 @@
+'use client'
+
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { Heart, TrendingUp, AlertTriangle, Crown, Loader2 } from 'lucide-react'
+import { useAuth } from '@/contexts/AuthContext'
+import { referralService } from '@/lib/referralService'
+import type { PatientReferralWithPatients, ReferralKpi, PatientSearchResult } from '@/types/referral'
+import ReferralListTab from './ReferralListTab'
+import ReferrerRankingTab from './ReferrerRankingTab'
+import ReferralAddModal from './ReferralAddModal'
+import ThanksSmsModal from './ThanksSmsModal'
+import PointAdjustModal from './PointAdjustModal'
+
+type TabKey = 'list' | 'ranking'
+
+export default function ReferralManagement() {
+  const { user } = useAuth()
+  const clinicId = user?.clinic_id ?? ''
+  const clinicName = user?.hospital_name ?? '저희 병원'
+
+  const [activeTab, setActiveTab] = useState<TabKey>('list')
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [kpi, setKpi] = useState<ReferralKpi | null>(null)
+  const [kpiLoading, setKpiLoading] = useState(false)
+
+  // Modals
+  const [addOpen, setAddOpen] = useState(false)
+  const [thanksTarget, setThanksTarget] = useState<{ referralId?: string; referrer: { id: string; patient_name: string; phone_number: string | null } | null; refereeName: string } | null>(null)
+  const [pointTarget, setPointTarget] = useState<{ referralId?: string; patient: { id: string; patient_name: string }; defaultDelta?: number; defaultReason?: 'referral_reward' | 'referral_welcome' | 'manual_add' | 'manual_use'; defaultNote?: string } | null>(null)
+
+  const loadKpi = useCallback(async () => {
+    if (!clinicId) return
+    setKpiLoading(true)
+    try {
+      setKpi(await referralService.kpi(clinicId))
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setKpiLoading(false)
+    }
+  }, [clinicId])
+
+  useEffect(() => { loadKpi() }, [loadKpi, refreshKey])
+
+  const triggerRefresh = () => setRefreshKey(k => k + 1)
+
+  const handleSendThanks = (r: PatientReferralWithPatients) => {
+    if (!r.referrer) return
+    setThanksTarget({
+      referralId: r.id,
+      referrer: { id: r.referrer.id, patient_name: r.referrer.patient_name, phone_number: r.referrer.phone_number },
+      refereeName: r.referee?.patient_name ?? '신환',
+    })
+  }
+
+  const handleAddPoints = (r: PatientReferralWithPatients) => {
+    if (!r.referrer) return
+    setPointTarget({
+      referralId: r.id,
+      patient: { id: r.referrer.id, patient_name: r.referrer.patient_name },
+      defaultReason: 'referral_reward',
+      defaultNote: `${r.referee?.patient_name ?? '신환'}님 소개 감사`,
+    })
+  }
+
+  const handleCreated = (referralId: string, referrer: PatientSearchResult, referee: PatientSearchResult) => {
+    triggerRefresh()
+    setAddOpen(false)
+    setTimeout(() => {
+      const dlg = window.confirm(
+        `등록 완료!\n\n${referrer.patient_name}님께 감사 문자를 바로 발송하시겠습니까?\n(취소하면 포인트/선물 적립 화면으로 이동)`
+      )
+      if (dlg) {
+        setThanksTarget({
+          referralId,
+          referrer: { id: referrer.id, patient_name: referrer.patient_name, phone_number: referrer.phone_number },
+          refereeName: referee.patient_name,
+        })
+      } else {
+        setPointTarget({
+          referralId,
+          patient: { id: referrer.id, patient_name: referrer.patient_name },
+          defaultReason: 'referral_reward',
+          defaultNote: `${referee.patient_name}님 소개 감사`,
+        })
+      }
+    }, 80)
+  }
+
+  const monthlyDelta = useMemo(() => {
+    if (!kpi) return 0
+    return kpi.monthly_count - kpi.monthly_count_prev
+  }, [kpi])
+
+  if (!clinicId) {
+    return <div className="py-16 text-center text-sm text-[var(--at-text-weak)]">병원 정보를 불러오는 중입니다…</div>
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-[var(--at-accent-tag)] text-[var(--at-accent)]">
+            <Heart className="h-5 w-5" />
+          </span>
+          <div>
+            <h1 className="text-lg font-semibold text-[var(--at-text-primary)]">소개환자 관리</h1>
+            <p className="text-xs text-[var(--at-text-secondary)]">소개해주신 분과 신환을 한 곳에서 관리하고 감사 문자·포인트·선물을 적립합니다.</p>
+          </div>
+        </div>
+      </div>
+
+      {/* KPI 카드 */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <KpiCard
+          icon={<Heart className="h-4 w-4" />}
+          label="이번 달 소개"
+          value={kpi ? `${kpi.monthly_count}건` : '—'}
+          delta={kpi ? (monthlyDelta > 0 ? `+${monthlyDelta} vs 지난달` : monthlyDelta < 0 ? `${monthlyDelta} vs 지난달` : '동일') : ''}
+          tone="accent"
+          loading={kpiLoading}
+        />
+        <KpiCard
+          icon={<Crown className="h-4 w-4" />}
+          label="소개왕 1위"
+          value={kpi?.top_referrer ? kpi.top_referrer.patient_name : '없음'}
+          delta={kpi?.top_referrer ? `${kpi.top_referrer.referral_count}건 누적` : ''}
+          tone="purple"
+          loading={kpiLoading}
+        />
+        <KpiCard
+          icon={<TrendingUp className="h-4 w-4" />}
+          label="첫 결제 전환율"
+          value={kpi ? `${kpi.conversion_rate}%` : '—'}
+          delta="누적 기준"
+          tone="success"
+          loading={kpiLoading}
+        />
+        <KpiCard
+          icon={<AlertTriangle className="h-4 w-4" />}
+          label="매칭 필요"
+          value={kpi ? `${kpi.pending_link_count}건` : '—'}
+          delta="최근 90일 신환 중"
+          tone="warning"
+          loading={kpiLoading}
+        />
+      </div>
+
+      {/* 탭 */}
+      <div className="flex items-center gap-1 border-b border-[var(--at-border)]">
+        {([
+          { k: 'list', label: '소개 내역' },
+          { k: 'ranking', label: '소개왕 랭킹' },
+        ] as const).map(t => (
+          <button
+            key={t.k}
+            onClick={() => setActiveTab(t.k)}
+            className={`relative px-4 py-2.5 text-sm font-medium transition ${
+              activeTab === t.k
+                ? 'text-[var(--at-accent)]'
+                : 'text-[var(--at-text-secondary)] hover:text-[var(--at-text-primary)]'
+            }`}
+          >
+            {t.label}
+            {activeTab === t.k && (
+              <span className="absolute inset-x-2 bottom-0 h-0.5 rounded-full bg-[var(--at-accent)]" />
+            )}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'list' && (
+        <ReferralListTab
+          clinicId={clinicId}
+          refreshKey={refreshKey}
+          onSendThanks={handleSendThanks}
+          onAddPoints={handleAddPoints}
+          onAddReferral={() => setAddOpen(true)}
+          onDeleted={triggerRefresh}
+        />
+      )}
+      {activeTab === 'ranking' && (
+        <ReferrerRankingTab clinicId={clinicId} refreshKey={refreshKey} />
+      )}
+
+      <ReferralAddModal
+        clinicId={clinicId}
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        onCreated={handleCreated}
+      />
+      <ThanksSmsModal
+        clinicId={clinicId}
+        open={!!thanksTarget}
+        onClose={() => setThanksTarget(null)}
+        referralId={thanksTarget?.referralId}
+        referrer={thanksTarget?.referrer ?? null}
+        refereeName={thanksTarget?.refereeName ?? '신환'}
+        clinicName={clinicName}
+        userId={user?.id}
+        onSent={triggerRefresh}
+      />
+      <PointAdjustModal
+        clinicId={clinicId}
+        open={!!pointTarget}
+        onClose={() => setPointTarget(null)}
+        patient={pointTarget?.patient ?? null}
+        referralId={pointTarget?.referralId}
+        defaultDelta={pointTarget?.defaultDelta}
+        defaultReason={pointTarget?.defaultReason}
+        defaultNote={pointTarget?.defaultNote}
+        onSaved={triggerRefresh}
+      />
+    </div>
+  )
+}
+
+interface KpiCardProps {
+  icon: React.ReactNode
+  label: string
+  value: string
+  delta: string
+  tone: 'accent' | 'success' | 'warning' | 'purple'
+  loading?: boolean
+}
+
+function KpiCard({ icon, label, value, delta, tone, loading }: KpiCardProps) {
+  const toneMap = {
+    accent: 'bg-[var(--at-accent-tag)] text-[var(--at-accent)]',
+    success: 'bg-[var(--at-success-bg)] text-[var(--at-success)]',
+    warning: 'bg-[var(--at-warning-bg)] text-[var(--at-warning)]',
+    purple: 'bg-[#f3eaff] text-[var(--at-purple)]',
+  } as const
+  return (
+    <div className="rounded-xl border border-[var(--at-border)] bg-white p-4 shadow-[var(--shadow-at-soft)]">
+      <div className="mb-2 flex items-center gap-2">
+        <span className={`flex h-7 w-7 items-center justify-center rounded-lg ${toneMap[tone]}`}>{icon}</span>
+        <span className="text-xs font-medium text-[var(--at-text-secondary)]">{label}</span>
+      </div>
+      <div className="flex items-end justify-between">
+        <span className="text-xl font-semibold text-[var(--at-text-primary)] truncate">
+          {loading ? <Loader2 className="h-5 w-5 animate-spin" /> : value}
+        </span>
+        {delta && <span className="text-xs text-[var(--at-text-weak)] truncate">{delta}</span>}
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Referral/ReferrerRankingTab.tsx
+++ b/dental-clinic-manager/src/components/Referral/ReferrerRankingTab.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Crown, Loader2, Trophy } from 'lucide-react'
+import { referralService } from '@/lib/referralService'
+
+interface Props {
+  clinicId: string
+  refreshKey: number
+}
+
+interface RankRow {
+  id: string
+  patient_name: string
+  chart_number: string | null
+  count: number
+}
+
+export default function ReferrerRankingTab({ clinicId, refreshKey }: Props) {
+  const [range, setRange] = useState<'month' | 'all'>('month')
+  const [rows, setRows] = useState<RankRow[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    referralService.ranking(clinicId, range, 10)
+      .then(d => { if (!cancelled) setRows(d) })
+      .catch(e => { console.error(e); if (!cancelled) setRows([]) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [clinicId, range, refreshKey])
+
+  return (
+    <div className="rounded-xl border border-[var(--at-border)] bg-white p-5 shadow-[var(--shadow-at-soft)]">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-[var(--at-accent-tag)] text-[var(--at-accent)]">
+            <Trophy className="h-5 w-5" />
+          </span>
+          <div>
+            <h2 className="text-base font-semibold text-[var(--at-text-primary)]">소개왕 TOP 10</h2>
+            <p className="text-xs text-[var(--at-text-secondary)]">병원에 환자분을 가장 많이 소개해주신 분들입니다.</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1 rounded-lg border border-[var(--at-border)] bg-[var(--at-surface-alt)] p-1 text-xs">
+          {(['month', 'all'] as const).map(v => (
+            <button
+              key={v}
+              onClick={() => setRange(v)}
+              className={`rounded-md px-3 py-1 font-medium transition ${
+                range === v ? 'bg-white text-[var(--at-text-primary)] shadow-sm' : 'text-[var(--at-text-secondary)] hover:text-[var(--at-text-primary)]'
+              }`}
+            >
+              {v === 'month' ? '이번 달' : '누적'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex h-40 items-center justify-center text-[var(--at-text-weak)]">
+          <Loader2 className="h-5 w-5 animate-spin" />
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="flex h-40 items-center justify-center text-sm text-[var(--at-text-weak)]">
+          아직 소개 기록이 없습니다.
+        </div>
+      ) : (
+        <ul className="divide-y divide-[var(--at-border)]">
+          {rows.map((r, i) => {
+            const medal = i === 0 ? 'text-yellow-500' : i === 1 ? 'text-gray-400' : i === 2 ? 'text-orange-400' : 'text-[var(--at-text-weak)]'
+            return (
+              <li key={r.id} className="flex items-center justify-between py-3">
+                <div className="flex items-center gap-3">
+                  <span className={`flex h-8 w-8 items-center justify-center rounded-full bg-[var(--at-surface-alt)] text-sm font-semibold ${medal}`}>
+                    {i < 3 ? <Crown className="h-4 w-4" /> : i + 1}
+                  </span>
+                  <div>
+                    <div className="font-medium text-[var(--at-text-primary)]">{r.patient_name}</div>
+                    <div className="text-xs text-[var(--at-text-weak)]">{r.chart_number ?? '차트 없음'}</div>
+                  </div>
+                </div>
+                <span className="rounded-full bg-[var(--at-accent-tag)] px-3 py-1 text-sm font-semibold text-[var(--at-accent)]">
+                  {r.count}건
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Referral/ThanksSmsModal.tsx
+++ b/dental-clinic-manager/src/components/Referral/ThanksSmsModal.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useState, useEffect, useMemo } from 'react'
+import { X, Send, Loader2, MessageCircle } from 'lucide-react'
+import { referralService } from '@/lib/referralService'
+
+interface Props {
+  clinicId: string
+  open: boolean
+  onClose: () => void
+  referralId?: string
+  referrer: { id: string; patient_name: string; phone_number: string | null } | null
+  refereeName: string
+  clinicName?: string
+  userId?: string
+  onSent: () => void
+}
+
+export default function ThanksSmsModal({ clinicId, open, onClose, referralId, referrer, refereeName, clinicName = '저희 병원', userId, onSent }: Props) {
+  const [template, setTemplate] = useState<string>('')
+  const [message, setMessage] = useState<string>('')
+  const [loading, setLoading] = useState(false)
+  const [sending, setSending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setError(null); setSuccess(null)
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      try {
+        const t = await referralService.getThanksTemplate(clinicId)
+        if (cancelled) return
+        const content = (t?.content as string | undefined) ?? `안녕하세요, ${clinicName}입니다. {{환자명}}님 덕분에 {{소개받은신환명}}님을 모실 수 있게 되어 진심으로 감사드립니다.`
+        setTemplate(content)
+      } catch (e) {
+        console.error(e)
+        setTemplate(`안녕하세요, ${clinicName}입니다. {{환자명}}님 덕분에 {{소개받은신환명}}님을 모실 수 있게 되어 진심으로 감사드립니다.`)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => { cancelled = true }
+  }, [open, clinicId, clinicName])
+
+  useEffect(() => {
+    if (!template || !referrer) return
+    const replaced = template
+      .replace(/\{\{환자명\}\}/g, referrer.patient_name)
+      .replace(/\{\{소개받은신환명\}\}/g, refereeName)
+      .replace(/\{\{병원명\}\}/g, clinicName)
+    setMessage(replaced)
+  }, [template, referrer, refereeName, clinicName])
+
+  const byteSize = useMemo(() => new Blob([message]).size, [message])
+  const msgType: 'SMS' | 'LMS' = byteSize <= 90 ? 'SMS' : 'LMS'
+
+  const handleSend = async () => {
+    if (!referrer?.phone_number) {
+      setError('받는 분의 전화번호가 없습니다.')
+      return
+    }
+    if (!message.trim()) {
+      setError('문자 내용을 입력해주세요.')
+      return
+    }
+    setSending(true); setError(null); setSuccess(null)
+    try {
+      const res = await fetch('/api/referrals/sms', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          clinic_id: clinicId,
+          referral_id: referralId,
+          recipient_dentweb_patient_id: referrer.id,
+          phone_number: referrer.phone_number,
+          message,
+          msg_type: msgType,
+          title: msgType !== 'SMS' ? '소개 감사 인사' : undefined,
+          sent_by: userId,
+        }),
+      })
+      const json = await res.json()
+      if (json.success) {
+        setSuccess('감사 문자가 정상 발송되었습니다.')
+        onSent()
+        setTimeout(() => onClose(), 900)
+      } else {
+        setError(json.error ?? '발송에 실패했습니다.')
+      }
+    } catch (e) {
+      console.error(e)
+      setError('발송 중 오류가 발생했습니다.')
+    } finally {
+      setSending(false)
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4" onMouseDown={onClose}>
+      <div className="w-full max-w-xl rounded-xl bg-white shadow-[var(--shadow-at-card)]" onMouseDown={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between border-b border-[var(--at-border)] px-5 py-4">
+          <div className="flex items-center gap-2">
+            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-[var(--at-accent-tag)] text-[var(--at-accent)]">
+              <MessageCircle className="h-4 w-4" />
+            </span>
+            <h2 className="text-base font-semibold text-[var(--at-text-primary)]">감사 문자 발송</h2>
+          </div>
+          <button onClick={onClose} className="rounded-md p-1 text-[var(--at-text-weak)] hover:bg-[var(--at-surface-hover)]">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="space-y-3 px-5 py-4">
+          <div className="rounded-lg bg-[var(--at-surface-alt)] px-3 py-2.5 text-sm">
+            <span className="text-[var(--at-text-secondary)]">받는 분: </span>
+            <span className="font-medium text-[var(--at-text-primary)]">{referrer?.patient_name ?? '-'}</span>
+            <span className="ml-2 text-[var(--at-text-weak)]">{referrer?.phone_number ?? '전화번호 없음'}</span>
+          </div>
+
+          {loading ? (
+            <div className="flex h-32 items-center justify-center text-[var(--at-text-weak)]">
+              <Loader2 className="h-5 w-5 animate-spin" />
+            </div>
+          ) : (
+            <>
+              <textarea
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                rows={6}
+                className="w-full rounded-lg border border-[var(--at-border)] px-3 py-2.5 text-sm focus:border-[var(--at-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--at-accent)]"
+              />
+              <div className="flex items-center justify-between text-xs text-[var(--at-text-secondary)]">
+                <span>변수 치환 완료 ({`{{환자명}}, {{소개받은신환명}}, {{병원명}}`})</span>
+                <span>
+                  <span className={`mr-1 rounded-full px-2 py-0.5 font-medium ${msgType === 'SMS' ? 'bg-[var(--at-success-bg)] text-[var(--at-success)]' : 'bg-[var(--at-warning-bg)] text-[var(--at-warning)]'}`}>
+                    {msgType}
+                  </span>
+                  {byteSize}바이트
+                </span>
+              </div>
+            </>
+          )}
+
+          {error && <div className="rounded-lg bg-[var(--at-error-bg)] px-3 py-2 text-sm text-[var(--at-error)]">{error}</div>}
+          {success && <div className="rounded-lg bg-[var(--at-success-bg)] px-3 py-2 text-sm text-[var(--at-success)]">{success}</div>}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-[var(--at-border)] px-5 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={sending}
+            className="rounded-lg border border-[var(--at-border)] bg-white px-4 py-2 text-sm font-medium text-[var(--at-text-primary)] hover:bg-[var(--at-surface-hover)] disabled:opacity-50"
+          >
+            닫기
+          </button>
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={sending || !referrer?.phone_number}
+            className="flex items-center gap-1.5 rounded-lg bg-[var(--at-accent)] px-4 py-2 text-sm font-medium text-white hover:bg-[var(--at-accent-hover)] disabled:opacity-50"
+          >
+            {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+            발송하기
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Referral/index.ts
+++ b/dental-clinic-manager/src/components/Referral/index.ts
@@ -1,0 +1,1 @@
+export { default as ReferralManagement } from './ReferralManagement'

--- a/dental-clinic-manager/src/config/menuConfig.ts
+++ b/dental-clinic-manager/src/config/menuConfig.ts
@@ -331,6 +331,16 @@ export const MENU_CONFIG: MenuConfigItem[] = [
     visible: true,
   },
   {
+    id: 'referral',
+    label: '소개환자 관리',
+    icon: 'Heart',
+    route: '/dashboard?tab=referral',
+    permissions: ['referral_view'],
+    categoryId: 'operations',
+    order: 15.7,
+    visible: true,
+  },
+  {
     id: 'marketing',
     label: '마케팅 자동화',
     icon: 'Sparkles',

--- a/dental-clinic-manager/src/hooks/usePermissions.ts
+++ b/dental-clinic-manager/src/hooks/usePermissions.ts
@@ -19,6 +19,7 @@ const NEW_FEATURE_PREFIXES = [
   'marketing_',
   'investment_',
   'monthly_report_',
+  'referral_',
 ] as const
 
 // 신규로 추가된 개별 권한(prefix 보충 대상이 아닌 단독 권한)

--- a/dental-clinic-manager/src/lib/referralService.ts
+++ b/dental-clinic-manager/src/lib/referralService.ts
@@ -1,0 +1,402 @@
+import { createClient } from '@/lib/supabase/client'
+import type {
+  PatientReferralWithPatients,
+  PatientPoint,
+  PatientPointBalance,
+  ReferralSettings,
+  ReferralSmsLog,
+  ReferralListFilters,
+  ReferralListResponse,
+  ReferralKpi,
+  PatientSearchResult,
+} from '@/types/referral'
+
+const supabase = createClient()
+
+export const referralService = {
+  async list(clinicId: string, filters: ReferralListFilters = {}): Promise<ReferralListResponse> {
+    const page = filters.page ?? 1
+    const pageSize = filters.pageSize ?? 20
+    const from = (page - 1) * pageSize
+    const to = from + pageSize - 1
+
+    let query = supabase
+      .from('patient_referrals')
+      .select(`
+        *,
+        referrer:dentweb_patients!patient_referrals_referrer_dentweb_patient_id_fkey (
+          id, patient_name, chart_number, phone_number
+        ),
+        referee:dentweb_patients!patient_referrals_referee_dentweb_patient_id_fkey (
+          id, patient_name, chart_number, phone_number, registration_date
+        )
+      `, { count: 'exact' })
+      .eq('clinic_id', clinicId)
+      .order('referred_at', { ascending: false })
+      .range(from, to)
+
+    if (filters.referrerId) {
+      query = query.eq('referrer_dentweb_patient_id', filters.referrerId)
+    }
+    if (filters.startDate) {
+      query = query.gte('referred_at', filters.startDate)
+    }
+    if (filters.endDate) {
+      query = query.lte('referred_at', filters.endDate)
+    }
+    if (filters.thanksSent === true) {
+      query = query.not('thanks_sms_sent_at', 'is', null)
+    } else if (filters.thanksSent === false) {
+      query = query.is('thanks_sms_sent_at', null)
+    }
+
+    const { data, error, count } = await query
+    if (error) throw error
+
+    let rows = (data ?? []) as unknown as PatientReferralWithPatients[]
+
+    if (filters.search && filters.search.trim()) {
+      const q = filters.search.trim().toLowerCase()
+      rows = rows.filter(r =>
+        (r.referrer?.patient_name?.toLowerCase().includes(q)) ||
+        (r.referee?.patient_name?.toLowerCase().includes(q)) ||
+        (r.referrer?.phone_number?.includes(q)) ||
+        (r.referee?.phone_number?.includes(q))
+      )
+    }
+
+    return {
+      rows,
+      total: count ?? 0,
+      page,
+      pageSize,
+    }
+  },
+
+  async create(input: {
+    clinicId: string
+    referrerId: string
+    refereeId: string
+    referredAt?: string
+    note?: string
+  }) {
+    const { data, error } = await supabase
+      .from('patient_referrals')
+      .insert({
+        clinic_id: input.clinicId,
+        referrer_dentweb_patient_id: input.referrerId,
+        referee_dentweb_patient_id: input.refereeId,
+        referred_at: input.referredAt ?? new Date().toISOString().slice(0, 10),
+        note: input.note ?? null,
+      })
+      .select()
+      .single()
+    if (error) throw error
+    return data
+  },
+
+  async update(id: string, patch: { referred_at?: string; note?: string | null; first_paid_at?: string | null; first_paid_amount?: number | null }) {
+    const { data, error } = await supabase
+      .from('patient_referrals')
+      .update(patch)
+      .eq('id', id)
+      .select()
+      .single()
+    if (error) throw error
+    return data
+  },
+
+  async delete(id: string) {
+    const { error } = await supabase.from('patient_referrals').delete().eq('id', id)
+    if (error) throw error
+  },
+
+  async searchPatients(clinicId: string, query: string, limit = 10): Promise<PatientSearchResult[]> {
+    const q = query.trim()
+    if (!q) return []
+    const orFilter = `patient_name.ilike.%${q}%,chart_number.ilike.%${q}%,phone_number.ilike.%${q}%`
+    const { data, error } = await supabase
+      .from('dentweb_patients')
+      .select('id, patient_name, chart_number, phone_number, birth_date, acquisition_channel, registration_date')
+      .eq('clinic_id', clinicId)
+      .eq('is_active', true)
+      .or(orFilter)
+      .limit(limit)
+    if (error) throw error
+    return data ?? []
+  },
+
+  async listReferralsByPatient(clinicId: string, dentwebPatientId: string) {
+    const { data: outgoing, error: outErr } = await supabase
+      .from('patient_referrals')
+      .select(`
+        *,
+        referee:dentweb_patients!patient_referrals_referee_dentweb_patient_id_fkey (
+          id, patient_name, chart_number, phone_number, registration_date
+        )
+      `)
+      .eq('clinic_id', clinicId)
+      .eq('referrer_dentweb_patient_id', dentwebPatientId)
+      .order('referred_at', { ascending: false })
+    if (outErr) throw outErr
+
+    const { data: incoming, error: inErr } = await supabase
+      .from('patient_referrals')
+      .select(`
+        *,
+        referrer:dentweb_patients!patient_referrals_referrer_dentweb_patient_id_fkey (
+          id, patient_name, chart_number, phone_number
+        )
+      `)
+      .eq('clinic_id', clinicId)
+      .eq('referee_dentweb_patient_id', dentwebPatientId)
+      .maybeSingle()
+    if (inErr && inErr.code !== 'PGRST116') throw inErr
+
+    return { outgoing: outgoing ?? [], incoming: incoming ?? null }
+  },
+
+  async kpi(clinicId: string): Promise<ReferralKpi> {
+    const now = new Date()
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10)
+    const prevMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1).toISOString().slice(0, 10)
+    const prevMonthEnd = new Date(now.getFullYear(), now.getMonth(), 0).toISOString().slice(0, 10)
+
+    const [{ count: monthlyCount }, { count: prevMonthlyCount }, allTimeRes, pendingRes] = await Promise.all([
+      supabase.from('patient_referrals').select('id', { count: 'exact', head: true })
+        .eq('clinic_id', clinicId).gte('referred_at', monthStart),
+      supabase.from('patient_referrals').select('id', { count: 'exact', head: true })
+        .eq('clinic_id', clinicId).gte('referred_at', prevMonthStart).lte('referred_at', prevMonthEnd),
+      supabase.from('patient_referrals')
+        .select('referrer_dentweb_patient_id, first_paid_at, referrer:dentweb_patients!patient_referrals_referrer_dentweb_patient_id_fkey(id, patient_name)')
+        .eq('clinic_id', clinicId),
+      supabase.from('dentweb_patients').select('id', { count: 'exact', head: true })
+        .eq('clinic_id', clinicId).eq('acquisition_channel', '소개')
+        .gte('registration_date', new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)),
+    ])
+
+    const all = (allTimeRes.data ?? []) as Array<{ referrer_dentweb_patient_id: string; first_paid_at: string | null; referrer: { id: string; patient_name: string } | null }>
+
+    const counts = new Map<string, { name: string; count: number }>()
+    let paidCount = 0
+    for (const r of all) {
+      if (r.first_paid_at) paidCount++
+      const key = r.referrer_dentweb_patient_id
+      const cur = counts.get(key)
+      if (cur) cur.count++
+      else counts.set(key, { name: r.referrer?.patient_name ?? '?', count: 1 })
+    }
+    const top = Array.from(counts.entries()).sort((a, b) => b[1].count - a[1].count)[0]
+    const linkedPending = await supabase.from('patient_referrals').select('referee_dentweb_patient_id')
+      .eq('clinic_id', clinicId)
+    const linkedSet = new Set(((linkedPending.data ?? []) as Array<{ referee_dentweb_patient_id: string }>).map(r => r.referee_dentweb_patient_id))
+
+    let pendingCount = 0
+    if (pendingRes.count) {
+      const { data: pendingPatients } = await supabase.from('dentweb_patients').select('id')
+        .eq('clinic_id', clinicId).eq('acquisition_channel', '소개')
+        .gte('registration_date', new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10))
+      pendingCount = ((pendingPatients ?? []) as Array<{ id: string }>).filter(p => !linkedSet.has(p.id)).length
+    }
+
+    return {
+      monthly_count: monthlyCount ?? 0,
+      monthly_count_prev: prevMonthlyCount ?? 0,
+      top_referrer: top ? { dentweb_patient_id: top[0], patient_name: top[1].name, referral_count: top[1].count } : null,
+      conversion_rate: all.length > 0 ? Math.round((paidCount / all.length) * 1000) / 10 : 0,
+      pending_link_count: pendingCount,
+    }
+  },
+
+  async ranking(clinicId: string, range: 'month' | 'all', limit = 10) {
+    let q = supabase
+      .from('patient_referrals')
+      .select(`
+        referrer_dentweb_patient_id,
+        referrer:dentweb_patients!patient_referrals_referrer_dentweb_patient_id_fkey (
+          id, patient_name, chart_number, phone_number
+        )
+      `)
+      .eq('clinic_id', clinicId)
+    if (range === 'month') {
+      const now = new Date()
+      const start = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10)
+      q = q.gte('referred_at', start)
+    }
+    const { data, error } = await q
+    if (error) throw error
+    const map = new Map<string, { id: string; patient_name: string; chart_number: string | null; count: number }>()
+    for (const row of (data ?? []) as Array<{ referrer_dentweb_patient_id: string; referrer: { id: string; patient_name: string; chart_number: string | null; phone_number: string | null } | null }>) {
+      if (!row.referrer) continue
+      const cur = map.get(row.referrer_dentweb_patient_id)
+      if (cur) cur.count++
+      else map.set(row.referrer_dentweb_patient_id, {
+        id: row.referrer.id,
+        patient_name: row.referrer.patient_name,
+        chart_number: row.referrer.chart_number,
+        count: 1,
+      })
+    }
+    return Array.from(map.values()).sort((a, b) => b.count - a.count).slice(0, limit)
+  },
+
+  async getBalance(clinicId: string, dentwebPatientId: string): Promise<number> {
+    const { data, error } = await supabase
+      .from('patient_point_balance')
+      .select('balance')
+      .eq('clinic_id', clinicId)
+      .eq('dentweb_patient_id', dentwebPatientId)
+      .maybeSingle()
+    if (error) throw error
+    return data?.balance ?? 0
+  },
+
+  async getBalances(clinicId: string, dentwebPatientIds: string[]): Promise<Record<string, number>> {
+    if (dentwebPatientIds.length === 0) return {}
+    const { data, error } = await supabase
+      .from('patient_point_balance')
+      .select('dentweb_patient_id, balance')
+      .eq('clinic_id', clinicId)
+      .in('dentweb_patient_id', dentwebPatientIds)
+    if (error) throw error
+    const map: Record<string, number> = {}
+    for (const r of (data ?? []) as Array<{ dentweb_patient_id: string; balance: number }>) {
+      map[r.dentweb_patient_id] = r.balance
+    }
+    return map
+  },
+
+  async addPoints(input: {
+    clinicId: string
+    dentwebPatientId: string
+    delta: number
+    reason: PatientPoint['reason']
+    referralId?: string
+    note?: string
+  }): Promise<PatientPoint> {
+    const { data, error } = await supabase
+      .from('patient_points')
+      .insert({
+        clinic_id: input.clinicId,
+        dentweb_patient_id: input.dentwebPatientId,
+        delta: input.delta,
+        reason: input.reason,
+        referral_id: input.referralId ?? null,
+        note: input.note ?? null,
+      })
+      .select()
+      .single()
+    if (error) throw error
+    return data as PatientPoint
+  },
+
+  async listPointHistory(clinicId: string, dentwebPatientId: string): Promise<PatientPoint[]> {
+    const { data, error } = await supabase
+      .from('patient_points')
+      .select('*')
+      .eq('clinic_id', clinicId)
+      .eq('dentweb_patient_id', dentwebPatientId)
+      .order('created_at', { ascending: false })
+    if (error) throw error
+    return (data ?? []) as PatientPoint[]
+  },
+
+  async getSettings(clinicId: string): Promise<ReferralSettings | null> {
+    const { data, error } = await supabase
+      .from('referral_settings')
+      .select('*')
+      .eq('clinic_id', clinicId)
+      .maybeSingle()
+    if (error) throw error
+    return data as ReferralSettings | null
+  },
+
+  async updateSettings(clinicId: string, patch: Partial<ReferralSettings>): Promise<ReferralSettings> {
+    const { data, error } = await supabase
+      .from('referral_settings')
+      .update(patch)
+      .eq('clinic_id', clinicId)
+      .select()
+      .single()
+    if (error) throw error
+    return data as ReferralSettings
+  },
+
+  async listSmsLogs(clinicId: string, referralId?: string): Promise<ReferralSmsLog[]> {
+    let q = supabase
+      .from('referral_sms_logs')
+      .select('*')
+      .eq('clinic_id', clinicId)
+      .order('sent_at', { ascending: false })
+      .limit(100)
+    if (referralId) q = q.eq('referral_id', referralId)
+    const { data, error } = await q
+    if (error) throw error
+    return (data ?? []) as ReferralSmsLog[]
+  },
+
+  async getThanksTemplate(clinicId: string) {
+    const { data, error } = await supabase
+      .from('recall_sms_templates')
+      .select('*')
+      .eq('clinic_id', clinicId)
+      .eq('name', '소개 감사 인사')
+      .eq('is_active', true)
+      .maybeSingle()
+    if (error) throw error
+    return data
+  },
+
+  async listGiftCategories(clinicId: string) {
+    const { data, error } = await supabase
+      .from('gift_categories')
+      .select('*')
+      .eq('clinic_id', clinicId)
+      .order('display_order', { ascending: true })
+    if (error) throw error
+    return data ?? []
+  },
+
+  async logGift(input: {
+    clinicId: string
+    dentwebPatientId: string
+    patientName: string
+    categoryId: number
+    giftType: string
+    quantity: number
+    notes?: string
+    referralId?: string
+    date?: string
+  }) {
+    const { data, error } = await supabase
+      .from('gift_logs')
+      .insert({
+        clinic_id: input.clinicId,
+        dentweb_patient_id: input.dentwebPatientId,
+        patient_name: input.patientName,
+        category_id: input.categoryId,
+        gift_type: input.giftType,
+        quantity: input.quantity,
+        notes: input.notes ?? null,
+        referral_id: input.referralId ?? null,
+        date: input.date ?? new Date().toISOString().slice(0, 10),
+      })
+      .select()
+      .single()
+    if (error) throw error
+    return data
+  },
+
+  async listGiftsByPatient(clinicId: string, dentwebPatientId: string) {
+    const { data, error } = await supabase
+      .from('gift_logs')
+      .select('*, category:gift_categories(id, name, color)')
+      .eq('clinic_id', clinicId)
+      .eq('dentweb_patient_id', dentwebPatientId)
+      .order('date', { ascending: false })
+    if (error) throw error
+    return data ?? []
+  },
+}
+
+export type ReferralService = typeof referralService

--- a/dental-clinic-manager/src/lib/rlModelService.ts
+++ b/dental-clinic-manager/src/lib/rlModelService.ts
@@ -1,0 +1,114 @@
+import type { RLModel, RLModelCreateInput } from '@/types/rlTrading'
+import { createClient } from '@/lib/supabase/server'
+
+const RL_SERVER_URL = process.env.RL_SERVER_URL ?? 'http://127.0.0.1:8001'
+const RL_API_KEY = process.env.RL_API_KEY ?? ''
+
+export const rlModelService = {
+  async listForClinic(clinicId: string): Promise<{ data: RLModel[]; error: string | null }> {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('rl_models')
+      .select('*')
+      .eq('clinic_id', clinicId)
+      .order('created_at', { ascending: false })
+    if (error) return { data: [], error: error.message }
+    return { data: (data ?? []) as RLModel[], error: null }
+  },
+
+  async create(
+    input: RLModelCreateInput,
+    userId: string,
+    clinicId: string,
+  ): Promise<{ data: RLModel | null; error: string | null }> {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('rl_models')
+      .insert({
+        user_id: userId,
+        clinic_id: clinicId,
+        name: input.name,
+        description: input.description ?? null,
+        source: input.source,
+        algorithm: input.algorithm,
+        kind: input.kind,
+        market: input.market ?? 'US',
+        timeframe: input.timeframe ?? '1d',
+        universe: input.universe ?? null,
+        input_features: input.input_features,
+        state_window: input.state_window,
+        output_shape: input.output_shape,
+        checkpoint_url: input.checkpoint_url,
+        checkpoint_sha256: input.checkpoint_sha256,
+        min_confidence: input.min_confidence ?? 0.6,
+        status: 'pending',
+      })
+      .select()
+      .single()
+    if (error) return { data: null, error: error.message }
+    return { data: data as RLModel, error: null }
+  },
+
+  async triggerDownload(modelId: string): Promise<{ success: boolean; error: string | null }> {
+    const supabase = await createClient()
+    const { data: model, error } = await supabase
+      .from('rl_models')
+      .select('*')
+      .eq('id', modelId)
+      .single()
+    if (error || !model) return { success: false, error: error?.message ?? 'not found' }
+
+    await supabase.from('rl_models').update({ status: 'downloading' }).eq('id', modelId)
+
+    try {
+      const resp = await fetch(`${RL_SERVER_URL}/models/download`, {
+        method: 'POST',
+        headers: { 'X-RL-API-KEY': RL_API_KEY, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model_id: modelId,
+          checkpoint_url: model.checkpoint_url,
+          checkpoint_sha256: model.checkpoint_sha256,
+        }),
+      })
+      if (!resp.ok) {
+        const text = await resp.text().catch(() => '')
+        await supabase
+          .from('rl_models')
+          .update({ status: 'failed', failure_reason: text })
+          .eq('id', modelId)
+        return { success: false, error: text }
+      }
+      const json = (await resp.json()) as { path?: string }
+      await supabase
+        .from('rl_models')
+        .update({ status: 'ready', checkpoint_path: json.path ?? null })
+        .eq('id', modelId)
+      return { success: true, error: null }
+    } catch (err) {
+      const msg = (err as Error).message
+      await supabase
+        .from('rl_models')
+        .update({ status: 'failed', failure_reason: msg })
+        .eq('id', modelId)
+      return { success: false, error: msg }
+    }
+  },
+
+  async archive(modelId: string, userId: string): Promise<{ success: boolean; error: string | null }> {
+    const supabase = await createClient()
+    // 1) Deactivate strategies referencing this model
+    await supabase
+      .from('investment_strategies')
+      .update({ is_active: false })
+      .eq('rl_model_id', modelId)
+      .eq('user_id', userId)
+    // 2) Mark archived
+    const { error } = await supabase
+      .from('rl_models')
+      .update({ status: 'archived' })
+      .eq('id', modelId)
+      .eq('user_id', userId)
+    if (error) return { success: false, error: error.message }
+    return { success: true, error: null }
+  },
+}

--- a/dental-clinic-manager/src/lib/rlModelService.ts
+++ b/dental-clinic-manager/src/lib/rlModelService.ts
@@ -79,9 +79,19 @@ export const rlModelService = {
         return { success: false, error: text }
       }
       const json = (await resp.json()) as { path?: string }
+      if (!json.path) {
+        await supabase
+          .from('rl_models')
+          .update({
+            status: 'failed',
+            failure_reason: 'rl-inference-server response missing path field',
+          })
+          .eq('id', modelId)
+        return { success: false, error: 'rl-inference-server response missing path field' }
+      }
       await supabase
         .from('rl_models')
-        .update({ status: 'ready', checkpoint_path: json.path ?? null })
+        .update({ status: 'ready', checkpoint_path: json.path })
         .eq('id', modelId)
       return { success: true, error: null }
     } catch (err) {

--- a/dental-clinic-manager/src/types/investment.ts
+++ b/dental-clinic-manager/src/types/investment.ts
@@ -194,6 +194,8 @@ export interface InvestmentStrategy {
   sell_conditions: ConditionGroup
   risk_settings: RiskSettings
   automation_level: AutomationLevel
+  strategy_type: 'rule' | 'rl_portfolio' | 'rl_single'
+  rl_model_id?: string | null
   credential_id: string | null
   is_active: boolean
   created_at: string
@@ -213,6 +215,8 @@ export interface StrategyInput {
   /** @deprecated 사용자별 자동매매 설정으로 이전됨. 하위 호환을 위해 유지. */
   riskSettings?: RiskSettings
   automationLevel: AutomationLevel
+  strategy_type?: 'rule' | 'rl_portfolio' | 'rl_single'  // default 'rule' on server side
+  rl_model_id?: string | null
 }
 
 /** 백테스트 등 기존 로직 호환을 위한 무효화된 RiskSettings (모든 안전장치 비활성) */

--- a/dental-clinic-manager/src/types/permissions.ts
+++ b/dental-clinic-manager/src/types/permissions.ts
@@ -99,6 +99,11 @@ export type Permission =
   // 월간 성과 보고서 권한
   | 'monthly_report_view'     // 월간 성과 보고서 조회
   | 'monthly_report_manage'   // 월간 성과 보고서 수동 재생성
+  // 소개환자 관리 권한
+  | 'referral_view'           // 소개환자 관리 조회
+  | 'referral_manage'         // 소개 등록/수정/삭제
+  | 'referral_sms_send'       // 감사 문자 발송
+  | 'referral_points_adjust'  // 포인트 적립/차감
 
 // 역할별 기본 권한 설정
 export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
@@ -147,7 +152,9 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     // 주식 자동매매 (모든 권한)
     'investment_view', 'investment_manage',
     // 월간 성과 보고서 (모든 권한)
-    'monthly_report_view', 'monthly_report_manage'
+    'monthly_report_view', 'monthly_report_manage',
+    // 소개환자 관리 (모든 권한)
+    'referral_view', 'referral_manage', 'referral_sms_send', 'referral_points_adjust'
   ],
   vice_director: [
     // 부원장은 직원 관리와 병원 설정, 프로토콜 삭제 제외한 모든 권한
@@ -191,7 +198,9 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     // 마케팅 자동화 (조회)
     'marketing_view',
     // 월간 성과 보고서 (조회)
-    'monthly_report_view'
+    'monthly_report_view',
+    // 소개환자 관리 (모든 권한)
+    'referral_view', 'referral_manage', 'referral_sms_send', 'referral_points_adjust'
   ],
   manager: [
     // 실장은 프로토콜 조회와 히스토리, 1차 승인만 가능
@@ -228,7 +237,9 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     // 경영 현황 (조회)
     'financial_view',
     // 월간 성과 보고서 (조회)
-    'monthly_report_view'
+    'monthly_report_view',
+    // 소개환자 관리 (모든 권한)
+    'referral_view', 'referral_manage', 'referral_sms_send', 'referral_points_adjust'
   ],
   team_leader: [
     // 팀장은 프로토콜 조회와 히스토리만 가능, 자신의 계약서 조회 및 서명만 가능
@@ -422,6 +433,12 @@ export const PERMISSION_GROUPS = {
     { key: 'monthly_report_view', label: '월간 성과 보고서 조회' },
     { key: 'monthly_report_manage', label: '보고서 수동 재생성' }
   ],
+  '소개환자 관리': [
+    { key: 'referral_view', label: '소개환자 관리 조회' },
+    { key: 'referral_manage', label: '소개 등록/수정/삭제' },
+    { key: 'referral_sms_send', label: '감사 문자 발송' },
+    { key: 'referral_points_adjust', label: '포인트 적립/차감' }
+  ],
   '기타': [
     { key: 'guide_view', label: '사용 안내 보기' }
   ]
@@ -527,5 +544,10 @@ export const PERMISSION_DESCRIPTIONS: Record<Permission, string> = {
   'investment_manage': '자동매매 전략을 설정하거나 주문을 관리할 수 있습니다.',
   // 월간 성과 보고서 권한 설명
   'monthly_report_view': '월간 성과 보고서(매출/신환/유입경로/연령대 분석)를 조회할 수 있습니다.',
-  'monthly_report_manage': '월간 성과 보고서를 수동으로 재생성할 수 있습니다.'
+  'monthly_report_manage': '월간 성과 보고서를 수동으로 재생성할 수 있습니다.',
+  // 소개환자 관리 권한 설명
+  'referral_view': '소개환자 관리 페이지의 소개 내역과 통계를 조회할 수 있습니다.',
+  'referral_manage': '환자 간 소개 관계를 등록·수정·삭제할 수 있습니다.',
+  'referral_sms_send': '소개해주신 분께 감사 문자를 발송할 수 있습니다.',
+  'referral_points_adjust': '환자에게 포인트를 적립하거나 차감할 수 있습니다.'
 }

--- a/dental-clinic-manager/src/types/referral.ts
+++ b/dental-clinic-manager/src/types/referral.ts
@@ -1,0 +1,133 @@
+// ========================================
+// 소개환자 관리 타입 정의
+// Patient Referral Management Types
+// ========================================
+
+export interface PatientReferral {
+  id: string
+  clinic_id: string
+  referrer_dentweb_patient_id: string
+  referee_dentweb_patient_id: string
+  referred_at: string
+  note: string | null
+  first_paid_at: string | null
+  first_paid_amount: number | null
+  thanks_sms_sent_at: string | null
+  created_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface PatientReferralWithPatients extends PatientReferral {
+  referrer: {
+    id: string
+    patient_name: string
+    chart_number: string | null
+    phone_number: string | null
+  } | null
+  referee: {
+    id: string
+    patient_name: string
+    chart_number: string | null
+    phone_number: string | null
+    registration_date: string | null
+  } | null
+  reward_summary?: {
+    referrer_points: number
+    referee_points: number
+    referrer_gift_count: number
+    referee_gift_count: number
+  }
+}
+
+export type PointReason =
+  | 'referral_reward'
+  | 'referral_welcome'
+  | 'manual_add'
+  | 'manual_use'
+  | 'expired'
+
+export interface PatientPoint {
+  id: string
+  clinic_id: string
+  dentweb_patient_id: string
+  delta: number
+  reason: PointReason
+  referral_id: string | null
+  note: string | null
+  created_by: string | null
+  created_at: string
+}
+
+export interface PatientPointBalance {
+  clinic_id: string
+  dentweb_patient_id: string
+  balance: number
+  last_transaction_at: string | null
+}
+
+export interface ReferralSettings {
+  clinic_id: string
+  referrer_default_points: number
+  referee_default_points: number
+  auto_thanks_enabled: boolean
+  auto_thanks_after_days: number
+  thanks_template_id: string | null
+  updated_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface ReferralSmsLog {
+  id: string
+  clinic_id: string
+  referral_id: string | null
+  recipient_dentweb_patient_id: string
+  phone_number: string
+  message_content: string
+  message_type: 'SMS' | 'LMS' | 'MMS' | null
+  status: 'sent' | 'failed'
+  aligo_msg_id: string | null
+  error_message: string | null
+  sent_by: string | null
+  sent_at: string
+}
+
+export interface ReferralListFilters {
+  search?: string
+  referrerId?: string
+  startDate?: string
+  endDate?: string
+  thanksSent?: boolean
+  page?: number
+  pageSize?: number
+}
+
+export interface ReferralListResponse {
+  rows: PatientReferralWithPatients[]
+  total: number
+  page: number
+  pageSize: number
+}
+
+export interface ReferralKpi {
+  monthly_count: number
+  monthly_count_prev: number
+  top_referrer: {
+    dentweb_patient_id: string
+    patient_name: string
+    referral_count: number
+  } | null
+  conversion_rate: number
+  pending_link_count: number
+}
+
+export interface PatientSearchResult {
+  id: string
+  patient_name: string
+  chart_number: string | null
+  phone_number: string | null
+  birth_date: string | null
+  acquisition_channel: string | null
+  registration_date: string | null
+}

--- a/dental-clinic-manager/src/types/rlTrading.ts
+++ b/dental-clinic-manager/src/types/rlTrading.ts
@@ -1,0 +1,75 @@
+export type RLModelSource = 'finrl_pretrained' | 'sb3_pretrained' | 'custom'
+export type RLModelKind = 'portfolio' | 'single_asset'
+export type RLModelStatus = 'pending' | 'downloading' | 'ready' | 'failed' | 'archived'
+export type RLAlgorithm = 'PPO' | 'A2C' | 'TD3' | 'DDPG' | 'DQN' | 'SAC'
+
+export interface RLOutputShape {
+  type: 'continuous' | 'discrete'
+  dim: number
+}
+
+export interface RLModel {
+  id: string
+  user_id: string
+  clinic_id: string
+  name: string
+  description?: string | null
+  source: RLModelSource
+  algorithm: RLAlgorithm
+  kind: RLModelKind
+  market: string
+  timeframe: string
+  universe: string[] | null
+  input_features: string[]
+  state_window: number
+  output_shape: RLOutputShape
+  checkpoint_url: string | null
+  checkpoint_path: string | null
+  checkpoint_sha256: string | null
+  min_confidence: number
+  status: RLModelStatus
+  metrics: Record<string, unknown> | null
+  failure_reason: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface RLModelCreateInput {
+  name: string
+  description?: string
+  source: RLModelSource
+  algorithm: RLAlgorithm
+  kind: RLModelKind
+  market?: string
+  timeframe?: string
+  universe?: string[]
+  input_features: string[]
+  state_window: number
+  output_shape: RLOutputShape
+  checkpoint_url: string
+  checkpoint_sha256: string
+  min_confidence?: number
+}
+
+export type RLDecision =
+  | 'order'
+  | 'hold'
+  | 'blocked_low_confidence'
+  | 'blocked_kill_switch'
+  | 'error'
+
+export interface RLInferenceLog {
+  id: string
+  strategy_id: string
+  rl_model_id: string
+  user_id: string
+  trade_date: string
+  state_hash: string
+  output: Record<string, unknown>
+  confidence: number | null
+  decision: RLDecision
+  blocked_reason: string | null
+  latency_ms: number | null
+  error_message: string | null
+  created_at: string
+}

--- a/dental-clinic-manager/supabase/migrations/20260429_create_patient_referrals.sql
+++ b/dental-clinic-manager/supabase/migrations/20260429_create_patient_referrals.sql
@@ -1,0 +1,264 @@
+-- ========================================
+-- 소개환자 관리 시스템
+-- Patient Referral Management System
+-- Migration: 20260429_create_patient_referrals
+-- ========================================
+
+-- 1. patient_referrals : 소개 관계 핵심 테이블
+CREATE TABLE IF NOT EXISTS patient_referrals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  referrer_dentweb_patient_id UUID NOT NULL REFERENCES dentweb_patients(id) ON DELETE RESTRICT,
+  referee_dentweb_patient_id UUID NOT NULL REFERENCES dentweb_patients(id) ON DELETE CASCADE,
+  referred_at DATE NOT NULL DEFAULT CURRENT_DATE,
+  note TEXT,
+  first_paid_at DATE,
+  first_paid_amount NUMERIC(12,0),
+  thanks_sms_sent_at TIMESTAMPTZ,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  CHECK (referrer_dentweb_patient_id <> referee_dentweb_patient_id),
+  UNIQUE(clinic_id, referee_dentweb_patient_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_patient_referrals_clinic_referrer
+  ON patient_referrals(clinic_id, referrer_dentweb_patient_id);
+CREATE INDEX IF NOT EXISTS idx_patient_referrals_clinic_referred_at
+  ON patient_referrals(clinic_id, referred_at DESC);
+
+-- 2. patient_points : 포인트 트랜잭션 (장부 방식, 단일 진실 원천)
+CREATE TABLE IF NOT EXISTS patient_points (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  dentweb_patient_id UUID NOT NULL REFERENCES dentweb_patients(id) ON DELETE CASCADE,
+  delta INTEGER NOT NULL,
+  reason TEXT NOT NULL CHECK (reason IN (
+    'referral_reward',  -- 소개해주신 분 적립
+    'referral_welcome', -- 신환 환영 적립
+    'manual_add',
+    'manual_use',
+    'expired'
+  )),
+  referral_id UUID REFERENCES patient_referrals(id) ON DELETE SET NULL,
+  note TEXT,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_patient_points_clinic_patient
+  ON patient_points(clinic_id, dentweb_patient_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_patient_points_referral
+  ON patient_points(referral_id) WHERE referral_id IS NOT NULL;
+
+-- 3. patient_families / patient_family_members : 가족관계 묶음 (Phase 2)
+CREATE TABLE IF NOT EXISTS patient_families (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  family_name TEXT NOT NULL,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS patient_family_members (
+  family_id UUID NOT NULL REFERENCES patient_families(id) ON DELETE CASCADE,
+  dentweb_patient_id UUID NOT NULL REFERENCES dentweb_patients(id) ON DELETE CASCADE,
+  relation_label TEXT,
+  added_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (family_id, dentweb_patient_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_patient_families_clinic ON patient_families(clinic_id);
+CREATE INDEX IF NOT EXISTS idx_patient_family_members_patient
+  ON patient_family_members(dentweb_patient_id);
+
+-- 4. referral_sms_logs : 감사 문자 발송 이력
+CREATE TABLE IF NOT EXISTS referral_sms_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  referral_id UUID REFERENCES patient_referrals(id) ON DELETE SET NULL,
+  recipient_dentweb_patient_id UUID NOT NULL REFERENCES dentweb_patients(id) ON DELETE CASCADE,
+  phone_number TEXT NOT NULL,
+  message_content TEXT NOT NULL,
+  message_type TEXT CHECK (message_type IN ('SMS','LMS','MMS')),
+  status TEXT NOT NULL CHECK (status IN ('sent','failed')) DEFAULT 'sent',
+  aligo_msg_id TEXT,
+  error_message TEXT,
+  sent_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  sent_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_referral_sms_logs_clinic_sent
+  ON referral_sms_logs(clinic_id, sent_at DESC);
+CREATE INDEX IF NOT EXISTS idx_referral_sms_logs_referral
+  ON referral_sms_logs(referral_id);
+
+-- 5. referral_settings : 병원별 소개 정책 (포인트 기본값 등)
+CREATE TABLE IF NOT EXISTS referral_settings (
+  clinic_id UUID PRIMARY KEY REFERENCES clinics(id) ON DELETE CASCADE,
+  referrer_default_points INTEGER NOT NULL DEFAULT 5000,
+  referee_default_points INTEGER NOT NULL DEFAULT 3000,
+  auto_thanks_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  auto_thanks_after_days INTEGER NOT NULL DEFAULT 0,
+  thanks_template_id UUID REFERENCES recall_sms_templates(id) ON DELETE SET NULL,
+  updated_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- 6. gift_logs 확장 : 소개 환자/카테고리/소개관계 연결 컬럼
+ALTER TABLE gift_logs
+  ADD COLUMN IF NOT EXISTS dentweb_patient_id UUID REFERENCES dentweb_patients(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS category_id INT REFERENCES gift_categories(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS referral_id UUID REFERENCES patient_referrals(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_gift_logs_dentweb_patient
+  ON gift_logs(clinic_id, dentweb_patient_id) WHERE dentweb_patient_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_gift_logs_referral
+  ON gift_logs(referral_id) WHERE referral_id IS NOT NULL;
+
+-- 7. user_notifications.type CHECK 확장 (referral_new_added 추가)
+ALTER TABLE user_notifications DROP CONSTRAINT IF EXISTS user_notifications_type_check;
+ALTER TABLE user_notifications ADD CONSTRAINT user_notifications_type_check
+  CHECK (type = ANY (ARRAY[
+    'leave_approval_pending', 'leave_approved', 'leave_rejected', 'leave_forwarded',
+    'contract_signature_required', 'contract_signed', 'contract_completed', 'contract_cancelled',
+    'document_resignation', 'document_approved', 'document_rejected', 'document',
+    'telegram_board_approved', 'telegram_board_rejected', 'telegram_board_pending',
+    'task_assigned', 'task_completed',
+    'protocol_review_requested', 'protocol_review_approved', 'protocol_review_rejected',
+    'subscription_upgrade_required', 'subscription_payment_succeeded',
+    'important', 'system', 'monthly_report_ready',
+    'referral_new_added'
+  ]));
+
+-- 8. patient_point_balance VIEW : 환자별 포인트 잔액 (단일 진실 원천)
+CREATE OR REPLACE VIEW patient_point_balance AS
+SELECT
+  clinic_id,
+  dentweb_patient_id,
+  COALESCE(SUM(delta), 0)::INTEGER AS balance,
+  MAX(created_at) AS last_transaction_at
+FROM patient_points
+GROUP BY clinic_id, dentweb_patient_id;
+
+-- 9. RLS 정책
+ALTER TABLE patient_referrals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE patient_points ENABLE ROW LEVEL SECURITY;
+ALTER TABLE patient_families ENABLE ROW LEVEL SECURITY;
+ALTER TABLE patient_family_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE referral_sms_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE referral_settings ENABLE ROW LEVEL SECURITY;
+
+-- patient_referrals
+CREATE POLICY "clinic users can view referrals" ON patient_referrals FOR SELECT
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+CREATE POLICY "clinic users can insert referrals" ON patient_referrals FOR INSERT
+  WITH CHECK (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+CREATE POLICY "clinic users can update referrals" ON patient_referrals FOR UPDATE
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+CREATE POLICY "clinic users can delete referrals" ON patient_referrals FOR DELETE
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+
+-- patient_points
+CREATE POLICY "clinic users can view points" ON patient_points FOR SELECT
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+CREATE POLICY "clinic users can insert points" ON patient_points FOR INSERT
+  WITH CHECK (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+
+-- patient_families
+CREATE POLICY "clinic users can view families" ON patient_families FOR SELECT
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+CREATE POLICY "clinic users can manage families" ON patient_families FOR ALL
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()))
+  WITH CHECK (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+
+-- patient_family_members
+CREATE POLICY "clinic users can view family members" ON patient_family_members FOR SELECT
+  USING (family_id IN (SELECT id FROM patient_families WHERE clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())));
+CREATE POLICY "clinic users can manage family members" ON patient_family_members FOR ALL
+  USING (family_id IN (SELECT id FROM patient_families WHERE clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())))
+  WITH CHECK (family_id IN (SELECT id FROM patient_families WHERE clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())));
+
+-- referral_sms_logs
+CREATE POLICY "clinic users can view referral sms logs" ON referral_sms_logs FOR SELECT
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+CREATE POLICY "clinic users can insert referral sms logs" ON referral_sms_logs FOR INSERT
+  WITH CHECK (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+
+-- referral_settings
+CREATE POLICY "clinic users can view referral settings" ON referral_settings FOR SELECT
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+CREATE POLICY "clinic users can manage referral settings" ON referral_settings FOR ALL
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()))
+  WITH CHECK (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+
+-- 10. updated_at 자동 갱신 트리거
+CREATE OR REPLACE FUNCTION set_referral_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_patient_referrals_updated_at ON patient_referrals;
+CREATE TRIGGER trg_patient_referrals_updated_at BEFORE UPDATE ON patient_referrals
+  FOR EACH ROW EXECUTE FUNCTION set_referral_updated_at();
+
+DROP TRIGGER IF EXISTS trg_patient_families_updated_at ON patient_families;
+CREATE TRIGGER trg_patient_families_updated_at BEFORE UPDATE ON patient_families
+  FOR EACH ROW EXECUTE FUNCTION set_referral_updated_at();
+
+DROP TRIGGER IF EXISTS trg_referral_settings_updated_at ON referral_settings;
+CREATE TRIGGER trg_referral_settings_updated_at BEFORE UPDATE ON referral_settings
+  FOR EACH ROW EXECUTE FUNCTION set_referral_updated_at();
+
+-- 11. 기존 모든 병원에 referral_settings 기본값 시드
+INSERT INTO referral_settings (clinic_id)
+SELECT id FROM clinics
+WHERE NOT EXISTS (SELECT 1 FROM referral_settings WHERE clinic_id = clinics.id);
+
+-- 12. 새 병원 생성 시 referral_settings 자동 생성 트리거
+CREATE OR REPLACE FUNCTION create_default_referral_settings()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO referral_settings (clinic_id) VALUES (NEW.id)
+  ON CONFLICT (clinic_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_create_referral_settings ON clinics;
+CREATE TRIGGER trg_create_referral_settings AFTER INSERT ON clinics
+  FOR EACH ROW EXECUTE FUNCTION create_default_referral_settings();
+
+-- 13. gift_categories 시드 : 소개 감사 / 소개 환영
+INSERT INTO gift_categories (clinic_id, name, description, color, display_order)
+SELECT c.id, '소개 감사 선물', '환자를 소개해주신 분께 드리는 감사 선물', '#1b61c9', 4
+FROM clinics c
+WHERE NOT EXISTS (SELECT 1 FROM gift_categories gc WHERE gc.clinic_id = c.id AND gc.name = '소개 감사 선물')
+ON CONFLICT (clinic_id, name) DO NOTHING;
+
+INSERT INTO gift_categories (clinic_id, name, description, color, display_order)
+SELECT c.id, '소개 환영 선물', '소개로 오신 신환에게 드리는 환영 선물', '#6b3fa0', 5
+FROM clinics c
+WHERE NOT EXISTS (SELECT 1 FROM gift_categories gc WHERE gc.clinic_id = c.id AND gc.name = '소개 환영 선물')
+ON CONFLICT (clinic_id, name) DO NOTHING;
+
+-- 14. recall_sms_templates 시드 : 소개 감사 기본 템플릿 (병원별)
+INSERT INTO recall_sms_templates (clinic_id, name, content, is_default, is_active)
+SELECT c.id,
+       '소개 감사 인사',
+       '안녕하세요, ' || c.name || '입니다. {{환자명}}님 덕분에 {{소개받은신환명}}님을 모실 수 있게 되어 진심으로 감사드립니다. 소중한 추천에 보답하고자 작은 마음을 준비했습니다. 늘 건강하시기 바랍니다.',
+       false,
+       true
+FROM clinics c
+WHERE NOT EXISTS (
+  SELECT 1 FROM recall_sms_templates t WHERE t.clinic_id = c.id AND t.name = '소개 감사 인사'
+);
+
+-- ========================================
+-- Migration Complete
+-- ========================================

--- a/dental-clinic-manager/supabase/migrations/20260429_intraday_cache_allow_1d.sql
+++ b/dental-clinic-manager/supabase/migrations/20260429_intraday_cache_allow_1d.sql
@@ -1,0 +1,8 @@
+-- ============================================
+-- intraday_price_cache: timeframe '1d' 허용
+-- RL 일봉 재교형(dailyRebalanceJob.fetchOhlcvWindow)에서 일봉을 동일 캐시에서 읽기 위함.
+-- 기존 분봉(1m/5m/15m) 데이터는 그대로 보존.
+-- ============================================
+ALTER TABLE intraday_price_cache DROP CONSTRAINT IF EXISTS intraday_price_cache_timeframe_check;
+ALTER TABLE intraday_price_cache ADD CONSTRAINT intraday_price_cache_timeframe_check
+  CHECK (timeframe = ANY (ARRAY['1m'::text, '5m'::text, '15m'::text, '1d'::text]));

--- a/dental-clinic-manager/supabase/migrations/20260429_rl_trading.sql
+++ b/dental-clinic-manager/supabase/migrations/20260429_rl_trading.sql
@@ -1,0 +1,98 @@
+-- ============================================
+-- RL 트레이딩 Phase 1
+-- - rl_models: 사전학습 모델 메타데이터
+-- - rl_inference_logs: 일봉 추론 감사 로그
+-- - investment_strategies 확장: strategy_type, rl_model_id
+-- - user_investment_settings 확장: rl_paused_at, rl_paused_reason
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS rl_models (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  description TEXT,
+  source TEXT NOT NULL CHECK (source IN ('finrl_pretrained','sb3_pretrained','custom')),
+  algorithm TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('portfolio','single_asset')),
+  market TEXT NOT NULL DEFAULT 'US',
+  timeframe TEXT NOT NULL DEFAULT '1d',
+  universe JSONB,
+  input_features JSONB NOT NULL,
+  state_window INT NOT NULL DEFAULT 60 CHECK (state_window > 0 AND state_window <= 500),
+  output_shape JSONB NOT NULL,
+  checkpoint_url TEXT,
+  checkpoint_path TEXT,
+  checkpoint_sha256 TEXT,
+  min_confidence NUMERIC(3,2) DEFAULT 0.60 CHECK (min_confidence >= 0 AND min_confidence <= 1),
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','downloading','ready','failed','archived')),
+  metrics JSONB,
+  failure_reason TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_rl_models_clinic ON rl_models(clinic_id);
+CREATE INDEX IF NOT EXISTS idx_rl_models_status ON rl_models(status);
+
+ALTER TABLE investment_strategies
+  ADD COLUMN IF NOT EXISTS strategy_type TEXT NOT NULL DEFAULT 'rule'
+    CHECK (strategy_type IN ('rule','rl_portfolio','rl_single')),
+  ADD COLUMN IF NOT EXISTS rl_model_id UUID REFERENCES rl_models(id) ON DELETE SET NULL;
+ALTER TABLE investment_strategies DROP CONSTRAINT IF EXISTS rl_strategy_requires_model;
+ALTER TABLE investment_strategies
+  ADD CONSTRAINT rl_strategy_requires_model
+  CHECK (strategy_type = 'rule' OR rl_model_id IS NOT NULL);
+CREATE INDEX IF NOT EXISTS idx_strategies_type ON investment_strategies(strategy_type);
+CREATE INDEX IF NOT EXISTS idx_strategies_rl_model ON investment_strategies(rl_model_id);
+
+CREATE TABLE IF NOT EXISTS rl_inference_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  strategy_id UUID NOT NULL REFERENCES investment_strategies(id) ON DELETE CASCADE,
+  rl_model_id UUID NOT NULL REFERENCES rl_models(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  trade_date DATE NOT NULL,
+  state_hash TEXT NOT NULL,
+  output JSONB NOT NULL,
+  confidence NUMERIC(4,3),
+  decision TEXT NOT NULL CHECK (decision IN ('order','hold','blocked_low_confidence','blocked_kill_switch','error')),
+  blocked_reason TEXT,
+  latency_ms INT,
+  error_message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT rl_inference_unique_per_day UNIQUE (strategy_id, trade_date)
+);
+CREATE INDEX IF NOT EXISTS idx_rl_logs_strategy_date ON rl_inference_logs(strategy_id, trade_date DESC);
+CREATE INDEX IF NOT EXISTS idx_rl_logs_user_date ON rl_inference_logs(user_id, trade_date DESC);
+
+ALTER TABLE user_investment_settings
+  ADD COLUMN IF NOT EXISTS rl_paused_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS rl_paused_reason TEXT;
+
+ALTER TABLE rl_models ENABLE ROW LEVEL SECURITY;
+ALTER TABLE rl_inference_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view clinic models" ON rl_models;
+CREATE POLICY "Users can view clinic models" ON rl_models
+  FOR SELECT USING (
+    clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Users can manage own models" ON rl_models;
+CREATE POLICY "Users can manage own models" ON rl_models
+  FOR ALL USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Users can view own logs" ON rl_inference_logs;
+CREATE POLICY "Users can view own logs" ON rl_inference_logs
+  FOR SELECT USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Service can write logs" ON rl_inference_logs;
+CREATE POLICY "Service can write logs" ON rl_inference_logs
+  FOR INSERT WITH CHECK (true);
+
+CREATE OR REPLACE FUNCTION update_rl_models_updated_at()
+RETURNS TRIGGER AS $$ BEGIN NEW.updated_at = NOW(); RETURN NEW; END; $$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_rl_models_updated_at ON rl_models;
+CREATE TRIGGER trigger_rl_models_updated_at BEFORE UPDATE ON rl_models
+  FOR EACH ROW EXECUTE FUNCTION update_rl_models_updated_at();

--- a/dental-clinic-manager/supabase/migrations/20260429_rl_trading_rls_fix.sql
+++ b/dental-clinic-manager/supabase/migrations/20260429_rl_trading_rls_fix.sql
@@ -1,0 +1,19 @@
+-- ============================================
+-- RL trading RLS hardening
+-- - rl_models: enforce clinic_id ownership in WITH CHECK
+-- - rl_inference_logs: restrict INSERT to own user_id
+-- ============================================
+
+DROP POLICY IF EXISTS "Users can manage own models" ON rl_models;
+CREATE POLICY "Users can manage own models" ON rl_models
+  FOR ALL
+  USING (user_id = auth.uid())
+  WITH CHECK (
+    user_id = auth.uid()
+    AND clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Service can write logs" ON rl_inference_logs;
+CREATE POLICY "Users can write own logs" ON rl_inference_logs
+  FOR INSERT
+  WITH CHECK (user_id = auth.uid());

--- a/rl-inference-server/.env.example
+++ b/rl-inference-server/.env.example
@@ -1,0 +1,12 @@
+# 외부 노출 금지 - 반드시 localhost
+RL_SERVER_HOST=127.0.0.1
+RL_SERVER_PORT=8001
+
+# trading-worker가 헤더에 같은 값을 보내야 함
+RL_API_KEY=change-me-to-long-random-string
+
+# 모델 ckpt 영구 저장 디렉터리 (sha256 하위 디렉터리)
+MODEL_DIR=/Users/hhs/.cache/rl-inference/models
+
+# 로그 레벨
+LOG_LEVEL=INFO

--- a/rl-inference-server/.gitignore
+++ b/rl-inference-server/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.env

--- a/rl-inference-server/.gitignore
+++ b/rl-inference-server/.gitignore
@@ -3,3 +3,7 @@ __pycache__/
 *.pyc
 .pytest_cache/
 .env
+
+# 학습된 모델 ckpt (sha256으로 재생성/캐시 가능)
+trained/
+.cache/

--- a/rl-inference-server/README.md
+++ b/rl-inference-server/README.md
@@ -1,0 +1,21 @@
+# rl-inference-server
+
+RL 모델 추론 서버. 별도 Python 프로세스로 동작 (PM2 관리).
+
+## 빠른 시작
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+cp .env.example .env
+# .env에 RL_API_KEY를 충분히 길게 설정
+
+uvicorn src.main:app --host 127.0.0.1 --port 8001 --reload
+```
+
+## 테스트
+
+```bash
+pytest -v
+```

--- a/rl-inference-server/README.md
+++ b/rl-inference-server/README.md
@@ -19,3 +19,17 @@ uvicorn src.main:app --host 127.0.0.1 --port 8001 --reload
 ```bash
 pytest -v
 ```
+
+## Training
+
+자체 학습으로 Dow 30 PPO ckpt를 생성하려면:
+
+```bash
+cd rl-inference-server
+source .venv/bin/activate
+pip install yfinance  # 학습용 의존성
+python -m scripts.train_ppo_dow30 --steps 50000 --output ./trained/ppo_dow30.zip
+```
+
+학습 완료 시 sha256 + 등록 메타데이터가 stdout에 출력된다.
+50k steps은 Mac mini M4 CPU에서 약 1~2시간 소요.

--- a/rl-inference-server/pyproject.toml
+++ b/rl-inference-server/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 
 [project.optional-dependencies]
 finrl = ["finrl>=0.3.6"]
-dev = ["pytest>=8.3", "pytest-asyncio>=0.24", "ruff>=0.7"]
+dev = ["pytest>=8.3", "pytest-asyncio>=0.24", "ruff>=0.7", "gymnasium>=0.29"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/rl-inference-server/pyproject.toml
+++ b/rl-inference-server/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 
 [project.optional-dependencies]
 finrl = ["finrl>=0.3.6"]
-dev = ["pytest>=8.3", "pytest-asyncio>=0.24", "ruff>=0.7", "gymnasium>=0.29"]
+dev = ["pytest>=8.3", "pytest-asyncio>=0.24", "ruff>=0.7", "gymnasium>=0.29", "yfinance>=0.2.40"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/rl-inference-server/pyproject.toml
+++ b/rl-inference-server/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "rl-inference-server"
+version = "0.1.0"
+description = "RL 모델 추론 서버 (FastAPI + PyTorch + stable-baselines3)"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.115",
+  "uvicorn[standard]>=0.32",
+  "pydantic>=2.9",
+  "pydantic-settings>=2.6",
+  "torch>=2.2",
+  "stable-baselines3>=2.3",
+  "numpy>=1.26",
+  "pandas>=2.2",
+  "httpx>=0.27",
+  "python-dotenv>=1.0",
+]
+
+[project.optional-dependencies]
+finrl = ["finrl>=0.3.6"]
+dev = ["pytest>=8.3", "pytest-asyncio>=0.24", "ruff>=0.7"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/rl-inference-server/scripts/benchmark_dow30.py
+++ b/rl-inference-server/scripts/benchmark_dow30.py
@@ -1,0 +1,227 @@
+"""Benchmark RL ckpt against simple baselines on the same OOS period.
+
+Baselines:
+  - Buy & Hold: 첫 거래일에 1/N 동일 비중으로 매수 후 holding
+  - Equal-weight monthly rebal: 매월 첫 거래일에 1/N로 rebalance
+  - Min-variance monthly: 60일 lookback 기반 공분산 행렬로 min-var weights
+  - RL (체크포인트): 매월 첫 거래일에 RL 모델로 rebalance
+
+모두 동일 OOS 기간(2024-01-01 → latest)에서 Sharpe / Total return / Max drawdown.
+
+사용:
+  python -m scripts.benchmark_dow30 --checkpoint trained/sweep/trial_4.zip
+"""
+from __future__ import annotations
+import argparse
+import json
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+
+from scripts.data_loader import load_dow30, DEFAULT_UNIVERSE
+from src.adapters.sb3 import SB3Adapter
+from src.inference.portfolio import PortfolioInferenceEngine
+from src.schemas import PredictRequest, OHLCVRow
+
+
+def _metrics(equity: np.ndarray) -> dict:
+    if equity.size < 2:
+        return {"total_return": 0.0, "sharpe": 0.0, "max_drawdown": 0.0}
+    rets = np.diff(equity) / equity[:-1]
+    total_return = float(equity[-1] / equity[0] - 1.0)
+    sharpe = float(rets.mean() / rets.std() * np.sqrt(252)) if rets.std() > 0 else 0.0
+    peak = np.maximum.accumulate(equity)
+    drawdown = (equity - peak) / peak
+    return {
+        "total_return": total_return,
+        "sharpe": sharpe,
+        "max_drawdown": float(drawdown.min()),
+    }
+
+
+def _simulate(
+    prices: pd.DataFrame,
+    weights_at: Callable[[int, np.ndarray], np.ndarray],
+    initial_capital: float = 10_000.0,
+) -> np.ndarray:
+    """주어진 weights 함수로 portfolio equity 곡선 산출.
+
+    weights_at(i, prices_array): 인덱스 i에서 주어진 lookback 가격으로 next-day weights 반환.
+    """
+    arr = prices.values
+    n = arr.shape[0]
+    equity = np.empty(n)
+    equity[0] = initial_capital
+    weights = np.zeros(arr.shape[1])
+    for i in range(1, n):
+        if i > 0:
+            ret = np.log(np.clip(arr[i] / arr[i - 1], 1e-6, None))
+            equity[i] = equity[i - 1] * float(np.exp((weights * ret).sum()))
+        else:
+            equity[i] = equity[i - 1]
+        weights = weights_at(i, arr)
+    return equity
+
+
+def _is_first_of_month(d: pd.Timestamp, prev: pd.Timestamp | None) -> bool:
+    return prev is None or (d.month != prev.month) or (d.year != prev.year)
+
+
+def buy_and_hold_weights(window: int) -> Callable[[int, np.ndarray], np.ndarray]:
+    state = {"set": False}
+    def fn(i: int, arr: np.ndarray) -> np.ndarray:
+        if not state["set"]:
+            state["set"] = True
+            return np.ones(arr.shape[1]) / arr.shape[1]
+        # already holding — no rebalance
+        return state.setdefault("w", np.ones(arr.shape[1]) / arr.shape[1])
+    return fn
+
+
+def equal_weight_monthly(prices: pd.DataFrame, window: int) -> np.ndarray:
+    arr = prices.values
+    n = arr.shape[0]
+    equity = np.empty(n)
+    equity[0] = 10_000.0
+    weights = np.ones(arr.shape[1]) / arr.shape[1]
+    last_month: tuple[int, int] | None = None
+    for i in range(1, n):
+        ret = np.log(np.clip(arr[i] / arr[i - 1], 1e-6, None))
+        equity[i] = equity[i - 1] * float(np.exp((weights * ret).sum()))
+        d = prices.index[i]
+        if _is_first_of_month(d, prices.index[i - 1] if i > 0 else None):
+            weights = np.ones(arr.shape[1]) / arr.shape[1]
+    return equity
+
+
+def buy_and_hold_curve(prices: pd.DataFrame) -> np.ndarray:
+    arr = prices.values
+    n = arr.shape[0]
+    equity = np.empty(n)
+    equity[0] = 10_000.0
+    weights = np.ones(arr.shape[1]) / arr.shape[1]
+    for i in range(1, n):
+        ret = np.log(np.clip(arr[i] / arr[i - 1], 1e-6, None))
+        equity[i] = equity[i - 1] * float(np.exp((weights * ret).sum()))
+    return equity
+
+
+def min_variance_monthly(prices: pd.DataFrame, lookback: int = 60) -> np.ndarray:
+    arr = prices.values
+    n = arr.shape[0]
+    equity = np.empty(n)
+    equity[0] = 10_000.0
+    weights = np.ones(arr.shape[1]) / arr.shape[1]
+    for i in range(1, n):
+        ret = np.log(np.clip(arr[i] / arr[i - 1], 1e-6, None))
+        equity[i] = equity[i - 1] * float(np.exp((weights * ret).sum()))
+        d = prices.index[i]
+        is_first = i == 1 or (prices.index[i - 1].month != d.month)
+        if is_first and i >= lookback:
+            window = arr[i - lookback:i]
+            log_ret = np.diff(np.log(np.clip(window, 1e-6, None)), axis=0)
+            cov = np.cov(log_ret.T)
+            ones = np.ones(arr.shape[1])
+            try:
+                inv = np.linalg.pinv(cov)
+                raw = inv @ ones
+                w = raw / raw.sum()
+                w = np.clip(w, 0.0, None)
+                if w.sum() > 0:
+                    weights = w / w.sum()
+            except np.linalg.LinAlgError:
+                pass
+    return equity
+
+
+def rl_monthly(prices: pd.DataFrame, adapter: SB3Adapter, window: int = 30) -> np.ndarray:
+    arr = prices.values
+    tickers = list(prices.columns)
+    n = arr.shape[0]
+    equity = np.empty(n)
+    equity[0] = 10_000.0
+    weights = np.ones(arr.shape[1]) / arr.shape[1]
+    engine = PortfolioInferenceEngine(adapter)
+
+    for i in range(1, n):
+        ret = np.log(np.clip(arr[i] / arr[i - 1], 1e-6, None))
+        equity[i] = equity[i - 1] * float(np.exp((weights * ret).sum()))
+        d = prices.index[i]
+        is_first = i == 1 or (prices.index[i - 1].month != d.month)
+        if is_first and i >= window:
+            ohlcv: dict[str, list[OHLCVRow]] = {}
+            for j, t in enumerate(tickers):
+                rows: list[OHLCVRow] = []
+                for k in range(i - window, i):
+                    p = float(arr[k, j])
+                    rows.append(OHLCVRow(date=str(prices.index[k].date()), open=p, high=p, low=p, close=p, volume=0))
+                ohlcv[t] = rows
+            req = PredictRequest(
+                model_id="bench-rl",
+                checkpoint_path="",
+                algorithm="PPO",
+                kind="portfolio",
+                state_window=window,
+                input_features=["log_returns_window"],
+                ohlcv=ohlcv,
+            )
+            try:
+                pred = engine.run(req)
+                w_dict = pred.weights
+                weights = np.array([w_dict.get(t, 0.0) for t in tickers], dtype=np.float32)
+            except Exception:
+                pass
+    return equity
+
+
+def main(args: argparse.Namespace) -> None:
+    print(f"[bench] loading OOS {args.start} → {args.end or 'latest'}")
+    prices = load_dow30(start=args.start, end=args.end, cache_dir=args.cache_dir)
+    print(f"[bench] {len(prices)} rows × {prices.shape[1]} tickers")
+
+    print("[bench] running buy_and_hold...")
+    eq_bah = buy_and_hold_curve(prices)
+    print("[bench] running equal_weight_monthly...")
+    eq_eq = equal_weight_monthly(prices, window=args.window)
+    print("[bench] running min_variance_monthly...")
+    eq_mv = min_variance_monthly(prices, lookback=args.window * 2)
+    print("[bench] running RL...")
+    adapter = SB3Adapter.load(checkpoint_path=args.checkpoint, algorithm="PPO")
+    eq_rl = rl_monthly(prices, adapter, window=args.window)
+
+    summary = {
+        "period": f"{args.start} → {args.end or 'latest'}",
+        "n_days": len(prices),
+        "n_tickers": prices.shape[1],
+        "checkpoint": args.checkpoint,
+        "results": {
+            "buy_and_hold_1n": _metrics(eq_bah),
+            "equal_weight_monthly": _metrics(eq_eq),
+            "min_variance_monthly": _metrics(eq_mv),
+            "rl_monthly": _metrics(eq_rl),
+        },
+    }
+    print("\n" + "=" * 80)
+    print("BENCHMARK SUMMARY")
+    print(json.dumps(summary, indent=2, default=str))
+    print("=" * 80)
+
+    print("\n| Strategy                | Total Return | Sharpe | Max DD  |")
+    print("|-------------------------|--------------|--------|---------|")
+    for name, m in summary["results"].items():
+        print(f"| {name:<23} | {m['total_return']:+.2%}      | {m['sharpe']:+.3f} | {m['max_drawdown']:+.2%} |")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--checkpoint", required=True)
+    p.add_argument("--start", default="2024-01-01")
+    p.add_argument("--end", default=None)
+    p.add_argument("--window", type=int, default=30)
+    p.add_argument("--cache-dir", default="./.cache/dow30")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/rl-inference-server/scripts/data_loader.py
+++ b/rl-inference-server/scripts/data_loader.py
@@ -4,9 +4,11 @@ from pathlib import Path
 import pandas as pd
 
 DEFAULT_UNIVERSE = [
+    # WBA(Walgreens)는 2024-02 Dow에서 제외, AMZN로 대체.
+    # 학습용으로 데이터 수급 안정적인 30종목 유지.
     "AAPL","MSFT","UNH","JNJ","V","WMT","PG","JPM","HD","CVX",
     "MA","KO","PFE","DIS","CSCO","VZ","ADBE","NKE","CRM","INTC",
-    "MRK","WBA","BA","CAT","GS","IBM","MMM","AXP","TRV","DOW",
+    "MRK","AMZN","BA","CAT","GS","IBM","MMM","AXP","TRV","DOW",
 ]
 
 

--- a/rl-inference-server/scripts/data_loader.py
+++ b/rl-inference-server/scripts/data_loader.py
@@ -1,0 +1,38 @@
+"""Dow 30 OHLCV loader with parquet cache."""
+from __future__ import annotations
+from pathlib import Path
+import pandas as pd
+
+DEFAULT_UNIVERSE = [
+    "AAPL","MSFT","UNH","JNJ","V","WMT","PG","JPM","HD","CVX",
+    "MA","KO","PFE","DIS","CSCO","VZ","ADBE","NKE","CRM","INTC",
+    "MRK","WBA","BA","CAT","GS","IBM","MMM","AXP","TRV","DOW",
+]
+
+
+def load_dow30(
+    start: str = "2014-01-01",
+    end: str | None = None,
+    universe: list[str] | None = None,
+    cache_dir: str | None = None,
+) -> pd.DataFrame:
+    """Return wide DataFrame indexed by date with columns = tickers; cells = adjusted close."""
+    universe = universe or DEFAULT_UNIVERSE
+    if cache_dir is not None:
+        cache_path = Path(cache_dir) / f"dow30_{start}_{end or 'latest'}.parquet"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        if cache_path.exists():
+            return pd.read_parquet(cache_path)
+
+    import yfinance as yf
+    df = yf.download(
+        tickers=" ".join(universe),
+        start=start, end=end,
+        auto_adjust=True, progress=False, threads=True, group_by="ticker",
+    )
+    # yfinance returns multi-index when multiple tickers; flatten to close-only
+    closes = pd.DataFrame({t: df[t]["Close"] for t in universe if t in df.columns.get_level_values(0)})
+    closes = closes.dropna(axis=0, how="any")
+    if cache_dir is not None:
+        closes.to_parquet(cache_path)
+    return closes

--- a/rl-inference-server/scripts/data_loader_v2.py
+++ b/rl-inference-server/scripts/data_loader_v2.py
@@ -1,0 +1,40 @@
+"""yfinance loader returning both close prices and volumes (for env v2)."""
+from __future__ import annotations
+from pathlib import Path
+import pandas as pd
+
+from scripts.data_loader import DEFAULT_UNIVERSE
+
+
+def load_dow30_with_volume(
+    start: str = "2014-01-01",
+    end: str | None = None,
+    universe: list[str] | None = None,
+    cache_dir: str | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    universe = universe or DEFAULT_UNIVERSE
+    if cache_dir is not None:
+        cdir = Path(cache_dir)
+        cdir.mkdir(parents=True, exist_ok=True)
+        prices_path = cdir / f"v2_close_{start}_{end or 'latest'}.parquet"
+        volumes_path = cdir / f"v2_volume_{start}_{end or 'latest'}.parquet"
+        if prices_path.exists() and volumes_path.exists():
+            return pd.read_parquet(prices_path), pd.read_parquet(volumes_path)
+
+    import yfinance as yf
+    df = yf.download(
+        tickers=" ".join(universe),
+        start=start, end=end,
+        auto_adjust=True, progress=False, threads=True, group_by="ticker",
+    )
+    closes = pd.DataFrame({t: df[t]["Close"] for t in universe if t in df.columns.get_level_values(0)})
+    volumes = pd.DataFrame({t: df[t]["Volume"] for t in universe if t in df.columns.get_level_values(0)})
+    # 둘 다 같은 인덱스에서 dropna(any) → 일관된 시계열
+    common_idx = closes.dropna(how="any").index.intersection(volumes.dropna(how="any").index)
+    closes = closes.loc[common_idx]
+    volumes = volumes.loc[common_idx]
+
+    if cache_dir is not None:
+        closes.to_parquet(prices_path)
+        volumes.to_parquet(volumes_path)
+    return closes, volumes

--- a/rl-inference-server/scripts/dow30_env.py
+++ b/rl-inference-server/scripts/dow30_env.py
@@ -1,0 +1,72 @@
+"""Minimal Dow 30 portfolio environment for SB3 training.
+
+State: previous-day returns for each ticker (length N).
+Action: portfolio weights in [-1, 1]^N. Internally we long-only normalize
+        positive entries to sum=1 (equal split if all <=0).
+Reward: portfolio log return on next step minus a small turnover penalty.
+"""
+from __future__ import annotations
+import numpy as np
+import pandas as pd
+import gymnasium as gym
+from gymnasium import spaces
+
+
+class Dow30PortfolioEnv(gym.Env):
+    metadata = {"render_modes": []}
+
+    def __init__(
+        self,
+        prices: pd.DataFrame,
+        window: int = 30,
+        turnover_penalty: float = 1e-4,
+    ) -> None:
+        super().__init__()
+        if prices.empty:
+            raise ValueError("prices is empty")
+        self._prices = prices.values.astype(np.float32)
+        self._tickers = list(prices.columns)
+        self._n = len(self._tickers)
+        self._window = window
+        self._turnover_penalty = turnover_penalty
+        # Observation: previous `window` daily returns flattened → length N*window
+        self.observation_space = spaces.Box(low=-1.0, high=1.0, shape=(self._n * window,), dtype=np.float32)
+        self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(self._n,), dtype=np.float32)
+        self._t = 0
+        self._weights = np.ones(self._n, dtype=np.float32) / self._n
+
+    def _state(self) -> np.ndarray:
+        # Past `window` log returns
+        end = self._t
+        start = end - self._window
+        slice_ = self._prices[start:end]
+        prev = self._prices[start - 1:end - 1]
+        rets = np.log(np.clip(slice_ / np.clip(prev, 1e-6, None), 1e-6, None))
+        return np.clip(rets.flatten(), -1.0, 1.0).astype(np.float32)
+
+    def _normalize(self, action: np.ndarray) -> np.ndarray:
+        a = np.clip(action, 0.0, None)
+        s = a.sum()
+        if s <= 0:
+            return np.ones(self._n, dtype=np.float32) / self._n
+        return (a / s).astype(np.float32)
+
+    def reset(self, *, seed: int | None = None, options=None):
+        super().reset(seed=seed)
+        # Need at least window+1 rows for the first state
+        self._t = self._window + 1
+        self._weights = np.ones(self._n, dtype=np.float32) / self._n
+        return self._state(), {}
+
+    def step(self, action: np.ndarray):
+        new_weights = self._normalize(np.asarray(action, dtype=np.float32))
+        # Reward = portfolio log return from t-1 to t under previous weights
+        ret = np.log(np.clip(self._prices[self._t] / self._prices[self._t - 1], 1e-6, None))
+        portfolio_log_ret = float((self._weights * ret).sum())
+        turnover = float(np.abs(new_weights - self._weights).sum())
+        reward = portfolio_log_ret - self._turnover_penalty * turnover
+        self._weights = new_weights
+        self._t += 1
+        terminated = False
+        truncated = self._t >= len(self._prices)
+        return self._state(), reward, terminated, truncated, {}

--- a/rl-inference-server/scripts/dow30_env_v2.py
+++ b/rl-inference-server/scripts/dow30_env_v2.py
@@ -1,0 +1,134 @@
+"""Dow30PortfolioEnvV2 — reward shaping + 확장 state + regime feature.
+
+v1 대비 변경:
+  - Reward: log return − downside_penalty * max(0, -log_return)^2 − turnover_penalty * Σ|Δw|
+    (Sortino-style: 손실에만 quadratic penalty, 이익은 그대로)
+  - State 확장: 종목별 (log_returns, log_volumes, RSI14) × window
+                + 시장 regime (cross-sectional vol of last `window` returns)
+  - Action space는 v1과 동일 (Box(N,) [-1,1] long-only normalize)
+
+Adapter 호환: portfolio.py가 raw_action.size == n_tickers면 그대로 weights로 매핑하므로 OK.
+"""
+from __future__ import annotations
+import numpy as np
+import pandas as pd
+import gymnasium as gym
+from gymnasium import spaces
+
+
+def _rsi(close: np.ndarray, period: int = 14) -> np.ndarray:
+    """Wilder RSI on a 1-D array. 첫 period 길이는 50.0(중립)으로 채움."""
+    n = close.shape[0]
+    out = np.full(n, 50.0, dtype=np.float32)
+    if n <= period:
+        return out
+    deltas = np.diff(close)
+    up = np.clip(deltas, 0.0, None)
+    dn = np.clip(-deltas, 0.0, None)
+    avg_up = up[:period].mean()
+    avg_dn = dn[:period].mean()
+    for i in range(period, n):
+        if i > period:
+            avg_up = (avg_up * (period - 1) + up[i - 1]) / period
+            avg_dn = (avg_dn * (period - 1) + dn[i - 1]) / period
+        rs = avg_up / max(avg_dn, 1e-9)
+        out[i] = 100.0 - 100.0 / (1.0 + rs)
+    return out
+
+
+class Dow30PortfolioEnvV2(gym.Env):
+    metadata = {"render_modes": []}
+
+    def __init__(
+        self,
+        prices: pd.DataFrame,
+        volumes: pd.DataFrame | None = None,
+        window: int = 30,
+        turnover_penalty: float = 1e-4,
+        downside_penalty: float = 5.0,
+    ) -> None:
+        super().__init__()
+        if prices.empty:
+            raise ValueError("prices is empty")
+        # Align volumes (optional). 없으면 1.0으로 채움 → log volume = 0 (state는 0).
+        if volumes is None or volumes.empty:
+            volumes = pd.DataFrame(np.ones_like(prices.values), index=prices.index, columns=prices.columns)
+        else:
+            volumes = volumes.reindex_like(prices).ffill().fillna(1.0)
+        self._prices = prices.values.astype(np.float32)
+        self._volumes = np.clip(volumes.values.astype(np.float32), 1.0, None)
+        self._tickers = list(prices.columns)
+        self._n = len(self._tickers)
+        self._window = window
+        self._turnover_penalty = turnover_penalty
+        self._downside_penalty = downside_penalty
+
+        # RSI per ticker (precompute once)
+        self._rsi = np.column_stack([_rsi(self._prices[:, j]) for j in range(self._n)]).astype(np.float32)
+        # log volumes (per-ticker z-score over full series for stable scale)
+        log_vol = np.log(self._volumes)
+        self._log_vol_norm = ((log_vol - log_vol.mean(axis=0)) / (log_vol.std(axis=0) + 1e-6)).astype(np.float32)
+
+        # State per step:
+        #   - per-ticker × window: log_return + log_volume_z + rsi_norm  → 3 channels × N × window
+        #   - market regime: cross-sectional vol of last `window` returns (1 scalar)
+        #   - state size = 3 * N * window + 1
+        self._state_dim = 3 * self._n * window + 1
+        self.observation_space = spaces.Box(low=-5.0, high=5.0, shape=(self._state_dim,), dtype=np.float32)
+        self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(self._n,), dtype=np.float32)
+
+        self._t = 0
+        self._weights = np.ones(self._n, dtype=np.float32) / self._n
+
+    def _state(self) -> np.ndarray:
+        end = self._t
+        start = end - self._window
+        # log returns
+        slice_p = self._prices[start:end]
+        prev_p = self._prices[start - 1:end - 1]
+        rets = np.log(np.clip(slice_p / np.clip(prev_p, 1e-6, None), 1e-6, None))
+        rets = np.clip(rets, -1.0, 1.0)
+
+        # log volumes (z-score)
+        vols = self._log_vol_norm[start:end]
+        vols = np.clip(vols, -5.0, 5.0)
+
+        # RSI normalized to [-1, 1] (0..100 → -1..1)
+        rsi = (self._rsi[start:end] - 50.0) / 50.0
+        rsi = np.clip(rsi, -1.0, 1.0)
+
+        # Market regime: cross-sectional vol of returns
+        regime = float(np.std(rets))
+
+        # Concat in (3, window, n_tickers) → flatten
+        state = np.concatenate([rets.flatten(), vols.flatten(), rsi.flatten(), [regime]]).astype(np.float32)
+        return state
+
+    def _normalize(self, action: np.ndarray) -> np.ndarray:
+        a = np.clip(action, 0.0, None)
+        s = a.sum()
+        if s <= 0:
+            return np.ones(self._n, dtype=np.float32) / self._n
+        return (a / s).astype(np.float32)
+
+    def reset(self, *, seed: int | None = None, options=None):
+        super().reset(seed=seed)
+        self._t = self._window + 1
+        self._weights = np.ones(self._n, dtype=np.float32) / self._n
+        return self._state(), {}
+
+    def step(self, action: np.ndarray):
+        new_weights = self._normalize(np.asarray(action, dtype=np.float32))
+        ret = np.log(np.clip(self._prices[self._t] / self._prices[self._t - 1], 1e-6, None))
+        portfolio_log_ret = float((self._weights * ret).sum())
+
+        # Sortino-style downside penalty: quadratic on negative returns only
+        downside = max(0.0, -portfolio_log_ret)
+        turnover = float(np.abs(new_weights - self._weights).sum())
+        reward = portfolio_log_ret - self._downside_penalty * (downside ** 2) - self._turnover_penalty * turnover
+
+        self._weights = new_weights
+        self._t += 1
+        terminated = False
+        truncated = self._t >= len(self._prices)
+        return self._state(), reward, terminated, truncated, {}

--- a/rl-inference-server/scripts/ensemble_dow30.py
+++ b/rl-inference-server/scripts/ensemble_dow30.py
@@ -1,0 +1,131 @@
+"""Ensemble: blend PPO weights with Min-Variance weights and compare across α values.
+
+매월 rebalance 시점에:
+  ensemble_weights = α * PPO + (1 - α) * MinVar     (둘 다 long-only normalize)
+
+α를 [0.0, 0.25, 0.5, 0.75, 1.0]에서 grid 비교 → OOS Sharpe/Return/MDD.
+
+α=0.0 → Min-Var only
+α=1.0 → PPO only
+중간값 → blend
+
+사용:
+  python -m scripts.ensemble_dow30 --checkpoint trained/sweep/trial_4.zip
+"""
+from __future__ import annotations
+import argparse
+import json
+import numpy as np
+import pandas as pd
+
+from scripts.data_loader import load_dow30, DEFAULT_UNIVERSE
+from src.adapters.sb3 import SB3Adapter
+from src.inference.portfolio import PortfolioInferenceEngine
+from src.schemas import PredictRequest, OHLCVRow
+
+
+def _metrics(equity: np.ndarray) -> dict:
+    if equity.size < 2:
+        return {"total_return": 0.0, "sharpe": 0.0, "max_drawdown": 0.0}
+    rets = np.diff(equity) / equity[:-1]
+    total = float(equity[-1] / equity[0] - 1.0)
+    sharpe = float(rets.mean() / rets.std() * np.sqrt(252)) if rets.std() > 0 else 0.0
+    peak = np.maximum.accumulate(equity)
+    dd = (equity - peak) / peak
+    return {"total_return": total, "sharpe": sharpe, "max_drawdown": float(dd.min())}
+
+
+def _min_var_weights(window: np.ndarray, n: int) -> np.ndarray:
+    log_ret = np.diff(np.log(np.clip(window, 1e-6, None)), axis=0)
+    cov = np.cov(log_ret.T)
+    ones = np.ones(n)
+    try:
+        inv = np.linalg.pinv(cov)
+        raw = inv @ ones
+        w = np.clip(raw / raw.sum(), 0.0, None)
+        if w.sum() > 0:
+            return w / w.sum()
+    except np.linalg.LinAlgError:
+        pass
+    return np.ones(n) / n
+
+
+def _ppo_weights(adapter: SB3Adapter, window_arr: np.ndarray, tickers: list[str], dates: list[pd.Timestamp]) -> np.ndarray:
+    """v1-style portfolio engine을 호출 (tickers × window OHLCV)."""
+    engine = PortfolioInferenceEngine(adapter)
+    ohlcv: dict[str, list[OHLCVRow]] = {}
+    for j, t in enumerate(tickers):
+        rows: list[OHLCVRow] = []
+        for k in range(window_arr.shape[0]):
+            p = float(window_arr[k, j])
+            rows.append(OHLCVRow(date=str(dates[k].date()), open=p, high=p, low=p, close=p, volume=0))
+        ohlcv[t] = rows
+    req = PredictRequest(
+        model_id="ensemble", checkpoint_path="", algorithm="PPO", kind="portfolio",
+        state_window=window_arr.shape[0], input_features=["log_returns_window"], ohlcv=ohlcv,
+    )
+    try:
+        pred = engine.run(req)
+        return np.array([pred.weights.get(t, 0.0) for t in tickers], dtype=np.float64)
+    except Exception:
+        return np.ones(len(tickers)) / len(tickers)
+
+
+def simulate_ensemble(prices: pd.DataFrame, adapter: SB3Adapter, alpha: float, window: int = 30) -> np.ndarray:
+    arr = prices.values.astype(np.float64)
+    tickers = list(prices.columns)
+    n_tickers = arr.shape[1]
+    n_days = arr.shape[0]
+    equity = np.empty(n_days)
+    equity[0] = 10_000.0
+    weights = np.ones(n_tickers) / n_tickers
+
+    for i in range(1, n_days):
+        ret = np.log(np.clip(arr[i] / arr[i - 1], 1e-6, None))
+        equity[i] = equity[i - 1] * float(np.exp((weights * ret).sum()))
+        d = prices.index[i]
+        is_first = i == 1 or (prices.index[i - 1].month != d.month)
+        if is_first and i >= window:
+            window_arr = arr[i - window:i]
+            ppo_w = _ppo_weights(adapter, window_arr, tickers, list(prices.index[i - window:i]))
+            mv_w = _min_var_weights(window_arr, n_tickers)
+            blend = alpha * ppo_w + (1.0 - alpha) * mv_w
+            s = blend.sum()
+            weights = blend / s if s > 0 else np.ones(n_tickers) / n_tickers
+    return equity
+
+
+def main(args: argparse.Namespace) -> None:
+    print(f"[ensemble] loading {args.start} → {args.end or 'latest'}")
+    prices = load_dow30(start=args.start, end=args.end, cache_dir=args.cache_dir)
+    print(f"[ensemble] {len(prices)} rows × {prices.shape[1]} tickers")
+    adapter = SB3Adapter.load(checkpoint_path=args.checkpoint, algorithm="PPO")
+
+    alphas = [0.0, 0.25, 0.5, 0.75, 1.0]
+    results: list[dict] = []
+    for a in alphas:
+        eq = simulate_ensemble(prices, adapter, alpha=a, window=args.window)
+        m = _metrics(eq)
+        results.append({"alpha": a, **m})
+        print(f"[ensemble α={a:.2f}] return={m['total_return']:+.2%}  sharpe={m['sharpe']:+.3f}  mdd={m['max_drawdown']:+.2%}")
+
+    # Sort by sharpe to highlight best blend
+    best = max(results, key=lambda r: r["sharpe"])
+    print("\n" + "=" * 70)
+    print(json.dumps({"period": f"{args.start}..{args.end or 'latest'}", "results": results, "best": best}, indent=2, default=str))
+    print("=" * 70)
+    print(f"\n[best] α={best['alpha']:.2f}  Sharpe={best['sharpe']:+.3f}  Return={best['total_return']:+.2%}")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--checkpoint", required=True)
+    p.add_argument("--start", default="2024-01-01")
+    p.add_argument("--end", default=None)
+    p.add_argument("--window", type=int, default=30)
+    p.add_argument("--cache-dir", default="./.cache/dow30")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/rl-inference-server/scripts/eval_ppo_dow30.py
+++ b/rl-inference-server/scripts/eval_ppo_dow30.py
@@ -1,0 +1,129 @@
+"""학습된 PPO Dow30 ckpt를 backtest로 평가.
+
+In-process로 SB3Adapter + run_backtest를 직접 호출하여 sharpe/MDD/total_return 산출.
+학습 데이터 기간(in-sample) + 별도 검증 기간(out-of-sample) 두 번 돌려 overfitting을 본다.
+
+사용:
+  python -m scripts.eval_ppo_dow30 \
+    --checkpoint trained/ppo_dow30_200k.zip \
+    --train-start 2014-01-01 --train-end 2023-12-31 \
+    --test-start 2024-01-01  --test-end 2026-04-29
+"""
+from __future__ import annotations
+import argparse
+import json
+from pathlib import Path
+
+from src.adapters.sb3 import SB3Adapter
+from src.inference.backtest import run_backtest
+from src.schemas import BacktestRequest, OHLCVRow
+from scripts.data_loader import load_dow30, DEFAULT_UNIVERSE
+
+
+def _to_ohlcv(prices_df) -> dict[str, list[OHLCVRow]]:
+    """yfinance close-only DataFrame을 BacktestRequest.ohlcv 형식으로 변환."""
+    out: dict[str, list[OHLCVRow]] = {}
+    for ticker in prices_df.columns:
+        rows: list[OHLCVRow] = []
+        for date, close in prices_df[ticker].items():
+            d = date.strftime("%Y-%m-%d") if hasattr(date, "strftime") else str(date)
+            close_f = float(close)
+            rows.append(OHLCVRow(date=d, open=close_f, high=close_f, low=close_f, close=close_f, volume=0))
+        out[ticker] = rows
+    return out
+
+
+def evaluate_period(
+    adapter: SB3Adapter,
+    ckpt: str,
+    universe: list[str],
+    start: str,
+    end: str | None,
+    state_window: int,
+    label: str,
+    cache_dir: str,
+) -> dict:
+    print(f"\n[eval:{label}] loading {start} → {end or 'latest'}")
+    prices = load_dow30(start=start, end=end, universe=universe, cache_dir=cache_dir)
+    print(f"[eval:{label}] {len(prices)} rows × {prices.shape[1]} tickers")
+    if len(prices) <= state_window + 5:
+        raise ValueError(f"{label}: 너무 짧은 기간 (rows={len(prices)})")
+
+    ohlcv = _to_ohlcv(prices)
+    # 매월 첫 거래일을 rebalance 시점으로 (최소 state_window 이후만)
+    all_dates = sorted({r.date for rows in ohlcv.values() for r in rows})
+    eligible = all_dates[state_window:]
+    rebalance_dates: list[str] = []
+    last_month: tuple[int, int] | None = None
+    for d in eligible:
+        y, m, _ = (int(x) for x in d.split("-"))
+        if last_month != (y, m):
+            rebalance_dates.append(d)
+            last_month = (y, m)
+
+    req = BacktestRequest(
+        model_id=f"eval-{label}",
+        checkpoint_path=ckpt,
+        algorithm="PPO",
+        kind="portfolio",
+        state_window=state_window,
+        input_features=["log_returns_window"],
+        ohlcv=ohlcv,
+        rebalance_dates=rebalance_dates,
+        initial_capital=10_000.0,
+    )
+    resp = run_backtest(adapter, req)
+    print(f"[eval:{label}] rebalances={resp.n_rebalances}  total_return={resp.total_return:.4f}  "
+          f"sharpe={resp.sharpe_ratio:.4f}  max_dd={resp.max_drawdown:.4f}")
+    return {
+        "label": label,
+        "start": start,
+        "end": end,
+        "rows": len(prices),
+        "n_rebalances": resp.n_rebalances,
+        "total_return": resp.total_return,
+        "sharpe_ratio": resp.sharpe_ratio,
+        "max_drawdown": resp.max_drawdown,
+        "metadata": resp.metadata,
+    }
+
+
+def main(args: argparse.Namespace) -> None:
+    ckpt = str(Path(args.checkpoint).resolve())
+    print(f"[eval] checkpoint: {ckpt}")
+    adapter = SB3Adapter.load(checkpoint_path=ckpt, algorithm="PPO")
+
+    in_sample = evaluate_period(
+        adapter, ckpt, DEFAULT_UNIVERSE, args.train_start, args.train_end,
+        args.window, "in_sample", args.cache_dir,
+    )
+    out_sample = evaluate_period(
+        adapter, ckpt, DEFAULT_UNIVERSE, args.test_start, args.test_end,
+        args.window, "out_of_sample", args.cache_dir,
+    )
+
+    summary = {
+        "checkpoint": ckpt,
+        "in_sample": in_sample,
+        "out_of_sample": out_sample,
+    }
+    print("\n" + "=" * 70)
+    print("EVAL SUMMARY (JSON)")
+    print(json.dumps(summary, indent=2, default=str))
+    print("=" * 70)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--checkpoint", required=True)
+    p.add_argument("--train-start", default="2014-01-01")
+    p.add_argument("--train-end", default="2023-12-31")
+    p.add_argument("--test-start", default="2024-01-01")
+    p.add_argument("--test-end", default=None)
+    p.add_argument("--window", type=int, default=30)
+    p.add_argument("--cache-dir", default="./.cache/dow30")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/rl-inference-server/scripts/eval_ppo_dow30_v2.py
+++ b/rl-inference-server/scripts/eval_ppo_dow30_v2.py
@@ -1,0 +1,85 @@
+"""Eval PPO v2 ckpt by stepping env v2 directly (bypass portfolio.py adapter).
+
+v2 obs shape이 v1과 달라 portfolio.py 매핑이 안 맞음 → env에서 매일 model.predict로
+action 받아 equity 곡선 직접 시뮬레이션.
+
+사용:
+  python -m scripts.eval_ppo_dow30_v2 --checkpoint trained/ppo_dow30_v2.zip
+"""
+from __future__ import annotations
+import argparse
+import json
+import numpy as np
+
+from stable_baselines3 import PPO
+
+from scripts.data_loader_v2 import load_dow30_with_volume
+from scripts.dow30_env_v2 import Dow30PortfolioEnvV2
+
+
+def _metrics(equity: np.ndarray) -> dict:
+    if equity.size < 2:
+        return {"total_return": 0.0, "sharpe": 0.0, "max_drawdown": 0.0}
+    rets = np.diff(equity) / equity[:-1]
+    total_return = float(equity[-1] / equity[0] - 1.0)
+    sharpe = float(rets.mean() / rets.std() * np.sqrt(252)) if rets.std() > 0 else 0.0
+    peak = np.maximum.accumulate(equity)
+    drawdown = (equity - peak) / peak
+    return {"total_return": total_return, "sharpe": sharpe, "max_drawdown": float(drawdown.min())}
+
+
+def evaluate(checkpoint: str, start: str, end: str | None, window: int, cache_dir: str, label: str) -> dict:
+    print(f"[eval v2:{label}] loading {start} → {end or 'latest'}")
+    prices, volumes = load_dow30_with_volume(start=start, end=end, cache_dir=cache_dir)
+    print(f"[eval v2:{label}] {len(prices)} rows × {prices.shape[1]} tickers")
+    if len(prices) <= window + 5:
+        return {"label": label, "skipped": True, "reason": "insufficient rows"}
+
+    env = Dow30PortfolioEnvV2(prices=prices, volumes=volumes, window=window)
+    model = PPO.load(checkpoint, device="cpu")
+    obs, _info = env.reset()
+
+    initial = 10_000.0
+    equity_curve: list[float] = [initial]
+    weights = np.ones(env._n) / env._n
+    while True:
+        action, _state = model.predict(obs, deterministic=True)
+        # Manually replicate env price step but track equity ourselves (env doesn't return equity).
+        new_w = env._normalize(np.asarray(action, dtype=np.float32))
+        ret = np.log(np.clip(env._prices[env._t] / env._prices[env._t - 1], 1e-6, None))
+        port_log_ret = float((weights * ret).sum())
+        equity_curve.append(equity_curve[-1] * float(np.exp(port_log_ret)))
+        weights = new_w
+        obs, _r, _term, truncated, _info = env.step(action)
+        if truncated:
+            break
+
+    eq = np.array(equity_curve, dtype=np.float64)
+    m = _metrics(eq)
+    print(f"[eval v2:{label}] return={m['total_return']:+.2%} sharpe={m['sharpe']:+.3f} mdd={m['max_drawdown']:+.2%}")
+    return {"label": label, "start": start, "end": end, "rows": len(prices), **m}
+
+
+def main(args: argparse.Namespace) -> None:
+    in_s = evaluate(args.checkpoint, args.train_start, args.train_end, args.window, args.cache_dir, "in_sample")
+    out_s = evaluate(args.checkpoint, args.test_start, args.test_end, args.window, args.cache_dir, "out_of_sample")
+    print("\n" + "=" * 70)
+    print("EVAL v2 SUMMARY")
+    print(json.dumps({"checkpoint": args.checkpoint, "in_sample": in_s, "out_of_sample": out_s}, indent=2, default=str))
+    print("=" * 70)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--checkpoint", required=True)
+    p.add_argument("--train-start", default="2019-04-01")
+    p.add_argument("--train-end", default="2023-12-31")
+    p.add_argument("--test-start", default="2024-01-01")
+    p.add_argument("--test-end", default=None)
+    p.add_argument("--window", type=int, default=30)
+    p.add_argument("--cache-dir", default="./.cache/dow30")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/rl-inference-server/scripts/sweep_ppo_dow30.py
+++ b/rl-inference-server/scripts/sweep_ppo_dow30.py
@@ -1,0 +1,138 @@
+"""Hyperparameter sweep for PPO Dow30 — manual grid over (lr, clip_range).
+
+각 trial:
+  1. 짧은 학습 (steps_per_trial)
+  2. 학습 데이터 in-sample + 2024~ out-of-sample 백테스트
+  3. out-of-sample Sharpe로 best 선정
+
+목적은 best 모델 산출보다 "어느 hyperparam이 안정적이고 데이터에 적합한지" 빠르게 보는 것.
+사용:
+  python -m scripts.sweep_ppo_dow30 --steps 30000 --n-envs 4
+"""
+from __future__ import annotations
+import argparse
+import itertools
+import json
+import time
+from pathlib import Path
+
+from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
+
+from scripts.data_loader import load_dow30, DEFAULT_UNIVERSE
+from scripts.dow30_env import Dow30PortfolioEnv
+from scripts.eval_ppo_dow30 import evaluate_period
+from src.adapters.sb3 import SB3Adapter
+
+
+def build_env(prices, window: int, n_envs: int):
+    def make():
+        return Dow30PortfolioEnv(prices=prices, window=window)
+    if n_envs > 1:
+        return SubprocVecEnv([make for _ in range(n_envs)], start_method="spawn")
+    return DummyVecEnv([make])
+
+
+def run_trial(
+    prices,
+    out_dir: Path,
+    trial_id: int,
+    lr: float,
+    clip_range: float,
+    gamma: float,
+    n_envs: int,
+    steps: int,
+    n_steps: int,
+    batch_size: int,
+    window: int,
+) -> dict:
+    print(f"\n[trial {trial_id}] lr={lr:.0e} clip={clip_range} gamma={gamma}")
+    env = build_env(prices, window, n_envs)
+    model = PPO(
+        "MlpPolicy", env,
+        n_steps=n_steps, batch_size=batch_size,
+        learning_rate=lr, clip_range=clip_range, gamma=gamma,
+        verbose=0, device="cpu",
+    )
+    t0 = time.time()
+    model.learn(total_timesteps=steps, progress_bar=False)
+    train_wall = time.time() - t0
+
+    ckpt_path = out_dir / f"trial_{trial_id}.zip"
+    model.save(str(ckpt_path))
+    if hasattr(env, "close"):
+        env.close()
+
+    # Eval
+    adapter = SB3Adapter.load(checkpoint_path=str(ckpt_path), algorithm="PPO")
+    in_s = evaluate_period(
+        adapter, str(ckpt_path), DEFAULT_UNIVERSE,
+        "2014-01-01", "2023-12-31", window, f"trial{trial_id}_in", "./.cache/dow30",
+    )
+    out_s = evaluate_period(
+        adapter, str(ckpt_path), DEFAULT_UNIVERSE,
+        "2024-01-01", None, window, f"trial{trial_id}_out", "./.cache/dow30",
+    )
+    return {
+        "trial": trial_id,
+        "lr": lr, "clip_range": clip_range, "gamma": gamma,
+        "train_wall_sec": round(train_wall, 1),
+        "in_sample_sharpe": in_s["sharpe_ratio"],
+        "out_of_sample_sharpe": out_s["sharpe_ratio"],
+        "out_of_sample_return": out_s["total_return"],
+        "out_of_sample_mdd": out_s["max_drawdown"],
+    }
+
+
+def main(args: argparse.Namespace) -> None:
+    print(f"[sweep] loading prices ({args.start} → {args.end})")
+    prices = load_dow30(start=args.start, end=args.end, cache_dir=args.cache_dir)
+    print(f"[sweep] {len(prices)} rows × {prices.shape[1]} tickers")
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Grid: 3 lr × 2 clip = 6 trials
+    lrs = [1e-4, 3e-4, 1e-3]
+    clips = [0.1, 0.3]
+    gamma = 0.99
+
+    results: list[dict] = []
+    for i, (lr, clip) in enumerate(itertools.product(lrs, clips)):
+        r = run_trial(
+            prices=prices, out_dir=out_dir, trial_id=i,
+            lr=lr, clip_range=clip, gamma=gamma,
+            n_envs=args.n_envs, steps=args.steps,
+            n_steps=args.n_steps, batch_size=args.batch_size, window=args.window,
+        )
+        results.append(r)
+        print(f"[trial {i}] OOS sharpe={r['out_of_sample_sharpe']:.3f} "
+              f"in={r['in_sample_sharpe']:.3f} return={r['out_of_sample_return']:+.2%} "
+              f"wall={r['train_wall_sec']}s")
+
+    results.sort(key=lambda x: x["out_of_sample_sharpe"], reverse=True)
+    print("\n" + "=" * 70)
+    print("SWEEP SUMMARY (sorted by OOS sharpe)")
+    print(json.dumps(results, indent=2))
+    print("=" * 70)
+    best = results[0]
+    print(f"\n[best] trial={best['trial']} lr={best['lr']:.0e} clip={best['clip_range']} "
+          f"OOS_sharpe={best['out_of_sample_sharpe']:.3f}")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--start", default="2014-01-01")
+    p.add_argument("--end", default="2023-12-31")
+    p.add_argument("--steps", type=int, default=30_000)
+    p.add_argument("--n-envs", type=int, default=4)
+    p.add_argument("--n-steps", type=int, default=2048)
+    p.add_argument("--batch-size", type=int, default=256)
+    p.add_argument("--window", type=int, default=30)
+    p.add_argument("--cache-dir", default="./.cache/dow30")
+    p.add_argument("--out-dir", default="./trained/sweep")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/rl-inference-server/scripts/train_ppo_dow30.py
+++ b/rl-inference-server/scripts/train_ppo_dow30.py
@@ -10,9 +10,10 @@ import argparse
 import hashlib
 from pathlib import Path
 
+import time
 import numpy as np
 from stable_baselines3 import PPO
-from stable_baselines3.common.vec_env import DummyVecEnv
+from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
 
 from scripts.data_loader import load_dow30, DEFAULT_UNIVERSE
 from scripts.dow30_env import Dow30PortfolioEnv
@@ -26,7 +27,13 @@ def main(args: argparse.Namespace) -> None:
     def make_env():
         return Dow30PortfolioEnv(prices=prices, window=args.window)
 
-    vec_env = DummyVecEnv([make_env])
+    if args.n_envs > 1:
+        vec_env = SubprocVecEnv([make_env for _ in range(args.n_envs)], start_method="spawn")
+        print(f"[train] using SubprocVecEnv with n_envs={args.n_envs} (spawn)")
+    else:
+        vec_env = DummyVecEnv([make_env])
+        print(f"[train] using DummyVecEnv (single env)")
+
     model = PPO(
         "MlpPolicy", vec_env,
         n_steps=args.n_steps,
@@ -36,8 +43,11 @@ def main(args: argparse.Namespace) -> None:
         verbose=1,
         device="cpu",
     )
-    print(f"[train] starting {args.steps} timesteps...")
+    print(f"[train] starting {args.steps} timesteps (n_envs={args.n_envs})...")
+    t0 = time.time()
     model.learn(total_timesteps=args.steps, progress_bar=False)
+    wall = time.time() - t0
+    print(f"[train] wall time: {wall:.1f}s ({args.steps / wall:.0f} steps/s wall)")
 
     out = Path(args.output)
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -62,6 +72,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--start", default="2014-01-01")
     p.add_argument("--end", default=None)
     p.add_argument("--steps", type=int, default=50_000)
+    p.add_argument("--n-envs", type=int, default=1, help="parallel envs (SubprocVecEnv if >1)")
     p.add_argument("--n-steps", type=int, default=2048)
     p.add_argument("--batch-size", type=int, default=64)
     p.add_argument("--lr", type=float, default=3e-4)

--- a/rl-inference-server/scripts/train_ppo_dow30.py
+++ b/rl-inference-server/scripts/train_ppo_dow30.py
@@ -1,0 +1,75 @@
+"""Train a SB3 PPO agent on Dow 30 portfolio env, save the ckpt + sha256.
+
+Usage:
+  python -m scripts.train_ppo_dow30 \
+    --start 2014-01-01 --end 2024-12-31 \
+    --steps 50000 --output ./trained/ppo_dow30.zip
+"""
+from __future__ import annotations
+import argparse
+import hashlib
+from pathlib import Path
+
+import numpy as np
+from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv
+
+from scripts.data_loader import load_dow30, DEFAULT_UNIVERSE
+from scripts.dow30_env import Dow30PortfolioEnv
+
+
+def main(args: argparse.Namespace) -> None:
+    print(f"[train] loading OHLCV {args.start} → {args.end}")
+    prices = load_dow30(start=args.start, end=args.end, cache_dir=args.cache_dir)
+    print(f"[train] loaded {len(prices)} rows × {prices.shape[1]} tickers")
+
+    def make_env():
+        return Dow30PortfolioEnv(prices=prices, window=args.window)
+
+    vec_env = DummyVecEnv([make_env])
+    model = PPO(
+        "MlpPolicy", vec_env,
+        n_steps=args.n_steps,
+        batch_size=args.batch_size,
+        learning_rate=args.lr,
+        gamma=0.99,
+        verbose=1,
+        device="cpu",
+    )
+    print(f"[train] starting {args.steps} timesteps...")
+    model.learn(total_timesteps=args.steps, progress_bar=False)
+
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    model.save(str(out))
+    sha256 = hashlib.sha256(out.read_bytes()).hexdigest()
+    size = out.stat().st_size
+    print(f"\n[train] saved {out} ({size} bytes)")
+    print(f"[train] sha256: {sha256}")
+    print("\n[train] register with the API by inserting into rl_models with:")
+    print(f"  source: 'custom'")
+    print(f"  algorithm: 'PPO'")
+    print(f"  kind: 'portfolio'")
+    print(f"  state_window: {args.window}")
+    print(f"  output_shape: {{type: 'continuous', dim: {len(prices.columns)}}}")
+    print(f"  universe: {list(prices.columns)}")
+    print(f"  checkpoint_url: file://{out.resolve()}")
+    print(f"  checkpoint_sha256: {sha256}")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--start", default="2014-01-01")
+    p.add_argument("--end", default=None)
+    p.add_argument("--steps", type=int, default=50_000)
+    p.add_argument("--n-steps", type=int, default=2048)
+    p.add_argument("--batch-size", type=int, default=64)
+    p.add_argument("--lr", type=float, default=3e-4)
+    p.add_argument("--window", type=int, default=30)
+    p.add_argument("--cache-dir", default="./.cache/dow30")
+    p.add_argument("--output", default="./trained/ppo_dow30.zip")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/rl-inference-server/scripts/train_ppo_dow30.py
+++ b/rl-inference-server/scripts/train_ppo_dow30.py
@@ -11,7 +11,6 @@ import hashlib
 from pathlib import Path
 
 import time
-import numpy as np
 from stable_baselines3 import PPO
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
 
@@ -39,7 +38,8 @@ def main(args: argparse.Namespace) -> None:
         n_steps=args.n_steps,
         batch_size=args.batch_size,
         learning_rate=args.lr,
-        gamma=0.99,
+        clip_range=args.clip_range,
+        gamma=args.gamma,
         verbose=1,
         device="cpu",
     )
@@ -76,6 +76,8 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--n-steps", type=int, default=2048)
     p.add_argument("--batch-size", type=int, default=64)
     p.add_argument("--lr", type=float, default=3e-4)
+    p.add_argument("--clip-range", type=float, default=0.2)
+    p.add_argument("--gamma", type=float, default=0.99)
     p.add_argument("--window", type=int, default=30)
     p.add_argument("--cache-dir", default="./.cache/dow30")
     p.add_argument("--output", default="./trained/ppo_dow30.zip")

--- a/rl-inference-server/scripts/train_ppo_dow30_v2.py
+++ b/rl-inference-server/scripts/train_ppo_dow30_v2.py
@@ -1,0 +1,82 @@
+"""Train PPO on Dow30PortfolioEnvV2 (reward shaping + 확장 state).
+
+사용:
+  python -m scripts.train_ppo_dow30_v2 \
+    --start 2019-04-01 --end 2023-12-31 \
+    --steps 60000 --n-envs 8 --lr 1e-3 --clip-range 0.1 \
+    --output ./trained/ppo_dow30_v2.zip
+"""
+from __future__ import annotations
+import argparse
+import hashlib
+import time
+from pathlib import Path
+
+from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
+
+from scripts.data_loader_v2 import load_dow30_with_volume
+from scripts.dow30_env_v2 import Dow30PortfolioEnvV2
+
+
+def main(args: argparse.Namespace) -> None:
+    print(f"[train v2] loading {args.start} → {args.end}")
+    prices, volumes = load_dow30_with_volume(start=args.start, end=args.end, cache_dir=args.cache_dir)
+    print(f"[train v2] loaded {len(prices)} rows × {prices.shape[1]} tickers")
+
+    def make_env():
+        return Dow30PortfolioEnvV2(
+            prices=prices, volumes=volumes,
+            window=args.window,
+            turnover_penalty=args.turnover_penalty,
+            downside_penalty=args.downside_penalty,
+        )
+
+    if args.n_envs > 1:
+        env = SubprocVecEnv([make_env for _ in range(args.n_envs)], start_method="spawn")
+        print(f"[train v2] SubprocVecEnv n_envs={args.n_envs}")
+    else:
+        env = DummyVecEnv([make_env])
+
+    model = PPO(
+        "MlpPolicy", env,
+        n_steps=args.n_steps, batch_size=args.batch_size,
+        learning_rate=args.lr, clip_range=args.clip_range, gamma=args.gamma,
+        verbose=1, device="cpu",
+    )
+    print(f"[train v2] {args.steps} steps (downside={args.downside_penalty}, turnover={args.turnover_penalty})")
+    t0 = time.time()
+    model.learn(total_timesteps=args.steps, progress_bar=False)
+    wall = time.time() - t0
+    print(f"[train v2] wall {wall:.1f}s ({args.steps / wall:.0f} steps/s)")
+
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    model.save(str(out))
+    sha = hashlib.sha256(out.read_bytes()).hexdigest()
+    size = out.stat().st_size
+    print(f"\n[train v2] saved {out} ({size} bytes)")
+    print(f"[train v2] sha256: {sha}")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--start", default="2019-04-01")
+    p.add_argument("--end", default="2023-12-31")
+    p.add_argument("--steps", type=int, default=60_000)
+    p.add_argument("--n-envs", type=int, default=8)
+    p.add_argument("--n-steps", type=int, default=2048)
+    p.add_argument("--batch-size", type=int, default=256)
+    p.add_argument("--lr", type=float, default=1e-3)
+    p.add_argument("--clip-range", type=float, default=0.1)
+    p.add_argument("--gamma", type=float, default=0.99)
+    p.add_argument("--window", type=int, default=30)
+    p.add_argument("--turnover-penalty", type=float, default=1e-4)
+    p.add_argument("--downside-penalty", type=float, default=5.0)
+    p.add_argument("--cache-dir", default="./.cache/dow30")
+    p.add_argument("--output", default="./trained/ppo_dow30_v2.zip")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/rl-inference-server/scripts/walkforward_dow30.py
+++ b/rl-inference-server/scripts/walkforward_dow30.py
@@ -1,0 +1,149 @@
+"""Walk-forward cross-validation for PPO Dow30.
+
+여러 rolling windows에 대해 학습+OOS 평가를 반복해 robustness 측정.
+
+기본:
+  Window i: train [start, train_end_i], test [train_end_i+1day, train_end_i+1y]
+  expanding window (start fixed, train_end 매년 증가)
+
+사용:
+  python -m scripts.walkforward_dow30 --steps 30000 --n-envs 4
+"""
+from __future__ import annotations
+import argparse
+import json
+import time
+from pathlib import Path
+
+from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
+
+from scripts.data_loader import load_dow30, DEFAULT_UNIVERSE
+from scripts.dow30_env import Dow30PortfolioEnv
+from scripts.eval_ppo_dow30 import evaluate_period
+from src.adapters.sb3 import SB3Adapter
+
+
+def build_env(prices, window: int, n_envs: int):
+    def make():
+        return Dow30PortfolioEnv(prices=prices, window=window)
+    if n_envs > 1:
+        return SubprocVecEnv([make for _ in range(n_envs)], start_method="spawn")
+    return DummyVecEnv([make])
+
+
+def run_window(
+    out_dir: Path,
+    window_id: int,
+    train_start: str,
+    train_end: str,
+    test_start: str,
+    test_end: str | None,
+    steps: int,
+    n_envs: int,
+    n_steps: int,
+    batch_size: int,
+    lr: float,
+    clip_range: float,
+    gamma: float,
+    window: int,
+    cache_dir: str,
+) -> dict:
+    print(f"\n[wf {window_id}] train {train_start}→{train_end}  test {test_start}→{test_end or 'latest'}")
+    train_prices = load_dow30(start=train_start, end=train_end, cache_dir=cache_dir)
+    print(f"[wf {window_id}] train rows: {len(train_prices)}")
+
+    env = build_env(train_prices, window, n_envs)
+    model = PPO(
+        "MlpPolicy", env,
+        n_steps=n_steps, batch_size=batch_size,
+        learning_rate=lr, clip_range=clip_range, gamma=gamma,
+        verbose=0, device="cpu",
+    )
+    t0 = time.time()
+    model.learn(total_timesteps=steps, progress_bar=False)
+    train_wall = time.time() - t0
+    if hasattr(env, "close"):
+        env.close()
+
+    ckpt = out_dir / f"wf_{window_id}.zip"
+    model.save(str(ckpt))
+    adapter = SB3Adapter.load(checkpoint_path=str(ckpt), algorithm="PPO")
+    test_metrics = evaluate_period(
+        adapter, str(ckpt), DEFAULT_UNIVERSE,
+        test_start, test_end, window, f"wf{window_id}_test", cache_dir,
+    )
+    return {
+        "window_id": window_id,
+        "train_period": f"{train_start}..{train_end}",
+        "test_period": f"{test_start}..{test_end or 'latest'}",
+        "train_wall_sec": round(train_wall, 1),
+        "sharpe": test_metrics["sharpe_ratio"],
+        "total_return": test_metrics["total_return"],
+        "max_drawdown": test_metrics["max_drawdown"],
+        "n_rebalances": test_metrics["n_rebalances"],
+    }
+
+
+def main(args: argparse.Namespace) -> None:
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Expanding-window WF: train [2019-04, year_end], test [year+1].
+    # 시작이 2019-04인 이유: DOW(Dow Inc.)가 2019-04 spinoff이므로 그 이전 데이터 없음 →
+    # 30종목 dropna로 빈 데이터프레임이 됨. 2019-04부터는 30종목 모두 가용.
+    train_start = "2019-04-01"
+    test_years = [2021, 2022, 2023, 2024]  # train end는 (year-1)-12-31
+    results: list[dict] = []
+    for i, ty in enumerate(test_years):
+        train_end = f"{ty - 1}-12-31"
+        test_start = f"{ty}-01-01"
+        test_end = f"{ty}-12-31"
+        r = run_window(
+            out_dir=out_dir, window_id=i,
+            train_start=train_start, train_end=train_end,
+            test_start=test_start, test_end=test_end,
+            steps=args.steps, n_envs=args.n_envs,
+            n_steps=args.n_steps, batch_size=args.batch_size,
+            lr=args.lr, clip_range=args.clip_range, gamma=args.gamma,
+            window=args.window, cache_dir=args.cache_dir,
+        )
+        results.append(r)
+        print(f"[wf {i}] sharpe={r['sharpe']:+.3f} return={r['total_return']:+.2%} mdd={r['max_drawdown']:+.2%} wall={r['train_wall_sec']}s")
+
+    sharpes = [r["sharpe"] for r in results]
+    returns = [r["total_return"] for r in results]
+    mean_sharpe = sum(sharpes) / len(sharpes)
+    std_sharpe = (sum((s - mean_sharpe) ** 2 for s in sharpes) / len(sharpes)) ** 0.5
+    mean_return = sum(returns) / len(returns)
+
+    print("\n" + "=" * 80)
+    print("WALK-FORWARD SUMMARY")
+    print(json.dumps({
+        "n_windows": len(results),
+        "mean_sharpe": round(mean_sharpe, 3),
+        "std_sharpe": round(std_sharpe, 3),
+        "mean_return": round(mean_return, 4),
+        "details": results,
+    }, indent=2, default=str))
+    print("=" * 80)
+    print(f"\n[wf] mean Sharpe={mean_sharpe:+.3f} ± {std_sharpe:.3f}  mean return={mean_return:+.2%}")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--steps", type=int, default=30_000)
+    p.add_argument("--n-envs", type=int, default=4)
+    p.add_argument("--n-steps", type=int, default=2048)
+    p.add_argument("--batch-size", type=int, default=256)
+    p.add_argument("--lr", type=float, default=1e-3)
+    p.add_argument("--clip-range", type=float, default=0.1)
+    p.add_argument("--gamma", type=float, default=0.99)
+    p.add_argument("--window", type=int, default=30)
+    p.add_argument("--cache-dir", default="./.cache/dow30")
+    p.add_argument("--out-dir", default="./trained/wf")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/rl-inference-server/scripts/walkforward_dow30_v2.py
+++ b/rl-inference-server/scripts/walkforward_dow30_v2.py
@@ -1,0 +1,107 @@
+"""Walk-forward CV for env v2."""
+from __future__ import annotations
+import argparse
+import json
+import time
+from pathlib import Path
+
+from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
+
+from scripts.data_loader_v2 import load_dow30_with_volume
+from scripts.dow30_env_v2 import Dow30PortfolioEnvV2
+from scripts.eval_ppo_dow30_v2 import evaluate as evaluate_v2
+
+
+def build_env(prices, volumes, window: int, n_envs: int):
+    def make():
+        return Dow30PortfolioEnvV2(prices=prices, volumes=volumes, window=window)
+    if n_envs > 1:
+        return SubprocVecEnv([make for _ in range(n_envs)], start_method="spawn")
+    return DummyVecEnv([make])
+
+
+def run_window(out_dir: Path, window_id: int, train_start: str, train_end: str,
+               test_start: str, test_end: str | None,
+               steps: int, n_envs: int, n_steps: int, batch_size: int,
+               lr: float, clip_range: float, gamma: float, window: int, cache_dir: str) -> dict:
+    print(f"\n[wf v2 {window_id}] train {train_start}→{train_end}  test {test_start}→{test_end or 'latest'}")
+    prices, volumes = load_dow30_with_volume(start=train_start, end=train_end, cache_dir=cache_dir)
+    print(f"[wf v2 {window_id}] train rows: {len(prices)}")
+
+    env = build_env(prices, volumes, window, n_envs)
+    model = PPO("MlpPolicy", env, n_steps=n_steps, batch_size=batch_size,
+                learning_rate=lr, clip_range=clip_range, gamma=gamma,
+                verbose=0, device="cpu")
+    t0 = time.time()
+    model.learn(total_timesteps=steps, progress_bar=False)
+    train_wall = time.time() - t0
+    if hasattr(env, "close"):
+        env.close()
+
+    ckpt = out_dir / f"wf_v2_{window_id}.zip"
+    model.save(str(ckpt))
+    test = evaluate_v2(str(ckpt), test_start, test_end, window, cache_dir, f"wf{window_id}")
+    return {
+        "window_id": window_id,
+        "train_period": f"{train_start}..{train_end}",
+        "test_period": f"{test_start}..{test_end or 'latest'}",
+        "train_wall_sec": round(train_wall, 1),
+        "sharpe": test["sharpe"],
+        "total_return": test["total_return"],
+        "max_drawdown": test["max_drawdown"],
+    }
+
+
+def main(args: argparse.Namespace) -> None:
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    train_start = "2019-04-01"
+    test_years = [2021, 2022, 2023, 2024]
+    results: list[dict] = []
+    for i, ty in enumerate(test_years):
+        r = run_window(
+            out_dir=out_dir, window_id=i,
+            train_start=train_start, train_end=f"{ty - 1}-12-31",
+            test_start=f"{ty}-01-01", test_end=f"{ty}-12-31",
+            steps=args.steps, n_envs=args.n_envs,
+            n_steps=args.n_steps, batch_size=args.batch_size,
+            lr=args.lr, clip_range=args.clip_range, gamma=args.gamma,
+            window=args.window, cache_dir=args.cache_dir,
+        )
+        results.append(r)
+        print(f"[wf v2 {i}] sharpe={r['sharpe']:+.3f} return={r['total_return']:+.2%} mdd={r['max_drawdown']:+.2%} wall={r['train_wall_sec']}s")
+
+    sharpes = [r["sharpe"] for r in results]
+    returns = [r["total_return"] for r in results]
+    mean_sharpe = sum(sharpes) / len(sharpes)
+    std_sharpe = (sum((s - mean_sharpe) ** 2 for s in sharpes) / len(sharpes)) ** 0.5
+    print("\n" + "=" * 70)
+    print(json.dumps({
+        "n_windows": len(results),
+        "mean_sharpe": round(mean_sharpe, 3),
+        "std_sharpe": round(std_sharpe, 3),
+        "mean_return": round(sum(returns) / len(returns), 4),
+        "details": results,
+    }, indent=2, default=str))
+    print(f"\n[wf v2] mean Sharpe={mean_sharpe:+.3f} ± {std_sharpe:.3f}")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--steps", type=int, default=60_000)
+    p.add_argument("--n-envs", type=int, default=4)
+    p.add_argument("--n-steps", type=int, default=2048)
+    p.add_argument("--batch-size", type=int, default=256)
+    p.add_argument("--lr", type=float, default=1e-3)
+    p.add_argument("--clip-range", type=float, default=0.1)
+    p.add_argument("--gamma", type=float, default=0.99)
+    p.add_argument("--window", type=int, default=30)
+    p.add_argument("--cache-dir", default="./.cache/dow30")
+    p.add_argument("--out-dir", default="./trained/wf_v2")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/rl-inference-server/src/adapters/base.py
+++ b/rl-inference-server/src/adapters/base.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+import numpy as np
+
+
+class AdapterBase(ABC):
+    """RL inference adapter common interface.
+
+    Each adapter provides raw observation → (action, logits/q_values) and
+    a confidence calculation in [0, 1].
+    """
+
+    @classmethod
+    @abstractmethod
+    def load(cls, checkpoint_path: str, algorithm: str) -> "AdapterBase":
+        ...
+
+    @abstractmethod
+    def predict_with_logits(self, obs: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Return (action, logits_or_qvalues). logits used for confidence."""
+
+    @abstractmethod
+    def compute_confidence(self, logits_or_q: np.ndarray) -> float:
+        """Adapter-specific confidence in [0, 1]. Do NOT return constant 1.0."""

--- a/rl-inference-server/src/adapters/sb3.py
+++ b/rl-inference-server/src/adapters/sb3.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 import numpy as np
 import torch
+import gymnasium as gym
 from src.adapters.base import AdapterBase
 
 _SUPPORTED = {"PPO", "A2C", "DQN", "TD3", "DDPG", "SAC"}
 
 
 class SB3Adapter(AdapterBase):
-    def __init__(self, model: object, algorithm: str) -> None:
+    def __init__(self, model: object, algorithm: str, is_discrete: bool) -> None:
         self._model = model
         self._algorithm = algorithm
+        self._is_discrete = is_discrete
 
     @classmethod
     def load(cls, checkpoint_path: str, algorithm: str) -> "SB3Adapter":
@@ -28,7 +30,10 @@ class SB3Adapter(AdapterBase):
         elif algorithm == "SAC":
             from stable_baselines3 import SAC as Cls
         model = Cls.load(checkpoint_path, device="cpu")
-        return cls(model, algorithm)
+        action_space = getattr(getattr(model, "policy", None), "action_space", None)
+        # Discrete and MultiDiscrete are integer-action spaces; everything else (Box, MultiBinary) treated as continuous.
+        is_discrete = isinstance(action_space, (gym.spaces.Discrete, gym.spaces.MultiDiscrete))
+        return cls(model, algorithm, is_discrete)
 
     def predict_with_logits(self, obs: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         action, _state = self._model.predict(obs, deterministic=True)
@@ -36,12 +41,13 @@ class SB3Adapter(AdapterBase):
             obs_tensor = torch.as_tensor(obs, dtype=torch.float32).unsqueeze(0)
             policy = getattr(self._model, "policy", None)
             if policy is None:
-                return np.asarray(action), np.array([1.0])
+                # No policy network access → empty logits signals "unknown"
+                return np.asarray(action), np.array([], dtype=np.float32)
             try:
                 dist = policy.get_distribution(obs_tensor)
                 logits = self._extract_distribution(dist)
             except Exception:
-                logits = np.array([1.0])
+                logits = np.array([], dtype=np.float32)
         return np.asarray(action), logits
 
     def _extract_distribution(self, dist) -> np.ndarray:
@@ -54,25 +60,27 @@ class SB3Adapter(AdapterBase):
             mean = inner.mean.detach().cpu().numpy().squeeze()
             std = inner.stddev.detach().cpu().numpy().squeeze()
             return np.concatenate([np.atleast_1d(mean), np.atleast_1d(std)])
-        return np.array([1.0])
+        return np.array([], dtype=np.float32)
 
     def compute_confidence(self, logits_or_q: np.ndarray) -> float:
         """
-        - discrete: softmax(logits).max()
-        - continuous (mean,std concatenated): 1 - mean(std) / std_max
+        Confidence in [0, 1] dispatched on action space kind, not logits shape.
+        - Empty input → 0.0 (unknown / fallback). NEVER return constant 1.0.
+        - Discrete: softmax(logits).max() = probability of selected action.
+        - Continuous: 1 - mean(std)/std_max (lower spread = higher confidence).
         """
         arr = np.asarray(logits_or_q, dtype=np.float32).ravel()
         if arr.size == 0:
             return 0.0
-        # continuous heuristic: even-sized array → assume (mean, std) halves
-        if arr.size >= 2 and arr.size % 2 == 0:
-            half = arr.size // 2
-            mean = arr[:half]
-            std = arr[half:]
-            std_max = max(float(std.max()), 1e-6)
-            conf = 1.0 - float(std.mean()) / std_max
-            return float(np.clip(conf, 0.0, 1.0))
-        # discrete: softmax max
-        e = np.exp(arr - arr.max())
-        probs = e / e.sum()
-        return float(np.clip(probs.max(), 0.0, 1.0))
+        if self._is_discrete:
+            e = np.exp(arr - arr.max())
+            probs = e / e.sum()
+            return float(np.clip(probs.max(), 0.0, 1.0))
+        # continuous: array is concatenated [mean..., std...]
+        if arr.size < 2 or arr.size % 2 != 0:
+            return 0.0
+        half = arr.size // 2
+        std = arr[half:]
+        std_max = max(float(std.max()), 1e-6)
+        conf = 1.0 - float(std.mean()) / std_max
+        return float(np.clip(conf, 0.0, 1.0))

--- a/rl-inference-server/src/adapters/sb3.py
+++ b/rl-inference-server/src/adapters/sb3.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+import numpy as np
+import torch
+from src.adapters.base import AdapterBase
+
+_SUPPORTED = {"PPO", "A2C", "DQN", "TD3", "DDPG", "SAC"}
+
+
+class SB3Adapter(AdapterBase):
+    def __init__(self, model: object, algorithm: str) -> None:
+        self._model = model
+        self._algorithm = algorithm
+
+    @classmethod
+    def load(cls, checkpoint_path: str, algorithm: str) -> "SB3Adapter":
+        if algorithm not in _SUPPORTED:
+            raise ValueError(f"unsupported algorithm: {algorithm}")
+        if algorithm == "PPO":
+            from stable_baselines3 import PPO as Cls
+        elif algorithm == "A2C":
+            from stable_baselines3 import A2C as Cls
+        elif algorithm == "DQN":
+            from stable_baselines3 import DQN as Cls
+        elif algorithm == "TD3":
+            from stable_baselines3 import TD3 as Cls
+        elif algorithm == "DDPG":
+            from stable_baselines3 import DDPG as Cls
+        elif algorithm == "SAC":
+            from stable_baselines3 import SAC as Cls
+        model = Cls.load(checkpoint_path, device="cpu")
+        return cls(model, algorithm)
+
+    def predict_with_logits(self, obs: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        action, _state = self._model.predict(obs, deterministic=True)
+        with torch.no_grad():
+            obs_tensor = torch.as_tensor(obs, dtype=torch.float32).unsqueeze(0)
+            policy = getattr(self._model, "policy", None)
+            if policy is None:
+                return np.asarray(action), np.array([1.0])
+            try:
+                dist = policy.get_distribution(obs_tensor)
+                logits = self._extract_distribution(dist)
+            except Exception:
+                logits = np.array([1.0])
+        return np.asarray(action), logits
+
+    def _extract_distribution(self, dist) -> np.ndarray:
+        # discrete (Categorical)
+        inner = getattr(dist, "distribution", None)
+        if inner is not None and hasattr(inner, "logits"):
+            return inner.logits.detach().cpu().numpy().squeeze()
+        # continuous (Normal): mean + std
+        if inner is not None and hasattr(inner, "mean") and hasattr(inner, "stddev"):
+            mean = inner.mean.detach().cpu().numpy().squeeze()
+            std = inner.stddev.detach().cpu().numpy().squeeze()
+            return np.concatenate([np.atleast_1d(mean), np.atleast_1d(std)])
+        return np.array([1.0])
+
+    def compute_confidence(self, logits_or_q: np.ndarray) -> float:
+        """
+        - discrete: softmax(logits).max()
+        - continuous (mean,std concatenated): 1 - mean(std) / std_max
+        """
+        arr = np.asarray(logits_or_q, dtype=np.float32).ravel()
+        if arr.size == 0:
+            return 0.0
+        # continuous heuristic: even-sized array → assume (mean, std) halves
+        if arr.size >= 2 and arr.size % 2 == 0:
+            half = arr.size // 2
+            mean = arr[:half]
+            std = arr[half:]
+            std_max = max(float(std.max()), 1e-6)
+            conf = 1.0 - float(std.mean()) / std_max
+            return float(np.clip(conf, 0.0, 1.0))
+        # discrete: softmax max
+        e = np.exp(arr - arr.max())
+        probs = e / e.sum()
+        return float(np.clip(probs.max(), 0.0, 1.0))

--- a/rl-inference-server/src/auth.py
+++ b/rl-inference-server/src/auth.py
@@ -1,0 +1,11 @@
+from fastapi import Header, HTTPException, status
+from src.config import get_settings
+
+
+def require_api_key(x_rl_api_key: str | None = Header(default=None)) -> None:
+    settings = get_settings()
+    if not x_rl_api_key or x_rl_api_key != settings.rl_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid or missing X-RL-API-KEY",
+        )

--- a/rl-inference-server/src/config.py
+++ b/rl-inference-server/src/config.py
@@ -1,0 +1,15 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_prefix="")
+
+    rl_server_host: str = "127.0.0.1"
+    rl_server_port: int = 8001
+    rl_api_key: str = "change-me"
+    model_dir: str = "/tmp/rl-inference/models"
+    log_level: str = "INFO"
+
+
+def get_settings() -> Settings:
+    return Settings()

--- a/rl-inference-server/src/inference/backtest.py
+++ b/rl-inference-server/src/inference/backtest.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+import time
+import numpy as np
+from src.adapters.sb3 import SB3Adapter
+from src.inference.portfolio import PortfolioInferenceEngine
+from src.schemas import BacktestRequest, BacktestResponse, EquityPoint, PredictRequest
+
+
+def run_backtest(adapter: SB3Adapter, req: BacktestRequest) -> BacktestResponse:
+    t0 = time.time()
+    engine = PortfolioInferenceEngine(adapter)
+    tickers = sorted(req.ohlcv.keys())
+    rows_by_t = {t: {row.date: row.close for row in req.ohlcv[t]} for t in tickers}
+    all_dates = sorted({row.date for t in tickers for row in req.ohlcv[t]})
+
+    equity = float(req.initial_capital)
+    weights: dict[str, float] = {t: 0.0 for t in tickers}
+    curve: list[EquityPoint] = []
+    n_rebalances = 0
+
+    prev_prices: dict[str, float] | None = None
+    rebal_set = set(req.rebalance_dates)
+
+    for date in all_dates:
+        prices = {t: rows_by_t[t].get(date) for t in tickers}
+        if any(p is None for p in prices.values()):
+            continue
+        if prev_prices is not None and any(weights.values()):
+            ret = sum(weights[t] * (prices[t] / prev_prices[t] - 1.0) for t in tickers)
+            equity *= (1.0 + ret)
+        prev_prices = prices
+
+        if date in rebal_set:
+            sub_req = PredictRequest(
+                model_id=req.model_id,
+                checkpoint_path=req.checkpoint_path,
+                algorithm=req.algorithm,
+                kind=req.kind,
+                state_window=req.state_window,
+                input_features=req.input_features,
+                ohlcv={
+                    t: [r for r in req.ohlcv[t] if r.date <= date][-req.state_window:]
+                    for t in tickers
+                },
+            )
+            try:
+                pred = engine.run(sub_req)
+                weights = pred.weights
+                n_rebalances += 1
+            except Exception:
+                pass
+
+        curve.append(EquityPoint(date=date, equity=equity))
+
+    if not curve:
+        curve = [EquityPoint(date=all_dates[0] if all_dates else "1970-01-01", equity=equity)]
+
+    equities = np.array([p.equity for p in curve], dtype=np.float64)
+    rets = np.diff(equities) / equities[:-1] if equities.size >= 2 else np.array([0.0])
+    total_return = float(equities[-1] / req.initial_capital - 1.0)
+    sharpe = float(rets.mean() / rets.std() * np.sqrt(252)) if rets.std() > 0 else 0.0
+    peak = np.maximum.accumulate(equities)
+    drawdown = (equities - peak) / peak
+    max_dd = float(drawdown.min()) if drawdown.size else 0.0
+
+    return BacktestResponse(
+        total_return=total_return,
+        sharpe_ratio=sharpe,
+        max_drawdown=max_dd,
+        n_rebalances=n_rebalances,
+        equity_curve=curve,
+        metadata={
+            "model_id": req.model_id,
+            "latency_ms": round((time.time() - t0) * 1000, 2),
+            "n_dates": len(all_dates),
+        },
+    )

--- a/rl-inference-server/src/inference/portfolio.py
+++ b/rl-inference-server/src/inference/portfolio.py
@@ -33,7 +33,9 @@ class PortfolioInferenceEngine:
         if raw.size != len(tickers):
             # dimension mismatch: equal split + low confidence
             weights = {t: 1.0 / len(tickers) for t in tickers}
-            confidence = min(confidence, 0.0)
+            # Dimension mismatch fallback: equal split + zero confidence.
+            # (fake 1.0 forbidden — see SB3Adapter.compute_confidence contract)
+            confidence = 0.0
         else:
             clipped = np.clip(raw, 0.0, None)
             s = clipped.sum()

--- a/rl-inference-server/src/inference/portfolio.py
+++ b/rl-inference-server/src/inference/portfolio.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+import time
+import numpy as np
+from src.adapters.sb3 import SB3Adapter
+from src.schemas import PredictRequest, PortfolioPredictResponse
+
+
+class PortfolioInferenceEngine:
+    def __init__(self, adapter: SB3Adapter) -> None:
+        self._adapter = adapter
+
+    def run(self, req: PredictRequest) -> PortfolioPredictResponse:
+        t0 = time.time()
+        tickers = sorted(req.ohlcv.keys())
+        windows = []
+        for t in tickers:
+            rows = req.ohlcv[t]
+            if len(rows) < req.state_window:
+                raise ValueError(f"insufficient OHLCV for {t}: need {req.state_window}, got {len(rows)}")
+            closes = [row.close for row in rows[-req.state_window:]]
+            windows.append(closes)
+        obs = np.array(windows, dtype=np.float32).flatten()
+
+        try:
+            action, logits = self._adapter.predict_with_logits(obs)
+            confidence = self._adapter.compute_confidence(logits)
+            raw = np.asarray(action, dtype=np.float32).ravel()
+        except Exception:
+            # obs-shape mismatch or any SB3/gym error → equal-weight fallback
+            raw = np.array([], dtype=np.float32)
+            confidence = 0.0
+
+        if raw.size != len(tickers):
+            # dimension mismatch: equal split + low confidence
+            weights = {t: 1.0 / len(tickers) for t in tickers}
+            confidence = min(confidence, 0.0)
+        else:
+            clipped = np.clip(raw, 0.0, None)
+            s = clipped.sum()
+            if s <= 0:
+                weights = {t: 1.0 / len(tickers) for t in tickers}
+            else:
+                normalized = clipped / s
+                weights = {t: float(w) for t, w in zip(tickers, normalized)}
+
+        return PortfolioPredictResponse(
+            weights=weights,
+            confidence=float(confidence),
+            raw_action=raw.tolist(),
+            metadata={
+                "model_id": req.model_id,
+                "algorithm": req.algorithm,
+                "latency_ms": round((time.time() - t0) * 1000, 2),
+                "n_tickers": len(tickers),
+            },
+        )

--- a/rl-inference-server/src/main.py
+++ b/rl-inference-server/src/main.py
@@ -1,8 +1,12 @@
 import time
 from fastapi import FastAPI, Depends
 from src.auth import require_api_key
+from src.config import get_settings
+from src.model_registry import ModelRegistry
 
+settings = get_settings()
 START_TIME = time.time()
+registry = ModelRegistry(model_dir=settings.model_dir)
 app = FastAPI(title="rl-inference-server", version="0.1.0")
 
 
@@ -10,6 +14,6 @@ app = FastAPI(title="rl-inference-server", version="0.1.0")
 def health():
     return {
         "status": "ok",
-        "loaded_models": [],  # Task 4 will wire this to model registry
+        "loaded_models": registry.loaded_models(),
         "uptime_seconds": round(time.time() - START_TIME, 2),
     }

--- a/rl-inference-server/src/main.py
+++ b/rl-inference-server/src/main.py
@@ -1,13 +1,25 @@
 import time
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI, Depends, HTTPException
 from src.auth import require_api_key
 from src.config import get_settings
 from src.model_registry import ModelRegistry
+from src.adapters.sb3 import SB3Adapter
+from src.inference.portfolio import PortfolioInferenceEngine
+from src.schemas import PredictRequest, PortfolioPredictResponse, SinglePredictResponse
 
 settings = get_settings()
 START_TIME = time.time()
 registry = ModelRegistry(model_dir=settings.model_dir)
 app = FastAPI(title="rl-inference-server", version="0.1.0")
+
+
+def _get_or_load_adapter(req: PredictRequest) -> SB3Adapter:
+    cached = registry._cache_get(req.model_id)
+    if isinstance(cached, SB3Adapter):
+        return cached
+    adapter = SB3Adapter.load(req.checkpoint_path, req.algorithm)
+    registry._cache_set(req.model_id, adapter)
+    return adapter
 
 
 @app.get("/health", dependencies=[Depends(require_api_key)])
@@ -17,3 +29,19 @@ def health():
         "loaded_models": registry.loaded_models(),
         "uptime_seconds": round(time.time() - START_TIME, 2),
     }
+
+
+@app.post(
+    "/predict",
+    dependencies=[Depends(require_api_key)],
+    response_model=PortfolioPredictResponse | SinglePredictResponse,
+)
+def predict(req: PredictRequest):
+    if req.kind != "portfolio":
+        raise HTTPException(status_code=400, detail="single_asset is not supported in Phase 1")
+    adapter = _get_or_load_adapter(req)
+    engine = PortfolioInferenceEngine(adapter)
+    try:
+        return engine.run(req)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/rl-inference-server/src/main.py
+++ b/rl-inference-server/src/main.py
@@ -16,11 +16,11 @@ app = FastAPI(title="rl-inference-server", version="0.1.0")
 
 
 def _get_or_load_adapter(req: PredictRequest) -> SB3Adapter:
-    cached = registry._cache_get(req.model_id)
+    cached = registry.get_adapter(req.model_id)
     if isinstance(cached, SB3Adapter):
         return cached
     adapter = SB3Adapter.load(req.checkpoint_path, req.algorithm)
-    registry._cache_set(req.model_id, adapter)
+    registry.put_adapter(req.model_id, adapter)
     return adapter
 
 

--- a/rl-inference-server/src/main.py
+++ b/rl-inference-server/src/main.py
@@ -5,7 +5,8 @@ from src.config import get_settings
 from src.model_registry import ModelRegistry
 from src.adapters.sb3 import SB3Adapter
 from src.inference.portfolio import PortfolioInferenceEngine
-from src.schemas import PredictRequest, PortfolioPredictResponse, SinglePredictResponse
+from src.schemas import PredictRequest, PortfolioPredictResponse, SinglePredictResponse, BacktestRequest, BacktestResponse
+from src.inference.backtest import run_backtest
 
 settings = get_settings()
 START_TIME = time.time()
@@ -45,3 +46,11 @@ def predict(req: PredictRequest):
         return engine.run(req)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@app.post("/backtest", dependencies=[Depends(require_api_key)], response_model=BacktestResponse)
+def backtest(req: BacktestRequest):
+    if req.kind != "portfolio":
+        raise HTTPException(status_code=400, detail="single_asset backtest not supported in Phase 1")
+    adapter = _get_or_load_adapter(req)
+    return run_backtest(adapter, req)

--- a/rl-inference-server/src/main.py
+++ b/rl-inference-server/src/main.py
@@ -1,0 +1,15 @@
+import time
+from fastapi import FastAPI, Depends
+from src.auth import require_api_key
+
+START_TIME = time.time()
+app = FastAPI(title="rl-inference-server", version="0.1.0")
+
+
+@app.get("/health", dependencies=[Depends(require_api_key)])
+def health():
+    return {
+        "status": "ok",
+        "loaded_models": [],  # Task 4 will wire this to model registry
+        "uptime_seconds": round(time.time() - START_TIME, 2),
+    }

--- a/rl-inference-server/src/main.py
+++ b/rl-inference-server/src/main.py
@@ -5,7 +5,8 @@ from src.config import get_settings
 from src.model_registry import ModelRegistry
 from src.adapters.sb3 import SB3Adapter
 from src.inference.portfolio import PortfolioInferenceEngine
-from src.schemas import PredictRequest, PortfolioPredictResponse, SinglePredictResponse, BacktestRequest, BacktestResponse
+from src.schemas import PredictRequest, PortfolioPredictResponse, SinglePredictResponse, BacktestRequest, BacktestResponse, DownloadRequest, DownloadResponse
+from src.model_registry import DownloadError, IntegrityError
 from src.inference.backtest import run_backtest
 
 settings = get_settings()
@@ -54,3 +55,14 @@ def backtest(req: BacktestRequest):
         raise HTTPException(status_code=400, detail="single_asset backtest not supported in Phase 1")
     adapter = _get_or_load_adapter(req)
     return run_backtest(adapter, req)
+
+
+@app.post("/models/download", dependencies=[Depends(require_api_key)], response_model=DownloadResponse)
+async def models_download(req: DownloadRequest):
+    try:
+        path = await registry.download(req.model_id, req.checkpoint_url, req.checkpoint_sha256)
+    except IntegrityError as e:
+        raise HTTPException(status_code=400, detail=f"sha256 mismatch: {e}")
+    except DownloadError as e:
+        raise HTTPException(status_code=502, detail=f"download failed: {e}")
+    return DownloadResponse(model_id=req.model_id, path=path)

--- a/rl-inference-server/src/model_registry.py
+++ b/rl-inference-server/src/model_registry.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import hashlib
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+import httpx
+
+
+class DownloadError(Exception):
+    pass
+
+
+class IntegrityError(Exception):
+    pass
+
+
+class ModelRegistry:
+    """ckpt download + sha256 verification + in-memory LRU cache."""
+
+    def __init__(self, model_dir: str, lru_capacity: int = 2) -> None:
+        self.model_dir = Path(model_dir)
+        self.model_dir.mkdir(parents=True, exist_ok=True)
+        self._lru: OrderedDict[str, Any] = OrderedDict()
+        self._capacity = lru_capacity
+
+    async def _fetch_bytes(self, url: str) -> bytes:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
+            r = await client.get(url, follow_redirects=True)
+            if r.status_code >= 400:
+                raise DownloadError(f"GET {url} -> {r.status_code}")
+            return r.content
+
+    async def download(self, model_id: str, url: str, expected_sha256: str) -> str:
+        data = await self._fetch_bytes(url)
+        actual = hashlib.sha256(data).hexdigest()
+        if actual != expected_sha256:
+            raise IntegrityError(
+                f"sha256 mismatch for {model_id}: expected {expected_sha256}, got {actual}"
+            )
+        target_dir = self.model_dir / actual
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target = target_dir / "model.zip"
+        target.write_bytes(data)
+        return str(target)
+
+    def _cache_set(self, key: str, value: Any) -> None:
+        if key in self._lru:
+            self._lru.move_to_end(key)
+        self._lru[key] = value
+        while len(self._lru) > self._capacity:
+            self._lru.popitem(last=False)
+
+    def _cache_get(self, key: str) -> Any | None:
+        if key not in self._lru:
+            return None
+        self._lru.move_to_end(key)
+        return self._lru[key]
+
+    def loaded_models(self) -> list[str]:
+        return list(self._lru.keys())

--- a/rl-inference-server/src/model_registry.py
+++ b/rl-inference-server/src/model_registry.py
@@ -24,11 +24,14 @@ class ModelRegistry:
         self._capacity = lru_capacity
 
     async def _fetch_bytes(self, url: str) -> bytes:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
-            r = await client.get(url, follow_redirects=True)
-            if r.status_code >= 400:
-                raise DownloadError(f"GET {url} -> {r.status_code}")
-            return r.content
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
+                r = await client.get(url, follow_redirects=True)
+                if r.status_code >= 400:
+                    raise DownloadError(f"GET {url} -> {r.status_code}")
+                return r.content
+        except httpx.RequestError as e:
+            raise DownloadError(f"network error for {url}: {e}") from e
 
     async def download(self, model_id: str, url: str, expected_sha256: str) -> str:
         data = await self._fetch_bytes(url)

--- a/rl-inference-server/src/model_registry.py
+++ b/rl-inference-server/src/model_registry.py
@@ -59,5 +59,31 @@ class ModelRegistry:
         self._lru.move_to_end(key)
         return self._lru[key]
 
+    # ---- Public adapter cache (separate from byte cache) ----
+
+    def get_adapter(self, model_id: str) -> Any | None:
+        """Return cached adapter object for model_id, or None if not cached."""
+        if not hasattr(self, "_adapter_cache"):
+            self._adapter_cache: OrderedDict[str, Any] = OrderedDict()
+        if model_id not in self._adapter_cache:
+            return None
+        self._adapter_cache.move_to_end(model_id)
+        return self._adapter_cache[model_id]
+
+    def put_adapter(self, model_id: str, adapter: Any) -> None:
+        """Cache an adapter under model_id. LRU evicts oldest beyond capacity."""
+        if not hasattr(self, "_adapter_cache"):
+            self._adapter_cache = OrderedDict()
+        if model_id in self._adapter_cache:
+            self._adapter_cache.move_to_end(model_id)
+        self._adapter_cache[model_id] = adapter
+        while len(self._adapter_cache) > self._capacity:
+            self._adapter_cache.popitem(last=False)
+
     def loaded_models(self) -> list[str]:
-        return list(self._lru.keys())
+        keys: list[str] = list(self._lru.keys())
+        if hasattr(self, "_adapter_cache"):
+            for k in self._adapter_cache.keys():
+                if k not in keys:
+                    keys.append(k)
+        return keys

--- a/rl-inference-server/src/schemas.py
+++ b/rl-inference-server/src/schemas.py
@@ -57,3 +57,15 @@ class BacktestResponse(BaseModel):
     n_rebalances: int
     equity_curve: list[EquityPoint]
     metadata: dict
+
+
+class DownloadRequest(BaseModel):
+    model_id: str
+    checkpoint_url: str
+    checkpoint_sha256: str
+
+
+class DownloadResponse(BaseModel):
+    model_id: str
+    path: str
+    status: Literal["ready"] = "ready"

--- a/rl-inference-server/src/schemas.py
+++ b/rl-inference-server/src/schemas.py
@@ -38,3 +38,22 @@ class SinglePredictResponse(BaseModel):
     size_hint: Optional[float] = None
     confidence: float
     metadata: dict
+
+
+class BacktestRequest(PredictRequest):
+    rebalance_dates: list[str]
+    initial_capital: float = 10000.0
+
+
+class EquityPoint(BaseModel):
+    date: str
+    equity: float
+
+
+class BacktestResponse(BaseModel):
+    total_return: float
+    sharpe_ratio: float
+    max_drawdown: float
+    n_rebalances: int
+    equity_curve: list[EquityPoint]
+    metadata: dict

--- a/rl-inference-server/src/schemas.py
+++ b/rl-inference-server/src/schemas.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+from typing import Literal, Optional
+from pydantic import BaseModel, Field
+
+
+class OHLCVRow(BaseModel):
+    date: str
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+class PredictRequest(BaseModel):
+    model_id: str
+    checkpoint_path: str
+    algorithm: str
+    kind: Literal["portfolio", "single_asset"]
+    state_window: int = Field(ge=1, le=500)
+    input_features: list[str]
+    ohlcv: dict[str, list[OHLCVRow]]
+    indicators: Optional[dict[str, dict[str, list[float]]]] = None
+    current_positions: Optional[dict[str, dict]] = None
+
+
+class PortfolioPredictResponse(BaseModel):
+    kind: Literal["portfolio"] = "portfolio"
+    weights: dict[str, float]
+    confidence: float
+    raw_action: list[float]
+    metadata: dict
+
+
+class SinglePredictResponse(BaseModel):
+    kind: Literal["single_asset"] = "single_asset"
+    action: Literal["buy", "sell", "hold"]
+    size_hint: Optional[float] = None
+    confidence: float
+    metadata: dict

--- a/rl-inference-server/src/state.py
+++ b/rl-inference-server/src/state.py
@@ -1,0 +1,8 @@
+import hashlib
+import json
+
+
+def hash_state(payload: dict) -> str:
+    """Deterministic SHA256 of state input."""
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/rl-inference-server/tests/conftest.py
+++ b/rl-inference-server/tests/conftest.py
@@ -1,0 +1,11 @@
+import os
+import sys
+from pathlib import Path
+
+# src 디렉터리를 PYTHONPATH에 추가
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+# 테스트용 환경변수
+os.environ.setdefault("RL_API_KEY", "test-api-key")
+os.environ.setdefault("MODEL_DIR", str(Path("/tmp/rl-inference-test/models")))

--- a/rl-inference-server/tests/test_backtest.py
+++ b/rl-inference-server/tests/test_backtest.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+
+def _make_dummy_ppo(tmp_path: Path) -> str:
+    import gymnasium as gym
+    from stable_baselines3 import PPO
+    env = gym.make("CartPole-v1")
+    model = PPO("MlpPolicy", env, n_steps=64, verbose=0)
+    path = tmp_path / "ppo.zip"
+    model.save(str(path))
+    return str(path)
+
+
+def test_backtest_returns_metrics(tmp_path, monkeypatch):
+    monkeypatch.setenv("RL_API_KEY", "test-key")
+    monkeypatch.setenv("MODEL_DIR", str(tmp_path / "models"))
+    from src.main import app
+    client = TestClient(app)
+    ckpt = _make_dummy_ppo(tmp_path)
+    n = 30
+    body = {
+        "model_id": "m1",
+        "checkpoint_path": ckpt,
+        "algorithm": "PPO",
+        "kind": "portfolio",
+        "state_window": 5,
+        "input_features": ["close"],
+        "ohlcv": {
+            "AAPL": [{"date": f"2026-03-{(i%28)+1:02d}", "open":1,"high":1,"low":1,"close":1.0+i*0.01,"volume":1} for i in range(n)],
+            "MSFT": [{"date": f"2026-03-{(i%28)+1:02d}", "open":1,"high":1,"low":1,"close":1.0,"volume":1} for i in range(n)],
+        },
+        "rebalance_dates": [f"2026-03-{i+1:02d}" for i in range(5, n) if i+1 <= 28],
+        "initial_capital": 10000.0,
+    }
+    resp = client.post("/backtest", headers={"X-RL-API-KEY": "test-key"}, json=body)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert "total_return" in data
+    assert "sharpe_ratio" in data
+    assert "equity_curve" in data
+    assert isinstance(data["equity_curve"], list)
+    assert len(data["equity_curve"]) >= 1

--- a/rl-inference-server/tests/test_dow30_env.py
+++ b/rl-inference-server/tests/test_dow30_env.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pandas as pd
+import pytest
+from scripts.dow30_env import Dow30PortfolioEnv
+
+
+def make_synthetic_prices(n_days: int = 100, n_tickers: int = 5, seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    rets = rng.normal(0, 0.01, size=(n_days, n_tickers))
+    prices = 100 * np.exp(rets.cumsum(axis=0))
+    return pd.DataFrame(prices, columns=[f"T{i}" for i in range(n_tickers)])
+
+
+def test_env_observation_action_shapes():
+    prices = make_synthetic_prices(n_days=100, n_tickers=5)
+    env = Dow30PortfolioEnv(prices=prices, window=10)
+    assert env.observation_space.shape == (50,)  # 5 tickers × 10 window
+    assert env.action_space.shape == (5,)
+    obs, _info = env.reset()
+    assert obs.shape == (50,)
+
+
+def test_env_step_returns_finite_reward():
+    prices = make_synthetic_prices(n_days=60, n_tickers=3)
+    env = Dow30PortfolioEnv(prices=prices, window=5)
+    obs, _ = env.reset()
+    action = np.array([0.5, 0.3, 0.2], dtype=np.float32)
+    obs2, reward, terminated, truncated, info = env.step(action)
+    assert obs2.shape == obs.shape
+    assert np.isfinite(reward)
+    assert not terminated
+
+
+def test_env_negative_action_uses_equal_weights():
+    prices = make_synthetic_prices(n_days=30, n_tickers=4)
+    env = Dow30PortfolioEnv(prices=prices, window=5)
+    env.reset()
+    obs2, reward, _, _, _ = env.step(np.array([-1.0, -1.0, -1.0, -1.0], dtype=np.float32))
+    # equal-split fallback: weights should be uniform 1/4 internally
+    assert np.isfinite(reward)
+
+
+def test_env_truncates_at_end_of_data():
+    prices = make_synthetic_prices(n_days=20, n_tickers=2)
+    env = Dow30PortfolioEnv(prices=prices, window=5)
+    env.reset()
+    truncated = False
+    for _ in range(50):
+        _, _, _, truncated, _ = env.step(np.array([0.5, 0.5], dtype=np.float32))
+        if truncated:
+            break
+    assert truncated is True

--- a/rl-inference-server/tests/test_health.py
+++ b/rl-inference-server/tests/test_health.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+
+
+def test_health_returns_200_with_status(monkeypatch):
+    monkeypatch.setenv("RL_API_KEY", "test-key")
+    from src.main import app
+    client = TestClient(app)
+    resp = client.get("/health", headers={"X-RL-API-KEY": "test-key"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert "loaded_models" in body
+    assert "uptime_seconds" in body
+
+
+def test_health_rejects_missing_api_key(monkeypatch):
+    monkeypatch.setenv("RL_API_KEY", "test-key")
+    from src.main import app
+    client = TestClient(app)
+    resp = client.get("/health")
+    assert resp.status_code == 401
+
+
+def test_health_rejects_wrong_api_key(monkeypatch):
+    monkeypatch.setenv("RL_API_KEY", "test-key")
+    from src.main import app
+    client = TestClient(app)
+    resp = client.get("/health", headers={"X-RL-API-KEY": "wrong"})
+    assert resp.status_code == 401

--- a/rl-inference-server/tests/test_model_registry.py
+++ b/rl-inference-server/tests/test_model_registry.py
@@ -1,0 +1,55 @@
+import hashlib
+from pathlib import Path
+import pytest
+from src.model_registry import ModelRegistry, DownloadError, IntegrityError
+
+
+def make_dummy_bytes(n: int = 1024) -> bytes:
+    return bytes((i % 256 for i in range(n)))
+
+
+@pytest.mark.asyncio
+async def test_download_writes_to_sha256_subdir(tmp_path, monkeypatch):
+    payload = make_dummy_bytes()
+    expected_sha = hashlib.sha256(payload).hexdigest()
+    registry = ModelRegistry(model_dir=str(tmp_path))
+
+    async def fake_fetch(url: str) -> bytes:
+        return payload
+
+    monkeypatch.setattr(registry, "_fetch_bytes", fake_fetch)
+    path = await registry.download("model-1", "https://example.com/x.zip", expected_sha)
+    p = Path(path)
+    assert p.exists()
+    assert expected_sha in str(p)
+
+
+@pytest.mark.asyncio
+async def test_download_rejects_sha_mismatch(tmp_path, monkeypatch):
+    payload = make_dummy_bytes()
+    bad_sha = "0" * 64
+    registry = ModelRegistry(model_dir=str(tmp_path))
+
+    async def fake_fetch(url: str) -> bytes:
+        return payload
+
+    monkeypatch.setattr(registry, "_fetch_bytes", fake_fetch)
+    with pytest.raises(IntegrityError):
+        await registry.download("model-1", "https://example.com/x.zip", bad_sha)
+
+
+def test_lru_evicts_oldest_when_capacity_exceeded():
+    registry = ModelRegistry(model_dir="/tmp", lru_capacity=2)
+    registry._cache_set("a", "obj-a")
+    registry._cache_set("b", "obj-b")
+    registry._cache_set("c", "obj-c")  # 'a' should be evicted
+    assert registry._cache_get("a") is None
+    assert registry._cache_get("b") == "obj-b"
+    assert registry._cache_get("c") == "obj-c"
+
+
+def test_loaded_models_returns_cached_keys():
+    registry = ModelRegistry(model_dir="/tmp", lru_capacity=2)
+    registry._cache_set("a", "obj-a")
+    registry._cache_set("b", "obj-b")
+    assert sorted(registry.loaded_models()) == ["a", "b"]

--- a/rl-inference-server/tests/test_model_registry.py
+++ b/rl-inference-server/tests/test_model_registry.py
@@ -82,3 +82,23 @@ def test_download_endpoint_writes_file_and_returns_path(tmp_path, monkeypatch):
     data = resp.json()
     assert "path" in data
     assert expected in data["path"]
+
+
+def test_download_endpoint_502_on_network_error(tmp_path, monkeypatch):
+    """If httpx fails (timeout / connect error), endpoint should return 502 not 500."""
+    monkeypatch.setenv("RL_API_KEY", "test-key")
+    monkeypatch.setenv("MODEL_DIR", str(tmp_path))
+    from src.main import app, registry
+    from fastapi.testclient import TestClient
+
+    async def fake_fetch_raises(_url: str) -> bytes:
+        # Simulate the wrapped DownloadError path
+        from src.model_registry import DownloadError
+        raise DownloadError("network error: simulated timeout")
+
+    monkeypatch.setattr(registry, "_fetch_bytes", fake_fetch_raises)
+
+    client = TestClient(app)
+    body = {"model_id": "m_net_err", "checkpoint_url": "https://nope.invalid/x.zip", "checkpoint_sha256": "0" * 64}
+    resp = client.post("/models/download", headers={"X-RL-API-KEY": "test-key"}, json=body)
+    assert resp.status_code == 502, resp.text

--- a/rl-inference-server/tests/test_model_registry.py
+++ b/rl-inference-server/tests/test_model_registry.py
@@ -102,3 +102,18 @@ def test_download_endpoint_502_on_network_error(tmp_path, monkeypatch):
     body = {"model_id": "m_net_err", "checkpoint_url": "https://nope.invalid/x.zip", "checkpoint_sha256": "0" * 64}
     resp = client.post("/models/download", headers={"X-RL-API-KEY": "test-key"}, json=body)
     assert resp.status_code == 502, resp.text
+
+
+def test_adapter_cache_public_api():
+    from src.model_registry import ModelRegistry
+    registry = ModelRegistry(model_dir="/tmp", lru_capacity=2)
+    assert registry.get_adapter("a") is None
+    registry.put_adapter("a", "ADAPTER_A")
+    registry.put_adapter("b", "ADAPTER_B")
+    assert registry.get_adapter("a") == "ADAPTER_A"
+    assert registry.get_adapter("b") == "ADAPTER_B"
+    # LRU eviction
+    registry.put_adapter("c", "ADAPTER_C")
+    assert registry.get_adapter("a") is None  # 'a' evicted (least recent)
+    assert registry.get_adapter("b") == "ADAPTER_B"
+    assert registry.get_adapter("c") == "ADAPTER_C"

--- a/rl-inference-server/tests/test_model_registry.py
+++ b/rl-inference-server/tests/test_model_registry.py
@@ -53,3 +53,32 @@ def test_loaded_models_returns_cached_keys():
     registry._cache_set("a", "obj-a")
     registry._cache_set("b", "obj-b")
     assert sorted(registry.loaded_models()) == ["a", "b"]
+
+
+import hashlib
+
+def test_download_endpoint_writes_file_and_returns_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("RL_API_KEY", "test-key")
+    monkeypatch.setenv("MODEL_DIR", str(tmp_path))
+    from src.main import app, registry
+    from fastapi.testclient import TestClient
+
+    payload = b"fake-model-bytes"
+    expected = hashlib.sha256(payload).hexdigest()
+
+    async def fake_fetch(_url: str) -> bytes:
+        return payload
+
+    monkeypatch.setattr(registry, "_fetch_bytes", fake_fetch)
+
+    client = TestClient(app)
+    body = {
+        "model_id": "m1",
+        "checkpoint_url": "https://example.com/m.zip",
+        "checkpoint_sha256": expected,
+    }
+    resp = client.post("/models/download", headers={"X-RL-API-KEY": "test-key"}, json=body)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert "path" in data
+    assert expected in data["path"]

--- a/rl-inference-server/tests/test_predict_portfolio.py
+++ b/rl-inference-server/tests/test_predict_portfolio.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import numpy as np
+from fastapi.testclient import TestClient
+
+
+def _make_dummy_ppo(tmp_path: Path) -> str:
+    import gymnasium as gym
+    from stable_baselines3 import PPO
+
+    env = gym.make("CartPole-v1")
+    model = PPO("MlpPolicy", env, n_steps=64, verbose=0)
+    path = tmp_path / "ppo.zip"
+    model.save(str(path))
+    return str(path)
+
+
+def _build_request(ckpt: str) -> dict:
+    return {
+        "model_id": "test-model-1",
+        "checkpoint_path": ckpt,
+        "algorithm": "PPO",
+        "kind": "portfolio",
+        "state_window": 5,
+        "input_features": ["close"],
+        "ohlcv": {
+            "AAPL": [{"date": f"2026-04-{20+i:02d}", "open": 1, "high": 1, "low": 1, "close": 1.0, "volume": 1} for i in range(5)],
+            "MSFT": [{"date": f"2026-04-{20+i:02d}", "open": 1, "high": 1, "low": 1, "close": 1.0, "volume": 1} for i in range(5)],
+        },
+        "indicators": None,
+        "current_positions": None,
+    }
+
+
+def test_predict_returns_weights_and_confidence(tmp_path, monkeypatch):
+    monkeypatch.setenv("RL_API_KEY", "test-key")
+    monkeypatch.setenv("MODEL_DIR", str(tmp_path / "models"))
+    from src.main import app
+    client = TestClient(app)
+    ckpt = _make_dummy_ppo(tmp_path)
+    body = _build_request(ckpt)
+    resp = client.post("/predict", headers={"X-RL-API-KEY": "test-key"}, json=body)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["kind"] == "portfolio"
+    assert isinstance(data["weights"], dict)
+    assert set(data["weights"].keys()) == {"AAPL", "MSFT"}
+    weight_sum = sum(data["weights"].values())
+    assert abs(weight_sum - 1.0) < 1e-3
+    assert 0 <= data["confidence"] <= 1

--- a/rl-inference-server/tests/test_sb3_adapter.py
+++ b/rl-inference-server/tests/test_sb3_adapter.py
@@ -41,3 +41,30 @@ def test_sb3_adapter_rejects_unknown_algorithm():
     from src.adapters.sb3 import SB3Adapter
     with pytest.raises(ValueError):
         SB3Adapter.load(checkpoint_path="/dev/null", algorithm="UNSUPPORTED")
+
+
+def test_sb3_adapter_cartpole_discrete_dispatch(tmp_path):
+    """CartPole has 2 discrete actions (even size). Previously misclassified as continuous."""
+    from src.adapters.sb3 import SB3Adapter
+
+    ckpt = _make_tiny_ppo_zip(tmp_path)
+    adapter = SB3Adapter.load(checkpoint_path=ckpt, algorithm="PPO")
+    assert adapter._is_discrete is True
+    obs = np.zeros((4,), dtype=np.float32)
+    _, logits = adapter.predict_with_logits(obs)
+    # discrete logits for 2 actions → array of length 2
+    assert logits.size == 2
+    conf = adapter.compute_confidence(logits)
+    # softmax of [a, b] is in (0, 1] for the max — never exactly 0 in practice
+    assert conf > 0.0
+    assert conf <= 1.0
+
+
+def test_sb3_adapter_empty_logits_fallback_returns_zero(tmp_path):
+    """Empty logits (fallback path) must NOT yield 1.0 confidence."""
+    from src.adapters.sb3 import SB3Adapter
+
+    ckpt = _make_tiny_ppo_zip(tmp_path)
+    adapter = SB3Adapter.load(checkpoint_path=ckpt, algorithm="PPO")
+    conf = adapter.compute_confidence(np.array([], dtype=np.float32))
+    assert conf == 0.0

--- a/rl-inference-server/tests/test_sb3_adapter.py
+++ b/rl-inference-server/tests/test_sb3_adapter.py
@@ -1,0 +1,43 @@
+"""SB3 adapter test: train a tiny PPO on CartPole-v1, save ckpt, load via adapter."""
+from pathlib import Path
+import numpy as np
+import pytest
+
+
+def _make_tiny_ppo_zip(tmp_path: Path) -> str:
+    import gymnasium as gym
+    from stable_baselines3 import PPO
+
+    env = gym.make("CartPole-v1")
+    model = PPO("MlpPolicy", env, n_steps=64, verbose=0)
+    path = tmp_path / "ppo.zip"
+    model.save(str(path))
+    return str(path)
+
+
+def test_sb3_adapter_loads_and_predicts(tmp_path):
+    from src.adapters.sb3 import SB3Adapter
+
+    ckpt = _make_tiny_ppo_zip(tmp_path)
+    adapter = SB3Adapter.load(checkpoint_path=ckpt, algorithm="PPO")
+    obs = np.zeros((4,), dtype=np.float32)
+    raw_action, action_logits = adapter.predict_with_logits(obs)
+    assert raw_action is not None
+    assert action_logits is not None
+
+
+def test_sb3_adapter_compute_confidence_returns_in_unit_range(tmp_path):
+    from src.adapters.sb3 import SB3Adapter
+
+    ckpt = _make_tiny_ppo_zip(tmp_path)
+    adapter = SB3Adapter.load(checkpoint_path=ckpt, algorithm="PPO")
+    obs = np.zeros((4,), dtype=np.float32)
+    _, logits = adapter.predict_with_logits(obs)
+    conf = adapter.compute_confidence(logits)
+    assert 0.0 <= conf <= 1.0
+
+
+def test_sb3_adapter_rejects_unknown_algorithm():
+    from src.adapters.sb3 import SB3Adapter
+    with pytest.raises(ValueError):
+        SB3Adapter.load(checkpoint_path="/dev/null", algorithm="UNSUPPORTED")

--- a/trading-worker/ecosystem.config.js
+++ b/trading-worker/ecosystem.config.js
@@ -2,24 +2,39 @@
  * PM2 설정 파일
  *
  * 실행: pm2 start ecosystem.config.js
- * 무중단 배포: pm2 reload trading-worker --update-env
+ * 무중단 배포: pm2 reload <app> --update-env
  */
 module.exports = {
-  apps: [{
-    name: 'trading-worker',
-    script: './dist/index.js',
-    instances: 1,
-    autorestart: true,
-    watch: false,
-    max_memory_restart: '500M',
-    env: {
-      NODE_ENV: 'production',
-      // 환경변수는 .env 또는 PM2 ecosystem에서 설정
-      // SUPABASE_URL: '',
-      // SUPABASE_SERVICE_ROLE_KEY: '',
-      // ENCRYPTION_KEY: '',
-      // TELEGRAM_BOT_TOKEN: '',
-      // WORKER_SECRET_KEY: '',
+  apps: [
+    {
+      name: 'trading-worker',
+      script: './dist/index.js',
+      instances: 1,
+      autorestart: true,
+      watch: false,
+      max_memory_restart: '500M',
+      env: {
+        NODE_ENV: 'production',
+        // 환경변수는 .env 또는 PM2 ecosystem에서 설정
+        // SUPABASE_URL: '',
+        // SUPABASE_SERVICE_ROLE_KEY: '',
+        // ENCRYPTION_KEY: '',
+        // TELEGRAM_BOT_TOKEN: '',
+        // WORKER_SECRET_KEY: '',
+      },
     },
-  }],
+    {
+      name: 'rl-inference',
+      cwd: '/Users/hhs/Project/dental-clinic-manager/rl-inference-server',
+      script: '.venv/bin/uvicorn',
+      args: 'src.main:app --host 127.0.0.1 --port 8001',
+      interpreter: 'none',
+      instances: 1,
+      autorestart: true,
+      max_memory_restart: '2000M',
+      env: {
+        PYTHONUNBUFFERED: '1',
+      },
+    },
+  ],
 }

--- a/trading-worker/package-lock.json
+++ b/trading-worker/package-lock.json
@@ -20,7 +20,8 @@
         "@types/node-cron": "^3.0.11",
         "@types/ws": "^8.5.14",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "vitest": "^2.1.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -465,11 +466,368 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.103.3",
@@ -557,6 +915,13 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -582,6 +947,129 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -589,6 +1077,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/colorette": {
@@ -604,6 +1129,34 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dotenv": {
@@ -626,6 +1179,13 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -667,6 +1227,26 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-copy": {
@@ -733,6 +1313,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -740,6 +1337,32 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/node-cron": {
@@ -771,6 +1394,30 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pino": {
       "version": "9.14.0",
@@ -842,6 +1489,35 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -893,6 +1569,51 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -918,6 +1639,13 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -925,6 +1653,16 @@
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/split2": {
@@ -935,6 +1673,20 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "5.0.3",
@@ -955,6 +1707,50 @@
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -1010,6 +1806,602 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/trading-worker/package.json
+++ b/trading-worker/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "tsx watch src/index.ts"
+    "dev": "tsx watch src/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.4",
@@ -21,6 +23,7 @@
     "@types/node-cron": "^3.0.11",
     "@types/ws": "^8.5.14",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
   }
 }

--- a/trading-worker/src/dailyRebalanceDeps.ts
+++ b/trading-worker/src/dailyRebalanceDeps.ts
@@ -1,0 +1,179 @@
+/**
+ * dailyRebalanceDeps.ts
+ *
+ * Builds the DailyRebalanceDeps object wired to real Supabase + KIS infra.
+ */
+
+import type { DailyRebalanceDeps } from './dailyRebalanceJob'
+import { RLInferenceClient } from './rlInferenceClient'
+import { getSupabase } from './supabaseClient'
+import { logger } from './logger'
+import { sendSignalAlert } from './telegramNotifier'
+import { executeAutoOrder } from './orderExecutor'
+
+export async function buildDailyRebalanceDeps(): Promise<DailyRebalanceDeps> {
+  const rlClient = new RLInferenceClient({
+    baseUrl: process.env.RL_SERVER_URL ?? 'http://127.0.0.1:8001',
+    apiKey: process.env.RL_API_KEY ?? '',
+    timeoutMs: 5000,
+  })
+  const today = new Date().toISOString().slice(0, 10)
+
+  return {
+    today,
+    rlClient,
+
+    fetchActiveRLStrategies: async () => {
+      const supabase = getSupabase()
+      const { data, error } = await supabase
+        .from('investment_strategies')
+        .select(
+          'id, user_id, strategy_type, automation_level, rl_models!inner(id, min_confidence, universe, state_window, algorithm, input_features, checkpoint_path)',
+        )
+        .eq('is_active', true)
+        .in('strategy_type', ['rl_portfolio', 'rl_single'])
+      if (error) {
+        logger.error({ error }, 'fetchActiveRLStrategies failed')
+        return []
+      }
+      return (data ?? []).map((s: Record<string, unknown>) => ({
+        id: s.id as string,
+        user_id: s.user_id as string,
+        strategy_type: s.strategy_type as 'rl_portfolio' | 'rl_single',
+        automation_level: s.automation_level as 1 | 2,
+        rl_model: s.rl_models as {
+          id: string
+          min_confidence: number
+          universe: string[]
+          state_window: number
+          algorithm: string
+          input_features: string[]
+          checkpoint_path: string
+        },
+      }))
+    },
+
+    fetchUserSettings: async (userId) => {
+      const supabase = getSupabase()
+      const { data } = await supabase
+        .from('user_investment_settings')
+        .select('rl_paused_at')
+        .eq('user_id', userId)
+        .maybeSingle()
+      return { rl_paused_at: (data as { rl_paused_at: string | null } | null)?.rl_paused_at ?? null }
+    },
+
+    fetchOhlcvWindow: async (universe, stateWindow) => {
+      const supabase = getSupabase()
+      const result: Record<
+        string,
+        Array<{ date: string; open: number; high: number; low: number; close: number; volume: number }>
+      > = {}
+      for (const ticker of universe) {
+        const { data, error } = await supabase
+          .from('intraday_price_cache')
+          .select('datetime, open, high, low, close, volume')
+          .eq('ticker', ticker)
+          .eq('market', 'US')
+          .eq('timeframe', '1d')
+          .order('datetime', { ascending: false })
+          .limit(stateWindow)
+        if (error) {
+          logger.warn({ ticker, error }, 'fetchOhlcvWindow: query failed, returning empty for ticker')
+          result[ticker] = []
+          continue
+        }
+        result[ticker] = (data ?? [])
+          .slice()
+          .reverse()
+          .map((row: Record<string, unknown>) => ({
+            date:
+              typeof row.datetime === 'string'
+                ? row.datetime.slice(0, 10)
+                : new Date(row.datetime as string).toISOString().slice(0, 10),
+            open: Number(row.open),
+            high: Number(row.high),
+            low: Number(row.low),
+            close: Number(row.close),
+            volume: Number(row.volume),
+          }))
+      }
+      return result
+    },
+
+    fetchCurrentPositions: async (userId) => {
+      const supabase = getSupabase()
+      const { data, error } = await supabase
+        .from('positions')
+        .select('ticker, quantity, avg_entry_price')
+        .eq('user_id', userId)
+        .eq('status', 'open')
+      if (error) {
+        logger.error({ error }, 'fetchCurrentPositions failed')
+        return {}
+      }
+      const map: Record<string, { qty: number; avg_price: number }> = {}
+      for (const p of data ?? []) {
+        const row = p as { ticker: string; quantity: unknown; avg_entry_price: unknown }
+        map[row.ticker] = { qty: Number(row.quantity), avg_price: Number(row.avg_entry_price) }
+      }
+      return map
+    },
+
+    insertInferenceLog: async (log) => {
+      const supabase = getSupabase()
+      const { error } = await supabase.from('rl_inference_logs').insert(log)
+      if (error) {
+        // ON CONFLICT (strategy_id, trade_date) — idempotent log already exists
+        if ((error as { code?: string }).code === '23505') {
+          logger.warn(
+            { strategy_id: log.strategy_id, trade_date: log.trade_date },
+            'rl_inference_logs duplicate; skipping',
+          )
+          return
+        }
+        logger.error({ error, log }, 'insertInferenceLog failed')
+      }
+    },
+
+    sendTelegram: async (userId, message) => {
+      try {
+        // sendSignalAlert resolves the userId → chatId lookup internally.
+        // We piggy-back on it by passing a minimal signal payload whose formatted
+        // text is replaced by a custom note in the strategyName field.
+        // For a raw free-text message we use sendSignalAlert with type 'buy_signal'
+        // and embed the full message in strategyName — this is the closest available
+        // public API that takes a userId rather than a chatId.
+        await sendSignalAlert(userId, {
+          type: 'buy_signal',
+          strategyName: message,
+          ticker: '',
+          market: '',
+        })
+      } catch (err) {
+        logger.warn({ err, userId }, 'sendTelegram failed (non-fatal)')
+      }
+    },
+
+    executeAutoOrder: async (params) => {
+      // executeAutoOrder in orderExecutor.ts takes:
+      //   { userId, strategyId, ticker, market, orderType, quantity, price, signalData? }
+      // and returns Promise<boolean>.
+      //
+      // The job passes orderMethod ('market' | 'limit') but no price.
+      // We translate: market → price=0, limit → we have no price so fall back to market (price=0).
+      const price = params.orderMethod === 'limit' ? 0 : 0 // Phase 1: always market order (price=0)
+      const ok = await executeAutoOrder({
+        userId: params.userId,
+        strategyId: params.strategyId,
+        ticker: params.ticker,
+        market: 'US',
+        orderType: params.orderType,
+        quantity: params.quantity,
+        price,
+        signalData: params.signalData,
+      })
+      return { ok, orderId: undefined, error: ok ? undefined : 'executeAutoOrder returned false' }
+    },
+  }
+}

--- a/trading-worker/src/dailyRebalanceDeps.ts
+++ b/trading-worker/src/dailyRebalanceDeps.ts
@@ -8,7 +8,7 @@ import type { DailyRebalanceDeps } from './dailyRebalanceJob'
 import { RLInferenceClient } from './rlInferenceClient'
 import { getSupabase } from './supabaseClient'
 import { logger } from './logger'
-import { sendSignalAlert } from './telegramNotifier'
+import { sendSystemNotice } from './telegramNotifier'
 import { executeAutoOrder } from './orderExecutor'
 
 export async function buildDailyRebalanceDeps(): Promise<DailyRebalanceDeps> {
@@ -138,21 +138,25 @@ export async function buildDailyRebalanceDeps(): Promise<DailyRebalanceDeps> {
 
     sendTelegram: async (userId, message) => {
       try {
-        // sendSignalAlert resolves the userId → chatId lookup internally.
-        // We piggy-back on it by passing a minimal signal payload whose formatted
-        // text is replaced by a custom note in the strategyName field.
-        // For a raw free-text message we use sendSignalAlert with type 'buy_signal'
-        // and embed the full message in strategyName — this is the closest available
-        // public API that takes a userId rather than a chatId.
-        await sendSignalAlert(userId, {
-          type: 'buy_signal',
-          strategyName: message,
-          ticker: '',
-          market: '',
-        })
+        await sendSystemNotice(userId, message)
       } catch (err) {
         logger.warn({ err, userId }, 'sendTelegram failed (non-fatal)')
       }
+    },
+
+    checkLogExists: async (strategyId, tradeDate) => {
+      const supabase = getSupabase()
+      const { data, error } = await supabase
+        .from('rl_inference_logs')
+        .select('id')
+        .eq('strategy_id', strategyId)
+        .eq('trade_date', tradeDate)
+        .maybeSingle()
+      if (error) {
+        logger.warn({ error, strategyId, tradeDate }, 'checkLogExists query failed; assuming no log')
+        return false
+      }
+      return Boolean(data)
     },
 
     executeAutoOrder: async (params) => {

--- a/trading-worker/src/dailyRebalanceJob.ts
+++ b/trading-worker/src/dailyRebalanceJob.ts
@@ -1,0 +1,161 @@
+import type { RLInferenceClient, PortfolioPredictResponse } from './rlInferenceClient'
+
+export interface RLStrategyRow {
+  id: string
+  user_id: string
+  strategy_type: 'rl_portfolio' | 'rl_single'
+  automation_level: 1 | 2
+  rl_model: {
+    id: string
+    min_confidence: number
+    universe: string[]
+    state_window: number
+    algorithm: string
+    input_features: string[]
+    checkpoint_path: string
+  }
+}
+
+export interface DailyRebalanceDeps {
+  fetchActiveRLStrategies: () => Promise<RLStrategyRow[]>
+  fetchUserSettings: (userId: string) => Promise<{ rl_paused_at: string | null }>
+  fetchOhlcvWindow: (
+    universe: string[], stateWindow: number,
+  ) => Promise<Record<string, Array<{ date: string; open: number; high: number; low: number; close: number; volume: number }>>>
+  fetchCurrentPositions: (userId: string) => Promise<Record<string, { qty: number; avg_price: number }>>
+  rlClient: Pick<RLInferenceClient, 'predict' | 'health'>
+  insertInferenceLog: (log: InferenceLogEntry) => Promise<void>
+  sendTelegram: (userId: string, message: string) => Promise<void>
+  executeAutoOrder: (params: {
+    userId: string; strategyId: string; ticker: string; orderType: 'buy' | 'sell';
+    quantity: number; orderMethod: 'market' | 'limit'; signalData: Record<string, unknown>
+  }) => Promise<{ ok: boolean; orderId?: string; error?: string }>
+  today: string
+}
+
+export interface InferenceLogEntry {
+  strategy_id: string
+  rl_model_id: string
+  user_id: string
+  trade_date: string
+  state_hash: string
+  output: Record<string, unknown>
+  confidence: number | null
+  decision: 'order' | 'hold' | 'blocked_low_confidence' | 'blocked_kill_switch' | 'error'
+  blocked_reason?: string | null
+  error_message?: string | null
+  latency_ms?: number | null
+}
+
+interface RebalanceResult { processed: number; ordered: number; blocked: number; errored: number }
+
+export async function runDailyRebalance(deps: DailyRebalanceDeps): Promise<RebalanceResult> {
+  const result: RebalanceResult = { processed: 0, ordered: 0, blocked: 0, errored: 0 }
+  const strategies = await deps.fetchActiveRLStrategies()
+
+  for (const s of strategies) {
+    result.processed++
+    try {
+      const settings = await deps.fetchUserSettings(s.user_id)
+      if (settings.rl_paused_at) {
+        await deps.insertInferenceLog({
+          strategy_id: s.id, rl_model_id: s.rl_model.id, user_id: s.user_id,
+          trade_date: deps.today, state_hash: '',
+          output: {}, confidence: null, decision: 'blocked_kill_switch',
+          blocked_reason: `paused at ${settings.rl_paused_at}`,
+        })
+        result.blocked++
+        continue
+      }
+
+      const ohlcv = await deps.fetchOhlcvWindow(s.rl_model.universe, s.rl_model.state_window)
+      const positions = await deps.fetchCurrentPositions(s.user_id)
+      const t0 = Date.now()
+      const prediction = await deps.rlClient.predict({
+        model_id: s.rl_model.id,
+        checkpoint_path: s.rl_model.checkpoint_path,
+        algorithm: s.rl_model.algorithm,
+        kind: 'portfolio',
+        state_window: s.rl_model.state_window,
+        input_features: s.rl_model.input_features,
+        ohlcv,
+        current_positions: positions,
+      }) as PortfolioPredictResponse
+      const latencyMs = Date.now() - t0
+
+      if (prediction.confidence < s.rl_model.min_confidence) {
+        await deps.insertInferenceLog({
+          strategy_id: s.id, rl_model_id: s.rl_model.id, user_id: s.user_id,
+          trade_date: deps.today, state_hash: '',
+          output: prediction as unknown as Record<string, unknown>,
+          confidence: prediction.confidence, decision: 'blocked_low_confidence',
+          blocked_reason: `confidence ${prediction.confidence} < ${s.rl_model.min_confidence}`,
+          latency_ms: latencyMs,
+        })
+        await deps.sendTelegram(s.user_id, `[RL] ${s.id} 신뢰도 ${prediction.confidence.toFixed(2)} 낮아 hold`)
+        result.blocked++
+        continue
+      }
+
+      const orders = computeOrdersFromWeights(prediction.weights, positions, 10000)
+
+      if (s.automation_level === 1) {
+        await deps.sendTelegram(s.user_id, `[RL] ${s.id} 신호: ${JSON.stringify(orders.slice(0, 5))}`)
+      } else {
+        for (const o of orders) {
+          await deps.executeAutoOrder({
+            userId: s.user_id, strategyId: s.id,
+            ticker: o.ticker, orderType: o.side, quantity: o.qty,
+            orderMethod: 'market',
+            signalData: { source: 'rl', model_id: s.rl_model.id, weights: prediction.weights },
+          })
+        }
+        result.ordered++
+      }
+
+      await deps.insertInferenceLog({
+        strategy_id: s.id, rl_model_id: s.rl_model.id, user_id: s.user_id,
+        trade_date: deps.today, state_hash: '',
+        output: prediction as unknown as Record<string, unknown>,
+        confidence: prediction.confidence, decision: 'order', latency_ms: latencyMs,
+      })
+    } catch (err) {
+      const message = (err as Error).message
+      await deps.insertInferenceLog({
+        strategy_id: s.id, rl_model_id: s.rl_model.id, user_id: s.user_id,
+        trade_date: deps.today, state_hash: '',
+        output: {}, confidence: null, decision: 'error',
+        error_message: message,
+      })
+      try { await deps.sendTelegram(s.user_id, `[RL] ${s.id} 오류: ${message}`) } catch {}
+      result.errored++
+    }
+  }
+  return result
+}
+
+interface PlannedOrder { ticker: string; side: 'buy' | 'sell'; qty: number }
+
+function computeOrdersFromWeights(
+  weights: Record<string, number>,
+  current: Record<string, { qty: number; avg_price: number }>,
+  totalCapitalFallback: number,
+): PlannedOrder[] {
+  const orders: PlannedOrder[] = []
+  const totalQty = Object.values(current).reduce((s, p) => s + p.qty * p.avg_price, 0)
+  const total = totalQty > 0 ? totalQty : totalCapitalFallback
+  for (const [ticker, w] of Object.entries(weights)) {
+    const targetValue = total * w
+    const currentQty = current[ticker]?.qty ?? 0
+    const currentValue = currentQty * (current[ticker]?.avg_price ?? 0)
+    const diff = targetValue - currentValue
+    if (Math.abs(diff) < total * 0.01) continue
+    if (diff > 0) {
+      orders.push({ ticker, side: 'buy', qty: Math.max(1, Math.floor(diff / Math.max(current[ticker]?.avg_price ?? 1, 1))) })
+    } else {
+      const qty = Math.min(currentQty, Math.floor(Math.abs(diff) / Math.max(current[ticker]?.avg_price ?? 1, 1)))
+      if (qty > 0) orders.push({ ticker, side: 'sell', qty })
+    }
+  }
+  return orders
+}

--- a/trading-worker/src/dailyRebalanceJob.ts
+++ b/trading-worker/src/dailyRebalanceJob.ts
@@ -55,6 +55,17 @@ export async function runDailyRebalance(deps: DailyRebalanceDeps): Promise<Rebal
 
   for (const s of strategies) {
     result.processed++
+    if (s.strategy_type !== 'rl_portfolio') {
+      // Phase 1 only supports rl_portfolio. rl_single is registered but not auto-traded.
+      await deps.insertInferenceLog({
+        strategy_id: s.id, rl_model_id: s.rl_model.id, user_id: s.user_id,
+        trade_date: deps.today, state_hash: '',
+        output: {}, confidence: null, decision: 'hold',
+        blocked_reason: `strategy_type ${s.strategy_type} not supported in Phase 1`,
+      })
+      result.blocked++
+      continue
+    }
     try {
       const settings = await deps.fetchUserSettings(s.user_id)
       if (settings.rl_paused_at) {

--- a/trading-worker/src/dailyRebalanceJob.ts
+++ b/trading-worker/src/dailyRebalanceJob.ts
@@ -26,6 +26,7 @@ export interface DailyRebalanceDeps {
   rlClient: Pick<RLInferenceClient, 'predict' | 'health'>
   insertInferenceLog: (log: InferenceLogEntry) => Promise<void>
   sendTelegram: (userId: string, message: string) => Promise<void>
+  checkLogExists: (strategyId: string, tradeDate: string) => Promise<boolean>
   executeAutoOrder: (params: {
     userId: string; strategyId: string; ticker: string; orderType: 'buy' | 'sell';
     quantity: number; orderMethod: 'market' | 'limit'; signalData: Record<string, unknown>
@@ -66,6 +67,12 @@ export async function runDailyRebalance(deps: DailyRebalanceDeps): Promise<Rebal
       result.blocked++
       continue
     }
+
+    // Idempotency: skip strategies that already have today's log
+    if (await deps.checkLogExists(s.id, deps.today)) {
+      continue
+    }
+
     try {
       const settings = await deps.fetchUserSettings(s.user_id)
       if (settings.rl_paused_at) {
@@ -108,7 +115,24 @@ export async function runDailyRebalance(deps: DailyRebalanceDeps): Promise<Rebal
         continue
       }
 
-      const orders = computeOrdersFromWeights(prediction.weights, positions, 10000)
+      const positionsTotal = Object.values(positions).reduce((sum, p) => sum + p.qty * p.avg_price, 0)
+      if (positionsTotal <= 0) {
+        // No existing positions → cannot derive capital baseline. Log + notify, do not place orders.
+        await deps.insertInferenceLog({
+          strategy_id: s.id, rl_model_id: s.rl_model.id, user_id: s.user_id,
+          trade_date: deps.today, state_hash: '',
+          output: prediction as unknown as Record<string, unknown>,
+          confidence: prediction.confidence,
+          decision: 'hold',
+          blocked_reason: 'no_capital_baseline (positions empty); seed initial position manually',
+          latency_ms: latencyMs,
+        })
+        await deps.sendTelegram(s.user_id,
+          `[RL] ${s.id} 추론 신뢰도 ${prediction.confidence.toFixed(2)}이지만 보유 포지션이 없어 자동 주문을 보류했습니다. 첫 매수는 수동으로 진행하세요.`)
+        result.blocked++
+        continue
+      }
+      const orders = computeOrdersFromWeights(prediction.weights, positions, positionsTotal)
 
       if (s.automation_level === 1) {
         await deps.sendTelegram(s.user_id, `[RL] ${s.id} 신호: ${JSON.stringify(orders.slice(0, 5))}`)

--- a/trading-worker/src/index.ts
+++ b/trading-worker/src/index.ts
@@ -14,12 +14,14 @@ import 'dotenv/config'
  * - SIGINT/SIGTERM 수신 시 WebSocket 해제 → 진행 중 작업 완료 대기 → 종료
  */
 
+import cron from 'node-cron'
 import { logger } from './logger'
 import { loadConfig } from './config'
 import { getSupabase } from './supabaseClient'
 import { startMarketScheduler, stopMarketScheduler } from './marketScheduler'
 import { startSignalProcessor, stopSignalProcessor } from './signalProcessor'
 import { startReconciler, stopReconciler } from './reconciler'
+import { runDailyRebalance } from './dailyRebalanceJob'
 
 let isShuttingDown = false
 
@@ -57,6 +59,17 @@ async function main() {
 
   // 6. 주문 재조정 배치 시작 (5분 주기)
   startReconciler()
+
+  // 7. RL 일일 리밸런스 크론 (평일 오전 7시, Asia/Seoul)
+  // Note: 실제 Supabase + KIS deps는 Task 11에서 연결됩니다. 현재는 placeholder입니다.
+  cron.schedule('0 7 * * 2-6', async () => {
+    try {
+      logger.info('[dailyRebalance] start')
+      logger.warn('[dailyRebalance] deps not wired yet; skipping (will be wired in Task 11)')
+    } catch (err) {
+      logger.error({ err }, '[dailyRebalance] failed')
+    }
+  }, { timezone: 'Asia/Seoul' })
 
   logger.info('=== 트레이딩 워커 준비 완료 ===')
 

--- a/trading-worker/src/index.ts
+++ b/trading-worker/src/index.ts
@@ -62,6 +62,9 @@ async function main() {
   startReconciler()
 
   // 7. RL 일일 리밸런스 크론 (평일 오전 7시, Asia/Seoul)
+  // DST 안전성: ET 마감(16:00 local) → KST 05:00 (EDT, UTC-4) / KST 06:00 (EST, UTC-5).
+  // KST 07:00은 항상 ET 마감 대비 최소 1시간(EDT) ~ 2시간(EST) 마진을 확보.
+  // node-cron의 timezone 옵션으로 KST 기준 고정되어 있어 미국 DST 전환에 무관.
   cron.schedule('0 7 * * 2-6', async () => {
     try {
       logger.info('[dailyRebalance] start')

--- a/trading-worker/src/index.ts
+++ b/trading-worker/src/index.ts
@@ -23,6 +23,7 @@ import { startSignalProcessor, stopSignalProcessor } from './signalProcessor'
 import { startReconciler, stopReconciler } from './reconciler'
 import { runDailyRebalance } from './dailyRebalanceJob'
 import { buildDailyRebalanceDeps } from './dailyRebalanceDeps'
+import { runOhlcvIngestion, buildIngestionDeps, DEFAULT_UNIVERSE } from './ohlcvIngestionJob'
 
 let isShuttingDown = false
 
@@ -73,6 +74,19 @@ async function main() {
       logger.info({ result }, '[dailyRebalance] done')
     } catch (err) {
       logger.error({ err }, '[dailyRebalance] failed')
+    }
+  }, { timezone: 'Asia/Seoul' })
+
+  // 8. OHLCV 일일 수집 크론 (평일 KST 06:30)
+  // ET 마감(KST 05:00 EDT / 06:00 EST) 직후 → Yahoo Finance에서 Dow 30 일봉 30일치 fetch
+  cron.schedule('30 6 * * 2-6', async () => {
+    try {
+      logger.info('[ohlcvIngestion] start')
+      const deps = await buildIngestionDeps(getSupabase())
+      const r = await runOhlcvIngestion(DEFAULT_UNIVERSE, 30, deps)
+      logger.info({ result: r }, '[ohlcvIngestion] done')
+    } catch (err) {
+      logger.error({ err }, '[ohlcvIngestion] failed')
     }
   }, { timezone: 'Asia/Seoul' })
 

--- a/trading-worker/src/index.ts
+++ b/trading-worker/src/index.ts
@@ -22,6 +22,7 @@ import { startMarketScheduler, stopMarketScheduler } from './marketScheduler'
 import { startSignalProcessor, stopSignalProcessor } from './signalProcessor'
 import { startReconciler, stopReconciler } from './reconciler'
 import { runDailyRebalance } from './dailyRebalanceJob'
+import { buildDailyRebalanceDeps } from './dailyRebalanceDeps'
 
 let isShuttingDown = false
 
@@ -61,11 +62,12 @@ async function main() {
   startReconciler()
 
   // 7. RL 일일 리밸런스 크론 (평일 오전 7시, Asia/Seoul)
-  // Note: 실제 Supabase + KIS deps는 Task 11에서 연결됩니다. 현재는 placeholder입니다.
   cron.schedule('0 7 * * 2-6', async () => {
     try {
       logger.info('[dailyRebalance] start')
-      logger.warn('[dailyRebalance] deps not wired yet; skipping (will be wired in Task 11)')
+      const deps = await buildDailyRebalanceDeps()
+      const result = await runDailyRebalance(deps)
+      logger.info({ result }, '[dailyRebalance] done')
     } catch (err) {
       logger.error({ err }, '[dailyRebalance] failed')
     }

--- a/trading-worker/src/ohlcvIngestionJob.ts
+++ b/trading-worker/src/ohlcvIngestionJob.ts
@@ -31,28 +31,55 @@ export interface IngestionResult {
   failed: { ticker: string; error: string }[]
 }
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+export interface IngestionOptions {
+  throttleMs?: number  // 종목 사이 sleep
+  retries?: number     // 429/5xx 재시도
+}
+
 export async function runOhlcvIngestion(
   universe: string[],
   daysBack: number,
   deps: IngestionDeps,
+  options: IngestionOptions = {},
 ): Promise<IngestionResult> {
+  const throttleMs = options.throttleMs ?? 1500
+  const retries = options.retries ?? 3
   const result: IngestionResult = { tickers: 0, inserted: 0, failed: [] }
-  for (const ticker of universe) {
+
+  for (let i = 0; i < universe.length; i++) {
+    const ticker = universe[i]
     result.tickers++
-    try {
-      const rows = await deps.fetchYahoo(ticker, daysBack)
-      if (rows.length === 0) continue
-      const r = await deps.upsert(rows)
-      if (r.error) {
-        result.failed.push({ ticker, error: r.error })
-        continue
+    let lastErr = ''
+    let rows: OhlcvRow[] | null = null
+
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        rows = await deps.fetchYahoo(ticker, daysBack)
+        lastErr = ''
+        break
+      } catch (err) {
+        lastErr = (err as Error).message
+        // 429 또는 5xx로 보이면 exponential backoff (1s, 2s, 4s, ...)
+        if (attempt < retries) {
+          const wait = throttleMs * Math.pow(2, attempt)
+          logger.warn({ ticker, attempt, wait, err: lastErr }, 'ohlcvIngestion: retry after backoff')
+          await sleep(wait)
+        }
       }
-      result.inserted += r.inserted
-    } catch (err) {
-      const msg = (err as Error).message
-      result.failed.push({ ticker, error: msg })
-      logger.warn({ ticker, err: msg }, 'ohlcvIngestion: ticker failed')
     }
+
+    if (lastErr || !rows) {
+      result.failed.push({ ticker, error: lastErr || 'fetch returned null' })
+    } else if (rows.length > 0) {
+      const r = await deps.upsert(rows)
+      if (r.error) result.failed.push({ ticker, error: r.error })
+      else result.inserted += r.inserted
+    }
+
+    // 다음 종목 전 throttle (마지막 종목은 sleep 생략)
+    if (i < universe.length - 1) await sleep(throttleMs)
   }
   return result
 }

--- a/trading-worker/src/ohlcvIngestionJob.ts
+++ b/trading-worker/src/ohlcvIngestionJob.ts
@@ -1,0 +1,106 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { logger } from './logger'
+
+// Dow 30 (2026 기준 일반적 종목; 인덱스 변경 가능 — 학습 데이터와 일치 우선이면 정책에 따라 조정)
+export const DEFAULT_UNIVERSE = [
+  'AAPL','MSFT','UNH','JNJ','V','WMT','PG','JPM','HD','CVX',
+  'MA','KO','PFE','DIS','CSCO','VZ','ADBE','NKE','CRM','INTC',
+  'MRK','WBA','BA','CAT','GS','IBM','MMM','AXP','TRV','DOW',
+]
+
+export interface OhlcvRow {
+  ticker: string
+  market: 'US'
+  timeframe: '1d'
+  datetime: string  // ISO with timezone
+  open: number
+  high: number
+  low: number
+  close: number
+  volume: number
+}
+
+export interface IngestionDeps {
+  fetchYahoo: (ticker: string, days: number) => Promise<OhlcvRow[]>
+  upsert: (rows: OhlcvRow[]) => Promise<{ inserted: number; error: string | null }>
+}
+
+export interface IngestionResult {
+  tickers: number
+  inserted: number
+  failed: { ticker: string; error: string }[]
+}
+
+export async function runOhlcvIngestion(
+  universe: string[],
+  daysBack: number,
+  deps: IngestionDeps,
+): Promise<IngestionResult> {
+  const result: IngestionResult = { tickers: 0, inserted: 0, failed: [] }
+  for (const ticker of universe) {
+    result.tickers++
+    try {
+      const rows = await deps.fetchYahoo(ticker, daysBack)
+      if (rows.length === 0) continue
+      const r = await deps.upsert(rows)
+      if (r.error) {
+        result.failed.push({ ticker, error: r.error })
+        continue
+      }
+      result.inserted += r.inserted
+    } catch (err) {
+      const msg = (err as Error).message
+      result.failed.push({ ticker, error: msg })
+      logger.warn({ ticker, err: msg }, 'ohlcvIngestion: ticker failed')
+    }
+  }
+  return result
+}
+
+// Yahoo Finance Chart API helper
+export async function fetchYahooChart(ticker: string, daysBack: number): Promise<OhlcvRow[]> {
+  const range = daysBack <= 5 ? '5d' : daysBack <= 30 ? '1mo' : daysBack <= 90 ? '3mo' : '1y'
+  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(ticker)}?interval=1d&range=${range}`
+  const resp = await fetch(url, {
+    headers: {
+      // Yahoo blocks default UA; use a browser-like UA.
+      'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120 Safari/537.36',
+      'accept': 'application/json',
+    },
+  })
+  if (!resp.ok) throw new Error(`yahoo ${ticker} ${resp.status}`)
+  const json = (await resp.json()) as any
+  const r = json?.chart?.result?.[0]
+  if (!r) return []
+  const ts = r.timestamp as number[] | undefined
+  const q = r.indicators?.quote?.[0]
+  if (!ts || !q) return []
+  const out: OhlcvRow[] = []
+  for (let i = 0; i < ts.length; i++) {
+    const open = q.open?.[i], high = q.high?.[i], low = q.low?.[i], close = q.close?.[i], volume = q.volume?.[i]
+    if (open == null || high == null || low == null || close == null) continue
+    const datetime = new Date(ts[i] * 1000).toISOString()
+    out.push({
+      ticker, market: 'US', timeframe: '1d', datetime,
+      open: Number(open), high: Number(high), low: Number(low), close: Number(close),
+      volume: Number(volume ?? 0),
+    })
+  }
+  return out
+}
+
+export async function buildIngestionDeps(
+  supabase: SupabaseClient,
+): Promise<IngestionDeps> {
+  return {
+    fetchYahoo: fetchYahooChart,
+    upsert: async (rows) => {
+      if (rows.length === 0) return { inserted: 0, error: null }
+      const { error } = await supabase
+        .from('intraday_price_cache')
+        .upsert(rows, { onConflict: 'ticker,market,timeframe,datetime' })
+      if (error) return { inserted: 0, error: error.message }
+      return { inserted: rows.length, error: null }
+    },
+  }
+}

--- a/trading-worker/src/rlInferenceClient.ts
+++ b/trading-worker/src/rlInferenceClient.ts
@@ -1,0 +1,93 @@
+export interface RLInferenceConfig {
+  baseUrl: string
+  apiKey: string
+  timeoutMs: number
+}
+
+export interface PredictRequestBody {
+  model_id: string
+  checkpoint_path: string
+  algorithm: string
+  kind: 'portfolio' | 'single_asset'
+  state_window: number
+  input_features: string[]
+  ohlcv: Record<string, Array<{ date: string; open: number; high: number; low: number; close: number; volume: number }>>
+  indicators?: Record<string, Record<string, number[]>>
+  current_positions?: Record<string, { qty: number; avg_price: number }>
+}
+
+export interface PortfolioPredictResponse {
+  kind: 'portfolio'
+  weights: Record<string, number>
+  confidence: number
+  raw_action: number[]
+  metadata: Record<string, unknown>
+}
+
+export interface SinglePredictResponse {
+  kind: 'single_asset'
+  action: 'buy' | 'sell' | 'hold'
+  size_hint?: number
+  confidence: number
+  metadata: Record<string, unknown>
+}
+
+export type PredictResponse = PortfolioPredictResponse | SinglePredictResponse
+
+export class RLInferenceClient {
+  constructor(private cfg: RLInferenceConfig) {}
+
+  async predict(body: PredictRequestBody): Promise<PredictResponse> {
+    return this._post('/predict', body)
+  }
+
+  async health(): Promise<{ status: string; loaded_models: string[]; uptime_seconds: number }> {
+    return this._get('/health')
+  }
+
+  private async _post<T>(path: string, body: unknown): Promise<T> {
+    const ctrl = new AbortController()
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        ctrl.abort()
+        reject(new Error(`rl-inference-server ${path} timeout after ${this.cfg.timeoutMs}ms`))
+      }, this.cfg.timeoutMs)
+    })
+    const fetchPromise = fetch(`${this.cfg.baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'X-RL-API-KEY': this.cfg.apiKey,
+      },
+      body: JSON.stringify(body),
+      signal: ctrl.signal,
+    }).then(async (resp) => {
+      if (!resp.ok) {
+        const text = await resp.text().catch(() => '')
+        throw new Error(`rl-inference-server ${path} returned ${resp.status}: ${text}`)
+      }
+      return resp.json() as Promise<T>
+    })
+    return Promise.race([fetchPromise, timeoutPromise])
+  }
+
+  private async _get<T>(path: string): Promise<T> {
+    const ctrl = new AbortController()
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        ctrl.abort()
+        reject(new Error(`rl-inference-server /health timeout after ${this.cfg.timeoutMs}ms`))
+      }, this.cfg.timeoutMs)
+    })
+    const fetchPromise = fetch(`${this.cfg.baseUrl}${path}`, {
+      headers: { 'X-RL-API-KEY': this.cfg.apiKey },
+      signal: ctrl.signal,
+    }).then(async (resp) => {
+      if (!resp.ok) {
+        throw new Error(`rl-inference-server ${path} returned ${resp.status}`)
+      }
+      return resp.json() as Promise<T>
+    })
+    return Promise.race([fetchPromise, timeoutPromise])
+  }
+}

--- a/trading-worker/src/telegramNotifier.ts
+++ b/trading-worker/src/telegramNotifier.ts
@@ -102,6 +102,19 @@ export async function sendOrderResult(userId: string, data: OrderResultData) {
 }
 
 /**
+ * 사용자별 시스템 공지 (간단한 free-text).
+ * RL 신호처럼 구조화된 알림이 아닌 경우에 사용.
+ */
+export async function sendSystemNotice(userId: string, text: string): Promise<void> {
+  const chatId = await getUserTelegramChatId(userId)
+  if (!chatId) {
+    logger.warn({ userId }, 'Telegram chatId 없음 - 시스템 공지 건너뜀')
+    return
+  }
+  await sendTelegramMessage(chatId, text)
+}
+
+/**
  * 시스템 경보 (긴급)
  */
 export async function sendSystemAlert(message: string) {

--- a/trading-worker/tests/dailyRebalanceJob.test.ts
+++ b/trading-worker/tests/dailyRebalanceJob.test.ts
@@ -11,6 +11,7 @@ function makeDeps(overrides: Partial<DailyRebalanceDeps> = {}): DailyRebalanceDe
     insertInferenceLog: vi.fn().mockResolvedValue(undefined),
     sendTelegram: vi.fn().mockResolvedValue(undefined),
     executeAutoOrder: vi.fn().mockResolvedValue({ ok: true, orderId: 'o1' }),
+    checkLogExists: vi.fn().mockResolvedValue(false),
     today: '2026-04-29',
     ...overrides,
   }
@@ -63,7 +64,9 @@ describe('runDailyRebalance', () => {
   it('automation_level=2 invokes executeAutoOrder', async () => {
     const deps = makeDeps({
       fetchActiveRLStrategies: vi.fn().mockResolvedValue([{ ...baseStrategy, automation_level: 2 }]),
-      rlClient: { predict: vi.fn().mockResolvedValue({ kind: 'portfolio', weights: { AAPL: 1 }, confidence: 0.8, raw_action: [], metadata: {} }), health: vi.fn() } as any,
+      // positionsTotal = 5 * 100 = 500. weights: AAPL=0.5 → targetValue=250, currentValue=500 → diff=-250 → sell
+      fetchCurrentPositions: vi.fn().mockResolvedValue({ AAPL: { qty: 5, avg_price: 100 } }),
+      rlClient: { predict: vi.fn().mockResolvedValue({ kind: 'portfolio', weights: { AAPL: 0.5 }, confidence: 0.8, raw_action: [], metadata: {} }), health: vi.fn() } as any,
     })
     await runDailyRebalance(deps)
     expect(deps.executeAutoOrder).toHaveBeenCalled()
@@ -90,5 +93,32 @@ describe('runDailyRebalance', () => {
     expect(deps.insertInferenceLog).toHaveBeenCalledWith(
       expect.objectContaining({ decision: 'hold', blocked_reason: expect.stringContaining('rl_single') }),
     )
+  })
+
+  it('skips when log already exists for today (idempotency)', async () => {
+    const deps = makeDeps({
+      fetchActiveRLStrategies: vi.fn().mockResolvedValue([baseStrategy]),
+      checkLogExists: vi.fn().mockResolvedValue(true),
+    })
+    await runDailyRebalance(deps)
+    expect(deps.fetchOhlcvWindow).not.toHaveBeenCalled()
+    expect(deps.rlClient.predict).not.toHaveBeenCalled()
+  })
+
+  it('holds when positions empty (no capital baseline)', async () => {
+    const deps = makeDeps({
+      fetchActiveRLStrategies: vi.fn().mockResolvedValue([{ ...baseStrategy, automation_level: 2 }]),
+      fetchCurrentPositions: vi.fn().mockResolvedValue({}),
+      rlClient: {
+        predict: vi.fn().mockResolvedValue({ kind: 'portfolio', weights: { AAPL: 1 }, confidence: 0.9, raw_action: [], metadata: {} }),
+        health: vi.fn(),
+      } as any,
+    })
+    await runDailyRebalance(deps)
+    expect(deps.executeAutoOrder).not.toHaveBeenCalled()
+    expect(deps.insertInferenceLog).toHaveBeenCalledWith(expect.objectContaining({
+      decision: 'hold',
+      blocked_reason: expect.stringContaining('no_capital_baseline'),
+    }))
   })
 })

--- a/trading-worker/tests/dailyRebalanceJob.test.ts
+++ b/trading-worker/tests/dailyRebalanceJob.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { runDailyRebalance, DailyRebalanceDeps } from '../src/dailyRebalanceJob'
+
+function makeDeps(overrides: Partial<DailyRebalanceDeps> = {}): DailyRebalanceDeps {
+  return {
+    fetchActiveRLStrategies: vi.fn().mockResolvedValue([]),
+    fetchUserSettings: vi.fn().mockResolvedValue({ rl_paused_at: null }),
+    fetchOhlcvWindow: vi.fn().mockResolvedValue({}),
+    fetchCurrentPositions: vi.fn().mockResolvedValue({}),
+    rlClient: { predict: vi.fn(), health: vi.fn() } as any,
+    insertInferenceLog: vi.fn().mockResolvedValue(undefined),
+    sendTelegram: vi.fn().mockResolvedValue(undefined),
+    executeAutoOrder: vi.fn().mockResolvedValue({ ok: true, orderId: 'o1' }),
+    today: '2026-04-29',
+    ...overrides,
+  }
+}
+
+const baseStrategy = {
+  id: 's1', user_id: 'u1', strategy_type: 'rl_portfolio', automation_level: 1,
+  rl_model: { id: 'm1', min_confidence: 0.5, universe: ['AAPL'], state_window: 5, algorithm: 'PPO', input_features: ['close'], checkpoint_path: '/p' },
+}
+
+describe('runDailyRebalance', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('skips when no active RL strategies', async () => {
+    const deps = makeDeps()
+    const result = await runDailyRebalance(deps)
+    expect(result.processed).toBe(0)
+  })
+
+  it('blocks when kill switch is active', async () => {
+    const deps = makeDeps({
+      fetchActiveRLStrategies: vi.fn().mockResolvedValue([baseStrategy]),
+      fetchUserSettings: vi.fn().mockResolvedValue({ rl_paused_at: '2026-04-29T00:00:00Z' }),
+    })
+    await runDailyRebalance(deps)
+    expect(deps.insertInferenceLog).toHaveBeenCalledWith(expect.objectContaining({ decision: 'blocked_kill_switch' }))
+    expect(deps.executeAutoOrder).not.toHaveBeenCalled()
+  })
+
+  it('blocks when confidence below min_confidence', async () => {
+    const deps = makeDeps({
+      fetchActiveRLStrategies: vi.fn().mockResolvedValue([{ ...baseStrategy, automation_level: 2, rl_model: { ...baseStrategy.rl_model, min_confidence: 0.9 } }]),
+      rlClient: { predict: vi.fn().mockResolvedValue({ kind: 'portfolio', weights: { AAPL: 1 }, confidence: 0.5, raw_action: [], metadata: {} }), health: vi.fn() } as any,
+    })
+    await runDailyRebalance(deps)
+    expect(deps.insertInferenceLog).toHaveBeenCalledWith(expect.objectContaining({ decision: 'blocked_low_confidence' }))
+    expect(deps.executeAutoOrder).not.toHaveBeenCalled()
+  })
+
+  it('automation_level=1 sends Telegram only, no auto order', async () => {
+    const deps = makeDeps({
+      fetchActiveRLStrategies: vi.fn().mockResolvedValue([baseStrategy]),
+      rlClient: { predict: vi.fn().mockResolvedValue({ kind: 'portfolio', weights: { AAPL: 1 }, confidence: 0.8, raw_action: [], metadata: {} }), health: vi.fn() } as any,
+    })
+    await runDailyRebalance(deps)
+    expect(deps.sendTelegram).toHaveBeenCalled()
+    expect(deps.executeAutoOrder).not.toHaveBeenCalled()
+  })
+
+  it('automation_level=2 invokes executeAutoOrder', async () => {
+    const deps = makeDeps({
+      fetchActiveRLStrategies: vi.fn().mockResolvedValue([{ ...baseStrategy, automation_level: 2 }]),
+      rlClient: { predict: vi.fn().mockResolvedValue({ kind: 'portfolio', weights: { AAPL: 1 }, confidence: 0.8, raw_action: [], metadata: {} }), health: vi.fn() } as any,
+    })
+    await runDailyRebalance(deps)
+    expect(deps.executeAutoOrder).toHaveBeenCalled()
+  })
+
+  it('logs error and continues on prediction failure', async () => {
+    const deps = makeDeps({
+      fetchActiveRLStrategies: vi.fn().mockResolvedValue([{ ...baseStrategy, automation_level: 2 }]),
+      rlClient: { predict: vi.fn().mockRejectedValue(new Error('timeout')), health: vi.fn() } as any,
+    })
+    await runDailyRebalance(deps)
+    expect(deps.insertInferenceLog).toHaveBeenCalledWith(expect.objectContaining({ decision: 'error' }))
+  })
+})

--- a/trading-worker/tests/dailyRebalanceJob.test.ts
+++ b/trading-worker/tests/dailyRebalanceJob.test.ts
@@ -77,4 +77,18 @@ describe('runDailyRebalance', () => {
     await runDailyRebalance(deps)
     expect(deps.insertInferenceLog).toHaveBeenCalledWith(expect.objectContaining({ decision: 'error' }))
   })
+
+  it('skips rl_single strategies (Phase 1 portfolio-only)', async () => {
+    const deps = makeDeps({
+      fetchActiveRLStrategies: vi.fn().mockResolvedValue([
+        { ...baseStrategy, strategy_type: 'rl_single' },
+      ]),
+    })
+    await runDailyRebalance(deps)
+    expect(deps.rlClient.predict).not.toHaveBeenCalled()
+    expect(deps.executeAutoOrder).not.toHaveBeenCalled()
+    expect(deps.insertInferenceLog).toHaveBeenCalledWith(
+      expect.objectContaining({ decision: 'hold', blocked_reason: expect.stringContaining('rl_single') }),
+    )
+  })
 })

--- a/trading-worker/tests/ohlcvIngestionJob.test.ts
+++ b/trading-worker/tests/ohlcvIngestionJob.test.ts
@@ -14,10 +14,12 @@ const sampleRow = (ticker: string): OhlcvRow => ({
   open: 100, high: 101, low: 99, close: 100.5, volume: 1_000_000,
 })
 
+const FAST = { throttleMs: 0, retries: 0 } as const
+
 describe('runOhlcvIngestion', () => {
   it('upserts rows for each ticker', async () => {
     const deps = makeDeps({ AAPL: [sampleRow('AAPL')], MSFT: [sampleRow('MSFT')] })
-    const r = await runOhlcvIngestion(['AAPL', 'MSFT'], 5, deps)
+    const r = await runOhlcvIngestion(['AAPL', 'MSFT'], 5, deps, FAST)
     expect(r.tickers).toBe(2)
     expect(r.inserted).toBe(2)
     expect(r.failed).toHaveLength(0)
@@ -31,7 +33,7 @@ describe('runOhlcvIngestion', () => {
       }),
       upsert: vi.fn(async (rows: OhlcvRow[]) => ({ inserted: rows.length, error: null })),
     }
-    const r = await runOhlcvIngestion(['AAPL', 'BAD', 'MSFT'], 5, deps)
+    const r = await runOhlcvIngestion(['AAPL', 'BAD', 'MSFT'], 5, deps, FAST)
     expect(r.tickers).toBe(3)
     expect(r.inserted).toBe(2)
     expect(r.failed).toEqual([{ ticker: 'BAD', error: 'yahoo 500' }])
@@ -39,7 +41,7 @@ describe('runOhlcvIngestion', () => {
 
   it('skips empty fetch results', async () => {
     const deps = makeDeps({ AAPL: [] })
-    const r = await runOhlcvIngestion(['AAPL'], 5, deps)
+    const r = await runOhlcvIngestion(['AAPL'], 5, deps, FAST)
     expect(r.inserted).toBe(0)
     expect(r.failed).toHaveLength(0)
   })
@@ -49,8 +51,23 @@ describe('runOhlcvIngestion', () => {
       fetchYahoo: vi.fn(async (t: string) => [sampleRow(t)]),
       upsert: vi.fn(async () => ({ inserted: 0, error: 'duplicate key' })),
     }
-    const r = await runOhlcvIngestion(['AAPL'], 5, deps)
+    const r = await runOhlcvIngestion(['AAPL'], 5, deps, FAST)
     expect(r.inserted).toBe(0)
     expect(r.failed).toEqual([{ ticker: 'AAPL', error: 'duplicate key' }])
+  })
+
+  it('retries on transient fetch error then succeeds', async () => {
+    let calls = 0
+    const deps: IngestionDeps = {
+      fetchYahoo: vi.fn(async () => {
+        calls++
+        if (calls === 1) throw new Error('yahoo 429')
+        return [sampleRow('AAPL')]
+      }),
+      upsert: vi.fn(async (rows: OhlcvRow[]) => ({ inserted: rows.length, error: null })),
+    }
+    const r = await runOhlcvIngestion(['AAPL'], 5, deps, { throttleMs: 0, retries: 2 })
+    expect(r.inserted).toBe(1)
+    expect(calls).toBe(2)
   })
 })

--- a/trading-worker/tests/ohlcvIngestionJob.test.ts
+++ b/trading-worker/tests/ohlcvIngestionJob.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+import { runOhlcvIngestion, type IngestionDeps, type OhlcvRow } from '../src/ohlcvIngestionJob'
+
+function makeDeps(rowsByTicker: Record<string, OhlcvRow[]>): IngestionDeps {
+  return {
+    fetchYahoo: vi.fn(async (t: string) => rowsByTicker[t] ?? []),
+    upsert: vi.fn(async (rows: OhlcvRow[]) => ({ inserted: rows.length, error: null })),
+  }
+}
+
+const sampleRow = (ticker: string): OhlcvRow => ({
+  ticker, market: 'US', timeframe: '1d',
+  datetime: '2026-04-28T20:00:00.000Z',
+  open: 100, high: 101, low: 99, close: 100.5, volume: 1_000_000,
+})
+
+describe('runOhlcvIngestion', () => {
+  it('upserts rows for each ticker', async () => {
+    const deps = makeDeps({ AAPL: [sampleRow('AAPL')], MSFT: [sampleRow('MSFT')] })
+    const r = await runOhlcvIngestion(['AAPL', 'MSFT'], 5, deps)
+    expect(r.tickers).toBe(2)
+    expect(r.inserted).toBe(2)
+    expect(r.failed).toHaveLength(0)
+  })
+
+  it('continues when one ticker fetch fails', async () => {
+    const deps: IngestionDeps = {
+      fetchYahoo: vi.fn(async (t: string) => {
+        if (t === 'BAD') throw new Error('yahoo 500')
+        return [sampleRow(t)]
+      }),
+      upsert: vi.fn(async (rows: OhlcvRow[]) => ({ inserted: rows.length, error: null })),
+    }
+    const r = await runOhlcvIngestion(['AAPL', 'BAD', 'MSFT'], 5, deps)
+    expect(r.tickers).toBe(3)
+    expect(r.inserted).toBe(2)
+    expect(r.failed).toEqual([{ ticker: 'BAD', error: 'yahoo 500' }])
+  })
+
+  it('skips empty fetch results', async () => {
+    const deps = makeDeps({ AAPL: [] })
+    const r = await runOhlcvIngestion(['AAPL'], 5, deps)
+    expect(r.inserted).toBe(0)
+    expect(r.failed).toHaveLength(0)
+  })
+
+  it('records upsert errors as failures', async () => {
+    const deps: IngestionDeps = {
+      fetchYahoo: vi.fn(async (t: string) => [sampleRow(t)]),
+      upsert: vi.fn(async () => ({ inserted: 0, error: 'duplicate key' })),
+    }
+    const r = await runOhlcvIngestion(['AAPL'], 5, deps)
+    expect(r.inserted).toBe(0)
+    expect(r.failed).toEqual([{ ticker: 'AAPL', error: 'duplicate key' }])
+  })
+})

--- a/trading-worker/tests/rlInferenceClient.test.ts
+++ b/trading-worker/tests/rlInferenceClient.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RLInferenceClient } from '../src/rlInferenceClient'
+
+describe('RLInferenceClient', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('predict() POSTs with X-RL-API-KEY and parses portfolio response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          kind: 'portfolio',
+          weights: { AAPL: 0.5, MSFT: 0.5 },
+          confidence: 0.8,
+          raw_action: [0.5, 0.5],
+          metadata: {},
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+    global.fetch = fetchMock as unknown as typeof fetch
+    const client = new RLInferenceClient({ baseUrl: 'http://127.0.0.1:8001', apiKey: 'k', timeoutMs: 1000 })
+    const res = await client.predict({
+      model_id: 'm',
+      checkpoint_path: '/p',
+      algorithm: 'PPO',
+      kind: 'portfolio',
+      state_window: 5,
+      input_features: ['close'],
+      ohlcv: {},
+    })
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [, init] = fetchMock.mock.calls[0]
+    expect((init as RequestInit).headers).toMatchObject({ 'X-RL-API-KEY': 'k' })
+    expect(res.kind).toBe('portfolio')
+    expect((res as { confidence: number }).confidence).toBe(0.8)
+  })
+
+  it('throws timeout error after timeoutMs', async () => {
+    global.fetch = vi.fn().mockImplementation(
+      () => new Promise(() => {}),
+    ) as unknown as typeof fetch
+    const client = new RLInferenceClient({ baseUrl: 'http://x', apiKey: 'k', timeoutMs: 50 })
+    await expect(
+      client.predict({
+        model_id: 'm', checkpoint_path: '/p', algorithm: 'PPO', kind: 'portfolio',
+        state_window: 5, input_features: ['close'], ohlcv: {},
+      }),
+    ).rejects.toThrow(/timeout/i)
+  })
+
+  it('throws on non-2xx response', async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response('bad', { status: 500 })) as unknown as typeof fetch
+    const client = new RLInferenceClient({ baseUrl: 'http://x', apiKey: 'k', timeoutMs: 1000 })
+    await expect(
+      client.predict({
+        model_id: 'm', checkpoint_path: '/p', algorithm: 'PPO', kind: 'portfolio',
+        state_window: 5, input_features: ['close'], ohlcv: {},
+      }),
+    ).rejects.toThrow(/500/)
+  })
+})

--- a/trading-worker/vitest.config.ts
+++ b/trading-worker/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+    testTimeout: 10000,
+  },
+})


### PR DESCRIPTION
## Summary

`develop` 브랜치를 `main`에 머지. 다음 4개의 큰 작업이 포함됨:

### 1. 🤖 RL 트레이딩 Phase 1 (전체)
- DB schema (`rl_models`, `rl_inference_logs`, `investment_strategies` 확장, kill switch)
- **rl-inference-server** (Python FastAPI + PyTorch + stable-baselines3) — 새 디렉터리
- **trading-worker** 확장 — `dailyRebalanceJob`, `rlInferenceClient`, OHLCV 일봉 cron
- 메인 앱 — RL 모델 라이브러리 페이지, 전략 생성 폼, kill switch API
- 안전 가드 — default level=1, kill switch, min_confidence, idempotency, 5s timeout
- Spec: [docs/superpowers/specs/2026-04-29-rl-trading-design.md](dental-clinic-manager/docs/superpowers/specs/2026-04-29-rl-trading-design.md)
- Plan: [docs/superpowers/plans/2026-04-29-rl-trading-phase1.md](dental-clinic-manager/docs/superpowers/plans/2026-04-29-rl-trading-phase1.md)
- 운영 가이드: [docs/superpowers/operations/rl-trading-operations.md](dental-clinic-manager/docs/superpowers/operations/rl-trading-operations.md)

### 2. 📊 RL Phase 2 baseline 실험
- 자체 학습 파이프라인 (FinRL 의존 없음, 자체 gymnasium env)
- Hyperparameter sweep (lr × clip_range)
- Walk-forward CV (4 windows)
- Benchmark vs Buy&Hold / Equal-weight / Min-Variance
- Reward shaping (Sortino downside) + state 확장 (volume, RSI, regime) v2
- Ensemble (PPO × Min-Var blend)
- **결론**: Phase 1 RL은 baseline 수준 (WF mean Sharpe 0.51±0.53), production-ready 아님. Min-Variance가 동일 OOS에서 더 우수.

### 3. 🗓 일정 위젯 (schedule-widget)
- 대시보드 메인 컬럼 상단에 일정 위젯 추가
- 오늘/주/월 탭, 휴일 배너, 일정 상세 모달
- 게시판 일정 자동 추출 + 환자 약속 통합

### 4. 👥 소개환자 관리 시스템
- 등록 + 감사문자 + 포인트 + 선물 통합

## 안전 가드 (RL 자동매매)

- `automation_level=1` (알림만) 기본값
- 사용자별 kill switch (`rl_paused_at`)
- 모델별 `min_confidence` 임계값
- `(strategy_id, trade_date)` UNIQUE idempotency
- 5초 추론 timeout + retry 0회
- emergency-stop 호출 시 RL 전략도 함께 비활성화

## Test plan

- [x] Python pytest: 21 PASS (rl-inference-server)
- [x] Node vitest: 17 PASS (trading-worker)
- [x] Next.js tsc: 클린 (RL 코드)
- [x] E2E manual (Step 1~7 모두 통과): 마이그레이션 / /health / 모델 등록 / 전략 생성 / cron 강제 트리거 / idempotency / kill switch
- [x] 실 ckpt(`HuggingFace 2045max/finrl-ppo-dow30-quick`) 다운로드 + sha256 검증 + ready 전이
- [x] 자체 학습 ckpt(PPO 200k Dow30, sweep best lr=1e-3 clip=0.1) 등록 + 추론 검증

## 주요 follow-up (운영 시작 전)

- [ ] KIS paper credential 등록 후 dry-run 1주
- [ ] Telegram chat_id 매핑 (현재 알림 "chat_id 없음 - 건너뜀" 워닝)
- [ ] `intraday_price_cache` 일봉 ingestion이 매일 KST 06:30에 정상 동작하는지 1주 모니터
- [ ] Phase 2 — Sharpe-direct reward / S&P 500 universe / Regime classifier stacking

🤖 Generated with [Claude Code](https://claude.com/claude-code)