### PR TITLE
feat: backtest history + referral Phase 2 + RL trading + misc fixes

### DIFF
--- a/dental-clinic-manager/__tests__/api/investment/backtest-get.test.ts
+++ b/dental-clinic-manager/__tests__/api/investment/backtest-get.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// requireAuth + getSupabaseAdmin을 mock
+vi.mock('@/lib/auth/requireAuth', () => ({
+  requireAuth: vi.fn(async () => ({ user: { id: 'user-1' }, error: null, status: 200 })),
+}))
+
+const supabaseChain = {
+  from: vi.fn().mockReturnThis(),
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  gte: vi.fn().mockReturnThis(),
+  lte: vi.fn().mockReturnThis(),
+  in: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  single: vi.fn(),
+}
+
+vi.mock('@/lib/supabase/admin', () => ({
+  getSupabaseAdmin: vi.fn(() => supabaseChain),
+}))
+
+import { GET } from '@/app/api/investment/backtest/route'
+
+function makeReq(qs: string): Request {
+  return new Request(`http://localhost/api/investment/backtest?${qs}`)
+}
+
+describe('GET /api/investment/backtest filters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.values(supabaseChain).forEach((fn: any) => {
+      if (typeof fn === 'function' && 'mockReturnThis' in fn) fn.mockReturnThis()
+    })
+  })
+
+  it('returns rows with strategy_id + ticker + since + limit', async () => {
+    const rows = [
+      { id: 'r1', strategy_id: 's1', ticker: 'AAPL', total_return: 0.18, executed_at: '2026-04-29T00:00:00Z' },
+    ]
+    // 종단 메서드는 await 시 Promise<{data, error}> 형태
+    const last = vi.fn().mockResolvedValue({ data: rows, error: null })
+    supabaseChain.limit = last as any
+
+    const resp = await GET(makeReq('strategy_id=s1&ticker=AAPL&since=2026-04-01&limit=50') as any)
+    expect(resp.status).toBe(200)
+    const body = await resp.json()
+    expect(body.data).toEqual(rows)
+    expect(supabaseChain.eq).toHaveBeenCalledWith('user_id', 'user-1')
+    expect(supabaseChain.eq).toHaveBeenCalledWith('strategy_id', 's1')
+    expect(supabaseChain.eq).toHaveBeenCalledWith('ticker', 'AAPL')
+    expect(supabaseChain.gte).toHaveBeenCalledWith('executed_at', '2026-04-01')
+    expect(supabaseChain.limit).toHaveBeenCalledWith(50)
+  })
+
+  it('caps limit to 200', async () => {
+    const last = vi.fn().mockResolvedValue({ data: [], error: null })
+    supabaseChain.limit = last as any
+    await GET(makeReq('limit=999') as any)
+    expect(supabaseChain.limit).toHaveBeenCalledWith(200)
+  })
+
+  it('returns specific rows for ids=a,b,c', async () => {
+    const last = vi.fn().mockResolvedValue({ data: [{ id: 'a' }, { id: 'b' }], error: null })
+    supabaseChain.in = last as any
+    const resp = await GET(makeReq('ids=a,b') as any)
+    expect(resp.status).toBe(200)
+    expect(supabaseChain.in).toHaveBeenCalledWith('id', ['a', 'b'])
+  })
+
+  it('rejects when ids contains non-uuid junk over 50 items', async () => {
+    const ids = Array.from({ length: 60 }, (_, i) => `id${i}`).join(',')
+    const resp = await GET(makeReq(`ids=${ids}`) as any)
+    expect(resp.status).toBe(400)
+  })
+
+  it('returns single row for ?id=xxx (existing behavior preserved)', async () => {
+    supabaseChain.single = vi.fn().mockResolvedValue({ data: { id: 'r1' }, error: null }) as any
+    const resp = await GET(makeReq('id=r1') as any)
+    expect(resp.status).toBe(200)
+    const body = await resp.json()
+    expect(body.data).toEqual({ id: 'r1' })
+  })
+})

--- a/dental-clinic-manager/__tests__/api/investment/backtest-get.test.ts
+++ b/dental-clinic-manager/__tests__/api/investment/backtest-get.test.ts
@@ -17,6 +17,10 @@ const supabaseChain = {
   single: vi.fn(),
 }
 
+const originalLimit = supabaseChain.limit
+const originalIn = supabaseChain.in
+const originalSingle = supabaseChain.single
+
 vi.mock('@/lib/supabase/admin', () => ({
   getSupabaseAdmin: vi.fn(() => supabaseChain),
 }))
@@ -30,8 +34,13 @@ function makeReq(qs: string): Request {
 describe('GET /api/investment/backtest filters', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    supabaseChain.limit = originalLimit
+    supabaseChain.in = originalIn
+    supabaseChain.single = originalSingle
     Object.values(supabaseChain).forEach((fn: any) => {
-      if (typeof fn === 'function' && 'mockReturnThis' in fn) fn.mockReturnThis()
+      if (fn && typeof fn === 'function' && 'mockReturnThis' in fn) {
+        fn.mockReturnThis()
+      }
     })
   })
 

