### PR TITLE
fix(rl-trading): RL 전략 백테스트 정상 동작 (strategy_type 분기 + server-side fetch)

### DIFF
--- a/dental-clinic-manager/package-lock.json
+++ b/dental-clinic-manager/package-lock.json
@@ -195,6 +195,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -419,6 +420,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
       "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -3098,6 +3100,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
       "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.71.1",
         "@supabase/functions-js": "2.4.6",
@@ -3424,6 +3427,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.9.0.tgz",
       "integrity": "sha512-2f460x1yMJ2vXctrbFw6m4/uZk7g5BgsxsJCJtDDjpyasMk5f+BdJTDCb0dwewWb75U+cbdH88AF7NXtLEs6XQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3672,6 +3676,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.7.2.tgz",
       "integrity": "sha512-/tYHmEkOGcVweAc9ZgnAXkzua5aJfu7TjZcKTq5fmDt6x9MY1eY1+egS7D9hVR2sUSAC10VgXmYdYPDsKF3p2g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3764,6 +3769,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.7.2.tgz",
       "integrity": "sha512-1sBOrYHoMDcygPSuBfunp/bw21rea/r7L8AQaeZ/NIo2RZ6GXWxI9sRzTkLWijZ4xC3md0O/ylmvxvLL4V0SVA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3869,6 +3875,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.9.0.tgz",
       "integrity": "sha512-by/GH4A5kaiQqujA2KtXI1ZfQLMuFbb5tylAupPq+Pv6qzEU+Engx7vwUxb/dYvFHh+pxQPJeG6zxWf+WiGPQw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3908,6 +3915,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.7.2.tgz",
       "integrity": "sha512-FaToSdU9fhQk2swkaXrAQNgdaE0dwLbUHcvilW5F4xTpQfZ3J535u5U2TUYf+f9KKSV5fTmD4QGNY9qxY7ihTg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3922,6 +3930,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.9.0.tgz",
       "integrity": "sha512-MN1gL1OZWD489a/OmwV+InyNoRY+nKMKZ2EuZGL5ouQRdi5qSTvtMCmqzBHqrDzJCDPNCaY4NWW5DiKqIiJ2Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4189,6 +4198,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4198,6 +4208,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -4281,6 +4292,7 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -4827,6 +4839,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6297,6 +6310,7 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6471,6 +6485,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9294,6 +9309,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9633,6 +9649,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
       "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -9662,6 +9679,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -9710,6 +9728,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
       "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -9829,6 +9848,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.2.tgz",
       "integrity": "sha512-MdWVitvLbQULD+4DP8GYjZUrepGW7d+GQkNVqJEzNxE+e9WIa4egVFE/RDfVb1u9u/Jw7dNMmPB4IqxzbFYJ0w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9838,6 +9858,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.2.tgz",
       "integrity": "sha512-dEoydsCp50i7kS1xHOmPXq4zQYoGWedUsvqv9H6zdif2r7yLHygyfP9qou71TulRN0d6ng9EbRVsQhSqfUc19g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -9882,13 +9903,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -10047,7 +10070,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -11157,6 +11181,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11396,6 +11421,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/dental-clinic-manager/src/app/api/cron/referral-thanks/route.ts
+++ b/dental-clinic-manager/src/app/api/cron/referral-thanks/route.ts
@@ -1,0 +1,150 @@
+// 자동 감사 문자 발송 크론
+// Vercel Cron schedule: "0 0 * * *" → 매일 KST 09:00 (UTC 00:00) 실행
+// 각 클리닉의 referral_settings.auto_thanks_enabled = true인 곳을 대상으로
+// 미발송 + (referred_at + auto_thanks_after_days <= today) 인 소개 건에 일괄 발송
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+export const maxDuration = 60
+
+const ALIGO_API_URL = 'https://apis.aligo.in'
+
+interface ReferralRow {
+  id: string
+  clinic_id: string
+  referrer_dentweb_patient_id: string
+  referee_dentweb_patient_id: string
+  referred_at: string
+  referrer: { id: string; patient_name: string; phone_number: string | null } | null
+  referee: { patient_name: string } | null
+}
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization')
+  const cronSecret = process.env.CRON_SECRET
+  const isVercelCron = request.headers.get('x-vercel-cron') === '1'
+  if (!isVercelCron) {
+    if (!cronSecret || authHeader !== `Bearer ${cronSecret.trim()}`) {
+      return new NextResponse('Unauthorized', { status: 401 })
+    }
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !supabaseServiceKey) {
+    return NextResponse.json({ success: false, error: 'Supabase configuration missing' }, { status: 500 })
+  }
+  const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+  const today = new Date().toISOString().slice(0, 10)
+  const summary = { totalSent: 0, totalFailed: 0, clinicsProcessed: 0, errors: [] as string[] }
+
+  const { data: settings, error: setErr } = await supabase
+    .from('referral_settings')
+    .select('clinic_id, auto_thanks_enabled, auto_thanks_after_days, thanks_template_id, clinic:clinics(name)')
+    .eq('auto_thanks_enabled', true)
+  if (setErr) return NextResponse.json({ success: false, error: setErr.message }, { status: 500 })
+
+  type SettingRow = {
+    clinic_id: string
+    auto_thanks_enabled: boolean
+    auto_thanks_after_days: number
+    thanks_template_id: string | null
+    clinic: { name: string } | { name: string }[] | null
+  }
+
+  for (const s of ((settings ?? []) as unknown as SettingRow[])) {
+    summary.clinicsProcessed++
+    const clinicRel = Array.isArray(s.clinic) ? s.clinic[0] : s.clinic
+    const clinicName = clinicRel?.name ?? '저희 병원'
+    const cutoffDate = new Date()
+    cutoffDate.setDate(cutoffDate.getDate() - (s.auto_thanks_after_days ?? 0))
+    const cutoffStr = cutoffDate.toISOString().slice(0, 10)
+
+    const { data: aligo } = await supabase
+      .from('aligo_settings')
+      .select('api_key, user_id, sender_number')
+      .eq('clinic_id', s.clinic_id)
+      .single()
+    if (!aligo?.api_key || !aligo.user_id || !aligo.sender_number) {
+      summary.errors.push(`${clinicName}: aligo 미설정`)
+      continue
+    }
+
+    let templateContent = `안녕하세요, ${clinicName}입니다. {{환자명}}님 덕분에 {{소개받은신환명}}님을 모실 수 있게 되어 진심으로 감사드립니다.`
+    if (s.thanks_template_id) {
+      const { data: t } = await supabase.from('recall_sms_templates').select('content').eq('id', s.thanks_template_id).single()
+      if (t?.content) templateContent = t.content
+    } else {
+      const { data: t } = await supabase
+        .from('recall_sms_templates')
+        .select('content')
+        .eq('clinic_id', s.clinic_id)
+        .eq('name', '소개 감사 인사')
+        .eq('is_active', true)
+        .maybeSingle()
+      if (t?.content) templateContent = t.content
+    }
+
+    const { data: pending } = await supabase
+      .from('patient_referrals')
+      .select(`
+        id, clinic_id, referrer_dentweb_patient_id, referee_dentweb_patient_id, referred_at,
+        referrer:dentweb_patients!patient_referrals_referrer_dentweb_patient_id_fkey (id, patient_name, phone_number),
+        referee:dentweb_patients!patient_referrals_referee_dentweb_patient_id_fkey (patient_name)
+      `)
+      .eq('clinic_id', s.clinic_id)
+      .is('thanks_sms_sent_at', null)
+      .lte('referred_at', cutoffStr)
+      .limit(50)
+
+    for (const r of (pending ?? []) as unknown as ReferralRow[]) {
+      if (!r.referrer?.phone_number) continue
+      const message = templateContent
+        .replace(/\{\{환자명\}\}/g, r.referrer.patient_name)
+        .replace(/\{\{소개받은신환명\}\}/g, r.referee?.patient_name ?? '신환')
+        .replace(/\{\{병원명\}\}/g, clinicName)
+
+      const byteSize = new Blob([message]).size
+      const msgType = byteSize > 90 ? 'LMS' : 'SMS'
+
+      const fd = new FormData()
+      fd.append('key', aligo.api_key)
+      fd.append('user_id', aligo.user_id)
+      fd.append('sender', aligo.sender_number)
+      fd.append('receiver', r.referrer.phone_number)
+      fd.append('msg', message)
+      fd.append('msg_type', msgType)
+      if (msgType === 'LMS') fd.append('title', '소개 감사 인사')
+
+      try {
+        const res = await fetch(`${ALIGO_API_URL}/send/`, { method: 'POST', body: fd })
+        const json = await res.json()
+        const ok = json.result_code === '1'
+        await supabase.from('referral_sms_logs').insert({
+          clinic_id: s.clinic_id,
+          referral_id: r.id,
+          recipient_dentweb_patient_id: r.referrer.id,
+          phone_number: r.referrer.phone_number,
+          message_content: message,
+          message_type: msgType,
+          status: ok ? 'sent' : 'failed',
+          aligo_msg_id: json.msg_id ?? null,
+          error_message: ok ? null : json.message,
+        })
+        if (ok) {
+          await supabase.from('patient_referrals').update({ thanks_sms_sent_at: new Date().toISOString() }).eq('id', r.id)
+          summary.totalSent++
+        } else {
+          summary.totalFailed++
+          summary.errors.push(`${clinicName}: ${r.referrer.patient_name} - ${json.message}`)
+        }
+      } catch (e) {
+        summary.totalFailed++
+        summary.errors.push(`${clinicName}: ${r.referrer.patient_name} - ${(e as Error).message}`)
+      }
+    }
+  }
+
+  return NextResponse.json({ success: true, executedAt: today, ...summary })
+}

