### PR TITLE
fix(monthly-report): 연령대 변화 차트 스택/범례를 어린 나이 순으로 정렬

### DIFF
--- a/dental-clinic-manager/src/types/monthlyReport.ts
+++ b/dental-clinic-manager/src/types/monthlyReport.ts
@@ -23,16 +23,18 @@ export const AGE_GROUP_LABELS: Record<AgeGroupKey, string> = {
   unknown: '미상',
 }
 
-// 범례/스택 표시 순서: 10대 → 60대+ → (10세 미만/미상)
-// 사용자 요구사항: 10대부터 60대 이상으로 순서대로 배열
+// 범례/스택 표시 순서: 어린 연령대 → 높은 연령대 → 미상
+// 스택 차트에서 맨 아래(=배열 첫 항목)가 가장 어린 연령대,
+// 맨 위가 가장 높은 연령대가 되도록 오름차순 정렬한다.
+// 범례도 동일 순서로 좌측부터 어린 나이 순으로 표시된다.
 export const AGE_GROUP_ORDER: AgeGroupKey[] = [
+  'under_10',
   'teens',
   'twenties',
   'thirties',
   'forties',
   'fifties',
   'sixties_plus',
-  'under_10',
   'unknown',
 ]
 


### PR DESCRIPTION
## Summary

신환 연령대 변화 차트의 스택 순서와 범례 순서를 어린 나이 → 높은 나이로 정렬했습니다.

## 변경

- `AGE_GROUP_ORDER`: under_10 → teens → twenties → thirties → forties → fifties → sixties_plus → unknown
- 100% Stacked Bar에서 맨 아래가 10세 미만, 맨 위가 60대+
- 범례도 좌측부터 어린 나이 순으로 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)