--- a/dental-clinic-manager/docs/superpowers/plans/2026-04-30-backtest-history.md
+++ b/dental-clinic-manager/docs/superpowers/plans/2026-04-30-backtest-history.md
@@ -1,0 +1,1410 @@
+# 백테스트 히스토리 — 비교 페이지 통합 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/investment/compare` 페이지에 [히스토리] 탭을 추가해 `backtest_runs` 누적 결과를 필터링·정렬·다중선택비교 가능하게 한다.
+
+**Architecture:** 기존 `CompareContent.tsx`(1698줄)는 그대로 두고 상단 탭 wrapper만 추가. 신규 코드는 `src/components/Investment/CompareHistory/` 하위에 격리. API는 `/api/investment/backtest` GET 핸들러에 필터 파라미터를 추가만 한다 (DB 스키마 변경 없음).
+
+**Tech Stack:**
+- Next.js 15 App Router (route handler) + Supabase (`backtest_runs` 테이블)
+- React 19 + TypeScript + Tailwind (AT Tokens)
+- 정렬·필터는 클라이언트 + 서버 hybrid (필터=서버, 정렬=클라이언트)
+
+**Spec 참조:** [docs/superpowers/specs/2026-04-30-backtest-history-design.md](../specs/2026-04-30-backtest-history-design.md)
+
+---
+
+## File Structure
+
+### 수정
+| 파일 | 책임 |
+|---|---|
+| `src/app/api/investment/backtest/route.ts` | GET에 `strategy_id` / `ticker` / `since` / `until` / `limit` / `ids` 파라미터 추가 |
+| `src/components/Investment/CompareContent.tsx` | 최상단 탭 wrapper만 추가 (기존 메인 콘텐츠는 별도 함수로 분리해 한 탭에 렌더) |
+
+### 신규
+```
+src/components/Investment/CompareHistory/
+├── HistoryTab.tsx           # 컨테이너 (filters + table + 다중선택 비교)
+├── HistoryFilters.tsx       # 전략 select + ticker 검색 + 기간 preset
+├── HistoryTable.tsx         # 정렬 가능 컬럼 + 체크박스 + 펼침 토글
+├── HistoryRowDetail.tsx     # 인라인 펼침 콘텐츠 (sparkline + trades + 메트릭)
+└── HistoryCompareView.tsx   # 다중 선택 matrix table + equity overlay
+```
+
+### 테스트
+- API: `dental-clinic-manager/__tests__/api/investment/backtest-get.test.ts` (vitest. 프로젝트 내 vitest 미설치 시 Task 1에서 추가)
+
+---
+
+## 진행 원칙
+
+- TDD 흐름은 API에만 적용 (UI는 smoke test 수준만)
+- 각 task 완료 시 `develop` 브랜치에 commit. push는 모든 task 완료 후 일괄
+- AT Tokens (`bg-at-accent`, `text-at-text`, `border-at-border`, `rounded-xl`) 준수
+- 큰 변경은 별도 task로 격리
+
+---
+
+## Task 1: vitest 도입 + GET 라우트 단위 테스트 환경
+
+**Files:**
+- Modify: `dental-clinic-manager/package.json` (vitest devDep)
+- Create: `dental-clinic-manager/vitest.config.ts`
+- Create: `dental-clinic-manager/__tests__/api/investment/backtest-get.test.ts`
+
+- [ ] **Step 1: vitest 설치 여부 확인**
+
+```bash
+cd /Users/hhs/Project/dental-clinic-manager/dental-clinic-manager
+grep -E '"vitest"' package.json || echo "no vitest"
+```
+
+`no vitest`이면 Step 2로. 이미 있으면 Step 3로 직진.
+
+- [ ] **Step 2: vitest devDependency + 스크립트 추가**
+
+`package.json`의 `devDependencies`에 추가:
+
+```json
+"vitest": "^2.1.0"
+```
+
+`scripts`에 추가:
+
+```json
+"test:unit": "vitest run",
+"test:unit:watch": "vitest"
+```
+
+설치:
+
+```bash
+npm install
+```
+
+`vitest.config.ts`(루트):
+
+```typescript
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['__tests__/**/*.test.ts', '__tests__/**/*.test.tsx'],
+    environment: 'node',
+    testTimeout: 10000,
+  },
+})
+```
+
+- [ ] **Step 3: 첫 실패 테스트 작성**
+
+`dental-clinic-manager/__tests__/api/investment/backtest-get.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// requireAuth + getSupabaseAdmin을 mock
+vi.mock('@/lib/auth/requireAuth', () => ({
+  requireAuth: vi.fn(async () => ({ user: { id: 'user-1' }, error: null, status: 200 })),
+}))
+
+const supabaseChain = {
+  from: vi.fn().mockReturnThis(),
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  gte: vi.fn().mockReturnThis(),
+  lte: vi.fn().mockReturnThis(),
+  in: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  single: vi.fn(),
+}
+
+vi.mock('@/lib/supabase/admin', () => ({
+  getSupabaseAdmin: vi.fn(() => supabaseChain),
+}))
+
+import { GET } from '@/app/api/investment/backtest/route'
+
+function makeReq(qs: string): Request {
+  return new Request(`http://localhost/api/investment/backtest?${qs}`)
+}
+
+describe('GET /api/investment/backtest filters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.values(supabaseChain).forEach((fn: any) => {
+      if (typeof fn === 'function' && 'mockReturnThis' in fn) fn.mockReturnThis()
+    })
+  })
+
+  it('returns rows with strategy_id + ticker + since + limit', async () => {
+    const rows = [
+      { id: 'r1', strategy_id: 's1', ticker: 'AAPL', total_return: 0.18, executed_at: '2026-04-29T00:00:00Z' },
+    ]
+    // 종단 메서드는 await 시 Promise<{data, error}> 형태
+    const last = vi.fn().mockResolvedValue({ data: rows, error: null })
+    supabaseChain.limit = last as any
+
+    const resp = await GET(makeReq('strategy_id=s1&ticker=AAPL&since=2026-04-01&limit=50') as any)
+    expect(resp.status).toBe(200)
+    const body = await resp.json()
+    expect(body.data).toEqual(rows)
+    expect(supabaseChain.eq).toHaveBeenCalledWith('user_id', 'user-1')
+    expect(supabaseChain.eq).toHaveBeenCalledWith('strategy_id', 's1')
+    expect(supabaseChain.eq).toHaveBeenCalledWith('ticker', 'AAPL')
+    expect(supabaseChain.gte).toHaveBeenCalledWith('executed_at', '2026-04-01')
+    expect(supabaseChain.limit).toHaveBeenCalledWith(50)
+  })
+
+  it('caps limit to 200', async () => {
+    const last = vi.fn().mockResolvedValue({ data: [], error: null })
+    supabaseChain.limit = last as any
+    await GET(makeReq('limit=999') as any)
+    expect(supabaseChain.limit).toHaveBeenCalledWith(200)
+  })
+
+  it('returns specific rows for ids=a,b,c', async () => {
+    const last = vi.fn().mockResolvedValue({ data: [{ id: 'a' }, { id: 'b' }], error: null })
+    supabaseChain.in = last as any
+    const resp = await GET(makeReq('ids=a,b') as any)
+    expect(resp.status).toBe(200)
+    expect(supabaseChain.in).toHaveBeenCalledWith('id', ['a', 'b'])
+  })
+
+  it('rejects when ids contains non-uuid junk over 50 items', async () => {
+    const ids = Array.from({ length: 60 }, (_, i) => `id${i}`).join(',')
+    const resp = await GET(makeReq(`ids=${ids}`) as any)
+    expect(resp.status).toBe(400)
+  })
+
+  it('returns single row for ?id=xxx (existing behavior preserved)', async () => {
+    supabaseChain.single = vi.fn().mockResolvedValue({ data: { id: 'r1' }, error: null }) as any
+    const resp = await GET(makeReq('id=r1') as any)
+    expect(resp.status).toBe(200)
+    const body = await resp.json()
+    expect(body.data).toEqual({ id: 'r1' })
+  })
+})
+```
+
+- [ ] **Step 4: 실행 → FAIL (현재 라우트는 strategy_id/ticker/since/until/ids/limit cap을 지원하지 않음)**
+
+```bash
+npm run test:unit -- backtest-get
+```
+
+Expected: 4~5 fail (strategy_id/ticker/since/limit cap/ids 파라미터 미지원).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /Users/hhs/Project/dental-clinic-manager
+git add dental-clinic-manager/package.json dental-clinic-manager/package-lock.json dental-clinic-manager/vitest.config.ts dental-clinic-manager/__tests__/api/investment/backtest-get.test.ts
+git commit -m "test(backtest-history): add vitest + failing tests for GET filters"
+```
+
+---
+
+## Task 2: GET 라우트에 필터 구현
+
+**Files:**
+- Modify: `dental-clinic-manager/src/app/api/investment/backtest/route.ts:198-248`
+
+- [ ] **Step 1: 기존 GET 핸들러 전체 교체**
+
+`src/app/api/investment/backtest/route.ts`의 GET 함수만 다음으로 교체. POST 핸들러는 그대로 둔다.
+
+```typescript
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const userId = auth.user!.id
+
+  const supabase = getSupabaseAdmin()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+  const strategyId = searchParams.get('strategyId') ?? searchParams.get('strategy_id')
+  const ticker = searchParams.get('ticker')?.trim() || null
+  const since = searchParams.get('since')
+  const until = searchParams.get('until')
+  const idsCsv = searchParams.get('ids')
+  const limitRaw = searchParams.get('limit')
+
+  // 1) 단일 결과 — 기존 호환
+  if (id) {
+    const { data, error } = await supabase
+      .from('backtest_runs')
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .single()
+    if (error || !data) {
+      return NextResponse.json({ error: '결과를 찾을 수 없습니다' }, { status: 404 })
+    }
+    return NextResponse.json({ data })
+  }
+
+  // 2) 다중 IDs (비교 view 로드용)
+  if (idsCsv) {
+    const ids = idsCsv.split(',').map(s => s.trim()).filter(Boolean)
+    if (ids.length > 50) {
+      return NextResponse.json({ error: 'ids는 최대 50개까지 가능합니다' }, { status: 400 })
+    }
+    const { data, error } = await supabase
+      .from('backtest_runs')
+      .select('*')
+      .eq('user_id', userId)
+      .in('id', ids)
+    if (error) {
+      return NextResponse.json({ error: '조회 실패' }, { status: 500 })
+    }
+    return NextResponse.json({ data: data ?? [] })
+  }
+
+  // 3) 필터 + 최신순 (히스토리 탭)
+  let query = supabase
+    .from('backtest_runs')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('status', 'completed')
+
+  if (strategyId) {
+    if (!UUID_RE.test(strategyId)) {
+      return NextResponse.json({ error: 'strategy_id 형식이 올바르지 않습니다' }, { status: 400 })
+    }
+    query = query.eq('strategy_id', strategyId)
+  }
+  if (ticker) {
+    query = query.eq('ticker', ticker.toUpperCase())
+  }
+  if (since) {
+    query = query.gte('executed_at', since)
+  }
+  if (until) {
+    query = query.lte('executed_at', until)
+  }
+  const limit = Math.min(Number(limitRaw) || 50, 200)
+  query = query.order('executed_at', { ascending: false }).limit(limit)
+
+  const { data, error } = await query
+  if (error) {
+    return NextResponse.json({ error: '조회 실패' }, { status: 500 })
+  }
+  return NextResponse.json({ data: data ?? [] })
+}
+```
+
+- [ ] **Step 2: 테스트 실행 → 모두 PASS**
+
+```bash
+cd dental-clinic-manager && npm run test:unit -- backtest-get
+```
+
+Expected: 5 PASS.
+
+- [ ] **Step 3: 타입 체크**
+
+```bash
+npx tsc --noEmit 2>&1 | grep -i "backtest/route" | head
+```
+
+Expected: 출력 없음.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /Users/hhs/Project/dental-clinic-manager
+git add dental-clinic-manager/src/app/api/investment/backtest/route.ts
+git commit -m "feat(backtest-api): GET filters strategy_id/ticker/since/until/ids/limit"
+```
+
+---
+
+## Task 3: CompareContent에 탭 wrapper 추가
+
+**Files:**
+- Modify: `dental-clinic-manager/src/components/Investment/CompareContent.tsx`
+
+기존 1698줄짜리 컴포넌트는 그대로 두고, default export 를 새 wrapper로 교체. 기존 콘텐츠는 `LiveCompareSection` 같은 내부 함수로 이름만 변경 후 wrapper에서 렌더한다.
+
+- [ ] **Step 1: 파일 상단 import에 useState 추가 확인**
+
+`src/components/Investment/CompareContent.tsx` 첫 줄들:
+
+```typescript
+import { useState, useEffect, useCallback, useMemo, Fragment } from 'react'
+```
+
+이미 useState 있음 — 변경 불필요.
+
+- [ ] **Step 2: 기존 default export 함수명을 변경**
+
+원본:
+
+```typescript
+export default function CompareContent() {
+  // ...기존 1500여 줄
+}
+```
+
+다음으로 변경:
+
+```typescript
+function LiveCompareSection() {
+  // ...기존 본문 그대로
+}
+```
+
+(`export default` 키워드 제거, 함수명만 `LiveCompareSection`으로)
+
+- [ ] **Step 3: 파일 끝에 새 default export wrapper 추가**
+
+파일 맨 끝(다른 internal 컴포넌트들 뒤)에 추가:
+
+```typescript
+import HistoryTab from './CompareHistory/HistoryTab'
+
+type CompareTab = 'live' | 'history'
+
+export default function CompareContent() {
+  const [tab, setTab] = useState<CompareTab>('live')
+
+  return (
+    <div className="bg-white min-h-screen">
+      <div className="sticky top-14 z-10 bg-white border-b border-at-border px-4 sm:px-6 pt-4 pb-3 -mx-4 sm:-mx-6 flex gap-2">
+        <button
+          onClick={() => setTab('live')}
+          className={`py-2 px-4 inline-flex items-center rounded-xl font-medium text-sm transition-colors ${
+            tab === 'live' ? 'bg-at-accent-light text-at-accent' : 'text-at-text-weak hover:text-at-text-secondary hover:bg-at-surface-alt'
+          }`}
+        >
+          새로 비교
+        </button>
+        <button
+          onClick={() => setTab('history')}
+          className={`py-2 px-4 inline-flex items-center rounded-xl font-medium text-sm transition-colors ${
+            tab === 'history' ? 'bg-at-accent-light text-at-accent' : 'text-at-text-weak hover:text-at-text-secondary hover:bg-at-surface-alt'
+          }`}
+        >
+          히스토리
+        </button>
+      </div>
+
+      <div className="pt-4">
+        {tab === 'live' ? <LiveCompareSection /> : <HistoryTab />}
+      </div>
+    </div>
+  )
+}
+```
+
+`import HistoryTab` 줄은 파일 상단 다른 import들과 함께 두는 게 깔끔하나, IDE가 자동 정렬할 가능성도 있어 위 위치 그대로 OK. 다음 task에서 HistoryTab을 만들기 전이라 import는 미존재 → 의도적 빌드 실패 (다음 task에서 해소).
+
+- [ ] **Step 4: 빌드 시도 (실패 예상)**
+
+```bash
+cd dental-clinic-manager && npx tsc --noEmit 2>&1 | grep "CompareHistory/HistoryTab" | head
+```
+
+Expected: `Cannot find module './CompareHistory/HistoryTab'` — 다음 task에서 해소.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add dental-clinic-manager/src/components/Investment/CompareContent.tsx
+git commit -m "feat(compare): add live/history tabs wrapper (HistoryTab stub follows)"
+```
+
+---
+
+## Task 4: HistoryTab 컨테이너 (필터+표+선택바 골격)
+
+**Files:**
+- Create: `dental-clinic-manager/src/components/Investment/CompareHistory/HistoryTab.tsx`
+
+- [ ] **Step 1: 골격 작성**
+
+```tsx
+'use client'
+
+import { useEffect, useMemo, useState, useCallback } from 'react'
+import { History as HistoryIcon } from 'lucide-react'
+import HistoryFilters, { type HistoryFilterState } from './HistoryFilters'
+import HistoryTable from './HistoryTable'
+import HistoryCompareView from './HistoryCompareView'
+
+export interface BacktestRunRow {
+  id: string
+  strategy_id: string | null
+  ticker: string
+  market: 'KR' | 'US'
+  start_date: string
+  end_date: string
+  initial_capital: number
+  status: string
+  total_return: number | null
+  sharpe_ratio: number | null
+  max_drawdown: number | null
+  total_trades: number | null
+  win_rate: number | null
+  equity_curve: Array<{ date: string; equity: number }> | null
+  trades: Array<Record<string, unknown>> | null
+  full_metrics: Record<string, unknown> | null
+  executed_at: string
+}
+
+interface StrategyOption {
+  id: string
+  name: string
+  strategy_type: 'rule' | 'rl_portfolio' | 'rl_single'
+}
+
+const today = () => new Date().toISOString().slice(0, 10)
+const daysAgo = (n: number) => {
+  const d = new Date()
+  d.setDate(d.getDate() - n)
+  return d.toISOString().slice(0, 10)
+}
+
+const DEFAULT_FILTER: HistoryFilterState = {
+  strategyId: '',     // '전체'
+  ticker: '',
+  preset: '30d',
+}
+
+function presetToSince(preset: HistoryFilterState['preset']): string | null {
+  switch (preset) {
+    case '7d': return daysAgo(7)
+    case '30d': return daysAgo(30)
+    case '90d': return daysAgo(90)
+    case 'all': return null
+  }
+}
+
+export default function HistoryTab() {
+  const [filter, setFilter] = useState<HistoryFilterState>(DEFAULT_FILTER)
+  const [strategies, setStrategies] = useState<StrategyOption[]>([])
+  const [rows, setRows] = useState<BacktestRunRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [showCompare, setShowCompare] = useState(false)
+
+  // 전략 옵션 1회 로드
+  useEffect(() => {
+    fetch('/api/investment/strategies')
+      .then(r => r.json())
+      .then((j: { data?: Array<{ id: string; name: string; strategy_type: StrategyOption['strategy_type'] }> }) => {
+        setStrategies(j.data ?? [])
+      })
+      .catch(() => setStrategies([]))
+  }, [])
+
+  // 필터 변경 시 백테스트 재조회 (debounce 300ms)
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const params = new URLSearchParams()
+        if (filter.strategyId) params.set('strategy_id', filter.strategyId)
+        if (filter.ticker.trim()) params.set('ticker', filter.ticker.trim())
+        const since = presetToSince(filter.preset)
+        if (since) params.set('since', since)
+        params.set('limit', '50')
+        const r = await fetch(`/api/investment/backtest?${params.toString()}`)
+        if (!r.ok) {
+          const err = (await r.json().catch(() => ({}))) as { error?: string }
+          throw new Error(err.error ?? `${r.status}`)
+        }
+        const j = (await r.json()) as { data?: BacktestRunRow[] }
+        setRows(j.data ?? [])
+      } catch (e) {
+        setError((e as Error).message)
+        setRows([])
+      } finally {
+        setLoading(false)
+      }
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [filter])
+
+  const toggleSelected = useCallback((id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const selectedRows = useMemo(
+    () => rows.filter(r => selectedIds.has(r.id)),
+    [rows, selectedIds],
+  )
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4">
+      <HistoryFilters
+        value={filter}
+        onChange={setFilter}
+        strategies={strategies}
+      />
+
+      {error && (
+        <div className="p-3 rounded-xl bg-at-error-bg text-at-error text-sm">
+          조회 실패: {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-at-accent" />
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="text-center py-12 bg-at-surface-alt rounded-xl space-y-2">
+          <HistoryIcon className="w-10 h-10 mx-auto text-at-text-weak" aria-hidden="true" />
+          <p className="text-sm text-at-text-secondary">조건에 맞는 백테스트가 없습니다.</p>
+          <p className="text-xs text-at-text-weak">[새로 비교] 탭에서 첫 백테스트를 실행해보세요.</p>
+        </div>
+      ) : (
+        <HistoryTable
+          rows={rows}
+          strategies={strategies}
+          selectedIds={selectedIds}
+          onToggleSelected={toggleSelected}
+        />
+      )}
+
+      {selectedIds.size >= 2 && !showCompare && (
+        <div className="sticky bottom-4 z-10 flex justify-center">
+          <button
+            onClick={() => setShowCompare(true)}
+            className="px-5 py-2.5 bg-at-accent hover:bg-at-accent-hover text-white rounded-xl text-sm font-medium shadow-lg"
+          >
+            선택 {selectedIds.size}개 비교
+          </button>
+        </div>
+      )}
+
+      {showCompare && selectedRows.length >= 2 && (
+        <HistoryCompareView
+          rows={selectedRows}
+          strategies={strategies}
+          onClose={() => setShowCompare(false)}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 (다른 모듈 미존재로 일부 실패)**
+
+```bash
+cd dental-clinic-manager && npx tsc --noEmit 2>&1 | grep "CompareHistory" | head
+```
+
+Expected: HistoryFilters / HistoryTable / HistoryCompareView 미존재 — 다음 task들에서 해소.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add dental-clinic-manager/src/components/Investment/CompareHistory/HistoryTab.tsx
+git commit -m "feat(compare-history): HistoryTab container with filter+selection state"
+```
+
+---
+
+## Task 5: HistoryFilters
+
+**Files:**
+- Create: `dental-clinic-manager/src/components/Investment/CompareHistory/HistoryFilters.tsx`
+
+- [ ] **Step 1: 작성**
+
+```tsx
+'use client'
+
+import { Search } from 'lucide-react'
+
+export type PeriodPreset = '7d' | '30d' | '90d' | 'all'
+
+export interface HistoryFilterState {
+  strategyId: string  // '' = 전체
+  ticker: string
+  preset: PeriodPreset
+}
+
+interface StrategyOption {
+  id: string
+  name: string
+  strategy_type: 'rule' | 'rl_portfolio' | 'rl_single'
+}
+
+interface Props {
+  value: HistoryFilterState
+  onChange: (next: HistoryFilterState) => void
+  strategies: StrategyOption[]
+}
+
+const PRESET_LABELS: Record<PeriodPreset, string> = {
+  '7d': '최근 7일',
+  '30d': '최근 30일',
+  '90d': '최근 90일',
+  'all': '전체',
+}
+
+export default function HistoryFilters({ value, onChange, strategies }: Props) {
+  const set = <K extends keyof HistoryFilterState>(key: K, v: HistoryFilterState[K]) => {
+    onChange({ ...value, [key]: v })
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-3 bg-white border border-at-border rounded-xl p-3">
+      <label className="block">
+        <span className="text-xs font-medium text-at-text-secondary mb-1 inline-block">전략</span>
+        <select
+          value={value.strategyId}
+          onChange={(e) => set('strategyId', e.target.value)}
+          className="w-full px-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent text-sm"
+        >
+          <option value="">전체</option>
+          {strategies.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name} {s.strategy_type !== 'rule' ? `(${s.strategy_type === 'rl_portfolio' ? 'RL' : 'RL단일'})` : ''}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="block">
+        <span className="text-xs font-medium text-at-text-secondary mb-1 inline-block">종목</span>
+        <div className="relative">
+          <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-at-text-weak" aria-hidden="true" />
+          <input
+            type="text"
+            value={value.ticker}
+            onChange={(e) => set('ticker', e.target.value)}
+            placeholder="AAPL, 005930…"
+            className="w-full pl-9 pr-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent text-sm"
+          />
+        </div>
+      </label>
+
+      <label className="block">
+        <span className="text-xs font-medium text-at-text-secondary mb-1 inline-block">기간</span>
+        <select
+          value={value.preset}
+          onChange={(e) => set('preset', e.target.value as PeriodPreset)}
+          className="w-full px-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent text-sm"
+        >
+          {(['7d', '30d', '90d', 'all'] as PeriodPreset[]).map((p) => (
+            <option key={p} value={p}>{PRESET_LABELS[p]}</option>
+          ))}
+        </select>
+      </label>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add dental-clinic-manager/src/components/Investment/CompareHistory/HistoryFilters.tsx
+git commit -m "feat(compare-history): HistoryFilters (strategy/ticker/period)"
+```
+
+---
+
+## Task 6: HistoryTable + 펼침 상태
+
+**Files:**
+- Create: `dental-clinic-manager/src/components/Investment/CompareHistory/HistoryTable.tsx`
+
+- [ ] **Step 1: 작성**
+
+```tsx
+'use client'
+
+import { useMemo, useState } from 'react'
+import { ChevronDown, ChevronRight, ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react'
+import HistoryRowDetail from './HistoryRowDetail'
+import type { BacktestRunRow } from './HistoryTab'
+
+interface StrategyOption {
+  id: string
+  name: string
+  strategy_type: 'rule' | 'rl_portfolio' | 'rl_single'
+}
+
+interface Props {
+  rows: BacktestRunRow[]
+  strategies: StrategyOption[]
+  selectedIds: Set<string>
+  onToggleSelected: (id: string) => void
+}
+
+type SortKey = 'executed_at' | 'total_return' | 'sharpe_ratio'
+type SortDir = 'asc' | 'desc'
+
+const formatDate = (iso: string): string => {
+  try {
+    const d = new Date(iso)
+    return `${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`
+  } catch {
+    return iso.slice(0, 10)
+  }
+}
+
+const formatPct = (v: number | null | undefined): string => {
+  if (v == null) return '-'
+  const sign = v > 0 ? '+' : ''
+  return `${sign}${(v * 100).toFixed(1)}%`
+}
+
+const formatNum = (v: number | null | undefined, digits = 2): string => {
+  if (v == null) return '-'
+  return v.toFixed(digits)
+}
+
+export default function HistoryTable({ rows, strategies, selectedIds, onToggleSelected }: Props) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [sortKey, setSortKey] = useState<SortKey>('executed_at')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  const strategyById = useMemo(() => {
+    const map = new Map<string, StrategyOption>()
+    for (const s of strategies) map.set(s.id, s)
+    return map
+  }, [strategies])
+
+  const sorted = useMemo(() => {
+    const cp = [...rows]
+    cp.sort((a, b) => {
+      const av = (a[sortKey] ?? 0) as number | string
+      const bv = (b[sortKey] ?? 0) as number | string
+      if (av < bv) return sortDir === 'asc' ? -1 : 1
+      if (av > bv) return sortDir === 'asc' ? 1 : -1
+      return 0
+    })
+    return cp
+  }, [rows, sortKey, sortDir])
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+    else { setSortKey(key); setSortDir('desc') }
+  }
+
+  const toggleExpanded = (id: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const sortIcon = (key: SortKey) => {
+    if (sortKey !== key) return <ArrowUpDown className="w-3 h-3 inline-block opacity-50" aria-hidden="true" />
+    return sortDir === 'asc'
+      ? <ArrowUp className="w-3 h-3 inline-block" aria-hidden="true" />
+      : <ArrowDown className="w-3 h-3 inline-block" aria-hidden="true" />
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-at-border bg-white">
+      <table className="min-w-[900px] w-full text-sm">
+        <thead className="bg-at-surface-alt">
+          <tr>
+            <th className="px-3 py-2 w-8" />
+            <th
+              className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider cursor-pointer"
+              onClick={() => toggleSort('executed_at')}
+            >
+              날짜 {sortIcon('executed_at')}
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">전략</th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">종목</th>
+            <th
+              className="px-3 py-2 text-right text-xs font-medium text-at-text-weak uppercase tracking-wider cursor-pointer"
+              onClick={() => toggleSort('total_return')}
+            >
+              수익률 {sortIcon('total_return')}
+            </th>
+            <th
+              className="px-3 py-2 text-right text-xs font-medium text-at-text-weak uppercase tracking-wider cursor-pointer"
+              onClick={() => toggleSort('sharpe_ratio')}
+            >
+              Sharpe {sortIcon('sharpe_ratio')}
+            </th>
+            <th className="px-3 py-2 w-8" aria-label="펼침" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-at-border">
+          {sorted.map((row) => {
+            const strat = row.strategy_id ? strategyById.get(row.strategy_id) : null
+            const isExp = expanded.has(row.id)
+            const isSel = selectedIds.has(row.id)
+            const ret = row.total_return ?? null
+            return (
+              <Fragment key={row.id}>
+                <tr className={`hover:bg-at-surface-alt transition-colors ${isExp ? 'bg-at-surface-alt' : ''}`}>
+                  <td className="px-3 py-2.5">
+                    <input
+                      type="checkbox"
+                      checked={isSel}
+                      onChange={() => onToggleSelected(row.id)}
+                      aria-label={`${row.id} 선택`}
+                      className="rounded border-at-border text-at-accent focus:ring-at-accent"
+                    />
+                  </td>
+                  <td className="px-3 py-2.5 font-medium text-at-text">{formatDate(row.executed_at)}</td>
+                  <td className="px-3 py-2.5">
+                    <div className="flex items-center gap-2">
+                      <span>{strat?.name ?? '-'}</span>
+                      {strat?.strategy_type === 'rl_portfolio' && (
+                        <span className="px-1.5 py-0.5 text-xs rounded-full bg-at-accent-light text-at-accent">RL</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2.5 font-mono text-xs">
+                    {row.ticker === 'PORTFOLIO' ? (
+                      <span className="text-at-text-secondary">Portfolio</span>
+                    ) : row.ticker}
+                  </td>
+                  <td className={`px-3 py-2.5 text-right font-medium ${
+                    ret == null ? '' : ret >= 0 ? 'text-at-success' : 'text-at-error'
+                  }`}>
+                    {formatPct(ret)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right text-at-text">{formatNum(row.sharpe_ratio)}</td>
+                  <td className="px-3 py-2.5">
+                    <button
+                      onClick={() => toggleExpanded(row.id)}
+                      aria-label={isExp ? '접기' : '펼치기'}
+                      title={isExp ? '접기' : '펼치기'}
+                      className="p-1 rounded-xl hover:bg-at-surface-alt"
+                    >
+                      {isExp ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                    </button>
+                  </td>
+                </tr>
+                {isExp && (
+                  <tr className="bg-at-surface-alt">
+                    <td colSpan={7} className="px-3 py-3">
+                      <HistoryRowDetail row={row} />
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function Fragment({ children }: { children: React.ReactNode }): React.ReactElement {
+  return <>{children}</>
+}
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add dental-clinic-manager/src/components/Investment/CompareHistory/HistoryTable.tsx
+git commit -m "feat(compare-history): HistoryTable with sort/select/expand"
+```
+
+---
+
+## Task 7: HistoryRowDetail (인라인 펼침 상세)
+
+**Files:**
+- Create: `dental-clinic-manager/src/components/Investment/CompareHistory/HistoryRowDetail.tsx`
+
+- [ ] **Step 1: 작성**
+
+```tsx
+'use client'
+
+import { useMemo } from 'react'
+import type { BacktestRunRow } from './HistoryTab'
+
+interface Props {
+  row: BacktestRunRow
+}
+
+const formatPct = (v: number | null | undefined): string => {
+  if (v == null) return '-'
+  return `${(v * 100).toFixed(1)}%`
+}
+
+function sampleCurve(curve: Array<{ date: string; equity: number }>, maxPoints: number): Array<{ date: string; equity: number }> {
+  if (curve.length <= maxPoints) return curve
+  const step = curve.length / maxPoints
+  const out: Array<{ date: string; equity: number }> = []
+  for (let i = 0; i < maxPoints; i++) {
+    out.push(curve[Math.floor(i * step)])
+  }
+  out[out.length - 1] = curve[curve.length - 1]
+  return out
+}
+
+function Sparkline({ points, width = 320, height = 60 }: { points: Array<{ date: string; equity: number }>; width?: number; height?: number }) {
+  if (points.length < 2) {
+    return <div className="text-xs text-at-text-weak">곡선 데이터 부족</div>
+  }
+  const min = Math.min(...points.map(p => p.equity))
+  const max = Math.max(...points.map(p => p.equity))
+  const range = Math.max(max - min, 1e-6)
+  const path = points.map((p, i) => {
+    const x = (i / (points.length - 1)) * width
+    const y = height - ((p.equity - min) / range) * height
+    return `${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`
+  }).join(' ')
+  const lastY = height - ((points[points.length - 1].equity - min) / range) * height
+  const firstY = height - ((points[0].equity - min) / range) * height
+  const isUp = points[points.length - 1].equity >= points[0].equity
+  const color = isUp ? '#1b7a3d' : '#c5221f'  // at-success / at-error 헥스 (svg는 토큰 미해석)
+  return (
+    <svg width={width} height={height} className="block">
+      <path d={path} fill="none" stroke={color} strokeWidth={1.5} />
+      <line x1={0} y1={firstY} x2={width} y2={firstY} stroke="#e0e2e6" strokeDasharray="2 2" />
+      <circle cx={width} cy={lastY} r={3} fill={color} />
+    </svg>
+  )
+}
+
+export default function HistoryRowDetail({ row }: Props) {
+  const sampled = useMemo(
+    () => row.equity_curve ? sampleCurve(row.equity_curve, 60) : [],
+    [row.equity_curve],
+  )
+  const trades = (row.trades ?? []) as Array<Record<string, unknown>>
+  const previewTrades = trades.slice(0, 5)
+  const isRLPortfolio = row.ticker === 'PORTFOLIO'
+
+  return (
+    <div className="space-y-3">
+      {sampled.length > 0 && (
+        <div className="bg-white border border-at-border rounded-xl p-3">
+          <div className="text-xs text-at-text-secondary mb-1">자산곡선 (period: {row.start_date} ~ {row.end_date})</div>
+          <Sparkline points={sampled} />
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <div className="bg-white border border-at-border rounded-xl p-3">
+          <div className="text-xs text-at-text-secondary">총 수익률</div>
+          <div className={`text-xl font-bold ${(row.total_return ?? 0) >= 0 ? 'text-at-success' : 'text-at-error'}`}>
+            {formatPct(row.total_return)}
+          </div>
+        </div>
+        <div className="bg-white border border-at-border rounded-xl p-3">
+          <div className="text-xs text-at-text-secondary">Sharpe</div>
+          <div className="text-xl font-bold text-at-text">{(row.sharpe_ratio ?? 0).toFixed(2)}</div>
+        </div>
+        <div className="bg-white border border-at-border rounded-xl p-3">
+          <div className="text-xs text-at-text-secondary">최대 손실</div>
+          <div className="text-xl font-bold text-at-error">{formatPct(row.max_drawdown)}</div>
+        </div>
+        <div className="bg-white border border-at-border rounded-xl p-3">
+          <div className="text-xs text-at-text-secondary">{isRLPortfolio ? 'Rebalance' : '거래 수'}</div>
+          <div className="text-xl font-bold text-at-text">{row.total_trades ?? 0}</div>
+        </div>
+      </div>
+
+      {!isRLPortfolio && previewTrades.length > 0 && (
+        <div className="bg-white border border-at-border rounded-xl p-3">
+          <div className="text-xs font-medium text-at-text-secondary mb-2">최근 거래 ({previewTrades.length} / {trades.length})</div>
+          <div className="overflow-x-auto">
+            <table className="min-w-[480px] w-full text-xs">
+              <thead className="text-at-text-weak">
+                <tr>
+                  <th className="text-left px-2 py-1">진입</th>
+                  <th className="text-left px-2 py-1">청산</th>
+                  <th className="text-right px-2 py-1">수익률</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-at-border">
+                {previewTrades.map((t, i) => {
+                  const entry = (t.entryDate ?? t.entry_date ?? '') as string
+                  const exit = (t.exitDate ?? t.exit_date ?? '') as string
+                  const pnl = (t.returnPct ?? t.return_pct ?? null) as number | null
+                  return (
+                    <tr key={i}>
+                      <td className="px-2 py-1 font-mono">{entry || '-'}</td>
+                      <td className="px-2 py-1 font-mono">{exit || '-'}</td>
+                      <td className={`px-2 py-1 text-right ${pnl == null ? '' : pnl >= 0 ? 'text-at-success' : 'text-at-error'}`}>
+                        {pnl == null ? '-' : formatPct(pnl / 100)}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {isRLPortfolio && (
+        <div className="bg-at-surface-alt border border-at-border rounded-xl p-3 text-xs text-at-text-secondary">
+          이 백테스트는 RL portfolio (다종목 동시 결정) 결과로 개별 trade 대신 매월 rebalance 단위로 계산되었습니다.
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add dental-clinic-manager/src/components/Investment/CompareHistory/HistoryRowDetail.tsx
+git commit -m "feat(compare-history): HistoryRowDetail (sparkline + metrics + trades)"
+```
+
+---
+
+## Task 8: HistoryCompareView (다중 선택 비교)
+
+**Files:**
+- Create: `dental-clinic-manager/src/components/Investment/CompareHistory/HistoryCompareView.tsx`
+
+- [ ] **Step 1: 작성**
+
+```tsx
+'use client'
+
+import { useMemo } from 'react'
+import { X } from 'lucide-react'
+import type { BacktestRunRow } from './HistoryTab'
+
+interface StrategyOption {
+  id: string
+  name: string
+  strategy_type: 'rule' | 'rl_portfolio' | 'rl_single'
+}
+
+interface Props {
+  rows: BacktestRunRow[]
+  strategies: StrategyOption[]
+  onClose: () => void
+}
+
+const PALETTE = ['#1b61c9', '#c5221f', '#1b7a3d', '#c4720a', '#6b3fa0']
+
+const formatPct = (v: number | null | undefined): string => v == null ? '-' : `${(v * 100).toFixed(1)}%`
+
+function normalize(curve: Array<{ date: string; equity: number }>): Array<{ idx: number; pct: number }> {
+  if (curve.length === 0) return []
+  const base = curve[0].equity
+  return curve.map((p, i) => ({ idx: i, pct: (p.equity / base - 1) * 100 }))
+}
+
+function Overlay({ rows }: { rows: BacktestRunRow[] }) {
+  const series = useMemo(
+    () => rows.map((r, i) => ({
+      id: r.id, color: PALETTE[i % PALETTE.length],
+      points: r.equity_curve ? normalize(r.equity_curve) : [],
+    })),
+    [rows],
+  )
+  const allPoints = series.flatMap(s => s.points)
+  if (allPoints.length === 0) return <div className="text-sm text-at-text-secondary">자산곡선 데이터 없음</div>
+
+  const width = 600
+  const height = 200
+  const maxIdx = Math.max(...series.map(s => s.points.length - 1), 1)
+  const ys = allPoints.map(p => p.pct)
+  const minY = Math.min(...ys, 0)
+  const maxY = Math.max(...ys, 0)
+  const yRange = Math.max(maxY - minY, 1)
+  const yToPx = (v: number) => height - ((v - minY) / yRange) * height
+  const zeroY = yToPx(0)
+
+  return (
+    <svg width={width} height={height} className="w-full h-auto">
+      <line x1={0} y1={zeroY} x2={width} y2={zeroY} stroke="#e0e2e6" strokeDasharray="2 2" />
+      {series.map(s => {
+        if (s.points.length < 2) return null
+        const path = s.points.map((p, i) => {
+          const x = (p.idx / maxIdx) * width
+          const y = yToPx(p.pct)
+          return `${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`
+        }).join(' ')
+        return <path key={s.id} d={path} fill="none" stroke={s.color} strokeWidth={1.5} />
+      })}
+    </svg>
+  )
+}
+
+export default function HistoryCompareView({ rows, strategies, onClose }: Props) {
+  const strategyById = useMemo(() => {
+    const map = new Map<string, StrategyOption>()
+    for (const s of strategies) map.set(s.id, s)
+    return map
+  }, [strategies])
+
+  // 컬럼별 best 표시: total_return / sharpe_ratio 가장 높은 row
+  const bestReturn = useMemo(() => {
+    let best: string | null = null
+    let bestVal = -Infinity
+    for (const r of rows) {
+      const v = r.total_return ?? -Infinity
+      if (v > bestVal) { bestVal = v; best = r.id }
+    }
+    return best
+  }, [rows])
+  const bestSharpe = useMemo(() => {
+    let best: string | null = null
+    let bestVal = -Infinity
+    for (const r of rows) {
+      const v = r.sharpe_ratio ?? -Infinity
+      if (v > bestVal) { bestVal = v; best = r.id }
+    }
+    return best
+  }, [rows])
+
+  return (
+    <div className="bg-white border border-at-border rounded-xl p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-base font-semibold text-at-text">선택 {rows.length}개 비교</h3>
+        <button
+          onClick={onClose}
+          aria-label="비교 닫기"
+          title="닫기"
+          className="p-1.5 rounded-xl hover:bg-at-surface-alt text-at-text-secondary"
+        >
+          <X className="w-4 h-4" aria-hidden="true" />
+        </button>
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border border-at-border">
+        <table className="min-w-[640px] w-full text-sm">
+          <thead className="bg-at-surface-alt">
+            <tr>
+              {['전략', '종목', '기간', '수익률', 'Sharpe', '최대 손실', '거래/Reb'].map((h) => (
+                <th key={h} className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-at-border">
+            {rows.map((r) => {
+              const strat = r.strategy_id ? strategyById.get(r.strategy_id) : null
+              return (
+                <tr key={r.id} className="hover:bg-at-surface-alt">
+                  <td className="px-3 py-2">{strat?.name ?? '-'}</td>
+                  <td className="px-3 py-2 font-mono text-xs">{r.ticker === 'PORTFOLIO' ? 'Portfolio' : r.ticker}</td>
+                  <td className="px-3 py-2 text-xs text-at-text-secondary">{r.start_date} ~ {r.end_date}</td>
+                  <td className={`px-3 py-2 font-medium ${(r.total_return ?? 0) >= 0 ? 'text-at-success' : 'text-at-error'}`}>
+                    {formatPct(r.total_return)} {bestReturn === r.id && <span aria-label="최고">★</span>}
+                  </td>
+                  <td className="px-3 py-2">
+                    {(r.sharpe_ratio ?? 0).toFixed(2)} {bestSharpe === r.id && <span aria-label="최고">★</span>}
+                  </td>
+                  <td className="px-3 py-2 text-at-error">{formatPct(r.max_drawdown)}</td>
+                  <td className="px-3 py-2 text-at-text-secondary">{r.total_trades ?? 0}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+        <div className="px-3 py-2 text-xs text-at-text-weak bg-at-surface-alt">★ = 컬럼별 최고</div>
+      </div>
+
+      <div className="bg-at-surface-alt border border-at-border rounded-xl p-3">
+        <div className="text-xs font-medium text-at-text-secondary mb-2">자산곡선 비교 (시작 = 0%)</div>
+        <Overlay rows={rows} />
+        <div className="mt-2 flex flex-wrap gap-3 text-xs">
+          {rows.map((r, i) => {
+            const strat = r.strategy_id ? strategyById.get(r.strategy_id) : null
+            return (
+              <span key={r.id} className="inline-flex items-center gap-1">
+                <span style={{ background: PALETTE[i % PALETTE.length] }} className="w-2 h-2 rounded-full" aria-hidden="true" />
+                <span>{strat?.name ?? '-'} ({r.ticker})</span>
+              </span>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+```bash
+cd dental-clinic-manager && npx tsc --noEmit 2>&1 | grep -iE "CompareHistory|CompareContent" | head
+```
+
+Expected: 에러 없음.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add dental-clinic-manager/src/components/Investment/CompareHistory/HistoryCompareView.tsx
+git commit -m "feat(compare-history): HistoryCompareView (matrix + equity overlay)"
+```
+
+---
+
+## Task 9: smoke 테스트 (선택)
+
+**Files:**
+- Create: `dental-clinic-manager/__tests__/components/Investment/CompareHistory/HistoryTable.smoke.test.tsx`
+
+- [ ] **Step 1: vitest + jsdom 설정 확인**
+
+```bash
+grep -E '"jsdom"|"@testing-library/react"' dental-clinic-manager/package.json
+```
+
+설치 안 되어 있으면 다음을 추가하고 `npm install`:
+
+```json
+"@testing-library/react": "^16.0.0",
+"@testing-library/jest-dom": "^6.4.0",
+"jsdom": "^25.0.0"
+```
+
+`vitest.config.ts`의 environment를 'node'에서 'jsdom'으로 바꾸지 않고, smoke 테스트 파일에 `// @vitest-environment jsdom` pragma 사용.
+
+- [ ] **Step 2: smoke test**
+
+```typescript
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import HistoryTable from '@/components/Investment/CompareHistory/HistoryTable'
+import type { BacktestRunRow } from '@/components/Investment/CompareHistory/HistoryTab'
+
+const sampleRow = (id: string, ret: number): BacktestRunRow => ({
+  id, strategy_id: 's1', ticker: 'AAPL', market: 'US',
+  start_date: '2025-01-01', end_date: '2026-04-29', initial_capital: 1e7,
+  status: 'completed',
+  total_return: ret, sharpe_ratio: 1.2, max_drawdown: -0.1, total_trades: 5, win_rate: 0.6,
+  equity_curve: [{ date: '2025-01-01', equity: 1e7 }, { date: '2026-04-29', equity: 1.18e7 }],
+  trades: [], full_metrics: null, executed_at: '2026-04-29T00:00:00Z',
+})
+
+describe('HistoryTable smoke', () => {
+  it('renders rows + clicking expand toggle shows detail', () => {
+    const rows = [sampleRow('a', 0.18), sampleRow('b', -0.05)]
+    const sels = new Set<string>()
+    render(<HistoryTable rows={rows} strategies={[{ id: 's1', name: 'RSI', strategy_type: 'rule' }]} selectedIds={sels} onToggleSelected={() => {}} />)
+    expect(screen.getByText('+18.0%')).toBeTruthy()
+    const expandBtns = screen.getAllByLabelText('펼치기')
+    fireEvent.click(expandBtns[0])
+    expect(screen.queryByLabelText('접기')).not.toBeNull()
+  })
+
+  it('shows checkbox and respects selectedIds', () => {
+    const rows = [sampleRow('a', 0.1)]
+    const sels = new Set(['a'])
+    render(<HistoryTable rows={rows} strategies={[]} selectedIds={sels} onToggleSelected={() => {}} />)
+    const cb = screen.getByLabelText('a 선택') as HTMLInputElement
+    expect(cb.checked).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 3: 실행**
+
+```bash
+cd dental-clinic-manager && npm run test:unit -- HistoryTable
+```
+
+Expected: 2 PASS.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add dental-clinic-manager/__tests__/components/Investment/CompareHistory/HistoryTable.smoke.test.tsx dental-clinic-manager/package.json dental-clinic-manager/package-lock.json
+git commit -m "test(compare-history): HistoryTable smoke (sort/expand/select)"
+```
+
+(Step 1에서 jsdom/RTL 미설치 시: 본 task를 OUT으로 처리하고 사용자 수동 검증으로 대체. 그 경우 commit 메시지 없이 task 종료.)
+
+---
+
+## Task 10: 빌드 + Next.js dev 수동 검증 + 최종 push
+
+**Files:**
+- 변경 없음
+
+- [ ] **Step 1: TypeScript 전수 체크 — 우리 코드만 grep**
+
+```bash
+cd dental-clinic-manager && npx tsc --noEmit 2>&1 | grep -iE "CompareHistory|backtest/route|CompareContent" | head
+```
+
+Expected: 출력 없음 (RL trading PR 이전에 존재하던 unrelated TS errors는 무시).
+
+- [ ] **Step 2: 단위 테스트 전체 실행**
+
+```bash
+cd dental-clinic-manager && npm run test:unit
+```
+
+Expected: API 5건 + smoke 2건 = 7 PASS.
+
+- [ ] **Step 3: 수동 dev 검증**
+
+```bash
+cd dental-clinic-manager && npm run dev
+```
+
+브라우저에서 `http://localhost:3000/investment/compare`:
+- [새로 비교] 탭 → 기존 UI 정상
+- [히스토리] 탭 → 표 렌더, 필터 동작
+- 행 클릭 → 펼침 (sparkline + 메트릭)
+- 체크박스 2개 선택 → 하단 "선택 2개 비교" 버튼 → 클릭 시 matrix + overlay
+- 콘솔 에러 0건
+
+- [ ] **Step 4: 최종 push**
+
+```bash
+cd /Users/hhs/Project/dental-clinic-manager
+git push origin develop
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 탭 분리 → Task 3
+- HistoryTab 컨테이너 → Task 4
+- HistoryFilters (전략/종목/기간) → Task 5
+- HistoryTable (정렬/체크박스/펼침) → Task 6
+- HistoryRowDetail (sparkline/trades/메트릭) → Task 7
+- HistoryCompareView (matrix + overlay) → Task 8
+- API GET 확장 → Task 1+2
+- 빈 상태 → Task 4 (HistoryTab)
+- 권한 (RLS + user_id) → Task 2 (eq('user_id', userId))
+- RL portfolio ticker='PORTFOLIO' 라벨 → Task 6 (HistoryTable), Task 7 (HistoryRowDetail), Task 8 (HistoryCompareView)
+- limit cap (200) → Task 2
+
+**Placeholder scan:** TBD/TODO 없음. 단 Task 9는 환경 의존 (jsdom 설치 여부)이라 명시적 skip path 포함됨.
+
+**Type consistency:**
+- `BacktestRunRow` 인터페이스는 Task 4에서 정의 후 6/7/8에서 import — 일관
+- `HistoryFilterState` 는 Task 5에서 export, Task 4에서 import
+- `StrategyOption` 은 Task 4/5/6/8에서 같은 shape 사용 (id/name/strategy_type)

--- a/dental-clinic-manager/docs/superpowers/specs/2026-04-30-backtest-history-design.md
+++ b/dental-clinic-manager/docs/superpowers/specs/2026-04-30-backtest-history-design.md
@@ -1,0 +1,240 @@
+# 백테스트 히스토리 조회 — 비교 페이지 통합
+
+작성일: 2026-04-30
+영향 페이지: `/investment/compare`
+
+---
+
+## 1. Context
+
+`backtest_runs` 테이블에 100건 이상의 완료된 백테스트 결과가 누적되어 있으나, UI에서 조회할 진입점이 없다. 사용자는 동일한 전략·종목 조합을 매번 다시 실행해야 하고, 과거 결과를 비교하지 못한다.
+
+비교 페이지(`/investment/compare`)는 이미 다전략 백테스트 비교에 특화된 인터페이스를 갖추고 있어, 히스토리 조회를 같은 페이지의 **두 번째 탭**으로 통합하는 것이 자연스럽다.
+
+---
+
+## 2. 사용자 흐름
+
+```
+1. /investment/compare 진입 → 기본 [새로 비교] 탭 (기존 UI 유지)
+2. [히스토리] 탭 클릭 → 최근 30일 completed 백테스트 표 (최신순)
+3. 필터 조작 (전략 select / 종목 검색 / 기간 preset) → 표 갱신
+4. 행 클릭 → 행 아래로 펼침 (equity sparkline + trades + 메트릭)
+5. 체크박스 N개 선택 → 하단 sticky bar에 "선택 N개 비교" 활성
+6. 비교 클릭 → 같은 탭 하단에 matrix view 렌더 (행=백테스트 row, 열=메트릭/sparkline)
+```
+
+---
+
+## 3. 컴포넌트 구조
+
+```
+src/components/Investment/CompareContent.tsx (수정)
+└ <Tabs value={tab} onChange={setTab}>
+   ├ Tab "새로 비교" → 기존 LiveCompareSection (현재 UI 그대로)
+   └ Tab "히스토리"  → <HistoryTab />
+
+src/components/Investment/CompareHistory/ (신규 디렉터리)
+├ HistoryTab.tsx           # 메인 컨테이너 (filters + table + compare view)
+├ HistoryFilters.tsx       # 전략 select + ticker 검색 + period preset
+├ HistoryTable.tsx         # 체크박스 + 정렬 가능 컬럼 + 펼침 토글
+├ HistoryRowDetail.tsx     # 인라인 펼침 (sparkline + trades 미리보기 + 메트릭)
+└ HistoryCompareView.tsx   # 다중 선택 시 matrix-style 비교
+```
+
+**디자인 원칙:**
+- 기존 `CompareContent.tsx`(1698줄)는 가능한 건드리지 않고, 상단 탭 wrapper만 추가
+- 신규 코드는 `CompareHistory/` 하위에 격리
+
+---
+
+## 4. API
+
+### 기존 GET 확장
+
+[`src/app/api/investment/backtest/route.ts`](src/app/api/investment/backtest/route.ts)의 GET 핸들러에 필터 파라미터 추가:
+
+| 파라미터 | 동작 |
+|---|---|
+| `?id=<uuid>` | 단일 결과 (기존) |
+| `?strategyId=<uuid>` | 특정 전략 결과 (기존, limit 20) |
+| `?ids=<uuid>,<uuid>,...` | 다중 ID — 비교 view 로드 (신규) |
+| `?strategy_id=<uuid>&ticker=<str>&since=<ISO date>&until=<ISO date>&limit=50` | 필터 조합 (신규) |
+
+**응답 형식:** 기존 row 형식 그대로 (변경 없음). `data` 배열.
+
+**권한:** 모든 path는 `requireAuth()` 통과 후 `user_id=auth.uid` 필터.
+
+### 페이지네이션
+초기 limit 기본 50, 사용자가 "더 보기" 클릭 시 cursor (executed_at 기준 keyset). Phase 1은 단순 limit만, cursor는 Phase 2.
+
+---
+
+## 5. UI 상세
+
+### 5.1 필터 (`HistoryFilters.tsx`)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ [전략: 전체 ▼]  [종목 검색: AAPL]  [기간: 최근 30일 ▼]    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- 전략 select: `'전체'` + 사용자의 `investment_strategies` 리스트 (RL 포함, 모든 strategy_type)
+- 종목 검색: free-text input (debounce 300ms). 단일 ticker 또는 빈값(전체).
+- 기간 preset: `최근 7일 / 최근 30일 / 최근 90일 / 전체` — 첫 진입 시 `최근 30일`
+
+### 5.2 표 (`HistoryTable.tsx`)
+
+```
+┌───┬──────┬─────────────────────┬───────┬────────┬───────┬─────┐
+│ ☐ │ 날짜 │ 전략                  │ 종목  │ 수익률 │Sharpe │  ▼ │
+├───┼──────┼─────────────────────┼───────┼────────┼───────┼─────┤
+│ ☑ │04.29 │ FinRL Dow30 Quick   │ AAPL  │+18.5%  │ 1.42  │ ▼  │
+│   │ ┌─────────────────────────────────────────────┐         │
+│   │ │ [equity sparkline 30일치]                  │         │
+│   │ │ Trades: 12건 (W7/L5)  MDD: -8.7%          │         │
+│   │ │ 기간: 2025-10-29 ~ 2026-04-29              │         │
+│   │ └─────────────────────────────────────────────┘         │
+│ ☐ │04.28 │ RSI 과매도 반등         │272210 │+71.9%  │ 0.85  │ ▶  │
+│ ☐ │04.28 │ 골든크로스             │272210 │+90.9%  │ 0.92  │ ▶  │
+└───┴──────┴─────────────────────┴───────┴────────┴───────┴─────┘
+```
+
+**컬럼:**
+- 체크박스 (다중 선택)
+- 날짜 (executed_at 기준, "MM.DD")
+- 전략 (이름 + 작은 strategy_type 배지: rule / RL portfolio)
+- 종목 (`PORTFOLIO`이면 "Dow30 portfolio" 같은 라벨)
+- 수익률 (총 수익률, 색상: 양수 success / 음수 error)
+- Sharpe
+- 펼침 토글 (▶ / ▼)
+
+**정렬:** 날짜(기본 내림차순), 수익률, Sharpe 컬럼 헤더 클릭
+
+**빈 상태:** 아이콘 + "최근 30일 내 백테스트가 없습니다. [새로 비교] 탭에서 첫 백테스트를 실행해보세요."
+
+### 5.3 인라인 펼침 (`HistoryRowDetail.tsx`)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ [equity sparkline (30일 sample)]                        │
+│                                                          │
+│ ┌────────────┬──────────────┬──────────────┐            │
+│ │ Total: +18.5% │ Sharpe: 1.42 │ MDD: -8.7%  │            │
+│ └────────────┴──────────────┴──────────────┘            │
+│                                                          │
+│ Trades (최근 5건)                                        │
+│ ─────────────────────────────────────                   │
+│ 04.05 매수 100주 @ $182.30                              │
+│ 04.12 매도 100주 @ $189.45  (+3.9%)                     │
+│ ...                                                      │
+│                                                          │
+│ 기간: 2025-10-29 ~ 2026-04-29                           │
+└─────────────────────────────────────────────────────────┘
+```
+
+- equity_curve sampling (max 60 point)
+- trades 테이블 (최대 5건, "전체 N건 보기" 링크는 Phase 2)
+- RL portfolio (ticker='PORTFOLIO')은 trades 비어 있음 → "월별 rebalance N회" 표시
+
+### 5.4 다중 선택 비교 (`HistoryCompareView.tsx`)
+
+```
+┌──────────────────────────────────────────────────┐
+│ 선택 3개 비교                              [닫기] │
+├──────────────────────────────────────────────────┤
+│ ┌──────────────────┬───────────┬──────────┐     │
+│ │ 전략              │ 수익률    │ Sharpe   │     │
+│ ├──────────────────┼───────────┼──────────┤     │
+│ │ FinRL Dow30      │ +18.5% ★ │ 1.42 ★  │     │
+│ │ RSI 과매도        │ +71.9%   │ 0.85    │     │
+│ │ 골든크로스         │ +90.9% ★ │ 0.92    │     │
+│ └──────────────────┴───────────┴──────────┘     │
+│ ★ = 컬럼별 최고                                   │
+│                                                  │
+│ Equity 곡선 (정규화 0=백테스트 시작)              │
+│ [3개 라인 overlay 차트]                          │
+└──────────────────────────────────────────────────┘
+```
+
+- matrix table: 행=선택 백테스트, 열=핵심 메트릭 4~5개
+- equity overlay 차트 (각 백테스트의 equity_curve를 t=0에서 100으로 정규화 후 overlay)
+- 선택을 추가/제거하면 즉시 반영
+
+---
+
+## 6. 권한 / RLS
+
+- `backtest_runs` 테이블 RLS는 `user_id = auth.uid()` 기준 (기존)
+- API GET 핸들러에서도 명시적 user_id 필터 (이중 안전)
+- 다른 사용자의 백테스트는 절대 노출되지 않음
+
+---
+
+## 7. 테스트
+
+### 7.1 API
+- `?strategy_id=X` 만 → 해당 전략 결과
+- `?ticker=AAPL&since=2026-04-01` 조합
+- 다른 user_id 결과 누설 X
+- limit 초과 시 50개로 cap
+
+### 7.2 컴포넌트 (smoke)
+- 빈 결과 → 빈 상태 렌더
+- N건 결과 → 테이블 렌더, 정렬 동작
+- 행 펼침/접힘 토글
+- 다중선택 → "선택 N개 비교" 버튼 활성/비활성
+- 비교 view에서 사용자가 선택 해제 → 즉시 갱신
+
+### 7.3 E2E (수동)
+- 사용자 로그인 → 비교 페이지 → 히스토리 탭 → 필터 → 행 펼침 → 다중 선택 → 비교 view 표시 → 닫기
+
+---
+
+## 8. Phase 1 범위
+
+### IN
+- 비교 페이지 상단 [새로 비교 / 히스토리] 2-탭
+- HistoryFilters (전략 select + ticker 검색 + 기간 preset)
+- HistoryTable (정렬, 체크박스, 펼침)
+- HistoryRowDetail (sparkline + trades 미리보기 + 메트릭)
+- HistoryCompareView (다중 선택 matrix + equity overlay)
+- API GET 확장 (`?strategy_id`, `?ticker`, `?since`, `?until`, `?limit`)
+
+### OUT (Phase 2)
+- 백테스트 row 삭제 / 재실행
+- CSV / PDF export
+- 다중선택 결과를 새 비교 실행으로 보내기
+- cursor 페이지네이션
+- 실시간 (실행 중 백테스트 polling)
+- failed 백테스트 표시 토글
+
+---
+
+## 9. 핵심 파일
+
+**수정:**
+- [src/app/api/investment/backtest/route.ts](src/app/api/investment/backtest/route.ts) — GET 필터 파라미터 추가
+- [src/components/Investment/CompareContent.tsx](src/components/Investment/CompareContent.tsx) — 상단 탭 wrapper
+
+**신규:**
+- `src/components/Investment/CompareHistory/HistoryTab.tsx`
+- `src/components/Investment/CompareHistory/HistoryFilters.tsx`
+- `src/components/Investment/CompareHistory/HistoryTable.tsx`
+- `src/components/Investment/CompareHistory/HistoryRowDetail.tsx`
+- `src/components/Investment/CompareHistory/HistoryCompareView.tsx`
+
+---
+
+## 10. 검증 (구현 후 확인 방법)
+
+1. `/investment/compare` 접속 → 두 탭 표시
+2. [히스토리] 탭 클릭 → 최근 30일 결과 표시 (현재 DB 기준 100건 중 최근 N건)
+3. 전략 select에서 "FinRL Dow30 Quick" 선택 → 해당 전략 결과만 (현재 4건)
+4. 종목 검색 "AAPL" → ticker='AAPL' 결과만
+5. 기간 "최근 7일" → 7일 이내 executed_at만
+6. 행 클릭 → 펼침 (equity sparkline + trades + 메트릭)
+7. 체크박스 2~3개 선택 → 하단 "선택 N개 비교" 버튼 활성
+8. 비교 클릭 → matrix table + equity overlay 차트
+9. 다른 user 계정으로 로그인 시 자기 결과만 보이는지 (RLS 검증)

--- a/dental-clinic-manager/package-lock.json
+++ b/dental-clinic-manager/package-lock.json
@@ -94,7 +94,8 @@
         "eslint-config-next": "15.5.7",
         "supabase": "^2.92.1",
         "tailwindcss": "^4",
-        "typescript": "5.9.3"
+        "typescript": "5.9.3",
+        "vitest": "^2.1.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -263,6 +264,397 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2991,6 +3383,356 @@
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -4833,6 +5575,119 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -5104,6 +5959,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -5263,6 +6128,16 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -5385,6 +6260,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5400,6 +6292,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cheerio": {
@@ -5861,6 +6763,16 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -6216,6 +7128,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -6291,6 +7210,45 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -6722,6 +7680,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6737,6 +7705,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -7035,6 +8013,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -8600,6 +9593,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -9282,6 +10282,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/pdfjs-dist": {
@@ -10266,6 +11283,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rope-sequence": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
@@ -10597,6 +11659,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -10655,6 +11724,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -10664,6 +11740,13 @@
       "engines": {
         "node": ">=0.1.14"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -11140,6 +12223,20 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -11187,6 +12284,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -11636,6 +12763,155 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -11797,6 +13073,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wmf": {

--- a/dental-clinic-manager/package.json
+++ b/dental-clinic-manager/package.json
@@ -8,7 +8,9 @@
     "build": "NODE_OPTIONS='--max-old-space-size=4096' next build",
     "start": "next start",
     "lint": "eslint",
-    "check:menu": "node scripts/validate-menu-routes.mjs"
+    "check:menu": "node scripts/validate-menu-routes.mjs",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.79.0",
@@ -89,6 +91,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "vitest": "^2.1.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/dental-clinic-manager/src/app/api/investment/backtest/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/backtest/route.ts
@@ -278,40 +278,69 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url)
   const id = searchParams.get('id')
-  const strategyId = searchParams.get('strategyId')
+  const strategyId = searchParams.get('strategyId') ?? searchParams.get('strategy_id')
+  const ticker = searchParams.get('ticker')?.trim() || null
+  const since = searchParams.get('since')
+  const until = searchParams.get('until')
+  const idsCsv = searchParams.get('ids')
+  const limitRaw = searchParams.get('limit')
 
+  // 1) 단일 결과 — 기존 호환
   if (id) {
-    // 단일 결과 조회
     const { data, error } = await supabase
       .from('backtest_runs')
       .select('*')
       .eq('id', id)
       .eq('user_id', userId)
       .single()
-
     if (error || !data) {
       return NextResponse.json({ error: '결과를 찾을 수 없습니다' }, { status: 404 })
     }
-
     return NextResponse.json({ data })
   }
 
-  if (strategyId) {
-    // 전략별 결과 목록
+  // 2) 다중 IDs (비교 view 로드용)
+  if (idsCsv) {
+    const ids = idsCsv.split(',').map(s => s.trim()).filter(Boolean)
+    if (ids.length > 50) {
+      return NextResponse.json({ error: 'ids는 최대 50개까지 가능합니다' }, { status: 400 })
+    }
     const { data, error } = await supabase
       .from('backtest_runs')
       .select('*')
-      .eq('strategy_id', strategyId)
       .eq('user_id', userId)
-      .order('executed_at', { ascending: false })
-      .limit(20)
-
+      .in('id', ids)
     if (error) {
       return NextResponse.json({ error: '조회 실패' }, { status: 500 })
     }
-
-    return NextResponse.json({ data })
+    return NextResponse.json({ data: data ?? [] })
   }
 
-  return NextResponse.json({ error: 'id 또는 strategyId 파라미터가 필요합니다' }, { status: 400 })
+  // 3) 필터 + 최신순 (히스토리 탭)
+  let query = supabase
+    .from('backtest_runs')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('status', 'completed')
+
+  if (strategyId) {
+    query = query.eq('strategy_id', strategyId)
+  }
+  if (ticker) {
+    query = query.eq('ticker', ticker.toUpperCase())
+  }
+  if (since) {
+    query = query.gte('executed_at', since)
+  }
+  if (until) {
+    query = query.lte('executed_at', until)
+  }
+  const limit = Math.min(Number(limitRaw) || 50, 200)
+  query = query.order('executed_at', { ascending: false }).limit(limit)
+
+  const { data, error } = await query
+  if (error) {
+    return NextResponse.json({ error: '조회 실패' }, { status: 500 })
+  }
+  return NextResponse.json({ data: data ?? [] })
 }

--- a/dental-clinic-manager/src/components/Investment/CompareContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/CompareContent.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useState, useEffect, useCallback, useMemo, Fragment } from 'react'
+import HistoryTab from './CompareHistory/HistoryTab'
 import { GitCompare, Play, Loader2, AlertCircle, Trophy, X, CheckCircle2, Sparkles, User, ChevronDown, ChevronRight, Info, Wand2, TrendingUp, ArrowDown, ArrowUp, ArrowUpDown, LayoutGrid, List as ListIcon } from 'lucide-react'
 import TickerSearch from '@/components/Investment/TickerSearch'
 import { PRESET_STRATEGIES } from '@/components/Investment/StrategyBuilder/presets'
@@ -124,7 +125,7 @@ interface SelectedTicker {
 
 type ViewMode = 'matrix' | 'list'
 
-export default function CompareContent() {
+function LiveCompareSection() {
   const [strategies, setStrategies] = useState<InvestmentStrategy[]>([])
   const [loadingStrategies, setLoadingStrategies] = useState(true)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
@@ -1695,4 +1696,37 @@ function emptyMetrics(): BacktestMetrics {
     winRate: 0, totalTrades: 0, profitFactor: 0,
     avgWin: 0, avgLoss: 0, maxConsecutiveWins: 0, maxConsecutiveLosses: 0, avgHoldingDays: 0,
   }
+}
+
+type CompareTab = 'live' | 'history'
+
+export default function CompareContent() {
+  const [tab, setTab] = useState<CompareTab>('live')
+
+  return (
+    <div className="bg-white min-h-screen">
+      <div className="sticky top-14 z-10 bg-white border-b border-at-border px-4 sm:px-6 pt-4 pb-3 -mx-4 sm:-mx-6 flex gap-2">
+        <button
+          onClick={() => setTab('live')}
+          className={`py-2 px-4 inline-flex items-center rounded-xl font-medium text-sm transition-colors ${
+            tab === 'live' ? 'bg-at-accent-light text-at-accent' : 'text-at-text-weak hover:text-at-text-secondary hover:bg-at-surface-alt'
+          }`}
+        >
+          새로 비교
+        </button>
+        <button
+          onClick={() => setTab('history')}
+          className={`py-2 px-4 inline-flex items-center rounded-xl font-medium text-sm transition-colors ${
+            tab === 'history' ? 'bg-at-accent-light text-at-accent' : 'text-at-text-weak hover:text-at-text-secondary hover:bg-at-surface-alt'
+          }`}
+        >
+          히스토리
+        </button>
+      </div>
+
+      <div className="pt-4">
+        {tab === 'live' ? <LiveCompareSection /> : <HistoryTab />}
+      </div>
+    </div>
+  )
 }

--- a/dental-clinic-manager/src/components/Investment/CompareHistory/HistoryCompareView.tsx
+++ b/dental-clinic-manager/src/components/Investment/CompareHistory/HistoryCompareView.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useMemo } from 'react'
+import { X } from 'lucide-react'
+import type { BacktestRunRow } from './HistoryTab'
+
+interface StrategyOption {
+  id: string
+  name: string
+  strategy_type: 'rule' | 'rl_portfolio' | 'rl_single'
+}
+
+interface Props {
+  rows: BacktestRunRow[]
+  strategies: StrategyOption[]
+  onClose: () => void
+}
+
+const PALETTE = ['#1b61c9', '#c5221f', '#1b7a3d', '#c4720a', '#6b3fa0']
+
+const formatPct = (v: number | null | undefined): string => v == null ? '-' : `${(v * 100).toFixed(1)}%`
+
+function normalize(curve: Array<{ date: string; equity: number }>): Array<{ idx: number; pct: number }> {
+  if (curve.length === 0) return []
+  const base = curve[0].equity
+  return curve.map((p, i) => ({ idx: i, pct: (p.equity / base - 1) * 100 }))
+}
+
+function Overlay({ rows }: { rows: BacktestRunRow[] }) {
+  const series = useMemo(
+    () => rows.map((r, i) => ({
+      id: r.id, color: PALETTE[i % PALETTE.length],
+      points: r.equity_curve ? normalize(r.equity_curve) : [],
+    })),
+    [rows],
+  )
+  const allPoints = series.flatMap(s => s.points)
+  if (allPoints.length === 0) return <div className="text-sm text-at-text-secondary">자산곡선 데이터 없음</div>
+
+  const width = 600
+  const height = 200
+  const maxIdx = Math.max(...series.map(s => s.points.length - 1), 1)
+  const ys = allPoints.map(p => p.pct)
+  const minY = Math.min(...ys, 0)
+  const maxY = Math.max(...ys, 0)
+  const yRange = Math.max(maxY - minY, 1)
+  const yToPx = (v: number) => height - ((v - minY) / yRange) * height
+  const zeroY = yToPx(0)
+
+  return (
+    <svg width={width} height={height} className="w-full h-auto">
+      <line x1={0} y1={zeroY} x2={width} y2={zeroY} stroke="#e0e2e6" strokeDasharray="2 2" />
+      {series.map(s => {
+        if (s.points.length < 2) return null
+        const path = s.points.map((p, i) => {
+          const x = (p.idx / maxIdx) * width
+          const y = yToPx(p.pct)
+          return `${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`
+        }).join(' ')
+        return <path key={s.id} d={path} fill="none" stroke={s.color} strokeWidth={1.5} />
+      })}
+    </svg>
+  )
+}
+
+export default function HistoryCompareView({ rows, strategies, onClose }: Props) {
+  const strategyById = useMemo(() => {
+    const map = new Map<string, StrategyOption>()
+    for (const s of strategies) map.set(s.id, s)
+    return map
+  }, [strategies])
+
+  // 컬럼별 best 표시: total_return / sharpe_ratio 가장 높은 row
+  const bestReturn = useMemo(() => {
+    let best: string | null = null
+    let bestVal = -Infinity
+    for (const r of rows) {
+      const v = r.total_return ?? -Infinity
+      if (v > bestVal) { bestVal = v; best = r.id }
+    }
+    return best
+  }, [rows])
+  const bestSharpe = useMemo(() => {
+    let best: string | null = null
+    let bestVal = -Infinity
+    for (const r of rows) {
+      const v = r.sharpe_ratio ?? -Infinity
+      if (v > bestVal) { bestVal = v; best = r.id }
+    }
+    return best
+  }, [rows])
+
+  return (
+    <div className="bg-white border border-at-border rounded-xl p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-base font-semibold text-at-text">선택 {rows.length}개 비교</h3>
+        <button
+          onClick={onClose}
+          aria-label="비교 닫기"
+          title="닫기"
+          className="p-1.5 rounded-xl hover:bg-at-surface-alt text-at-text-secondary"
+        >
+          <X className="w-4 h-4" aria-hidden="true" />
+        </button>
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border border-at-border">
+        <table className="min-w-[640px] w-full text-sm">
+          <thead className="bg-at-surface-alt">
+            <tr>
+              {['전략', '종목', '기간', '수익률', 'Sharpe', '최대 손실', '거래/Reb'].map((h) => (
+                <th key={h} className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-at-border">
+            {rows.map((r) => {
+              const strat = r.strategy_id ? strategyById.get(r.strategy_id) : null
+              return (
+                <tr key={r.id} className="hover:bg-at-surface-alt">
+                  <td className="px-3 py-2">{strat?.name ?? '-'}</td>
+                  <td className="px-3 py-2 font-mono text-xs">{r.ticker === 'PORTFOLIO' ? 'Portfolio' : r.ticker}</td>
+                  <td className="px-3 py-2 text-xs text-at-text-secondary">{r.start_date} ~ {r.end_date}</td>
+                  <td className={`px-3 py-2 font-medium ${(r.total_return ?? 0) >= 0 ? 'text-at-success' : 'text-at-error'}`}>
+                    {formatPct(r.total_return)} {bestReturn === r.id && <span aria-label="최고">★</span>}
+                  </td>
+                  <td className="px-3 py-2">
+                    {(r.sharpe_ratio ?? 0).toFixed(2)} {bestSharpe === r.id && <span aria-label="최고">★</span>}
+                  </td>
+                  <td className="px-3 py-2 text-at-error">{formatPct(r.max_drawdown)}</td>
+                  <td className="px-3 py-2 text-at-text-secondary">{r.total_trades ?? 0}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+        <div className="px-3 py-2 text-xs text-at-text-weak bg-at-surface-alt">★ = 컬럼별 최고</div>
+      </div>
+
+      <div className="bg-at-surface-alt border border-at-border rounded-xl p-3">
+        <div className="text-xs font-medium text-at-text-secondary mb-2">자산곡선 비교 (시작 = 0%)</div>
+        <Overlay rows={rows} />
+        <div className="mt-2 flex flex-wrap gap-3 text-xs">
+          {rows.map((r, i) => {
+            const strat = r.strategy_id ? strategyById.get(r.strategy_id) : null
+            return (
+              <span key={r.id} className="inline-flex items-center gap-1">
+                <span style={{ background: PALETTE[i % PALETTE.length] }} className="w-2 h-2 rounded-full" aria-hidden="true" />
+                <span>{strat?.name ?? '-'} ({r.ticker})</span>
+              </span>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/CompareHistory/HistoryFilters.tsx
+++ b/dental-clinic-manager/src/components/Investment/CompareHistory/HistoryFilters.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { Search } from 'lucide-react'
+
+export type PeriodPreset = '7d' | '30d' | '90d' | 'all'
+
+export interface HistoryFilterState {
+  strategyId: string  // '' = 전체
+  ticker: string
+  preset: PeriodPreset
+}
+
+interface StrategyOption {
+  id: string
+  name: string
+  strategy_type: 'rule' | 'rl_portfolio' | 'rl_single'
+}
+
+interface Props {
+  value: HistoryFilterState
+  onChange: (next: HistoryFilterState) => void
+  strategies: StrategyOption[]
+}
+
+const PRESET_LABELS: Record<PeriodPreset, string> = {
+  '7d': '최근 7일',
+  '30d': '최근 30일',
+  '90d': '최근 90일',
+  'all': '전체',
+}
+
+export default function HistoryFilters({ value, onChange, strategies }: Props) {
+  const set = <K extends keyof HistoryFilterState>(key: K, v: HistoryFilterState[K]) => {
+    onChange({ ...value, [key]: v })
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-3 bg-white border border-at-border rounded-xl p-3">
+      <label className="block">
+        <span className="text-xs font-medium text-at-text-secondary mb-1 inline-block">전략</span>
+        <select
+          value={value.strategyId}
+          onChange={(e) => set('strategyId', e.target.value)}
+          className="w-full px-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent text-sm"
+        >
+          <option value="">전체</option>
+          {strategies.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name} {s.strategy_type !== 'rule' ? `(${s.strategy_type === 'rl_portfolio' ? 'RL' : 'RL단일'})` : ''}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="block">
+        <span className="text-xs font-medium text-at-text-secondary mb-1 inline-block">종목</span>
+        <div className="relative">
+          <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-at-text-weak" aria-hidden="true" />
+          <input
+            type="text"
+            value={value.ticker}
+            onChange={(e) => set('ticker', e.target.value)}
+            placeholder="AAPL, 005930…"
+            className="w-full pl-9 pr-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent text-sm"
+          />
+        </div>
+      </label>
+
+      <label className="block">
+        <span className="text-xs font-medium text-at-text-secondary mb-1 inline-block">기간</span>
+        <select
+          value={value.preset}
+          onChange={(e) => set('preset', e.target.value as PeriodPreset)}
+          className="w-full px-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent text-sm"
+        >
+          {(['7d', '30d', '90d', 'all'] as PeriodPreset[]).map((p) => (
+            <option key={p} value={p}>{PRESET_LABELS[p]}</option>
+          ))}
+        </select>
+      </label>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/CompareHistory/HistoryRowDetail.tsx
+++ b/dental-clinic-manager/src/components/Investment/CompareHistory/HistoryRowDetail.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { useMemo } from 'react'
+import type { BacktestRunRow } from './HistoryTab'
+
+interface Props {
+  row: BacktestRunRow
+}
+
+const formatPct = (v: number | null | undefined): string => {
+  if (v == null) return '-'
+  return `${(v * 100).toFixed(1)}%`
+}
+
+function sampleCurve(curve: Array<{ date: string; equity: number }>, maxPoints: number): Array<{ date: string; equity: number }> {
+  if (curve.length <= maxPoints) return curve
+  const step = curve.length / maxPoints
+  const out: Array<{ date: string; equity: number }> = []
+  for (let i = 0; i < maxPoints; i++) {
+    out.push(curve[Math.floor(i * step)])
+  }
+  out[out.length - 1] = curve[curve.length - 1]
+  return out
+}
+
+function Sparkline({ points, width = 320, height = 60 }: { points: Array<{ date: string; equity: number }>; width?: number; height?: number }) {
+  if (points.length < 2) {
+    return <div className="text-xs text-at-text-weak">곡선 데이터 부족</div>
+  }
+  const min = Math.min(...points.map(p => p.equity))
+  const max = Math.max(...points.map(p => p.equity))
+  const range = Math.max(max - min, 1e-6)
+  const path = points.map((p, i) => {
+    const x = (i / (points.length - 1)) * width
+    const y = height - ((p.equity - min) / range) * height
+    return `${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`
+  }).join(' ')
+  const lastY = height - ((points[points.length - 1].equity - min) / range) * height
+  const firstY = height - ((points[0].equity - min) / range) * height
+  const isUp = points[points.length - 1].equity >= points[0].equity
+  const color = isUp ? '#1b7a3d' : '#c5221f'  // at-success / at-error 헥스 (svg는 토큰 미해석)
+  return (
+    <svg width={width} height={height} className="block">
+      <path d={path} fill="none" stroke={color} strokeWidth={1.5} />
+      <line x1={0} y1={firstY} x2={width} y2={firstY} stroke="#e0e2e6" strokeDasharray="2 2" />
+      <circle cx={width} cy={lastY} r={3} fill={color} />
+    </svg>
+  )
+}
+
+export default function HistoryRowDetail({ row }: Props) {
+  const sampled = useMemo(
+    () => row.equity_curve ? sampleCurve(row.equity_curve, 60) : [],
+    [row.equity_curve],
+  )
+  const trades = (row.trades ?? []) as Array<Record<string, unknown>>
+  const previewTrades = trades.slice(0, 5)
+  const isRLPortfolio = row.ticker === 'PORTFOLIO'
+
+  return (
+    <div className="space-y-3">
+      {sampled.length > 0 && (
+        <div className="bg-white border border-at-border rounded-xl p-3">
+          <div className="text-xs text-at-text-secondary mb-1">자산곡선 (period: {row.start_date} ~ {row.end_date})</div>
+          <Sparkline points={sampled} />
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <div className="bg-white border border-at-border rounded-xl p-3">
+          <div className="text-xs text-at-text-secondary">총 수익률</div>
+          <div className={`text-xl font-bold ${(row.total_return ?? 0) >= 0 ? 'text-at-success' : 'text-at-error'}`}>
+            {formatPct(row.total_return)}
+          </div>
+        </div>
+        <div className="bg-white border border-at-border rounded-xl p-3">
+          <div className="text-xs text-at-text-secondary">Sharpe</div>
+          <div className="text-xl font-bold text-at-text">{(row.sharpe_ratio ?? 0).toFixed(2)}</div>
+        </div>
+        <div className="bg-white border border-at-border rounded-xl p-3">
+          <div className="text-xs text-at-text-secondary">최대 손실</div>
+          <div className="text-xl font-bold text-at-error">{formatPct(row.max_drawdown)}</div>
+        </div>
+        <div className="bg-white border border-at-border rounded-xl p-3">
+          <div className="text-xs text-at-text-secondary">{isRLPortfolio ? 'Rebalance' : '거래 수'}</div>
+          <div className="text-xl font-bold text-at-text">{row.total_trades ?? 0}</div>
+        </div>
+      </div>
+
+      {!isRLPortfolio && previewTrades.length > 0 && (
+        <div className="bg-white border border-at-border rounded-xl p-3">
+          <div className="text-xs font-medium text-at-text-secondary mb-2">최근 거래 ({previewTrades.length} / {trades.length})</div>
+          <div className="overflow-x-auto">
+            <table className="min-w-[480px] w-full text-xs">
+              <thead className="text-at-text-weak">
+                <tr>
+                  <th className="text-left px-2 py-1">진입</th>
+                  <th className="text-left px-2 py-1">청산</th>
+                  <th className="text-right px-2 py-1">수익률</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-at-border">
+                {previewTrades.map((t, i) => {
+                  const entry = (t.entryDate ?? t.entry_date ?? '') as string
+                  const exit = (t.exitDate ?? t.exit_date ?? '') as string
+                  const pnl = (t.returnPct ?? t.return_pct ?? null) as number | null
+                  return (
+                    <tr key={i}>
+                      <td className="px-2 py-1 font-mono">{entry || '-'}</td>
+                      <td className="px-2 py-1 font-mono">{exit || '-'}</td>
+                      <td className={`px-2 py-1 text-right ${pnl == null ? '' : pnl >= 0 ? 'text-at-success' : 'text-at-error'}`}>
+                        {pnl == null ? '-' : formatPct(pnl / 100)}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {isRLPortfolio && (
+        <div className="bg-at-surface-alt border border-at-border rounded-xl p-3 text-xs text-at-text-secondary">
+          이 백테스트는 RL portfolio (다종목 동시 결정) 결과로 개별 trade 대신 매월 rebalance 단위로 계산되었습니다.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/CompareHistory/HistoryTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/CompareHistory/HistoryTab.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useEffect, useMemo, useState, useCallback } from 'react'
+import { History as HistoryIcon } from 'lucide-react'
+import HistoryFilters, { type HistoryFilterState } from './HistoryFilters'
+import HistoryTable from './HistoryTable'
+import HistoryCompareView from './HistoryCompareView'
+
+export interface BacktestRunRow {
+  id: string
+  strategy_id: string | null
+  ticker: string
+  market: 'KR' | 'US'
+  start_date: string
+  end_date: string
+  initial_capital: number
+  status: string
+  total_return: number | null
+  sharpe_ratio: number | null
+  max_drawdown: number | null
+  total_trades: number | null
+  win_rate: number | null
+  equity_curve: Array<{ date: string; equity: number }> | null
+  trades: Array<Record<string, unknown>> | null
+  full_metrics: Record<string, unknown> | null
+  executed_at: string
+}
+
+interface StrategyOption {
+  id: string
+  name: string
+  strategy_type: 'rule' | 'rl_portfolio' | 'rl_single'
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const today = () => new Date().toISOString().slice(0, 10)
+const daysAgo = (n: number) => {
+  const d = new Date()
+  d.setDate(d.getDate() - n)
+  return d.toISOString().slice(0, 10)
+}
+
+const DEFAULT_FILTER: HistoryFilterState = {
+  strategyId: '',     // '전체'
+  ticker: '',
+  preset: '30d',
+}
+
+function presetToSince(preset: HistoryFilterState['preset']): string | null {
+  switch (preset) {
+    case '7d': return daysAgo(7)
+    case '30d': return daysAgo(30)
+    case '90d': return daysAgo(90)
+    case 'all': return null
+    default: return null
+  }
+}
+
+export default function HistoryTab() {
+  const [filter, setFilter] = useState<HistoryFilterState>(DEFAULT_FILTER)
+  const [strategies, setStrategies] = useState<StrategyOption[]>([])
+  const [rows, setRows] = useState<BacktestRunRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [showCompare, setShowCompare] = useState(false)
+
+  // 전략 옵션 1회 로드
+  useEffect(() => {
+    fetch('/api/investment/strategies')
+      .then(r => r.json())
+      .then((j: { data?: Array<{ id: string; name: string; strategy_type: StrategyOption['strategy_type'] }> }) => {
+        setStrategies(j.data ?? [])
+      })
+      .catch(() => setStrategies([]))
+  }, [])
+
+  // 필터 변경 시 백테스트 재조회 (debounce 300ms)
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const params = new URLSearchParams()
+        if (filter.strategyId) params.set('strategy_id', filter.strategyId)
+        if (filter.ticker.trim()) params.set('ticker', filter.ticker.trim())
+        const since = presetToSince(filter.preset)
+        if (since) params.set('since', since)
+        params.set('limit', '50')
+        const r = await fetch(`/api/investment/backtest?${params.toString()}`)
+        if (!r.ok) {
+          const err = (await r.json().catch(() => ({}))) as { error?: string }
+          throw new Error(err.error ?? `${r.status}`)
+        }
+        const j = (await r.json()) as { data?: BacktestRunRow[] }
+        setRows(j.data ?? [])
+      } catch (e) {
+        setError((e as Error).message)
+        setRows([])
+      } finally {
+        setLoading(false)
+      }
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [filter])
+
+  const toggleSelected = useCallback((id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const selectedRows = useMemo(
+    () => rows.filter(r => selectedIds.has(r.id)),
+    [rows, selectedIds],
+  )
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4">
+      <HistoryFilters
+        value={filter}
+        onChange={setFilter}
+        strategies={strategies}
+      />
+
+      {error && (
+        <div className="p-3 rounded-xl bg-at-error-bg text-at-error text-sm">
+          조회 실패: {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-at-accent" />
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="text-center py-12 bg-at-surface-alt rounded-xl space-y-2">
+          <HistoryIcon className="w-10 h-10 mx-auto text-at-text-weak" aria-hidden="true" />
+          <p className="text-sm text-at-text-secondary">조건에 맞는 백테스트가 없습니다.</p>
+          <p className="text-xs text-at-text-weak">[새로 비교] 탭에서 첫 백테스트를 실행해보세요.</p>
+        </div>
+      ) : (
+        <HistoryTable
+          rows={rows}
+          strategies={strategies}
+          selectedIds={selectedIds}
+          onToggleSelected={toggleSelected}
+        />
+      )}
+
+      {selectedIds.size >= 2 && !showCompare && (
+        <div className="sticky bottom-4 z-10 flex justify-center">
+          <button
+            onClick={() => setShowCompare(true)}
+            className="px-5 py-2.5 bg-at-accent hover:bg-at-accent-hover text-white rounded-xl text-sm font-medium shadow-lg"
+          >
+            선택 {selectedIds.size}개 비교
+          </button>
+        </div>
+      )}
+
+      {showCompare && selectedRows.length >= 2 && (
+        <HistoryCompareView
+          rows={selectedRows}
+          strategies={strategies}
+          onClose={() => setShowCompare(false)}
+        />
+      )}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/CompareHistory/HistoryTable.tsx
+++ b/dental-clinic-manager/src/components/Investment/CompareHistory/HistoryTable.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { Fragment, useMemo, useState } from 'react'
+import { ChevronDown, ChevronRight, ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react'
+import HistoryRowDetail from './HistoryRowDetail'
+import type { BacktestRunRow } from './HistoryTab'
+
+interface StrategyOption {
+  id: string
+  name: string
+  strategy_type: 'rule' | 'rl_portfolio' | 'rl_single'
+}
+
+interface Props {
+  rows: BacktestRunRow[]
+  strategies: StrategyOption[]
+  selectedIds: Set<string>
+  onToggleSelected: (id: string) => void
+}
+
+type SortKey = 'executed_at' | 'total_return' | 'sharpe_ratio'
+type SortDir = 'asc' | 'desc'
+
+const formatDate = (iso: string): string => {
+  try {
+    const d = new Date(iso)
+    return `${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`
+  } catch {
+    return iso.slice(0, 10)
+  }
+}
+
+const formatPct = (v: number | null | undefined): string => {
+  if (v == null) return '-'
+  const sign = v > 0 ? '+' : ''
+  return `${sign}${(v * 100).toFixed(1)}%`
+}
+
+const formatNum = (v: number | null | undefined, digits = 2): string => {
+  if (v == null) return '-'
+  return v.toFixed(digits)
+}
+
+export default function HistoryTable({ rows, strategies, selectedIds, onToggleSelected }: Props) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [sortKey, setSortKey] = useState<SortKey>('executed_at')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  const strategyById = useMemo(() => {
+    const map = new Map<string, StrategyOption>()
+    for (const s of strategies) map.set(s.id, s)
+    return map
+  }, [strategies])
+
+  const sorted = useMemo(() => {
+    const cp = [...rows]
+    cp.sort((a, b) => {
+      const av = (a[sortKey] ?? 0) as number | string
+      const bv = (b[sortKey] ?? 0) as number | string
+      if (av < bv) return sortDir === 'asc' ? -1 : 1
+      if (av > bv) return sortDir === 'asc' ? 1 : -1
+      return 0
+    })
+    return cp
+  }, [rows, sortKey, sortDir])
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+    else { setSortKey(key); setSortDir('desc') }
+  }
+
+  const toggleExpanded = (id: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const sortIcon = (key: SortKey) => {
+    if (sortKey !== key) return <ArrowUpDown className="w-3 h-3 inline-block opacity-50" aria-hidden="true" />
+    return sortDir === 'asc'
+      ? <ArrowUp className="w-3 h-3 inline-block" aria-hidden="true" />
+      : <ArrowDown className="w-3 h-3 inline-block" aria-hidden="true" />
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-at-border bg-white">
+      <table className="min-w-[900px] w-full text-sm">
+        <thead className="bg-at-surface-alt">
+          <tr>
+            <th className="px-3 py-2 w-8" />
+            <th
+              className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider cursor-pointer"
+              onClick={() => toggleSort('executed_at')}
+            >
+              날짜 {sortIcon('executed_at')}
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">전략</th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-at-text-weak uppercase tracking-wider">종목</th>
+            <th
+              className="px-3 py-2 text-right text-xs font-medium text-at-text-weak uppercase tracking-wider cursor-pointer"
+              onClick={() => toggleSort('total_return')}
+            >
+              수익률 {sortIcon('total_return')}
+            </th>
+            <th
+              className="px-3 py-2 text-right text-xs font-medium text-at-text-weak uppercase tracking-wider cursor-pointer"
+              onClick={() => toggleSort('sharpe_ratio')}
+            >
+              Sharpe {sortIcon('sharpe_ratio')}
+            </th>
+            <th className="px-3 py-2 w-8" aria-label="펼침" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-at-border">
+          {sorted.map((row) => {
+            const strat = row.strategy_id ? strategyById.get(row.strategy_id) : null
+            const isExp = expanded.has(row.id)
+            const isSel = selectedIds.has(row.id)
+            const ret = row.total_return ?? null
+            return (
+              <Fragment key={row.id}>
+                <tr className={`hover:bg-at-surface-alt transition-colors ${isExp ? 'bg-at-surface-alt' : ''}`}>
+                  <td className="px-3 py-2.5">
+                    <input
+                      type="checkbox"
+                      checked={isSel}
+                      onChange={() => onToggleSelected(row.id)}
+                      aria-label={`${row.id} 선택`}
+                      className="rounded border-at-border text-at-accent focus:ring-at-accent"
+                    />
+                  </td>
+                  <td className="px-3 py-2.5 font-medium text-at-text">{formatDate(row.executed_at)}</td>
+                  <td className="px-3 py-2.5">
+                    <div className="flex items-center gap-2">
+                      <span>{strat?.name ?? '-'}</span>
+                      {strat?.strategy_type === 'rl_portfolio' && (
+                        <span className="px-1.5 py-0.5 text-xs rounded-full bg-at-accent-light text-at-accent">RL</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2.5 font-mono text-xs">
+                    {row.ticker === 'PORTFOLIO' ? (
+                      <span className="text-at-text-secondary">Portfolio</span>
+                    ) : row.ticker}
+                  </td>
+                  <td className={`px-3 py-2.5 text-right font-medium ${
+                    ret == null ? '' : ret >= 0 ? 'text-at-success' : 'text-at-error'
+                  }`}>
+                    {formatPct(ret)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right text-at-text">{formatNum(row.sharpe_ratio)}</td>
+                  <td className="px-3 py-2.5">
+                    <button
+                      onClick={() => toggleExpanded(row.id)}
+                      aria-label={isExp ? '접기' : '펼치기'}
+                      title={isExp ? '접기' : '펼치기'}
+                      className="p-1 rounded-xl hover:bg-at-surface-alt"
+                    >
+                      {isExp ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                    </button>
+                  </td>
+                </tr>
+                {isExp && (
+                  <tr className="bg-at-surface-alt">
+                    <td colSpan={7} className="px-3 py-3">
+                      <HistoryRowDetail row={row} />
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/dental-clinic-manager/vitest.config.ts
+++ b/dental-clinic-manager/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+
+export default defineConfig({
+  test: {
+    include: ['__tests__/**/*.test.ts', '__tests__/**/*.test.tsx'],
+    environment: 'node',
+    testTimeout: 10000,
+  },
+  resolve: {
+    alias: { '@': path.resolve(__dirname, 'src') },
+  },
+  css: {
+    postcss: {
+      plugins: [],
+    },
+  },
+})

--- a/dental-clinic-manager/vitest.config.ts
+++ b/dental-clinic-manager/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
   resolve: {
     alias: { '@': path.resolve(__dirname, 'src') },
   },
+  // Suppress @tailwindcss/postcss in vitest's internal Vite loader.
+  // Tailwind v4's postcss plugin uses a string format Vite's PostCSS doesn't accept;
+  // tests don't need CSS processing, so we override with empty plugins.
   css: {
     postcss: {
       plugins: [],


### PR DESCRIPTION
## Summary

develop 브랜치 누적 작업을 main에 머지. 주요 변경:

### 🆕 백테스트 히스토리 조회 (이번 작업)
- \`/investment/compare\`에 [새로 비교]/[히스토리] 2-탭 UI
- 전략·종목·기간 필터 + 정렬·체크박스·인라인 펼침
- 다중선택 비교 (matrix table + equity overlay)
- API GET 필터 추가: \`strategy_id\`, \`ticker\`, \`since\`, \`until\`, \`ids\`, \`limit\`(cap 200)
- vitest 단위 테스트 5건 추가

### 📈 RL 트레이딩 Phase 1·2
- 강화학습 기반 적응형 트레이딩 모델 (FinRL/SB3 Dow30 PPO)
- rl-inference-server (FastAPI), trading-worker OHLCV 수집
- env v2 (reward shaping + state 확장 + regime classifier)
- ensemble strategy + walk-forward CV + benchmark scripts
- RL 전략 백테스트 strategy_type 분기 (server-side yfinance fetch)

### 👨‍👩‍👧 소개환자 관리 Phase 2
- 가족 묶음 (\`suggest_family_groups\` + 확정 모달)
- 전환율 차트 (12개월 ComposedChart)
- 자동 감사문자 cron (KST 09:00)
- 대시보드 위젯 + 설정 팝오버

### 🛠 기타
- 사용자 메뉴 DB 기반 저장 (계정 종속)
- 대표 원장 계약서 권한 타이밍 버그 수정
- 연차 수정 페이지 재설계

## Test plan
- [ ] \`/investment/compare\` 히스토리 탭 동작 확인 (필터/펼침/다중비교)
- [ ] 기존 [새로 비교] 탭 정상 동작
- [ ] RL 전략 백테스트 결과 표시 정상
- [ ] 소개환자 가족 그룹 추정/확정 정상
- [ ] 빌드 그린, 콘솔 에러 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)