--- a/dental-clinic-manager/src/app/api/investment/backtest/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/backtest/route.ts
@@ -10,7 +10,9 @@ import { requireAuth } from '@/lib/auth/requireAuth'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { runBacktest } from '@/lib/backtestEngine'
 import { fetchPrices } from '@/lib/stockDataService'
+import { runRLBacktest } from '@/lib/rlBacktestService'
 import type { Market, ConditionGroup, IndicatorConfig, RiskSettings } from '@/types/investment'
+import type { RLModel } from '@/types/rlTrading'
 
 // ============================================
 // POST - 백테스트 실행
@@ -77,6 +79,73 @@ export async function POST(request: NextRequest) {
     if (!strategy) {
       return NextResponse.json({ error: '전략을 찾을 수 없습니다' }, { status: 404 })
     }
+
+    // RL 전략은 portfolio 단위 백테스트 → rl-inference-server로 위임
+    if (strategy.strategy_type === 'rl_portfolio' || strategy.strategy_type === 'rl_single') {
+      if (strategy.strategy_type === 'rl_single') {
+        return NextResponse.json({
+          error: 'rl_single 전략의 백테스트는 Phase 1에서 지원되지 않습니다',
+        }, { status: 400 })
+      }
+      if (!strategy.rl_model_id) {
+        return NextResponse.json({ error: 'RL 전략에 모델이 연결되지 않았습니다' }, { status: 400 })
+      }
+      const { data: model } = await supabase
+        .from('rl_models')
+        .select('*')
+        .eq('id', strategy.rl_model_id)
+        .single()
+      if (!model) {
+        return NextResponse.json({ error: 'RL 모델을 찾을 수 없습니다' }, { status: 404 })
+      }
+      try {
+        const rl = await runRLBacktest({
+          model: model as RLModel,
+          startDate: startDate as string,
+          endDate: endDate as string,
+          initialCapital: capital,
+        })
+        const { data: run, error: insertError } = await supabase
+          .from('backtest_runs')
+          .insert({
+            strategy_id: strategyId,
+            user_id: userId,
+            ticker: 'PORTFOLIO',  // RL portfolio는 단일 종목 아님
+            market: market as string,
+            start_date: startDate as string,
+            end_date: endDate as string,
+            initial_capital: capital,
+            status: 'completed',
+            total_return: rl.total_return,
+            annualized_return: 0,  // 별도 계산 X
+            max_drawdown: rl.max_drawdown,
+            sharpe_ratio: rl.sharpe_ratio,
+            win_rate: 0,
+            total_trades: rl.n_rebalances,  // rebalance 횟수를 trade로 표기
+            profit_factor: 0,
+            equity_curve: rl.equity_curve as unknown as object,
+            trades: [] as unknown as object,  // RL portfolio엔 개별 trade 개념 없음
+            full_metrics: {
+              kind: 'rl_portfolio',
+              n_rebalances: rl.n_rebalances,
+              rl_metadata: rl.rl_metadata,
+            } as unknown as object,
+            completed_at: new Date().toISOString(),
+          })
+          .select()
+          .single()
+        if (insertError) {
+          console.error('RL 백테스트 결과 저장 실패:', insertError)
+          return NextResponse.json({ data: { ...rl, saved: false } })
+        }
+        return NextResponse.json({ data: { ...run, ...rl } })
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'RL 백테스트 실행 실패'
+        console.error('RL 백테스트 오류:', msg)
+        return NextResponse.json({ error: msg }, { status: 500 })
+      }
+    }
+
     indicators = strategy.indicators as IndicatorConfig[]
     buyConditions = strategy.buy_conditions as ConditionGroup
     sellConditions = strategy.sell_conditions as ConditionGroup

--- a/dental-clinic-manager/src/components/Contract/ContractDetail.tsx
+++ b/dental-clinic-manager/src/components/Contract/ContractDetail.tsx
@@ -26,7 +26,7 @@ interface ContractDetailProps {
 
 export default function ContractDetail({ contractId, currentUser }: ContractDetailProps) {
   const router = useRouter()
-  const { hasPermission } = usePermissions()
+  const { hasPermission, isLoading: permissionsLoading } = usePermissions()
   const [contract, setContract] = useState<EmploymentContract | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -45,10 +45,11 @@ export default function ContractDetail({ contractId, currentUser }: ContractDeta
   const [isPdfGenerating, setIsPdfGenerating] = useState(false)
   const contractContentRef = useRef<HTMLDivElement>(null)
 
-  // Load contract
+  // Load contract (권한 로딩 완료 후에만 실행 — hasPermission이 false로 잘못 평가되는 것 방지)
   useEffect(() => {
+    if (permissionsLoading) return
     loadContract()
-  }, [contractId])
+  }, [contractId, permissionsLoading])
 
   const loadContract = async () => {
     setError(null)

--- a/dental-clinic-manager/src/components/Contract/ContractList.tsx
+++ b/dental-clinic-manager/src/components/Contract/ContractList.tsx
@@ -39,17 +39,28 @@ const STATUS_COLORS: Record<ContractStatus, string> = {
 
 export default function ContractList({ currentUser, clinicId }: ContractListProps) {
   const router = useRouter()
-  const { hasPermission } = usePermissions()
+  const { hasPermission, isLoading: permissionsLoading } = usePermissions()
   const [contracts, setContracts] = useState<EmploymentContract[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   // 전체 직원 계약서 조회 권한이 있으면 전체 조회, 아니면 본인 계약서만
+  // 주의: usePermissions는 비동기 로딩이므로 useEffect로 갱신 (useState 초기값에 넣으면 false로 고정됨)
   const isFullAccessRole = hasPermission('contract_view_all')
   const [filters, setFilters] = useState<ContractListFilters>({
     status: undefined,
-    employee_user_id: isFullAccessRole ? undefined : currentUser.id,
+    employee_user_id: undefined,
     search: undefined
   })
+
+  // 권한 로딩 완료 후 employee_user_id 필터 갱신
+  useEffect(() => {
+    if (permissionsLoading) return
+    setFilters(prev => {
+      const desired = isFullAccessRole ? undefined : currentUser.id
+      if (prev.employee_user_id === desired) return prev
+      return { ...prev, employee_user_id: desired }
+    })
+  }, [permissionsLoading, isFullAccessRole, currentUser.id])
   const [deleteModalOpen, setDeleteModalOpen] = useState(false)
   const [contractToDelete, setContractToDelete] = useState<EmploymentContract | null>(null)
   const [deleting, setDeleting] = useState(false)
@@ -92,6 +103,11 @@ export default function ContractList({ currentUser, clinicId }: ContractListProp
   useEffect(() => {
     if (!isVerified) {
       console.log('[ContractList] Not verified yet, skipping contract load')
+      return
+    }
+    // 권한 로딩이 끝나기 전에는 fetch 보류 (필터가 잘못 적용되는 것 방지)
+    if (permissionsLoading) {
+      console.log('[ContractList] Permissions still loading, skipping contract load')
       return
     }
     const abortController = new AbortController()
@@ -163,7 +179,7 @@ export default function ContractList({ currentUser, clinicId }: ContractListProp
       abortController.abort()
       console.log('[ContractList] Cleanup: aborted pending requests')
     }
-  }, [clinicId, filters.status, filters.employee_user_id, filters.search, isVerified])
+  }, [clinicId, filters.status, filters.employee_user_id, filters.search, isVerified, permissionsLoading])
 
   const loadContracts = async () => {
     setError(null)

--- a/dental-clinic-manager/src/components/Dashboard/DashboardHome.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/DashboardHome.tsx
@@ -28,6 +28,7 @@ import {
 } from 'lucide-react'
 import MyTasksSection from './MyTasksSection'
 import ScheduleWidget from './ScheduleWidget'
+import ReferralPendingWidget from './ReferralPendingWidget'
 
 // 날씨 아이콘 매핑
 const weatherIcons: Record<string, React.ReactNode> = {
@@ -682,6 +683,9 @@ export default function DashboardHome() {
                 </div>
               )}
             </div>
+
+            {/* 소개환자 관리 위젯 */}
+            <ReferralPendingWidget />
 
             {/* 내 업무 (일회성 + 반복 업무 인스턴스) */}
             <MyTasksSection />

--- a/dental-clinic-manager/src/components/Dashboard/ReferralPendingWidget.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ReferralPendingWidget.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { Heart, ChevronRight } from 'lucide-react'
+import { useAuth } from '@/contexts/AuthContext'
+import { usePermissions } from '@/hooks/usePermissions'
+import { referralService } from '@/lib/referralService'
+
+export default function ReferralPendingWidget() {
+  const { user } = useAuth()
+  const { hasPermission } = usePermissions()
+  const [pending, setPending] = useState(0)
+  const [monthly, setMonthly] = useState(0)
+  const [loading, setLoading] = useState(true)
+
+  const canView = hasPermission('referral_view')
+  const clinicId = user?.clinic_id
+
+  useEffect(() => {
+    if (!canView || !clinicId) { setLoading(false); return }
+    let cancelled = false
+    referralService.kpi(clinicId)
+      .then(k => {
+        if (cancelled) return
+        setPending(k.pending_link_count)
+        setMonthly(k.monthly_count)
+      })
+      .catch(e => console.error(e))
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [canView, clinicId])
+
+  if (!canView || loading) return null
+
+  return (
+    <Link
+      href="/dashboard?tab=referral"
+      className="group block rounded-2xl border border-at-border bg-white p-4 transition hover:border-at-accent hover:shadow-[var(--shadow-at-card)]"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-at-accent-light text-at-accent">
+            <Heart className="h-5 w-5" />
+          </span>
+          <div>
+            <div className="text-sm font-semibold text-at-text">소개환자 관리</div>
+            <div className="mt-0.5 flex items-center gap-2 text-xs text-at-text-secondary">
+              <span>이번 달 <span className="font-semibold text-at-text">{monthly}건</span></span>
+              {pending > 0 ? (
+                <>
+                  <span className="text-at-text-weak">·</span>
+                  <span className="rounded-full bg-[var(--at-warning-bg)] px-2 py-0.5 font-medium text-[var(--at-warning)]">
+                    매칭 필요 {pending}건
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span className="text-at-text-weak">·</span>
+                  <span className="text-at-text-weak">소개해주신 분께 감사 표시하기</span>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+        <ChevronRight className="h-4 w-4 text-at-text-weak transition group-hover:text-at-accent group-hover:translate-x-0.5" />
+      </div>
+    </Link>
+  )
+}

--- a/dental-clinic-manager/src/components/Referral/FamilyConfirmModal.tsx
+++ b/dental-clinic-manager/src/components/Referral/FamilyConfirmModal.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { X, Users, Loader2 } from 'lucide-react'
+import { referralService } from '@/lib/referralService'
+import type { FamilyCandidate } from '@/types/referral'
+
+interface Props {
+  clinicId: string
+  candidate: FamilyCandidate | null
+  open: boolean
+  onClose: () => void
+  onConfirmed: () => void
+}
+
+export default function FamilyConfirmModal({ clinicId, candidate, open, onClose, onConfirmed }: Props) {
+  const [familyName, setFamilyName] = useState('')
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!candidate) return
+    const last = candidate.members[0]?.patient_name?.[0] ?? ''
+    setFamilyName(last ? `${last}OO 가족` : '가족')
+    setSelected(new Set(candidate.members.map(m => m.id)))
+    setError(null)
+  }, [candidate])
+
+  if (!open || !candidate) return null
+
+  const toggle = (id: string) => {
+    setSelected(prev => {
+      const n = new Set(prev)
+      if (n.has(id)) n.delete(id)
+      else n.add(id)
+      return n
+    })
+  }
+
+  const handleSubmit = async () => {
+    if (selected.size < 2) { setError('가족 구성원은 최소 2명 이상이어야 합니다.'); return }
+    if (!familyName.trim()) { setError('가족 이름을 입력해주세요.'); return }
+    setSubmitting(true); setError(null)
+    try {
+      await referralService.confirmFamily({
+        clinicId,
+        familyName: familyName.trim(),
+        memberIds: Array.from(selected),
+      })
+      onConfirmed()
+      onClose()
+    } catch (e) {
+      console.error(e)
+      setError('저장에 실패했습니다.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4" onMouseDown={onClose}>
+      <div className="w-full max-w-lg rounded-xl bg-white shadow-[var(--shadow-at-card)]" onMouseDown={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between border-b border-[var(--at-border)] px-5 py-4">
+          <div className="flex items-center gap-2">
+            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#f3eaff] text-[var(--at-purple)]">
+              <Users className="h-4 w-4" />
+            </span>
+            <h2 className="text-base font-semibold text-[var(--at-text-primary)]">가족 확정</h2>
+          </div>
+          <button onClick={onClose} className="rounded-md p-1 text-[var(--at-text-weak)] hover:bg-[var(--at-surface-hover)]">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="space-y-3 px-5 py-4">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-[var(--at-text-primary)]">가족 이름</label>
+            <input
+              type="text"
+              value={familyName}
+              onChange={(e) => setFamilyName(e.target.value)}
+              className="w-full rounded-lg border border-[var(--at-border)] px-3 py-2 text-sm focus:border-[var(--at-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--at-accent)]"
+            />
+          </div>
+
+          <div>
+            <p className="mb-2 text-xs text-[var(--at-text-secondary)]">
+              동일 전화번호({candidate.group_key})를 공유하는 환자들입니다. 가족이 아닌 분은 체크 해제하세요.
+            </p>
+            <div className="divide-y divide-[var(--at-border)] rounded-lg border border-[var(--at-border)]">
+              {candidate.members.map(m => (
+                <label key={m.id} className="flex cursor-pointer items-center gap-3 px-3 py-2.5 hover:bg-[var(--at-surface-hover)]">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(m.id)}
+                    onChange={() => toggle(m.id)}
+                    className="h-4 w-4 rounded border-[var(--at-border)] text-[var(--at-accent)] focus:ring-[var(--at-accent)]"
+                  />
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2 text-sm font-medium text-[var(--at-text-primary)]">
+                      {m.patient_name}
+                      {m.gender && <span className="text-xs text-[var(--at-text-weak)]">({m.gender === 'M' ? '남' : m.gender === 'F' ? '여' : m.gender})</span>}
+                    </div>
+                    <div className="text-xs text-[var(--at-text-secondary)]">
+                      {m.chart_number ?? '차트 없음'} · {m.birth_date ?? '생년월일 없음'}
+                    </div>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {error && <div className="rounded-lg bg-[var(--at-error-bg)] px-3 py-2 text-sm text-[var(--at-error)]">{error}</div>}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-[var(--at-border)] px-5 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="rounded-lg border border-[var(--at-border)] bg-white px-4 py-2 text-sm font-medium text-[var(--at-text-primary)] hover:bg-[var(--at-surface-hover)] disabled:opacity-50"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting || selected.size < 2}
+            className="flex items-center gap-1.5 rounded-lg bg-[var(--at-purple)] px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+          >
+            {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+            확정 ({selected.size}명)
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Referral/FamilyTab.tsx
+++ b/dental-clinic-manager/src/components/Referral/FamilyTab.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Users, AlertCircle, Loader2, Trash2, CheckCircle2 } from 'lucide-react'
+import { referralService } from '@/lib/referralService'
+import type { FamilyCandidate, ConfirmedFamily } from '@/types/referral'
+import FamilyConfirmModal from './FamilyConfirmModal'
+
+interface Props {
+  clinicId: string
+  refreshKey: number
+}
+
+export default function FamilyTab({ clinicId, refreshKey }: Props) {
+  const [candidates, setCandidates] = useState<FamilyCandidate[]>([])
+  const [confirmed, setConfirmed] = useState<ConfirmedFamily[]>([])
+  const [loading, setLoading] = useState(false)
+  const [target, setTarget] = useState<FamilyCandidate | null>(null)
+  const [internalKey, setInternalKey] = useState(0)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [c, f] = await Promise.all([
+        referralService.suggestFamilies(clinicId, 30),
+        referralService.listConfirmedFamilies(clinicId),
+      ])
+      setCandidates(c); setConfirmed(f)
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setLoading(false)
+    }
+  }, [clinicId])
+
+  useEffect(() => { load() }, [load, refreshKey, internalKey])
+
+  const handleDelete = async (familyId: string) => {
+    if (!window.confirm('이 가족 묶음을 해제하시겠습니까?')) return
+    try {
+      await referralService.deleteFamily(familyId)
+      setInternalKey(k => k + 1)
+    } catch (e) {
+      console.error(e)
+      alert('삭제에 실패했습니다.')
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <div className="rounded-xl border border-[var(--at-border)] bg-white p-5 shadow-[var(--shadow-at-soft)]">
+        <div className="mb-4 flex items-center gap-2">
+          <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-[var(--at-warning-bg)] text-[var(--at-warning)]">
+            <AlertCircle className="h-5 w-5" />
+          </span>
+          <div>
+            <h2 className="text-base font-semibold text-[var(--at-text-primary)]">추정 가족</h2>
+            <p className="text-xs text-[var(--at-text-secondary)]">동일 전화번호를 공유하는 환자들을 가족 후보로 자동 추정합니다. 확인 후 확정하세요.</p>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="flex h-40 items-center justify-center text-[var(--at-text-weak)]">
+            <Loader2 className="h-5 w-5 animate-spin" />
+          </div>
+        ) : candidates.length === 0 ? (
+          <div className="rounded-lg bg-[var(--at-surface-alt)] p-8 text-center text-sm text-[var(--at-text-weak)]">
+            추정할 가족 후보가 없습니다.
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {candidates.map(c => (
+              <li key={c.group_key} className="rounded-lg border border-[var(--at-border)] p-3 hover:border-[var(--at-warning)]">
+                <div className="mb-2 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="rounded-full bg-[var(--at-warning-bg)] px-2 py-0.5 text-xs font-medium text-[var(--at-warning)]">
+                      추정
+                    </span>
+                    <span className="text-sm text-[var(--at-text-secondary)]">{c.group_key}</span>
+                    <span className="text-xs text-[var(--at-text-weak)]">· {c.member_count}명</span>
+                  </div>
+                  <button
+                    onClick={() => setTarget(c)}
+                    className="rounded-md bg-[var(--at-purple)] px-2.5 py-1 text-xs font-medium text-white hover:opacity-90"
+                  >
+                    가족으로 확정
+                  </button>
+                </div>
+                <div className="flex flex-wrap gap-1.5 text-xs">
+                  {c.members.map(m => (
+                    <span key={m.id} className="rounded-md bg-[var(--at-surface-alt)] px-2 py-1 text-[var(--at-text-primary)]">
+                      {m.patient_name}
+                      {m.birth_date && <span className="ml-1 text-[var(--at-text-weak)]">{m.birth_date.slice(0, 7)}</span>}
+                    </span>
+                  ))}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-[var(--at-border)] bg-white p-5 shadow-[var(--shadow-at-soft)]">
+        <div className="mb-4 flex items-center gap-2">
+          <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#f3eaff] text-[var(--at-purple)]">
+            <Users className="h-5 w-5" />
+          </span>
+          <div>
+            <h2 className="text-base font-semibold text-[var(--at-text-primary)]">확정된 가족</h2>
+            <p className="text-xs text-[var(--at-text-secondary)]">현재 {confirmed.length}개 가족이 등록되어 있습니다.</p>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="flex h-40 items-center justify-center text-[var(--at-text-weak)]">
+            <Loader2 className="h-5 w-5 animate-spin" />
+          </div>
+        ) : confirmed.length === 0 ? (
+          <div className="rounded-lg bg-[var(--at-surface-alt)] p-8 text-center text-sm text-[var(--at-text-weak)]">
+            아직 확정된 가족이 없습니다.
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {confirmed.map(f => (
+              <li key={f.id} className="rounded-lg border border-[var(--at-border)] p-3">
+                <div className="mb-2 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <CheckCircle2 className="h-4 w-4 text-[var(--at-purple)]" />
+                    <span className="font-medium text-[var(--at-text-primary)]">{f.family_name}</span>
+                    <span className="text-xs text-[var(--at-text-weak)]">{f.members.length}명</span>
+                  </div>
+                  <button
+                    onClick={() => handleDelete(f.id)}
+                    title="해제"
+                    className="rounded-md p-1 text-[var(--at-text-weak)] hover:bg-[var(--at-error-bg)] hover:text-[var(--at-error)]"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+                <div className="flex flex-wrap gap-1.5 text-xs">
+                  {f.members.map(m => (
+                    <span key={m.id} className="rounded-md bg-[#f3eaff] px-2 py-1 text-[var(--at-purple)]">
+                      {m.patient_name}
+                    </span>
+                  ))}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <FamilyConfirmModal
+        clinicId={clinicId}
+        candidate={target}
+        open={!!target}
+        onClose={() => setTarget(null)}
+        onConfirmed={() => setInternalKey(k => k + 1)}
+      />
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Referral/ReferralManagement.tsx
+++ b/dental-clinic-manager/src/components/Referral/ReferralManagement.tsx
@@ -7,11 +7,14 @@ import { referralService } from '@/lib/referralService'
 import type { PatientReferralWithPatients, ReferralKpi, PatientSearchResult } from '@/types/referral'
 import ReferralListTab from './ReferralListTab'
 import ReferrerRankingTab from './ReferrerRankingTab'
+import FamilyTab from './FamilyTab'
+import ReferralStatsTab from './ReferralStatsTab'
 import ReferralAddModal from './ReferralAddModal'
 import ThanksSmsModal from './ThanksSmsModal'
 import PointAdjustModal from './PointAdjustModal'
+import SettingsPopover from './SettingsPopover'
 
-type TabKey = 'list' | 'ranking'
+type TabKey = 'list' | 'ranking' | 'family' | 'stats'
 
 export default function ReferralManagement() {
   const { user } = useAuth()
@@ -108,6 +111,7 @@ export default function ReferralManagement() {
             <p className="text-xs text-[var(--at-text-secondary)]">소개해주신 분과 신환을 한 곳에서 관리하고 감사 문자·포인트·선물을 적립합니다.</p>
           </div>
         </div>
+        <SettingsPopover clinicId={clinicId} />
       </div>
 
       {/* KPI 카드 */}
@@ -147,10 +151,12 @@ export default function ReferralManagement() {
       </div>
 
       {/* 탭 */}
-      <div className="flex items-center gap-1 border-b border-[var(--at-border)]">
+      <div className="flex items-center gap-1 border-b border-[var(--at-border)] overflow-x-auto">
         {([
           { k: 'list', label: '소개 내역' },
           { k: 'ranking', label: '소개왕 랭킹' },
+          { k: 'family', label: '가족 묶음' },
+          { k: 'stats', label: '전환율 분석' },
         ] as const).map(t => (
           <button
             key={t.k}
@@ -181,6 +187,12 @@ export default function ReferralManagement() {
       )}
       {activeTab === 'ranking' && (
         <ReferrerRankingTab clinicId={clinicId} refreshKey={refreshKey} />
+      )}
+      {activeTab === 'family' && (
+        <FamilyTab clinicId={clinicId} refreshKey={refreshKey} />
+      )}
+      {activeTab === 'stats' && (
+        <ReferralStatsTab clinicId={clinicId} refreshKey={refreshKey} />
       )}
 
       <ReferralAddModal

--- a/dental-clinic-manager/src/components/Referral/ReferralStatsTab.tsx
+++ b/dental-clinic-manager/src/components/Referral/ReferralStatsTab.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { TrendingUp, Loader2 } from 'lucide-react'
+import {
+  ResponsiveContainer,
+  ComposedChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts'
+import { referralService } from '@/lib/referralService'
+import type { MonthlyStatRow } from '@/types/referral'
+
+interface Props {
+  clinicId: string
+  refreshKey: number
+}
+
+export default function ReferralStatsTab({ clinicId, refreshKey }: Props) {
+  const [rows, setRows] = useState<MonthlyStatRow[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    referralService.monthlyStats(clinicId, 12)
+      .then(d => { if (!cancelled) setRows(d) })
+      .catch(e => { console.error(e); if (!cancelled) setRows([]) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [clinicId, refreshKey])
+
+  const chartData = rows.map(r => ({
+    name: r.year_month.slice(2).replace('-', '/'),
+    소개: r.referral_count,
+    결제전환: r.paid_count,
+    전환율: r.referral_count > 0 ? Math.round((r.paid_count / r.referral_count) * 1000) / 10 : 0,
+  }))
+
+  const totalReferrals = rows.reduce((s, r) => s + r.referral_count, 0)
+  const totalPaid = rows.reduce((s, r) => s + r.paid_count, 0)
+  const overallRate = totalReferrals > 0 ? Math.round((totalPaid / totalReferrals) * 1000) / 10 : 0
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <SummaryCard label="총 소개 (12개월)" value={`${totalReferrals}건`} tone="accent" />
+        <SummaryCard label="첫 결제 전환" value={`${totalPaid}건`} tone="success" />
+        <SummaryCard label="평균 전환율" value={`${overallRate}%`} tone="purple" />
+      </div>
+
+      <div className="rounded-xl border border-[var(--at-border)] bg-white p-5 shadow-[var(--shadow-at-soft)]">
+        <div className="mb-4 flex items-center gap-2">
+          <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-[var(--at-success-bg)] text-[var(--at-success)]">
+            <TrendingUp className="h-5 w-5" />
+          </span>
+          <div>
+            <h2 className="text-base font-semibold text-[var(--at-text-primary)]">월별 소개 → 첫 결제 전환</h2>
+            <p className="text-xs text-[var(--at-text-secondary)]">최근 12개월 추이입니다. 첫 결제일은 수동 또는 외부 동기화로 채워집니다.</p>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="flex h-72 items-center justify-center text-[var(--at-text-weak)]">
+            <Loader2 className="h-5 w-5 animate-spin" />
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="flex h-72 items-center justify-center text-sm text-[var(--at-text-weak)]">
+            데이터가 없습니다.
+          </div>
+        ) : (
+          <div className="h-72 w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <ComposedChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--at-border)" />
+                <XAxis dataKey="name" tick={{ fontSize: 12, fill: 'var(--at-text-secondary)' }} />
+                <YAxis yAxisId="left" tick={{ fontSize: 12, fill: 'var(--at-text-secondary)' }} />
+                <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 12, fill: 'var(--at-text-secondary)' }} unit="%" />
+                <Tooltip
+                  contentStyle={{
+                    background: 'white',
+                    border: '1px solid var(--at-border)',
+                    borderRadius: '0.5rem',
+                    fontSize: 12,
+                  }}
+                />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <Bar yAxisId="left" dataKey="소개" fill="#1b61c9" radius={[4, 4, 0, 0]} />
+                <Bar yAxisId="left" dataKey="결제전환" fill="#1b7a3d" radius={[4, 4, 0, 0]} />
+                <Line yAxisId="right" type="monotone" dataKey="전환율" stroke="#6b3fa0" strokeWidth={2} dot={{ r: 4 }} />
+              </ComposedChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function SummaryCard({ label, value, tone }: { label: string; value: string; tone: 'accent' | 'success' | 'purple' }) {
+  const toneMap = {
+    accent: 'text-[var(--at-accent)] bg-[var(--at-accent-tag)]',
+    success: 'text-[var(--at-success)] bg-[var(--at-success-bg)]',
+    purple: 'text-[var(--at-purple)] bg-[#f3eaff]',
+  } as const
+  return (
+    <div className="rounded-xl border border-[var(--at-border)] bg-white p-4 shadow-[var(--shadow-at-soft)]">
+      <div className={`mb-1 inline-block rounded-full px-2 py-0.5 text-xs font-medium ${toneMap[tone]}`}>{label}</div>
+      <div className="text-2xl font-semibold text-[var(--at-text-primary)]">{value}</div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Referral/SettingsPopover.tsx
+++ b/dental-clinic-manager/src/components/Referral/SettingsPopover.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { Settings, Loader2, Check } from 'lucide-react'
+import { referralService } from '@/lib/referralService'
+import type { ReferralSettings } from '@/types/referral'
+
+interface Props {
+  clinicId: string
+}
+
+export default function SettingsPopover({ clinicId }: Props) {
+  const [open, setOpen] = useState(false)
+  const [settings, setSettings] = useState<ReferralSettings | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [savedAt, setSavedAt] = useState<number | null>(null)
+  const wrapRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setLoading(true)
+    referralService.getSettings(clinicId)
+      .then(setSettings)
+      .catch(e => console.error(e))
+      .finally(() => setLoading(false))
+  }, [open, clinicId])
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  const update = async (patch: Partial<ReferralSettings>) => {
+    if (!settings) return
+    setSaving(true)
+    try {
+      const next = await referralService.updateSettings(clinicId, patch)
+      setSettings(next)
+      setSavedAt(Date.now())
+      setTimeout(() => setSavedAt(s => (s && Date.now() - s >= 1500 ? null : s)), 1600)
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div ref={wrapRef} className="relative">
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="flex items-center gap-1.5 rounded-lg border border-[var(--at-border)] bg-white px-3 py-2 text-sm font-medium text-[var(--at-text-secondary)] hover:bg-[var(--at-surface-hover)]"
+      >
+        <Settings className="h-4 w-4" />
+        설정
+      </button>
+
+      {open && (
+        <div className="absolute right-0 z-30 mt-2 w-80 rounded-xl border border-[var(--at-border)] bg-white p-4 shadow-[var(--shadow-at-card)]">
+          <div className="mb-3 flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-[var(--at-text-primary)]">소개 정책</h3>
+            {saving ? (
+              <Loader2 className="h-4 w-4 animate-spin text-[var(--at-accent)]" />
+            ) : savedAt ? (
+              <Check className="h-4 w-4 text-[var(--at-success)]" />
+            ) : null}
+          </div>
+
+          {loading || !settings ? (
+            <div className="flex h-24 items-center justify-center text-[var(--at-text-weak)]">
+              <Loader2 className="h-4 w-4 animate-spin" />
+            </div>
+          ) : (
+            <div className="space-y-3 text-sm">
+              <div className="flex items-center justify-between">
+                <label htmlFor="auto-thanks" className="cursor-pointer text-[var(--at-text-primary)]">자동 감사 문자</label>
+                <input
+                  id="auto-thanks"
+                  type="checkbox"
+                  checked={settings.auto_thanks_enabled}
+                  onChange={(e) => update({ auto_thanks_enabled: e.target.checked })}
+                  className="h-4 w-4 rounded border-[var(--at-border)] text-[var(--at-accent)] focus:ring-[var(--at-accent)]"
+                />
+              </div>
+              {settings.auto_thanks_enabled && (
+                <div>
+                  <label className="block text-xs text-[var(--at-text-secondary)]">소개 등록 후 며칠 뒤 자동 발송</label>
+                  <input
+                    type="number"
+                    min={0}
+                    max={30}
+                    value={settings.auto_thanks_after_days}
+                    onChange={(e) => update({ auto_thanks_after_days: Number(e.target.value) })}
+                    className="mt-1 w-24 rounded-lg border border-[var(--at-border)] px-2 py-1.5 text-sm focus:border-[var(--at-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--at-accent)]"
+                  />
+                  <span className="ml-2 text-xs text-[var(--at-text-weak)]">일 (0=즉시 익일)</span>
+                </div>
+              )}
+              <div className="grid grid-cols-2 gap-2 border-t border-[var(--at-border)] pt-3">
+                <div>
+                  <label className="block text-xs text-[var(--at-text-secondary)]">소개자 기본 P</label>
+                  <input
+                    type="number"
+                    min={0}
+                    step={500}
+                    value={settings.referrer_default_points}
+                    onChange={(e) => update({ referrer_default_points: Number(e.target.value) })}
+                    className="mt-1 w-full rounded-lg border border-[var(--at-border)] px-2 py-1.5 text-sm focus:border-[var(--at-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--at-accent)]"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-[var(--at-text-secondary)]">신환 기본 P</label>
+                  <input
+                    type="number"
+                    min={0}
+                    step={500}
+                    value={settings.referee_default_points}
+                    onChange={(e) => update({ referee_default_points: Number(e.target.value) })}
+                    className="mt-1 w-full rounded-lg border border-[var(--at-border)] px-2 py-1.5 text-sm focus:border-[var(--at-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--at-accent)]"
+                  />
+                </div>
+              </div>
+              <p className="text-xs text-[var(--at-text-weak)]">변경 사항은 자동 저장됩니다.</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/lib/menuSettingsService.ts
+++ b/dental-clinic-manager/src/lib/menuSettingsService.ts
@@ -133,9 +133,11 @@ export function clearMenuSettingsCache(id?: string): void {
 }
 
 /**
- * 사용자의 메뉴 설정 조회 (사용자별 개인 설정)
+ * 사용자의 메뉴 설정 조회 (사용자별 개인 설정 - DB 기반)
+ * 한 계정에서 메뉴를 수정하면 어느 컴퓨터에서 로그인하든 동일한 메뉴 구조가 보임.
+ * localStorage는 빠른 첫 페인트를 위한 캐시로만 사용하고, DB가 source of truth.
  * @param userId 사용자 ID
- * @param useCache 캐시 사용 여부 (기본값: true)
+ * @param useCache 캐시(localStorage) 우선 사용 여부 (기본값: true) — DB 조회는 백그라운드로 수행되어 새 기기에서도 동기화됨
  * @returns 메뉴 설정
  */
 export async function getUserMenuSettings(
@@ -143,44 +145,108 @@ export async function getUserMenuSettings(
   useCache: boolean = true
 ): Promise<{ success: boolean; data: UserMenuSettings | null; error?: string }> {
   try {
-    // 캐시 확인
-    if (useCache) {
-      const cached = getCachedUserMenuSettings(userId)
-      if (cached) {
-        console.log('[menuSettingsService] Using cached user menu settings')
+    const supabase = createClient()
 
-        // 새로운 메뉴가 추가되었을 수 있으므로 항상 정규화 수행
+    // DB에서 조회 (source of truth)
+    if (supabase) {
+      const { data, error } = await supabase
+        .from('user_menu_settings')
+        .select('settings, categories, updated_at')
+        .eq('user_id', userId)
+        .maybeSingle()
+
+      if (error) {
+        console.warn('[menuSettingsService] DB fetch error, falling back to cache:', error)
+      } else if (data) {
+        const normalizedCategories = normalizeCategorySettings(data.categories as MenuCategorySetting[] | undefined)
+        const normalizedSettings = normalizeMenuSettings(
+          (data.settings as MenuItemSetting[]) || [],
+          normalizedCategories
+        )
+
+        const userSettings: UserMenuSettings = {
+          user_id: userId,
+          settings: normalizedSettings,
+          categories: normalizedCategories,
+          updated_at: data.updated_at || new Date().toISOString()
+        }
+
+        // 캐시 업데이트
+        setCachedUserMenuSettings(userId, userSettings)
+        console.log('[menuSettingsService] Loaded user menu settings from DB')
+        return { success: true, data: userSettings }
+      }
+
+      // DB에 레코드가 없는 경우 — 캐시(localStorage)가 있으면 마이그레이션 차원에서 DB에 한 번 저장
+      const cached = getCachedUserMenuSettings(userId)
+      if (cached && cached.settings && cached.settings.length > 0) {
         const normalizedCategories = normalizeCategorySettings(cached.categories)
         const normalizedSettings = normalizeMenuSettings(cached.settings, normalizedCategories)
 
-        // 정규화된 설정 생성 (항상 최신 메뉴 포함)
-        const normalizedData: UserMenuSettings = {
-          ...cached,
+        const { error: upsertError } = await supabase
+          .from('user_menu_settings')
+          .upsert(
+            {
+              user_id: userId,
+              settings: normalizedSettings,
+              categories: normalizedCategories,
+              updated_at: new Date().toISOString()
+            },
+            { onConflict: 'user_id' }
+          )
+
+        if (!upsertError) {
+          console.log('[menuSettingsService] Migrated localStorage settings to DB')
+        } else {
+          console.warn('[menuSettingsService] Failed to migrate cache to DB:', upsertError)
+        }
+
+        const migrated: UserMenuSettings = {
+          user_id: userId,
           settings: normalizedSettings,
           categories: normalizedCategories,
+          updated_at: new Date().toISOString()
         }
+        setCachedUserMenuSettings(userId, migrated)
+        return { success: true, data: migrated }
+      }
 
-        // 캐시와 정규화된 설정이 다르면 캐시 업데이트
-        if (normalizedSettings.length !== cached.settings.length) {
-          console.log('[menuSettingsService] New menu items detected, updating cache')
-          normalizedData.updated_at = new Date().toISOString()
-          setCachedUserMenuSettings(userId, normalizedData)
+      // DB에도 캐시에도 없으면 기본값
+      const defaultSettings: UserMenuSettings = {
+        user_id: userId,
+        settings: [...DEFAULT_MENU_ITEMS],
+        categories: [...DEFAULT_CATEGORIES],
+        updated_at: new Date().toISOString()
+      }
+      return { success: true, data: defaultSettings }
+    }
+
+    // Supabase 클라이언트가 없는 경우(SSR 등) — 캐시 fallback
+    if (useCache) {
+      const cached = getCachedUserMenuSettings(userId)
+      if (cached) {
+        const normalizedCategories = normalizeCategorySettings(cached.categories)
+        const normalizedSettings = normalizeMenuSettings(cached.settings, normalizedCategories)
+        return {
+          success: true,
+          data: {
+            ...cached,
+            settings: normalizedSettings,
+            categories: normalizedCategories,
+          }
         }
-
-        // 항상 정규화된 설정 반환 (새 메뉴가 포함됨)
-        return { success: true, data: normalizedData }
       }
     }
 
-    // 기본값 반환 (localStorage 기반이므로 캐시가 없으면 기본값)
-    const defaultSettings: UserMenuSettings = {
-      user_id: userId,
-      settings: [...DEFAULT_MENU_ITEMS],
-      categories: [...DEFAULT_CATEGORIES],
-      updated_at: new Date().toISOString()
+    return {
+      success: true,
+      data: {
+        user_id: userId,
+        settings: [...DEFAULT_MENU_ITEMS],
+        categories: [...DEFAULT_CATEGORIES],
+        updated_at: new Date().toISOString()
+      }
     }
-
-    return { success: true, data: defaultSettings }
   } catch (error) {
     console.error('[menuSettingsService] Unexpected error:', error)
     return {
@@ -195,7 +261,7 @@ export async function getUserMenuSettings(
 }
 
 /**
- * 사용자의 메뉴 설정 저장 (개인 설정)
+ * 사용자의 메뉴 설정 저장 (개인 설정 - DB 기반)
  * @param userId 사용자 ID
  * @param settings 메뉴 설정 배열
  * @param categories 카테고리 설정 배열
@@ -207,19 +273,42 @@ export async function saveUserMenuSettings(
   categories: MenuCategorySetting[]
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    const userSettings: UserMenuSettings = {
-      user_id: userId,
-      settings,
-      categories,
-      updated_at: new Date().toISOString()
+    const supabase = createClient()
+    if (!supabase) {
+      return { success: false, error: '데이터베이스 연결에 실패했습니다.' }
     }
 
-    // 캐시에 저장
-    setCachedUserMenuSettings(userId, userSettings)
-    console.log('[menuSettingsService] User menu settings saved successfully')
+    const normalizedCategories = normalizeCategorySettings(categories)
+    const updatedAt = new Date().toISOString()
+
+    const { error } = await supabase
+      .from('user_menu_settings')
+      .upsert(
+        {
+          user_id: userId,
+          settings,
+          categories: normalizedCategories,
+          updated_at: updatedAt
+        },
+        { onConflict: 'user_id' }
+      )
+
+    if (error) {
+      console.error('[menuSettingsService] Error saving user menu settings:', error)
+      return { success: false, error: '메뉴 설정 저장에 실패했습니다.' }
+    }
+
+    // 캐시 업데이트 (다음 페이지 로드 시 빠른 표시용)
+    setCachedUserMenuSettings(userId, {
+      user_id: userId,
+      settings,
+      categories: normalizedCategories,
+      updated_at: updatedAt
+    })
+    console.log('[menuSettingsService] User menu settings saved to DB successfully')
 
     // 메뉴 설정 변경 이벤트 발생
-    emitMenuSettingsChanged(userId, settings, categories)
+    emitMenuSettingsChanged(userId, settings, normalizedCategories)
 
     return { success: true }
   } catch (error) {
@@ -229,7 +318,7 @@ export async function saveUserMenuSettings(
 }
 
 /**
- * 사용자의 메뉴 설정 초기화 (기본값으로 되돌리기)
+ * 사용자의 메뉴 설정 초기화 (기본값으로 되돌리기 - DB에서 삭제)
  * @param userId 사용자 ID
  * @returns 성공 여부
  */
@@ -237,7 +326,20 @@ export async function resetUserMenuSettings(
   userId: string
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    // 캐시 삭제
+    const supabase = createClient()
+    if (supabase) {
+      const { error } = await supabase
+        .from('user_menu_settings')
+        .delete()
+        .eq('user_id', userId)
+
+      if (error) {
+        console.error('[menuSettingsService] Error resetting user menu settings:', error)
+        return { success: false, error: '메뉴 설정 초기화에 실패했습니다.' }
+      }
+    }
+
+    // 캐시도 함께 삭제
     clearMenuSettingsCache(userId)
     console.log('[menuSettingsService] User menu settings reset successfully')
 

--- a/dental-clinic-manager/src/lib/referralService.ts
+++ b/dental-clinic-manager/src/lib/referralService.ts
@@ -9,6 +9,9 @@ import type {
   ReferralListResponse,
   ReferralKpi,
   PatientSearchResult,
+  FamilyCandidate,
+  ConfirmedFamily,
+  MonthlyStatRow,
 } from '@/types/referral'
 
 const supabase = createClient()
@@ -385,6 +388,78 @@ export const referralService = {
       .single()
     if (error) throw error
     return data
+  },
+
+  async suggestFamilies(clinicId: string, limit = 30): Promise<FamilyCandidate[]> {
+    const { data, error } = await supabase.rpc('suggest_family_groups', {
+      p_clinic_id: clinicId,
+      p_limit: limit,
+    })
+    if (error) throw error
+    return (data ?? []) as FamilyCandidate[]
+  },
+
+  async confirmFamily(input: { clinicId: string; familyName: string; memberIds: string[] }) {
+    const { data: family, error: famErr } = await supabase
+      .from('patient_families')
+      .insert({ clinic_id: input.clinicId, family_name: input.familyName })
+      .select()
+      .single()
+    if (famErr) throw famErr
+
+    const rows = input.memberIds.map(id => ({ family_id: family.id, dentweb_patient_id: id }))
+    const { error: memErr } = await supabase.from('patient_family_members').insert(rows)
+    if (memErr) throw memErr
+    return family
+  },
+
+  async listConfirmedFamilies(clinicId: string): Promise<ConfirmedFamily[]> {
+    const { data, error } = await supabase
+      .from('patient_families')
+      .select(`
+        id, family_name, created_at,
+        members:patient_family_members (
+          relation_label,
+          patient:dentweb_patients (id, patient_name, birth_date, chart_number, gender)
+        )
+      `)
+      .eq('clinic_id', clinicId)
+      .order('created_at', { ascending: false })
+    if (error) throw error
+    type Row = {
+      id: string
+      family_name: string
+      created_at: string
+      members: Array<{
+        relation_label: string | null
+        patient: { id: string; patient_name: string; birth_date: string | null; chart_number: string | null; gender: string | null } | null
+      }>
+    }
+    return ((data ?? []) as Row[]).map(f => ({
+      id: f.id,
+      family_name: f.family_name,
+      created_at: f.created_at,
+      members: f.members
+        .filter(m => m.patient)
+        .map(m => ({
+          ...(m.patient as NonNullable<typeof m.patient>),
+          relation_label: m.relation_label,
+        })),
+    }))
+  },
+
+  async deleteFamily(familyId: string) {
+    const { error } = await supabase.from('patient_families').delete().eq('id', familyId)
+    if (error) throw error
+  },
+
+  async monthlyStats(clinicId: string, months = 12): Promise<MonthlyStatRow[]> {
+    const { data, error } = await supabase.rpc('referral_monthly_stats', {
+      p_clinic_id: clinicId,
+      p_months: months,
+    })
+    if (error) throw error
+    return (data ?? []) as MonthlyStatRow[]
   },
 
   async listGiftsByPatient(clinicId: string, dentwebPatientId: string) {

--- a/dental-clinic-manager/src/lib/rlBacktestService.ts
+++ b/dental-clinic-manager/src/lib/rlBacktestService.ts
@@ -1,0 +1,89 @@
+/**
+ * RL 전략 백테스트 위임 서비스
+ *
+ * rl-inference-server `/backtest_universe` endpoint에 위임.
+ * Server side에서 yfinance로 OHLCV 페치 → portfolio simulation.
+ * 메인 앱 IP가 Yahoo에서 차단되어도 server 환경(Python yfinance)은 별도 client로 정상 동작.
+ */
+
+import type { RLModel } from '@/types/rlTrading'
+
+const RL_SERVER_URL = process.env.RL_SERVER_URL ?? 'http://127.0.0.1:8001'
+const RL_API_KEY = process.env.RL_API_KEY ?? ''
+
+interface RLBacktestResponse {
+  total_return: number
+  sharpe_ratio: number
+  max_drawdown: number
+  n_rebalances: number
+  equity_curve: Array<{ date: string; equity: number }>
+  metadata: Record<string, unknown>
+}
+
+export interface RLBacktestParams {
+  model: RLModel
+  startDate: string
+  endDate: string
+  initialCapital: number
+}
+
+export interface RLBacktestResult {
+  total_return: number
+  sharpe_ratio: number
+  max_drawdown: number
+  n_rebalances: number
+  equity_curve: Array<{ date: string; equity: number }>
+  rl_metadata: Record<string, unknown>
+}
+
+export async function runRLBacktest(params: RLBacktestParams): Promise<RLBacktestResult> {
+  const { model, startDate, endDate, initialCapital } = params
+
+  if (model.status !== 'ready' || !model.checkpoint_path) {
+    throw new Error('rl_model is not ready (status=' + model.status + ')')
+  }
+  const universe = (model.universe ?? []) as string[]
+  if (universe.length === 0) {
+    throw new Error('rl_model has empty universe')
+  }
+
+  const body = {
+    model_id: model.id,
+    checkpoint_path: model.checkpoint_path,
+    algorithm: model.algorithm,
+    kind: model.kind,
+    state_window: model.state_window,
+    input_features: model.input_features,
+    universe,
+    start_date: startDate,
+    end_date: endDate,
+    initial_capital: initialCapital,
+  }
+
+  const ctrl = new AbortController()
+  const timer = setTimeout(() => ctrl.abort(), 120_000)  // 2 min — yfinance fetch + simulation
+
+  try {
+    const resp = await fetch(`${RL_SERVER_URL}/backtest_universe`, {
+      method: 'POST',
+      headers: { 'X-RL-API-KEY': RL_API_KEY, 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: ctrl.signal,
+    })
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '')
+      throw new Error(`rl-inference-server /backtest_universe ${resp.status}: ${text.slice(0, 300)}`)
+    }
+    const json = (await resp.json()) as RLBacktestResponse
+    return {
+      total_return: json.total_return,
+      sharpe_ratio: json.sharpe_ratio,
+      max_drawdown: json.max_drawdown,
+      n_rebalances: json.n_rebalances,
+      equity_curve: json.equity_curve,
+      rl_metadata: json.metadata,
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/dental-clinic-manager/src/types/referral.ts
+++ b/dental-clinic-manager/src/types/referral.ts
@@ -131,3 +131,30 @@ export interface PatientSearchResult {
   acquisition_channel: string | null
   registration_date: string | null
 }
+
+export interface FamilyCandidateMember {
+  id: string
+  patient_name: string
+  birth_date: string | null
+  chart_number: string | null
+  gender: string | null
+}
+
+export interface FamilyCandidate {
+  group_key: string
+  member_count: number
+  members: FamilyCandidateMember[]
+}
+
+export interface ConfirmedFamily {
+  id: string
+  family_name: string
+  created_at: string
+  members: Array<FamilyCandidateMember & { relation_label: string | null }>
+}
+
+export interface MonthlyStatRow {
+  year_month: string
+  referral_count: number
+  paid_count: number
+}

--- a/dental-clinic-manager/supabase/migrations/20260429_create_user_menu_settings.sql
+++ b/dental-clinic-manager/supabase/migrations/20260429_create_user_menu_settings.sql
@@ -1,0 +1,56 @@
+-- 사용자별 메뉴 설정 테이블
+-- 한 계정에서 메뉴 구성을 변경하면 어떤 컴퓨터에서 로그인하든 동일한 메뉴 구조가 보이도록 DB에 저장
+
+CREATE TABLE IF NOT EXISTS user_menu_settings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  settings JSONB NOT NULL DEFAULT '[]'::jsonb,
+  categories JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  CONSTRAINT user_menu_settings_user_id_unique UNIQUE (user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_menu_settings_user_id ON user_menu_settings(user_id);
+
+COMMENT ON TABLE user_menu_settings IS '사용자별 좌측 탭 메뉴 개인 설정 (계정 종속)';
+COMMENT ON COLUMN user_menu_settings.user_id IS '사용자 ID (auth.users.id)';
+COMMENT ON COLUMN user_menu_settings.settings IS 'MenuItemSetting[] JSON';
+COMMENT ON COLUMN user_menu_settings.categories IS 'MenuCategorySetting[] JSON';
+
+ALTER TABLE user_menu_settings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "user_menu_settings_select_own" ON user_menu_settings;
+CREATE POLICY "user_menu_settings_select_own" ON user_menu_settings
+  FOR SELECT
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "user_menu_settings_insert_own" ON user_menu_settings;
+CREATE POLICY "user_menu_settings_insert_own" ON user_menu_settings
+  FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "user_menu_settings_update_own" ON user_menu_settings;
+CREATE POLICY "user_menu_settings_update_own" ON user_menu_settings
+  FOR UPDATE
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "user_menu_settings_delete_own" ON user_menu_settings;
+CREATE POLICY "user_menu_settings_delete_own" ON user_menu_settings
+  FOR DELETE
+  USING (user_id = auth.uid());
+
+CREATE OR REPLACE FUNCTION update_user_menu_settings_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS user_menu_settings_updated_at ON user_menu_settings;
+CREATE TRIGGER user_menu_settings_updated_at
+  BEFORE UPDATE ON user_menu_settings
+  FOR EACH ROW
+  EXECUTE FUNCTION update_user_menu_settings_updated_at();

--- a/dental-clinic-manager/supabase/migrations/20260429_referral_phase2_helpers.sql
+++ b/dental-clinic-manager/supabase/migrations/20260429_referral_phase2_helpers.sql
@@ -1,0 +1,69 @@
+-- ========================================
+-- 소개환자 관리 Phase 2 — 휴리스틱·통계 함수
+-- Migration: 20260429_referral_phase2_helpers
+-- ========================================
+
+-- 가족관계 자동 묶음 휴리스틱 함수
+-- 동일 phone_number를 공유하는 환자 그룹 (2~8명)을 후보로 반환
+CREATE OR REPLACE FUNCTION suggest_family_groups(p_clinic_id UUID, p_limit INT DEFAULT 50)
+RETURNS TABLE (
+  group_key TEXT,
+  member_count INT,
+  members JSONB
+) AS $$
+  SELECT
+    phone_number AS group_key,
+    COUNT(*)::INT AS member_count,
+    jsonb_agg(
+      jsonb_build_object(
+        'id', id,
+        'patient_name', patient_name,
+        'birth_date', birth_date,
+        'chart_number', chart_number,
+        'gender', gender
+      ) ORDER BY birth_date NULLS LAST
+    ) AS members
+  FROM dentweb_patients
+  WHERE clinic_id = p_clinic_id
+    AND COALESCE(is_active, true)
+    AND phone_number IS NOT NULL
+    AND length(regexp_replace(phone_number, '[^0-9]', '', 'g')) >= 10
+    AND id NOT IN (
+      SELECT fm.dentweb_patient_id
+      FROM patient_family_members fm
+      JOIN patient_families f ON f.id = fm.family_id
+      WHERE f.clinic_id = p_clinic_id
+    )
+  GROUP BY phone_number
+  HAVING COUNT(*) BETWEEN 2 AND 8
+  ORDER BY COUNT(*) DESC, MIN(patient_name)
+  LIMIT p_limit;
+$$ LANGUAGE sql STABLE;
+
+-- 월별 소개·전환 통계
+CREATE OR REPLACE FUNCTION referral_monthly_stats(p_clinic_id UUID, p_months INT DEFAULT 12)
+RETURNS TABLE (
+  year_month TEXT,
+  referral_count INT,
+  paid_count INT
+) AS $$
+  WITH months AS (
+    SELECT
+      to_char(d, 'YYYY-MM') AS ym,
+      date_trunc('month', d)::DATE AS month_start,
+      (date_trunc('month', d) + INTERVAL '1 month - 1 day')::DATE AS month_end
+    FROM generate_series(
+      date_trunc('month', CURRENT_DATE) - ((p_months - 1) || ' months')::INTERVAL,
+      date_trunc('month', CURRENT_DATE),
+      INTERVAL '1 month'
+    ) d
+  )
+  SELECT
+    m.ym AS year_month,
+    COALESCE(COUNT(pr.id) FILTER (WHERE pr.referred_at BETWEEN m.month_start AND m.month_end), 0)::INT AS referral_count,
+    COALESCE(COUNT(pr.id) FILTER (WHERE pr.referred_at BETWEEN m.month_start AND m.month_end AND pr.first_paid_at IS NOT NULL), 0)::INT AS paid_count
+  FROM months m
+  LEFT JOIN patient_referrals pr ON pr.clinic_id = p_clinic_id
+  GROUP BY m.ym, m.month_start
+  ORDER BY m.month_start;
+$$ LANGUAGE sql STABLE;

--- a/dental-clinic-manager/vercel.json
+++ b/dental-clinic-manager/vercel.json
@@ -25,6 +25,10 @@
     {
       "path": "/api/cron/monthly-report",
       "schedule": "0 15 * * *"
+    },
+    {
+      "path": "/api/cron/referral-thanks",
+      "schedule": "0 0 * * *"
     }
   ]
 }

--- a/rl-inference-server/src/main.py
+++ b/rl-inference-server/src/main.py
@@ -5,7 +5,11 @@ from src.config import get_settings
 from src.model_registry import ModelRegistry
 from src.adapters.sb3 import SB3Adapter
 from src.inference.portfolio import PortfolioInferenceEngine
-from src.schemas import PredictRequest, PortfolioPredictResponse, SinglePredictResponse, BacktestRequest, BacktestResponse, DownloadRequest, DownloadResponse
+from src.schemas import (
+    PredictRequest, PortfolioPredictResponse, SinglePredictResponse,
+    BacktestRequest, BacktestUniverseRequest, BacktestResponse,
+    DownloadRequest, DownloadResponse, OHLCVRow,
+)
 from src.model_registry import DownloadError, IntegrityError
 from src.inference.backtest import run_backtest
 
@@ -55,6 +59,74 @@ def backtest(req: BacktestRequest):
         raise HTTPException(status_code=400, detail="single_asset backtest not supported in Phase 1")
     adapter = _get_or_load_adapter(req)
     return run_backtest(adapter, req)
+
+
+@app.post("/backtest_universe", dependencies=[Depends(require_api_key)], response_model=BacktestResponse)
+def backtest_universe(req: BacktestUniverseRequest):
+    """Server-side fetch backtest: yfinance로 universe OHLCV를 가져와 시뮬레이션."""
+    if req.kind != "portfolio":
+        raise HTTPException(status_code=400, detail="single_asset backtest not supported in Phase 1")
+    try:
+        import yfinance as yf
+        import pandas as pd
+        import datetime as _dt
+    except ImportError as e:
+        raise HTTPException(status_code=500, detail=f"server missing yfinance: {e}")
+
+    # state_window 봉 lookback 확보를 위해 시작일을 앞당김
+    start = (_dt.datetime.fromisoformat(req.start_date) - _dt.timedelta(days=max(req.state_window * 2, 60))).strftime("%Y-%m-%d")
+    df = yf.download(
+        tickers=" ".join(req.universe), start=start, end=req.end_date,
+        auto_adjust=True, progress=False, threads=True, group_by="ticker",
+    )
+    closes_dict = {t: df[t]["Close"] for t in req.universe if t in df.columns.get_level_values(0)}
+    if not closes_dict:
+        raise HTTPException(status_code=502, detail="yfinance returned no data for universe")
+    closes = pd.DataFrame(closes_dict).dropna(axis=0, how="any")
+    if len(closes) <= req.state_window + 5:
+        raise HTTPException(
+            status_code=400,
+            detail=f"insufficient OHLCV after dropna: rows={len(closes)}, need >{req.state_window + 5}",
+        )
+
+    # OHLCVRow 객체로 변환 (close만 있어도 backtest 동작 — open/high/low/volume은 close로 채움)
+    ohlcv: dict[str, list[OHLCVRow]] = {}
+    for ticker in closes.columns:
+        rows: list[OHLCVRow] = []
+        for date_idx, close_val in closes[ticker].items():
+            d = date_idx.strftime("%Y-%m-%d") if hasattr(date_idx, "strftime") else str(date_idx)
+            cv = float(close_val)
+            rows.append(OHLCVRow(date=d, open=cv, high=cv, low=cv, close=cv, volume=0))
+        ohlcv[ticker] = rows
+
+    # rebalance_dates: 매월 첫 거래일 (start_date 이후)
+    all_dates = sorted({r.date for rows in ohlcv.values() for r in rows})
+    eligible = [d for d in all_dates if d >= req.start_date]
+    rebalance_dates: list[str] = []
+    last_month: str | None = None
+    for d in eligible:
+        ym = d[:7]
+        if ym != last_month:
+            rebalance_dates.append(d)
+            last_month = ym
+    if not rebalance_dates:
+        raise HTTPException(status_code=400, detail="no rebalance dates in given range")
+
+    # Reuse predict adapter cache via dummy PredictRequest-like loader
+    cached = registry.get_adapter(req.model_id)
+    if isinstance(cached, SB3Adapter):
+        adapter = cached
+    else:
+        adapter = SB3Adapter.load(req.checkpoint_path, req.algorithm)
+        registry.put_adapter(req.model_id, adapter)
+
+    inner_req = BacktestRequest(
+        model_id=req.model_id, checkpoint_path=req.checkpoint_path,
+        algorithm=req.algorithm, kind=req.kind, state_window=req.state_window,
+        input_features=req.input_features, ohlcv=ohlcv,
+        rebalance_dates=rebalance_dates, initial_capital=req.initial_capital,
+    )
+    return run_backtest(adapter, inner_req)
 
 
 @app.post("/models/download", dependencies=[Depends(require_api_key)], response_model=DownloadResponse)

--- a/rl-inference-server/src/schemas.py
+++ b/rl-inference-server/src/schemas.py
@@ -45,6 +45,20 @@ class BacktestRequest(PredictRequest):
     initial_capital: float = 10000.0
 
 
+class BacktestUniverseRequest(BaseModel):
+    """Server-side fetch 모드: OHLCV 페치를 server(yfinance)에 위임."""
+    model_id: str
+    checkpoint_path: str
+    algorithm: str
+    kind: Literal["portfolio"]
+    state_window: int = Field(ge=1, le=500)
+    input_features: list[str]
+    universe: list[str]
+    start_date: str
+    end_date: str
+    initial_capital: float = 10000.0
+
+
 class EquityPoint(BaseModel):
     date: str
     equity: float


### PR DESCRIPTION
## Summary

사용자 보고: RL 전략으로 백테스트 했는데 결과가 거래 0건 / total_return 0%로 나옴.

## 근본 원인

`/api/investment/backtest/route.ts`가 `strategy_type`을 무시하고 DB의 `indicators`/`buy_conditions`/`sell_conditions`를 그대로 룰 엔진(`runBacktest`)에 전달. RL 전략은 indicators=[], buy_conditions={type:group, conditions:[]}이라 매수 조건이 매칭되지 않아 거래 0건으로 `completed` 저장됨.

추가로 메인 앱 IP가 30종목 동시 Yahoo 호출 시 rate-limit 차단되어, 메인 앱 측 직접 fetch는 신뢰할 수 없음.

## 변경

- **`/api/investment/backtest/route.ts`** — `strategy_type LIKE 'rl_%'` 분기. RL이면 rl-inference-server로 위임
- **`src/lib/rlBacktestService.ts`** (신규) — server-side fetch 위임 client
- **rl-inference-server `/backtest_universe`** (신규 endpoint) — Python yfinance로 OHLCV 페치 + 시뮬레이션
- **결과 정규화** — `backtest_runs`에 ticker='PORTFOLIO', total_trades=n_rebalances, trades=[]
- `rl_single`은 명시적 400 (Phase 1 미지원)

## 검증

`80ae1609` (sweep best ckpt) + Dow 30 universe + 1년 OOS:
- Total Return **+39.5%**, Sharpe **2.23**, MDD **-9.7%**, 13 rebalances

이전: 동일 전략 백테스트 시 0% / 0건. fix 후 정상 portfolio simulation 결과.

## Test plan

- [x] Python pytest 21 PASS (rl-inference-server)
- [x] TS tsc 클린 (메인 앱)
- [x] `/backtest_universe` 직접 호출 검증 (HTTP 200, 의미 있는 metrics)
- [x] `rlBacktestService.runRLBacktest` ad-hoc tsx 실행 → SUCCESS
- [ ] UI에서 RL 전략 선택 → 백테스트 실행 → 결과 표시 (사용자 검증 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)