### PR TITLE
feat(monthly-report): 매출 차트 연도별 겹쳐보기 탭 + 과거 매출 전체 backfill

### DIFF
--- a/dental-clinic-manager/src/app/api/dentweb/request-revenue-sync/route.ts
+++ b/dental-clinic-manager/src/app/api/dentweb/request-revenue-sync/route.ts
@@ -6,8 +6,9 @@ const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
 
 /**
  * POST: 특정 월 또는 전체 과거 데이터 수입 동기화 요청
- * - mode: 'single' (단일 월) 또는 'backfill' (직전 N개월, default 24)
- * - months_back: backfill 모드에서 직전 몇 개월을 채울지 (1~48, default 24)
+ * - mode: 'single' (단일 월), 'backfill' (직전 N개월), 'all' (덴트웹의 모든 과거 매출)
+ * - months_back: backfill 모드에서 직전 몇 개월을 채울지 (1~360, default 24)
+ *   * all 모드는 360개월(30년) 윈도우로 자동 확장하여 사실상 모든 데이터를 끌어온다
  */
 export async function POST(request: NextRequest) {
   try {
@@ -36,10 +37,12 @@ export async function POST(request: NextRequest) {
 
     let newMonths: Array<{ year: number; month: number }> = []
 
-    if (mode === 'backfill') {
-      // 직전 N개월 (default 24, 최대 48) — 월간 보고서 12개월 윈도우 + 여유분
-      const requestedBack = Number.isFinite(Number(months_back)) ? parseInt(months_back) : 24
-      const monthsBack = Math.max(1, Math.min(48, requestedBack))
+    if (mode === 'backfill' || mode === 'all') {
+      // backfill: 직전 N개월 (default 24, 최대 360 = 30년)
+      // all: 360개월 강제 (덴트웹에 있는 사실상 모든 매출)
+      const defaultBack = mode === 'all' ? 360 : 24
+      const requestedBack = Number.isFinite(Number(months_back)) ? parseInt(months_back) : defaultBack
+      const monthsBack = Math.max(1, Math.min(360, requestedBack))
       const now = new Date()
       for (let i = monthsBack; i >= 1; i--) {
         const d = new Date(now.getFullYear(), now.getMonth() - i, 1)

--- a/dental-clinic-manager/src/components/Dashboard/DashboardHome.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/DashboardHome.tsx
@@ -554,8 +554,6 @@ export default function DashboardHome() {
       <div className="flex flex-col lg:flex-row gap-4 sm:gap-6">
           {/* 왼쪽: 메인 콘텐츠 */}
           <div className="flex-1 space-y-4 sm:space-y-5">
-            {/* 오늘의 현황 + 병원 일정 (lg에서 가로 2컬럼) */}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-5">
             {/* 오늘의 현황 */}
             <div>
               <h3 className="text-sm font-semibold text-at-text mb-3 tracking-[0.08px] flex items-center gap-2">
@@ -682,15 +680,15 @@ export default function DashboardHome() {
                 </div>
               )}
             </div>
-            {/* 병원 일정 */}
-            <ScheduleWidget />
-            </div>
 
             {/* 소개환자 관리 위젯 */}
             <ReferralPendingWidget />
 
-            {/* 내 업무 (일회성 + 반복 업무 인스턴스) */}
-            <MyTasksSection />
+            {/* 내 업무 + 병원 일정 (lg에서 가로 2컬럼) */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-5">
+              <MyTasksSection />
+              <ScheduleWidget />
+            </div>
 
             {/* 팀 출퇴근 현황 */}
             <div>

--- a/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/index.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/ScheduleWidget/index.tsx
@@ -2,7 +2,6 @@
 
 import React, { useMemo, useState } from 'react'
 import { Calendar } from 'lucide-react'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useAuth } from '@/contexts/AuthContext'
 import { cn } from '@/lib/utils'
 import type { ScheduleEvent, ViewType } from './types'
@@ -45,39 +44,37 @@ export default function ScheduleWidget() {
   }
 
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between gap-2">
-          <CardTitle className="flex items-center gap-2 text-sm font-semibold text-at-text tracking-[0.08px]">
-            <Calendar className="w-4 h-4 text-at-accent" />
-            병원 일정
-          </CardTitle>
-          <div
-            role="tablist"
-            aria-label="기간 선택"
-            className="flex items-center gap-1 bg-at-surface-alt rounded-xl p-1"
-          >
-            {TAB_LABELS.map(tab => (
-              <button
-                key={tab.key}
-                role="tab"
-                aria-selected={activeTab === tab.key}
-                onClick={() => setActiveTab(tab.key)}
-                className={cn(
-                  'px-3 py-1 rounded-lg text-xs font-medium transition-colors tracking-[0.07px]',
-                  activeTab === tab.key
-                    ? 'bg-at-accent text-white shadow-sm'
-                    : 'text-at-text-secondary hover:bg-at-surface-hover'
-                )}
-              >
-                <span className="hidden sm:inline">{tab.label}</span>
-                <span className="sm:hidden">{tab.shortLabel}</span>
-              </button>
-            ))}
-          </div>
+    <div>
+      <div className="flex items-center justify-between mb-3 gap-2">
+        <h3 className="text-sm font-semibold text-at-text tracking-[0.08px] flex items-center gap-2">
+          <Calendar className="w-4 h-4 text-at-accent" />
+          병원 일정
+        </h3>
+        <div
+          role="tablist"
+          aria-label="기간 선택"
+          className="flex items-center gap-0.5 bg-white rounded-xl p-0.5 border border-at-border"
+        >
+          {TAB_LABELS.map(tab => (
+            <button
+              key={tab.key}
+              role="tab"
+              aria-selected={activeTab === tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className={cn(
+                'px-2.5 py-1 rounded-lg text-xs font-medium transition-colors tracking-[0.07px]',
+                activeTab === tab.key
+                  ? 'bg-at-accent text-white'
+                  : 'text-at-text-secondary hover:bg-at-surface-hover'
+              )}
+            >
+              <span className="hidden sm:inline">{tab.label}</span>
+              <span className="sm:hidden">{tab.shortLabel}</span>
+            </button>
+          ))}
         </div>
-      </CardHeader>
-      <CardContent>
+      </div>
+      <div className="bg-at-surface-alt rounded-2xl p-4 border border-at-border">
         {activeTab === 'today' && (
           <TodayView events={events} loading={loading} todayIso={todayIso} onItemClick={handleItemClick} />
         )}
@@ -87,8 +84,8 @@ export default function ScheduleWidget() {
         {activeTab === 'month' && (
           <MonthView events={events} loading={loading} todayIso={todayIso} rangeStart={range.start} onItemClick={handleItemClick} />
         )}
-      </CardContent>
+      </div>
       <ScheduleDetailModal event={modalEvent} open={modalOpen} onOpenChange={setModalOpen} />
-    </Card>
+    </div>
   )
 }

--- a/dental-clinic-manager/src/components/MonthlyReport/RevenueTrendChart.tsx
+++ b/dental-clinic-manager/src/components/MonthlyReport/RevenueTrendChart.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import { useMemo, useState } from 'react'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import {
-  AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine,
+  AreaChart, Area, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip,
+  ResponsiveContainer, ReferenceLine, Legend,
 } from 'recharts'
 import type { MonthlyRevenuePoint } from '@/types/monthlyReport'
 
@@ -12,81 +14,175 @@ interface RevenueTrendChartProps {
   targetMonth: number
 }
 
+type ViewMode = 'timeline' | 'overlay'
+
 function formatKrwShort(value: number): string {
   if (value >= 100_000_000) return `${(value / 100_000_000).toFixed(1)}억`
   if (value >= 10_000) return `${Math.round(value / 10_000).toLocaleString()}만`
   return value.toLocaleString()
 }
 
-function monthLabel(year: number, month: number): string {
+function timelineLabel(year: number, month: number): string {
   return `${String(year).slice(2)}.${String(month).padStart(2, '0')}`
 }
 
+const MONTH_LABELS = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월']
+
+// 연도별 라인 색상 — 진하기로 시간 흐름 표현 (오래된 → 옅게, 최근 → 진하게)
+const YEAR_COLOR_PALETTE = ['#86efac', '#34d399', '#10b981', '#059669']
+
 export default function RevenueTrendChart({ data, targetYear, targetMonth }: RevenueTrendChartProps) {
-  const chartData = data.map((d) => ({
-    label: monthLabel(d.year, d.month),
+  const [view, setView] = useState<ViewMode>('timeline')
+
+  // 시계열 데이터 (전체 기간을 그대로 시간순으로)
+  const timelineData = useMemo(() => data.map((d) => ({
+    label: timelineLabel(d.year, d.month),
     year: d.year,
     month: d.month,
     total: d.total_revenue,
     isTarget: d.year === targetYear && d.month === targetMonth,
-  }))
+  })), [data, targetYear, targetMonth])
 
-  const targetIndex = chartData.findIndex((d) => d.isTarget)
-  const hasData = chartData.some((d) => d.total > 0)
-  const monthsCount = chartData.length
-
-  // 36개월 표시 시 모든 라벨을 그리면 빽빽해지므로 일정 간격마다 표시
+  const targetIndex = timelineData.findIndex((d) => d.isTarget)
+  const hasData = timelineData.some((d) => d.total > 0)
+  const monthsCount = timelineData.length
   const xInterval = monthsCount > 24 ? 2 : monthsCount > 12 ? 1 : 0
+
+  // 겹쳐보기 데이터: target 기준 최근 3개 연도를 1~12월 X축에 동시에 그리기
+  const overlay = useMemo(() => {
+    const years: number[] = []
+    for (let i = 2; i >= 0; i--) years.push(targetYear - i)
+    const valueByYearMonth = new Map<string, number>()
+    for (const d of data) {
+      valueByYearMonth.set(`${d.year}-${d.month}`, d.total_revenue)
+    }
+    const rows = MONTH_LABELS.map((label, idx) => {
+      const m = idx + 1
+      const row: Record<string, string | number | null> = { month: label }
+      for (const y of years) {
+        const v = valueByYearMonth.get(`${y}-${m}`)
+        row[String(y)] = v === undefined ? null : v
+      }
+      return row
+    })
+    return { years, rows }
+  }, [data, targetYear])
+
+  const overlayHasData = overlay.years.some((y) =>
+    overlay.rows.some((row) => typeof row[String(y)] === 'number' && (row[String(y)] as number) > 0),
+  )
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>월 매출 변화 (최근 3개년)</CardTitle>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <CardTitle>월 매출 변화</CardTitle>
+          <div className="inline-flex rounded-xl bg-at-surface-alt p-1 text-xs font-medium">
+            <button
+              type="button"
+              onClick={() => setView('timeline')}
+              className={`px-3 py-1.5 rounded-lg transition-colors ${
+                view === 'timeline'
+                  ? 'bg-white text-at-text shadow-sm'
+                  : 'text-at-text-secondary hover:text-at-text'
+              }`}
+            >
+              최근 3개년 추이
+            </button>
+            <button
+              type="button"
+              onClick={() => setView('overlay')}
+              className={`px-3 py-1.5 rounded-lg transition-colors ${
+                view === 'overlay'
+                  ? 'bg-white text-at-text shadow-sm'
+                  : 'text-at-text-secondary hover:text-at-text'
+              }`}
+            >
+              연도별 겹쳐보기
+            </button>
+          </div>
+        </div>
       </CardHeader>
       <CardContent>
-        {!hasData ? (
-          <div className="h-72 flex items-center justify-center text-at-text-secondary text-sm">
-            매출 데이터가 없습니다. 경영 현황에서 월별 매출을 입력하세요.
-          </div>
+        {view === 'timeline' ? (
+          !hasData ? (
+            <div className="h-72 flex items-center justify-center text-at-text-secondary text-sm">
+              매출 데이터가 없습니다. 경영 현황에서 월별 매출을 입력하세요.
+            </div>
+          ) : (
+            <div className="h-80">
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={timelineData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="revenueGradient" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="#10b981" stopOpacity={0.35} />
+                      <stop offset="100%" stopColor="#10b981" stopOpacity={0.02} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <XAxis dataKey="label" stroke="#6b7280" fontSize={11} interval={xInterval} minTickGap={20} />
+                  <YAxis stroke="#6b7280" fontSize={12} tickFormatter={formatKrwShort} />
+                  <Tooltip
+                    formatter={(value) => [`${Number(value).toLocaleString()}원`, '총 매출']}
+                    labelFormatter={(label) => `20${label}`}
+                    contentStyle={{ borderRadius: 12, border: '1px solid #e5e7eb' }}
+                  />
+                  {targetIndex >= 0 && (
+                    <ReferenceLine x={timelineData[targetIndex].label} stroke="#6366f1" strokeDasharray="3 3" />
+                  )}
+                  <Area
+                    type="monotone"
+                    dataKey="total"
+                    stroke="#10b981"
+                    strokeWidth={2.5}
+                    fill="url(#revenueGradient)"
+                    dot={{ r: 2.5, fill: '#10b981' }}
+                    activeDot={{ r: 5 }}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          )
         ) : (
-          <div className="h-80">
-            <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
-                <defs>
-                  <linearGradient id="revenueGradient" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor="#10b981" stopOpacity={0.35} />
-                    <stop offset="100%" stopColor="#10b981" stopOpacity={0.02} />
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                <XAxis
-                  dataKey="label"
-                  stroke="#6b7280"
-                  fontSize={11}
-                  interval={xInterval}
-                  minTickGap={20}
-                />
-                <YAxis stroke="#6b7280" fontSize={12} tickFormatter={formatKrwShort} />
-                <Tooltip
-                  formatter={(value) => [`${Number(value).toLocaleString()}원`, '총 매출']}
-                  labelFormatter={(label) => `20${label}`}
-                  contentStyle={{ borderRadius: 12, border: '1px solid #e5e7eb' }}
-                />
-                {targetIndex >= 0 && (
-                  <ReferenceLine x={chartData[targetIndex].label} stroke="#6366f1" strokeDasharray="3 3" />
-                )}
-                <Area
-                  type="monotone"
-                  dataKey="total"
-                  stroke="#10b981"
-                  strokeWidth={2.5}
-                  fill="url(#revenueGradient)"
-                  dot={{ r: 2.5, fill: '#10b981' }}
-                  activeDot={{ r: 5 }}
-                />
-              </AreaChart>
-            </ResponsiveContainer>
-          </div>
+          !overlayHasData ? (
+            <div className="h-72 flex items-center justify-center text-at-text-secondary text-sm">
+              비교할 데이터가 부족합니다. 매출 동기화가 완료되면 자동 표시됩니다.
+            </div>
+          ) : (
+            <div className="h-80">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={overlay.rows} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <XAxis dataKey="month" stroke="#6b7280" fontSize={12} />
+                  <YAxis stroke="#6b7280" fontSize={12} tickFormatter={formatKrwShort} />
+                  <Tooltip
+                    formatter={(value, name) => {
+                      if (value === null || value === undefined) return ['—', `${name}년`]
+                      return [`${Number(value).toLocaleString()}원`, `${name}년`]
+                    }}
+                    contentStyle={{ borderRadius: 12, border: '1px solid #e5e7eb' }}
+                  />
+                  <Legend formatter={(value: string) => `${value}년`} />
+                  {overlay.years.map((y, idx) => {
+                    const isTargetYear = y === targetYear
+                    return (
+                      <Line
+                        key={y}
+                        type="monotone"
+                        dataKey={String(y)}
+                        name={String(y)}
+                        stroke={YEAR_COLOR_PALETTE[idx + (4 - overlay.years.length)] ?? '#10b981'}
+                        strokeWidth={isTargetYear ? 3 : 2}
+                        dot={{ r: isTargetYear ? 4 : 3 }}
+                        activeDot={{ r: 6 }}
+                        connectNulls={false}
+                      />
+                    )
+                  })}
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary

- **매출 차트 연도별 겹쳐보기 탭** 추가 — 1년 단위로 끊어 3개 연도를 동시 표시
- **과거 매출 전체 backfill 지원** — 24년 4월 이전 데이터 누락 문제 해결 (2005-11부터 모든 매출 동기화)
- 일정 위젯 디자인 시스템 통일 + 내 업무 옆으로 위치 이동

## 주요 변경사항

### 매출 차트 (`src/components/MonthlyReport/RevenueTrendChart.tsx`)
- 탭 UI 추가
  - **최근 3개년 추이** — 기존 36개월 AreaChart 시계열
  - **연도별 겹쳐보기** — X축 1~12월, 3개 연도 라인 동시 표시
- 시간 흐름을 색 진하기로 표현 (오래된 연도 옅게, 최근 연도 진하게, 타깃 연도 굵게)

### 매출 backfill (`src/app/api/dentweb/request-revenue-sync/route.ts`)
- `months_back` 한도 48 → 360 (30년) 확장
- `mode='all'` 옵션 추가 (덴트웹의 모든 과거 매출을 한 번에 요청)
- 하얀치과: 2005-11 ~ 2024-03 누락 221개월 pending 주입 후 워커 자동 동기화 → 총 246개월 확보

### 일정 위젯 (`src/components/Dashboard/ScheduleWidget/`)
- Card/badge/Tailwind at-* 토큰 통일
- "내 업무" 카드 옆으로 위치 이동 (가로 레이아웃)

## Test plan
- [x] tsc --noEmit 통과
- [x] 하얀치과 revenue_records 246개월 확보 (2005-11 ~ 2026-04)
- [x] 17개 클리닉 보고서 재생성 성공
- [x] 4월 보고서 revenue_data 36개월 모두 채워짐 확인
- [x] pending_revenue_months 잔여 0건 (backfill 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)