### PR TITLE
feat(monthly-report): 덴트웹 내원경로 매핑 + 매출 3개년 차트 + 연령대 차트 개선

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
@@ -93,53 +93,38 @@ function formatDentwebDate(dateStr: string | null | undefined): string | null {
   return `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`;
 }
 
-// TB_환자정보에 존재할 가능성이 있는 내원경로/고객구분 컬럼 후보들
-// 실제 컬럼명을 INFORMATION_SCHEMA 조회로 찾아 매핑
-const ACQUISITION_CHANNEL_CANDIDATES = [
-  'sz내원경로', 'sz경로', 'sz유입경로', 'sz소개', 'sz채널', 'szChannel', 'szRoute', 'sz가입경로'
-];
-const CUSTOMER_TYPE_CANDIDATES = [
-  'sz고객구분', 'sz환자구분', 'sz구분', 'sz분류', 'szType', 'sz고객유형'
-];
-
-let resolvedAcquisitionColumn: string | null = null;
-let resolvedCustomerTypeColumn: string | null = null;
+// 덴트웹 TB_환자정보에는 다음과 같은 INTEGER FK 컬럼이 존재한다 (실측):
+//   n내원경로 → TB_내원경로(nID, sz내용)
+//   n고객구분 → TB_고객구분(nID, sz구분내용)
+//   n고객구분2 → TB_고객구분2(nID, sz구분내용) (보조)
+// 동기화 시 LEFT JOIN으로 텍스트를 가져온다. 컬럼이 없는 버전의 덴트웹을 위해
+// INFORMATION_SCHEMA 사전 점검 후 SELECT를 동적으로 구성한다.
+let hasRouteColumn = false;       // TB_환자정보.n내원경로 존재 여부
+let hasCustomerColumn = false;    // TB_환자정보.n고객구분 존재 여부
+let hasRouteTable = false;        // TB_내원경로 존재 여부
+let hasCustomerTable = false;     // TB_고객구분 존재 여부
 let columnDiscoveryDone = false;
 
 async function discoverPatientColumns(pool: sql.ConnectionPool): Promise<void> {
   if (columnDiscoveryDone) return;
   try {
-    const result = await pool.request().query(`
+    const colResult = await pool.request().query(`
       SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
       WHERE TABLE_NAME = 'TB_환자정보'
     `);
-    const columnNames = result.recordset.map((r: { COLUMN_NAME: string }) => r.COLUMN_NAME);
-    const lowerSet = new Set(columnNames.map((n) => n.toLowerCase()));
+    const columnNames = new Set(colResult.recordset.map((r: { COLUMN_NAME: string }) => r.COLUMN_NAME));
+    hasRouteColumn = columnNames.has('n내원경로');
+    hasCustomerColumn = columnNames.has('n고객구분');
 
-    for (const candidate of ACQUISITION_CHANNEL_CANDIDATES) {
-      if (lowerSet.has(candidate.toLowerCase())) {
-        resolvedAcquisitionColumn = candidate;
-        break;
-      }
-    }
-    if (!resolvedAcquisitionColumn) {
-      // 부분 일치: 한글 키워드 포함
-      const found = columnNames.find((n) => /경로|채널|유입|소개/.test(n));
-      if (found) resolvedAcquisitionColumn = found;
-    }
+    const tableResult = await pool.request().query(`
+      SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+      WHERE TABLE_NAME IN ('TB_내원경로', 'TB_고객구분')
+    `);
+    const tableNames = new Set(tableResult.recordset.map((r: { TABLE_NAME: string }) => r.TABLE_NAME));
+    hasRouteTable = tableNames.has('TB_내원경로');
+    hasCustomerTable = tableNames.has('TB_고객구분');
 
-    for (const candidate of CUSTOMER_TYPE_CANDIDATES) {
-      if (lowerSet.has(candidate.toLowerCase())) {
-        resolvedCustomerTypeColumn = candidate;
-        break;
-      }
-    }
-    if (!resolvedCustomerTypeColumn) {
-      const found = columnNames.find((n) => /구분|분류|유형/.test(n) && !/성별|진료/.test(n));
-      if (found) resolvedCustomerTypeColumn = found;
-    }
-
-    log('info', `[DentWeb] 컬럼 발견: 내원경로=${resolvedAcquisitionColumn ?? 'none'}, 고객구분=${resolvedCustomerTypeColumn ?? 'none'}`);
+    log('info', `[DentWeb] 컬럼 발견: n내원경로=${hasRouteColumn} (lookup=${hasRouteTable}), n고객구분=${hasCustomerColumn} (lookup=${hasCustomerTable})`);
   } catch (err) {
     log('warn', `[DentWeb] 컬럼 발견 실패 (계속 진행): ${err instanceof Error ? err.message : String(err)}`);
   } finally {
@@ -152,21 +137,12 @@ function formatPatientRow(row: Record<string, unknown>) {
   const genderBit = row['b성별'];
   const gender = genderBit === true || genderBit === 1 ? 'F' : genderBit === false || genderBit === 0 ? 'M' : null;
 
-  const acquisitionChannel = resolvedAcquisitionColumn
-    ? (() => {
-        const v = row[resolvedAcquisitionColumn!];
-        if (typeof v === 'string') return v.trim() || null;
-        return null;
-      })()
-    : null;
+  // SELECT에서 alias로 추출되어 들어오는 텍스트 (없으면 NULL)
+  const rawChannel = row['acquisition_channel'];
+  const acquisitionChannel = typeof rawChannel === 'string' && rawChannel.trim() ? rawChannel.trim() : null;
 
-  const customerType = resolvedCustomerTypeColumn
-    ? (() => {
-        const v = row[resolvedCustomerTypeColumn!];
-        if (typeof v === 'string') return v.trim() || null;
-        return null;
-      })()
-    : null;
+  const rawCustomerType = row['customer_type'];
+  const customerType = typeof rawCustomerType === 'string' && rawCustomerType.trim() ? rawCustomerType.trim() : null;
 
   return {
     dentweb_patient_id: String(row['n환자ID']),
@@ -200,10 +176,15 @@ function formatPatientRow(row: Record<string, unknown>) {
  */
 
 function buildPatientQueryBase(): string {
-  const extraColumns: string[] = [];
-  if (resolvedAcquisitionColumn) extraColumns.push(`p.[${resolvedAcquisitionColumn}]`);
-  if (resolvedCustomerTypeColumn) extraColumns.push(`p.[${resolvedCustomerTypeColumn}]`);
-  const extraSelect = extraColumns.length > 0 ? `,\n    ${extraColumns.join(',\n    ')}` : '';
+  // 내원경로 텍스트: TB_내원경로의 sz내용 (코드 → 텍스트)
+  const channelSelect = (hasRouteColumn && hasRouteTable)
+    ? `(SELECT TOP 1 r.sz내용 FROM TB_내원경로 r WHERE r.nID = p.n내원경로) AS acquisition_channel`
+    : `CAST(NULL AS NVARCHAR(100)) AS acquisition_channel`;
+
+  // 고객구분 텍스트: TB_고객구분의 sz구분내용
+  const customerSelect = (hasCustomerColumn && hasCustomerTable)
+    ? `(SELECT TOP 1 c.sz구분내용 FROM TB_고객구분 c WHERE c.nID = p.n고객구분) AS customer_type`
+    : `CAST(NULL AS NVARCHAR(100)) AS customer_type`;
 
   return `
     SELECT
@@ -214,7 +195,9 @@ function buildPatientQueryBase(): string {
       p.sz생년월일,
       p.b성별,
       p.sz최종내원일,
-      p.sz등록시각${extraSelect},
+      p.sz등록시각,
+      ${channelSelect},
+      ${customerSelect},
       -- 최근 진료 코드 (세부처치내역에서 취소되지 않은 최신 항목)
       (SELECT TOP 1 t.sz수가코드
        FROM TB_세부처치내역 t

--- a/dental-clinic-manager/src/components/Dashboard/DashboardHome.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/DashboardHome.tsx
@@ -554,9 +554,8 @@ export default function DashboardHome() {
       <div className="flex flex-col lg:flex-row gap-4 sm:gap-6">
           {/* 왼쪽: 메인 콘텐츠 */}
           <div className="flex-1 space-y-4 sm:space-y-5">
-            {/* 병원 일정 */}
-            <ScheduleWidget />
-
+            {/* 오늘의 현황 + 병원 일정 (lg에서 가로 2컬럼) */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-5">
             {/* 오늘의 현황 */}
             <div>
               <h3 className="text-sm font-semibold text-at-text mb-3 tracking-[0.08px] flex items-center gap-2">
@@ -682,6 +681,9 @@ export default function DashboardHome() {
                   )}
                 </div>
               )}
+            </div>
+            {/* 병원 일정 */}
+            <ScheduleWidget />
             </div>
 
             {/* 소개환자 관리 위젯 */}

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/MonthView.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/MonthView.tsx
@@ -9,37 +9,24 @@ interface MonthViewProps {
   events: ScheduleEvent[]
   loading: boolean
   todayIso: string
+  rangeStart: string
   onItemClick: (event: ScheduleEvent) => void
 }
 
-function expandEventToDates(ev: ScheduleEvent): string[] {
-  const dates: string[] = []
-  const start = new Date(`${ev.startDate}T00:00:00`)
-  const end = new Date(`${ev.endDate}T00:00:00`)
-  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-    const y = d.getFullYear()
-    const m = String(d.getMonth() + 1).padStart(2, '0')
-    const dy = String(d.getDate()).padStart(2, '0')
-    dates.push(`${y}-${m}-${dy}`)
-  }
-  return dates
-}
-
-function groupByDate(events: ScheduleEvent[]): Map<string, ScheduleEvent[]> {
+// 윈도우 내 첫 등장일에 한 번만 등록 (연속 일정을 단일 항목으로 표시)
+function groupByDate(events: ScheduleEvent[], rangeStart: string): Map<string, ScheduleEvent[]> {
   const map = new Map<string, ScheduleEvent[]>()
   for (const ev of events) {
-    const dates = expandEventToDates(ev)
-    for (const d of dates) {
-      const list = map.get(d) || []
-      list.push(ev)
-      map.set(d, list)
-    }
+    const placement = ev.startDate < rangeStart ? rangeStart : ev.startDate
+    const list = map.get(placement) || []
+    list.push(ev)
+    map.set(placement, list)
   }
   return map
 }
 
-export default function MonthView({ events, loading, todayIso, onItemClick }: MonthViewProps) {
-  const groups = useMemo(() => groupByDate(events), [events])
+export default function MonthView({ events, loading, todayIso, rangeStart, onItemClick }: MonthViewProps) {
+  const groups = useMemo(() => groupByDate(events, rangeStart), [events, rangeStart])
 
   if (loading) {
     return (

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/WeekView.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/WeekView.tsx
@@ -9,37 +9,24 @@ interface WeekViewProps {
   events: ScheduleEvent[]
   loading: boolean
   todayIso: string
+  rangeStart: string
   onItemClick: (event: ScheduleEvent) => void
 }
 
-function expandEventToDates(ev: ScheduleEvent): string[] {
-  const dates: string[] = []
-  const start = new Date(`${ev.startDate}T00:00:00`)
-  const end = new Date(`${ev.endDate}T00:00:00`)
-  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-    const y = d.getFullYear()
-    const m = String(d.getMonth() + 1).padStart(2, '0')
-    const dy = String(d.getDate()).padStart(2, '0')
-    dates.push(`${y}-${m}-${dy}`)
-  }
-  return dates
-}
-
-function groupByDate(events: ScheduleEvent[]): Map<string, ScheduleEvent[]> {
+// 윈도우 내 첫 등장일에 한 번만 등록 (연속 일정을 단일 항목으로 표시)
+function groupByDate(events: ScheduleEvent[], rangeStart: string): Map<string, ScheduleEvent[]> {
   const map = new Map<string, ScheduleEvent[]>()
   for (const ev of events) {
-    const dates = expandEventToDates(ev)
-    for (const d of dates) {
-      const list = map.get(d) || []
-      list.push(ev)
-      map.set(d, list)
-    }
+    const placement = ev.startDate < rangeStart ? rangeStart : ev.startDate
+    const list = map.get(placement) || []
+    list.push(ev)
+    map.set(placement, list)
   }
   return map
 }
 
-export default function WeekView({ events, loading, todayIso, onItemClick }: WeekViewProps) {
-  const groups = useMemo(() => groupByDate(events), [events])
+export default function WeekView({ events, loading, todayIso, rangeStart, onItemClick }: WeekViewProps) {
+  const groups = useMemo(() => groupByDate(events, rangeStart), [events, rangeStart])
 
   if (loading) {
     return (

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/index.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/index.tsx
@@ -36,7 +36,7 @@ export default function ScheduleWidget() {
   const todayIso = useMemo(() => todayIsoSeoul(), [])
   const anchorDate = useMemo(() => new Date(`${todayIso}T00:00:00`), [todayIso])
 
-  const { events, loading } = useScheduleData(user?.clinic_id ?? null, activeTab, anchorDate)
+  const { events, loading, range } = useScheduleData(user?.clinic_id ?? null, activeTab, anchorDate)
 
   const handleItemClick = (ev: ScheduleEvent) => {
     if (ev.source !== 'announcement' || !ev.announcementId) return
@@ -82,10 +82,10 @@ export default function ScheduleWidget() {
           <TodayView events={events} loading={loading} todayIso={todayIso} onItemClick={handleItemClick} />
         )}
         {activeTab === 'week' && (
-          <WeekView events={events} loading={loading} todayIso={todayIso} onItemClick={handleItemClick} />
+          <WeekView events={events} loading={loading} todayIso={todayIso} rangeStart={range.start} onItemClick={handleItemClick} />
         )}
         {activeTab === 'month' && (
-          <MonthView events={events} loading={loading} todayIso={todayIso} onItemClick={handleItemClick} />
+          <MonthView events={events} loading={loading} todayIso={todayIso} rangeStart={range.start} onItemClick={handleItemClick} />
         )}
       </CardContent>
       <ScheduleDetailModal event={modalEvent} open={modalOpen} onOpenChange={setModalOpen} />

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/useScheduleData.ts
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/useScheduleData.ts
@@ -86,6 +86,34 @@ function dedupeByDateAndTitle(events: ScheduleEvent[]): ScheduleEvent[] {
   return result
 }
 
+function nextDayIso(iso: string): string {
+  const d = new Date(`${iso}T00:00:00`)
+  d.setDate(d.getDate() + 1)
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`
+}
+
+// 같은 source/title을 가진 연속 단일일(또는 인접 기간) 이벤트를 단일 기간 이벤트로 병합.
+// holidayService가 clinic 휴무 기간을 개별 일짜로 펼쳐 반환하므로, 위젯에서 다시 합쳐서 보여준다.
+function mergeConsecutiveSameTitle(events: ScheduleEvent[]): ScheduleEvent[] {
+  const sorted = [...events].sort((a, b) => a.startDate.localeCompare(b.startDate))
+  const result: ScheduleEvent[] = []
+  for (const ev of sorted) {
+    const last = result[result.length - 1]
+    if (
+      last &&
+      last.source === ev.source &&
+      last.title === ev.title &&
+      last.badgeKind === ev.badgeKind &&
+      (last.endDate === ev.startDate || nextDayIso(last.endDate) === ev.startDate)
+    ) {
+      last.endDate = ev.endDate > last.endDate ? ev.endDate : last.endDate
+      continue
+    }
+    result.push({ ...ev })
+  }
+  return result
+}
+
 interface UseScheduleDataResult {
   events: ScheduleEvent[]
   loading: boolean
@@ -207,7 +235,9 @@ export function useScheduleData(
         }
 
         const merged = sortEvents(
-          dedupeByDateAndTitle([...annEvents, ...clinicHolidayEvents, ...publicHolidayEvents])
+          mergeConsecutiveSameTitle(
+            dedupeByDateAndTitle([...annEvents, ...clinicHolidayEvents, ...publicHolidayEvents])
+          )
         )
 
         if (!controller.signal.aborted) {

--- a/dental-clinic-manager/src/components/MonthlyReport/RevenueTrendChart.tsx
+++ b/dental-clinic-manager/src/components/MonthlyReport/RevenueTrendChart.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend, ReferenceLine,
+  AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine,
 } from 'recharts'
 import type { MonthlyRevenuePoint } from '@/types/monthlyReport'
 
@@ -28,18 +28,20 @@ export default function RevenueTrendChart({ data, targetYear, targetMonth }: Rev
     year: d.year,
     month: d.month,
     total: d.total_revenue,
-    insurance: d.insurance_revenue,
-    nonInsurance: d.non_insurance_revenue,
     isTarget: d.year === targetYear && d.month === targetMonth,
   }))
 
   const targetIndex = chartData.findIndex((d) => d.isTarget)
   const hasData = chartData.some((d) => d.total > 0)
+  const monthsCount = chartData.length
+
+  // 36개월 표시 시 모든 라벨을 그리면 빽빽해지므로 일정 간격마다 표시
+  const xInterval = monthsCount > 24 ? 2 : monthsCount > 12 ? 1 : 0
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>매출 추이 (최근 12개월)</CardTitle>
+        <CardTitle>월 매출 변화 (최근 3개년)</CardTitle>
       </CardHeader>
       <CardContent>
         {!hasData ? (
@@ -49,23 +51,40 @@ export default function RevenueTrendChart({ data, targetYear, targetMonth }: Rev
         ) : (
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+              <AreaChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="revenueGradient" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#10b981" stopOpacity={0.35} />
+                    <stop offset="100%" stopColor="#10b981" stopOpacity={0.02} />
+                  </linearGradient>
+                </defs>
                 <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                <XAxis dataKey="label" stroke="#6b7280" fontSize={12} />
+                <XAxis
+                  dataKey="label"
+                  stroke="#6b7280"
+                  fontSize={11}
+                  interval={xInterval}
+                  minTickGap={20}
+                />
                 <YAxis stroke="#6b7280" fontSize={12} tickFormatter={formatKrwShort} />
                 <Tooltip
-                  formatter={(value) => [`${Number(value).toLocaleString()}원`, '']}
+                  formatter={(value) => [`${Number(value).toLocaleString()}원`, '총 매출']}
                   labelFormatter={(label) => `20${label}`}
                   contentStyle={{ borderRadius: 12, border: '1px solid #e5e7eb' }}
                 />
-                <Legend />
                 {targetIndex >= 0 && (
                   <ReferenceLine x={chartData[targetIndex].label} stroke="#6366f1" strokeDasharray="3 3" />
                 )}
-                <Line type="monotone" dataKey="total" name="총 매출" stroke="#10b981" strokeWidth={2.5} dot={{ r: 3 }} activeDot={{ r: 5 }} />
-                <Line type="monotone" dataKey="insurance" name="보험" stroke="#3b82f6" strokeWidth={1.5} dot={{ r: 2 }} />
-                <Line type="monotone" dataKey="nonInsurance" name="비보험" stroke="#f59e0b" strokeWidth={1.5} dot={{ r: 2 }} />
-              </LineChart>
+                <Area
+                  type="monotone"
+                  dataKey="total"
+                  stroke="#10b981"
+                  strokeWidth={2.5}
+                  fill="url(#revenueGradient)"
+                  dot={{ r: 2.5, fill: '#10b981' }}
+                  activeDot={{ r: 5 }}
+                />
+              </AreaChart>
             </ResponsiveContainer>
           </div>
         )}

--- a/dental-clinic-manager/src/lib/monthlyReportService.ts
+++ b/dental-clinic-manager/src/lib/monthlyReportService.ts
@@ -16,6 +16,7 @@ import {
 } from '@/types/monthlyReport'
 
 const MONTH_WINDOW = 12
+const REVENUE_MONTH_WINDOW = 36 // 매출은 최근 3개년 추이로 표시
 
 /**
  * 직전 N개월 윈도우의 (year, month) 시퀀스를 오래된 순으로 반환.
@@ -296,8 +297,8 @@ export interface GenerateMonthlyReportInput {
 }
 
 /**
- * 보고서 생성: 매출/신환/유입경로/연령대 12개월 데이터 집계 후 monthly_reports에 upsert.
- * 기존 row가 있으면 덮어쓴다.
+ * 보고서 생성: 매출은 36개월(3개년), 그 외(신환/유입경로/연령대)는 12개월 윈도우로
+ * 집계한 후 monthly_reports에 upsert. 기존 row가 있으면 덮어쓴다.
  */
 export async function generateMonthlyReport({
   supabase,
@@ -307,9 +308,10 @@ export async function generateMonthlyReport({
   generatedBy,
 }: GenerateMonthlyReportInput): Promise<MonthlyReport> {
   const range = buildMonthRange(year, month, MONTH_WINDOW)
+  const revenueRange = buildMonthRange(year, month, REVENUE_MONTH_WINDOW)
 
   const [revenue, patients] = await Promise.all([
-    fetchRevenueSeries(supabase, clinicId, range),
+    fetchRevenueSeries(supabase, clinicId, revenueRange),
     fetchPatientsForRange(supabase, clinicId, range),
   ])
 

--- a/dental-clinic-manager/src/types/monthlyReport.ts
+++ b/dental-clinic-manager/src/types/monthlyReport.ts
@@ -23,26 +23,30 @@ export const AGE_GROUP_LABELS: Record<AgeGroupKey, string> = {
   unknown: '미상',
 }
 
+// 범례/스택 표시 순서: 10대 → 60대+ → (10세 미만/미상)
+// 사용자 요구사항: 10대부터 60대 이상으로 순서대로 배열
 export const AGE_GROUP_ORDER: AgeGroupKey[] = [
-  'under_10',
   'teens',
   'twenties',
   'thirties',
   'forties',
   'fifties',
   'sixties_plus',
+  'under_10',
   'unknown',
 ]
 
+// 색상 팔레트: 10대 → 60대+ 인접 그룹 간 색상 차이를 명확히 구분
+// (이전 보라/파랑/보라 중복 → 컬러 휠을 균등 분할)
 export const AGE_GROUP_COLORS: Record<AgeGroupKey, string> = {
-  under_10: '#a78bfa',
-  teens: '#60a5fa',
-  twenties: '#34d399',
-  thirties: '#fbbf24',
-  forties: '#fb923c',
-  fifties: '#f87171',
-  sixties_plus: '#c084fc',
-  unknown: '#9ca3af',
+  teens: '#0ea5e9',         // sky-500 - 청록색 (10대)
+  twenties: '#10b981',      // emerald-500 - 녹색 (20대)
+  thirties: '#eab308',      // yellow-500 - 노랑 (30대)
+  forties: '#f97316',       // orange-500 - 주황 (40대)
+  fifties: '#dc2626',       // red-600 - 빨강 (50대)
+  sixties_plus: '#7c3aed',  // violet-600 - 진보라 (60대+)
+  under_10: '#ec4899',      // pink-500 - 분홍 (10세 미만)
+  unknown: '#6b7280',       // gray-500 - 회색 (미상)
 }
 
 export interface MonthlyRevenuePoint {


### PR DESCRIPTION
## Summary

- **덴트웹 내원경로 정확한 매핑** — INTEGER FK → `TB_내원경로.sz내용` LEFT JOIN으로 텍스트 가져오기
- **매출 차트 최근 3개년(36개월)** 확장 + 보험/비보험 라인 제거
- **연령대 차트 색상/순서** 개선 (10대 → 60대+, 명확한 색상 구분)
- 일정 위젯 연속 일정 병합 + 오늘의 현황 옆 가로 배치

## 주요 변경사항

### 덴트웹 동기화 (`marketing-worker/electron/src/dentweb-bridge.ts`)
- `TB_환자정보.n내원경로` → `TB_내원경로.sz내용` LEFT JOIN
- `TB_환자정보.n고객구분` → `TB_고객구분.sz구분내용` LEFT JOIN
- 컬럼/lookup 테이블 존재 여부 사전 점검 후 SELECT 동적 구성 (구버전 덴트웹 호환)
- 하얀치과 9109명 중 639명 backfill 완료 (8개 채널)

### 매출 차트 (`src/components/MonthlyReport/RevenueTrendChart.tsx`)
- 보험/비보험 라인 제거 → 총 매출만 표시
- 윈도우 12개월 → 36개월 (최근 3개년)
- AreaChart + 그라데이션, X축 interval 자동 조정

### 연령대 차트 (`src/types/monthlyReport.ts`)
- AGE_GROUP_ORDER: 10대 → 60대+ → 10세 미만/미상 순으로 재배열
- AGE_GROUP_COLORS: 인접 그룹 간 명확한 색상 차이 (sky/emerald/yellow/orange/red/violet/pink/gray)

### 일정 위젯 (`src/components/Dashboard/ScheduleWidget/`)
- 연속 일정 단일 항목으로 병합
- 오늘의 현황 옆 가로 배치

## Test plan
- [x] tsc --noEmit 통과 (앱 + electron 워커)
- [x] 17개 클리닉 보고서 재생성 성공
- [x] 하얀치과 4월 보고서: top_channel "지나가다가, 같은 동네" 44.4%
- [x] revenue_data 36개월(2023-05 ~ 2026-04) 분리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)