### PR TITLE
release: develop → main (업무지시 일괄 변경/분류 + 월간 보고서 개선)

### DIFF
--- a/dental-clinic-manager/src/components/Bulletin/BulkAssigneeChangeModal.tsx
+++ b/dental-clinic-manager/src/components/Bulletin/BulkAssigneeChangeModal.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { X, Users } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import { ensureConnection } from '@/lib/supabase/connectionCheck'
+import { taskService } from '@/lib/bulletinService'
+import { appAlert } from '@/components/ui/AppDialog'
+
+interface StaffMember {
+  id: string
+  name: string
+  role: string
+}
+
+interface BulkAssigneeChangeModalProps {
+  selectedCount: number
+  selectedTaskIds: string[]
+  onClose: () => void
+  onSuccess: (updatedCount: number) => void
+}
+
+const roleLabel = (role: string) => {
+  const labels: Record<string, string> = {
+    master_admin: '마스터 관리자',
+    owner: '원장',
+    vice_director: '부원장',
+    manager: '매니저',
+    team_leader: '팀장',
+    staff: '직원',
+  }
+  return labels[role] || role
+}
+
+export default function BulkAssigneeChangeModal({
+  selectedCount,
+  selectedTaskIds,
+  onClose,
+  onSuccess,
+}: BulkAssigneeChangeModalProps) {
+  const [staff, setStaff] = useState<StaffMember[]>([])
+  const [newAssigneeId, setNewAssigneeId] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [loadingStaff, setLoadingStaff] = useState(true)
+
+  useEffect(() => {
+    const fetchStaff = async () => {
+      setLoadingStaff(true)
+      try {
+        const supabase = await ensureConnection()
+        if (!supabase) return
+        const clinicId =
+          sessionStorage.getItem('dental_clinic_id') || localStorage.getItem('dental_clinic_id')
+        if (!clinicId) return
+        const { data } = await (supabase as any)
+          .from('users')
+          .select('id, name, role')
+          .eq('clinic_id', clinicId)
+          .eq('status', 'active')
+          .order('name')
+        setStaff(data || [])
+      } catch (err) {
+        console.error('[BulkAssigneeChangeModal] fetchStaff error:', err)
+      } finally {
+        setLoadingStaff(false)
+      }
+    }
+    fetchStaff()
+  }, [])
+
+  const handleSubmit = async () => {
+    if (!newAssigneeId) {
+      await appAlert('변경할 담당자를 선택해주세요.')
+      return
+    }
+    setLoading(true)
+    const { success, updatedCount, error } = await taskService.bulkUpdateAssignee(
+      selectedTaskIds,
+      newAssigneeId
+    )
+    setLoading(false)
+    if (!success) {
+      await appAlert(error || '담당자 변경에 실패했습니다.')
+      return
+    }
+    onSuccess(updatedCount)
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-2xl border border-at-border w-full max-w-md shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-6 pt-5 pb-3 border-b border-at-border">
+          <div className="flex items-center gap-2">
+            <Users className="w-5 h-5 text-at-accent" />
+            <h3 className="text-base font-semibold text-at-text">담당자 일괄 변경</h3>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-at-surface-hover text-at-text-weak transition-colors"
+            aria-label="닫기"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="p-6 space-y-4">
+          <p className="text-sm text-at-text-secondary">
+            선택된 <span className="font-semibold text-at-accent">{selectedCount}건</span>의
+            업무 담당자를 한꺼번에 변경합니다.
+          </p>
+
+          <div>
+            <label className="block text-sm font-medium text-at-text mb-1.5">
+              새 담당자 <span className="text-at-error">*</span>
+            </label>
+            {loadingStaff ? (
+              <div className="text-sm text-at-text-weak">직원 목록을 불러오는 중...</div>
+            ) : (
+              <select
+                value={newAssigneeId}
+                onChange={(e) => setNewAssigneeId(e.target.value)}
+                className="w-full px-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent focus:border-at-accent transition-colors bg-white"
+              >
+                <option value="">담당자를 선택하세요</option>
+                {staff.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name} ({roleLabel(s.role)})
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          <p className="text-xs text-at-text-weak">
+            변경된 담당자에게는 업무 할당 알림이 발송됩니다.
+          </p>
+        </div>
+
+        <div className="flex justify-end gap-2 px-6 py-4 border-t border-at-border">
+          <Button type="button" variant="outline" onClick={onClose} disabled={loading}>
+            취소
+          </Button>
+          <Button type="button" onClick={handleSubmit} disabled={loading || loadingStaff}>
+            {loading ? '변경 중...' : `${selectedCount}건 담당자 변경`}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Bulletin/RecurrenceFields.tsx
+++ b/dental-clinic-manager/src/components/Bulletin/RecurrenceFields.tsx
@@ -47,14 +47,24 @@ export default function RecurrenceFields({
 
   const handleTypeChange = (type: RecurrenceType) => {
     // 주기 변경 시 이전 주기 필드 초기화
+    // quarterly: recurrence_month는 분기 내 몇 번째 달(1~3), recurrence_day_of_month는 일자
+    let nextMonth: number | undefined
+    if (type === 'yearly') {
+      nextMonth = value.recurrence_month ?? new Date().getMonth() + 1
+    } else if (type === 'quarterly') {
+      const m = value.recurrence_month
+      nextMonth = m && m >= 1 && m <= 3 ? m : 1
+    } else {
+      nextMonth = undefined
+    }
     update({
       recurrence_type: type,
       recurrence_weekday: type === 'weekly' ? (value.recurrence_weekday ?? new Date().getDay()) : undefined,
       recurrence_day_of_month:
-        type === 'monthly' || type === 'yearly'
+        type === 'monthly' || type === 'yearly' || type === 'quarterly'
           ? (value.recurrence_day_of_month ?? new Date().getDate())
           : undefined,
-      recurrence_month: type === 'yearly' ? (value.recurrence_month ?? new Date().getMonth() + 1) : undefined,
+      recurrence_month: nextMonth,
     })
   }
 
@@ -157,6 +167,40 @@ export default function RecurrenceFields({
             </div>
           )}
 
+          {/* 분기별: 분기 내 N번째 달 + 일자 */}
+          {value.recurrence_type === 'quarterly' && (
+            <div>
+              <label className="block text-sm font-medium text-at-text mb-1.5">
+                매분기 <span className="text-at-error">*</span>
+              </label>
+              <div className="flex items-center gap-2">
+                <select
+                  value={value.recurrence_month ?? 1}
+                  onChange={(e) => update({ recurrence_month: Number(e.target.value) })}
+                  className="px-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent focus:border-at-accent transition-colors bg-white"
+                >
+                  <option value={1}>첫째 달</option>
+                  <option value={2}>둘째 달</option>
+                  <option value={3}>셋째 달</option>
+                </select>
+                <select
+                  value={value.recurrence_day_of_month ?? ''}
+                  onChange={(e) => update({ recurrence_day_of_month: Number(e.target.value) })}
+                  className="w-24 px-3 py-2 border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent focus:border-at-accent transition-colors bg-white"
+                >
+                  {Array.from({ length: 31 }, (_, i) => i + 1).map((day) => (
+                    <option key={day} value={day}>
+                      {day}일
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <p className="text-xs text-at-text-weak mt-1.5">
+                * 분기는 1·2·3월 / 4·5·6월 / 7·8·9월 / 10·11·12월 기준입니다.
+              </p>
+            </div>
+          )}
+
           {/* 연간: 월·일 선택 */}
           {value.recurrence_type === 'yearly' && (
             <div>
@@ -235,6 +279,12 @@ export function validateRecurrence(value: RecurrenceFieldsValue): string | null 
       }
       break
     case 'monthly':
+      if (!value.recurrence_day_of_month) return '반복할 일자를 선택해주세요.'
+      break
+    case 'quarterly':
+      if (!value.recurrence_month || value.recurrence_month < 1 || value.recurrence_month > 3) {
+        return '분기 내 반복할 달(첫째/둘째/셋째)을 선택해주세요.'
+      }
       if (!value.recurrence_day_of_month) return '반복할 일자를 선택해주세요.'
       break
     case 'yearly':

--- a/dental-clinic-manager/src/components/Bulletin/TaskCardView.tsx
+++ b/dental-clinic-manager/src/components/Bulletin/TaskCardView.tsx
@@ -12,15 +12,20 @@ import {
   Flag,
   Eye,
 } from 'lucide-react'
-import type { Task, TaskStatus, TaskPriority } from '@/types/bulletin'
+import type { Task, TaskStatus, TaskPriority, TaskPeriod } from '@/types/bulletin'
 import {
   TASK_STATUS_LABELS,
   TASK_PRIORITY_LABELS,
+  TASK_PERIOD_LABELS,
+  TASK_PERIOD_COLORS,
 } from '@/types/bulletin'
 
 interface TaskCardViewProps {
   tasks: Task[]
   onTaskClick: (task: Task) => void
+  selectionMode?: boolean
+  selectedIds?: Set<string>
+  onToggleSelect?: (taskId: string) => void
 }
 
 const STATUS_ORDER: TaskStatus[] = ['pending', 'in_progress', 'review', 'completed', 'on_hold', 'cancelled']
@@ -89,7 +94,13 @@ const getAvatarColor = (name: string) => {
   return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length]
 }
 
-export default function TaskCardView({ tasks, onTaskClick }: TaskCardViewProps) {
+export default function TaskCardView({
+  tasks,
+  onTaskClick,
+  selectionMode = false,
+  selectedIds,
+  onToggleSelect,
+}: TaskCardViewProps) {
   // 상태별로 그룹핑
   const grouped = STATUS_ORDER.reduce((acc, status) => {
     acc[status] = tasks.filter(t => t.status === status)
@@ -101,11 +112,20 @@ export default function TaskCardView({ tasks, onTaskClick }: TaskCardViewProps) 
 
   if (tasks.length === 0) return null
 
+  // selectionMode면 첫 컬럼(체크박스 36px)을 앞에 추가
+  const colsCompleted = selectionMode
+    ? 'sm:grid-cols-[36px_1fr_120px_120px_120px_100px]'
+    : 'sm:grid-cols-[1fr_120px_120px_120px_100px]'
+  const colsDefault = selectionMode
+    ? 'sm:grid-cols-[36px_1fr_120px_120px_100px]'
+    : 'sm:grid-cols-[1fr_120px_120px_100px]'
+
   return (
     <div className="space-y-6">
       {activeStatuses.map((status) => {
         const style = STATUS_BADGE_STYLES[status]
         const statusTasks = grouped[status]
+        const gridCols = status === 'completed' ? colsCompleted : colsDefault
 
         return (
           <div key={status}>
@@ -119,7 +139,8 @@ export default function TaskCardView({ tasks, onTaskClick }: TaskCardViewProps) 
             </div>
 
             {/* 테이블 헤더 */}
-            <div className={`hidden sm:grid ${status === 'completed' ? 'sm:grid-cols-[1fr_120px_120px_120px_100px]' : 'sm:grid-cols-[1fr_120px_120px_100px]'} gap-4 px-4 py-2 text-xs font-medium text-at-text-weak uppercase tracking-wider`}>
+            <div className={`hidden sm:grid ${gridCols} gap-4 px-4 py-2 text-xs font-medium text-at-text-weak uppercase tracking-wider`}>
+              {selectionMode && <span></span>}
               <span>업무명</span>
               <span>담당자</span>
               <span>마감일</span>
@@ -129,20 +150,46 @@ export default function TaskCardView({ tasks, onTaskClick }: TaskCardViewProps) 
 
             {/* 업무 카드 목록 */}
             <div className={`bg-white rounded-2xl border ${style.border} divide-y divide-at-border`}>
-              {statusTasks.map((task) => (
+              {statusTasks.map((task) => {
+                const isChecked = selectedIds?.has(task.id) ?? false
+                const handleRowClick = () => {
+                  if (selectionMode) {
+                    onToggleSelect?.(task.id)
+                  } else {
+                    onTaskClick(task)
+                  }
+                }
+                const period: TaskPeriod = task.task_period || 'general'
+                return (
                 <div
                   key={task.id}
-                  onClick={() => onTaskClick(task)}
-                  className="px-4 py-3 hover:bg-at-surface-alt cursor-pointer transition-colors group"
+                  onClick={handleRowClick}
+                  className={`px-4 py-3 hover:bg-at-surface-alt cursor-pointer transition-colors group ${isChecked ? 'bg-at-accent-light/40' : ''}`}
                 >
                   {/* 모바일 레이아웃 */}
                   <div className="sm:hidden space-y-2">
                     <div className="flex items-start gap-2">
+                      {selectionMode && (
+                        <input
+                          type="checkbox"
+                          checked={isChecked}
+                          onChange={() => onToggleSelect?.(task.id)}
+                          onClick={(e) => e.stopPropagation()}
+                          className="mt-1 w-4 h-4 rounded border-at-border text-at-accent focus:ring-2 focus:ring-at-accent"
+                        />
+                      )}
                       <div className={`mt-0.5 ${style.text}`}>
                         {getStatusIcon(task.status)}
                       </div>
                       <div className="flex-1 min-w-0">
-                        <h4 className="text-sm font-medium text-at-text truncate">{task.title}</h4>
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <h4 className="text-sm font-medium text-at-text truncate">{task.title}</h4>
+                          {period !== 'general' && (
+                            <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded border ${TASK_PERIOD_COLORS[period]}`}>
+                              {TASK_PERIOD_LABELS[period]}
+                            </span>
+                          )}
+                        </div>
                         <div className="flex items-center gap-3 mt-1.5 text-xs text-at-text-weak">
                           <span className="flex items-center gap-1">
                             <User className="w-3 h-3" />
@@ -170,7 +217,18 @@ export default function TaskCardView({ tasks, onTaskClick }: TaskCardViewProps) 
                   </div>
 
                   {/* 데스크탑 레이아웃 (테이블 형태) */}
-                  <div className={`hidden sm:grid ${status === 'completed' ? 'sm:grid-cols-[1fr_120px_120px_120px_100px]' : 'sm:grid-cols-[1fr_120px_120px_100px]'} gap-4 items-center`}>
+                  <div className={`hidden sm:grid ${gridCols} gap-4 items-center`}>
+                    {selectionMode && (
+                      <div className="flex items-center justify-center">
+                        <input
+                          type="checkbox"
+                          checked={isChecked}
+                          onChange={() => onToggleSelect?.(task.id)}
+                          onClick={(e) => e.stopPropagation()}
+                          className="w-4 h-4 rounded border-at-border text-at-accent focus:ring-2 focus:ring-at-accent"
+                        />
+                      </div>
+                    )}
                     {/* 업무명 */}
                     <div className="flex items-center gap-3 min-w-0">
                       <div className={`flex-shrink-0 ${style.text}`}>
@@ -180,6 +238,11 @@ export default function TaskCardView({ tasks, onTaskClick }: TaskCardViewProps) 
                         <span className="text-sm font-medium text-at-text truncate group-hover:text-at-accent transition-colors">
                           {task.title}
                         </span>
+                        {period !== 'general' && (
+                          <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded border flex-shrink-0 ${TASK_PERIOD_COLORS[period]}`}>
+                            {TASK_PERIOD_LABELS[period]}
+                          </span>
+                        )}
                         {task.comments_count > 0 && (
                           <span className="flex items-center gap-0.5 text-xs text-at-text-weak flex-shrink-0">
                             <MessageCircle className="w-3 h-3" />
@@ -236,7 +299,8 @@ export default function TaskCardView({ tasks, onTaskClick }: TaskCardViewProps) 
                     </div>
                   </div>
                 </div>
-              ))}
+                )
+              })}
             </div>
           </div>
         )

--- a/dental-clinic-manager/src/components/Bulletin/TaskDetail.tsx
+++ b/dental-clinic-manager/src/components/Bulletin/TaskDetail.tsx
@@ -14,18 +14,22 @@ import {
   Loader2,
   Pause,
   XCircle,
-  Eye
+  Eye,
+  UserCog,
 } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { taskService, taskCommentService } from '@/lib/bulletinService'
-import type { Task, TaskStatus, TaskComment } from '@/types/bulletin'
+import { ensureConnection } from '@/lib/supabase/connectionCheck'
+import type { Task, TaskStatus, TaskComment, TaskPeriod } from '@/types/bulletin'
 import {
   TASK_STATUS_LABELS,
   TASK_STATUS_COLORS,
   TASK_PRIORITY_LABELS,
-  TASK_PRIORITY_COLORS
+  TASK_PRIORITY_COLORS,
+  TASK_PERIOD_LABELS,
+  TASK_PERIOD_COLORS,
 } from '@/types/bulletin'
-import { appConfirm } from '@/components/ui/AppDialog'
+import { appConfirm, appAlert } from '@/components/ui/AppDialog'
 import { sanitizeHtml } from '@/utils/sanitize'
 
 interface TaskDetailProps {
@@ -51,6 +55,9 @@ export default function TaskDetail({
   const [submittingComment, setSubmittingComment] = useState(false)
   const [progress, setProgress] = useState(task.progress)
   const [updatingProgress, setUpdatingProgress] = useState(false)
+  const [showAssigneePicker, setShowAssigneePicker] = useState(false)
+  const [staff, setStaff] = useState<Array<{ id: string; name: string; role: string }>>([])
+  const [updatingAssignee, setUpdatingAssignee] = useState(false)
 
   useEffect(() => {
     fetchComments()
@@ -161,6 +168,49 @@ export default function TaskDetail({
   const isAssignee = currentUserId === task.assignee_id
   const isAssigner = currentUserId === task.assigner_id
   const isOwner = currentUser?.role === 'owner'
+  const canChangeAssignee = isOwner || currentUser?.role === 'master_admin'
+
+  const period: TaskPeriod = task.task_period || 'general'
+
+  const openAssigneePicker = async () => {
+    if (staff.length === 0) {
+      try {
+        const supabase = await ensureConnection()
+        if (supabase) {
+          const clinicId =
+            sessionStorage.getItem('dental_clinic_id') || localStorage.getItem('dental_clinic_id')
+          if (clinicId) {
+            const { data } = await (supabase as any)
+              .from('users')
+              .select('id, name, role')
+              .eq('clinic_id', clinicId)
+              .eq('status', 'active')
+              .order('name')
+            setStaff(data || [])
+          }
+        }
+      } catch (err) {
+        console.error('[TaskDetail.openAssigneePicker] Error:', err)
+      }
+    }
+    setShowAssigneePicker(true)
+  }
+
+  const handleAssigneeChange = async (newAssigneeId: string) => {
+    if (!newAssigneeId || newAssigneeId === task.assignee_id) {
+      setShowAssigneePicker(false)
+      return
+    }
+    setUpdatingAssignee(true)
+    const { error } = await taskService.updateTask(task.id, { assignee_id: newAssigneeId })
+    setUpdatingAssignee(false)
+    if (error) {
+      await appAlert(`담당자 변경에 실패했습니다: ${error}`)
+      return
+    }
+    setShowAssigneePicker(false)
+    onRefresh()
+  }
 
   return (
     <div className="space-y-6">
@@ -199,10 +249,15 @@ export default function TaskDetail({
       <div className="bg-white rounded-2xl border border-at-border overflow-hidden">
         {/* 제목 영역 */}
         <div className="p-6 border-b border-at-border">
-          <div className="flex items-center gap-2 mb-3">
+          <div className="flex items-center gap-2 mb-3 flex-wrap">
             <span className={`text-xs px-2 py-0.5 rounded-full ${TASK_PRIORITY_COLORS[task.priority]}`}>
               {TASK_PRIORITY_LABELS[task.priority]}
             </span>
+            {period !== 'general' && (
+              <span className={`text-xs px-2 py-0.5 rounded-full border ${TASK_PERIOD_COLORS[period]}`}>
+                {TASK_PERIOD_LABELS[period]} 업무
+              </span>
+            )}
             <span className={`flex items-center gap-1 text-xs px-2 py-0.5 rounded-full ${TASK_STATUS_COLORS[task.status]}`}>
               {getStatusIcon(task.status)}
               {TASK_STATUS_LABELS[task.status]}
@@ -217,11 +272,43 @@ export default function TaskDetail({
 
           <div className="grid grid-cols-2 gap-4 text-sm">
             <div>
-              <span className="text-at-text-weak">담당자</span>
-              <p className="flex items-center gap-1 font-medium text-at-text mt-1">
-                <User className="w-4 h-4" />
-                {task.assignee_name}
-              </p>
+              <div className="flex items-center justify-between">
+                <span className="text-at-text-weak">담당자</span>
+                {canChangeAssignee && task.status !== 'completed' && task.status !== 'cancelled' && (
+                  <button
+                    type="button"
+                    onClick={openAssigneePicker}
+                    className="inline-flex items-center gap-1 text-xs text-at-accent hover:underline"
+                  >
+                    <UserCog className="w-3.5 h-3.5" />
+                    변경
+                  </button>
+                )}
+              </div>
+              {showAssigneePicker ? (
+                <div className="mt-1">
+                  <select
+                    autoFocus
+                    disabled={updatingAssignee}
+                    defaultValue={task.assignee_id}
+                    onChange={(e) => handleAssigneeChange(e.target.value)}
+                    onBlur={() => setShowAssigneePicker(false)}
+                    className="w-full px-2 py-1.5 border border-at-border rounded-lg text-sm focus:ring-2 focus:ring-at-accent focus:border-at-accent bg-white"
+                  >
+                    {staff.length === 0 && <option>불러오는 중...</option>}
+                    {staff.map((s) => (
+                      <option key={s.id} value={s.id}>
+                        {s.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ) : (
+                <p className="flex items-center gap-1 font-medium text-at-text mt-1">
+                  <User className="w-4 h-4" />
+                  {task.assignee_name}
+                </p>
+              )}
             </div>
             <div>
               <span className="text-at-text-weak">할당자</span>

--- a/dental-clinic-manager/src/components/Bulletin/TaskForm.tsx
+++ b/dental-clinic-manager/src/components/Bulletin/TaskForm.tsx
@@ -6,8 +6,8 @@ import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { taskService, recurringTaskTemplateService } from '@/lib/bulletinService'
 import { ensureConnection } from '@/lib/supabase/connectionCheck'
-import type { Task, TaskPriority, CreateTaskDto } from '@/types/bulletin'
-import { TASK_PRIORITY_LABELS } from '@/types/bulletin'
+import type { Task, TaskPriority, TaskPeriod, CreateTaskDto } from '@/types/bulletin'
+import { TASK_PRIORITY_LABELS, TASK_PERIOD_LABELS } from '@/types/bulletin'
 import EnhancedTiptapEditor from '@/components/Protocol/EnhancedTiptapEditor'
 import RecurrenceFields, { validateRecurrence, type RecurrenceFieldsValue } from './RecurrenceFields'
 
@@ -32,6 +32,7 @@ export default function TaskForm({
     title: task?.title || '',
     description: task?.description || '',
     priority: task?.priority || 'medium',
+    task_period: task?.task_period || 'general',
     assignee_id: task?.assignee_id || '',
     due_date: task?.due_date || '',
   })
@@ -125,6 +126,7 @@ export default function TaskForm({
         // 오늘 해당 패턴과 일치하면 즉시 첫 인스턴스 생성
         await recurringTaskTemplateService.materializeDueInstances()
       } else {
+        // 일회성 업무: 사용자가 명시한 task_period 그대로 저장 (default 'general')
         const { error: createError } = await taskService.createTask(formData)
         if (createError) throw new Error(createError)
       }
@@ -208,20 +210,40 @@ export default function TaskForm({
           )}
         </div>
 
-        {/* 우선순위 */}
-        <div>
-          <label className="block text-sm font-medium text-at-text-secondary mb-2">
-            우선순위
-          </label>
-          <select
-            value={formData.priority}
-            onChange={(e) => setFormData({ ...formData, priority: e.target.value as TaskPriority })}
-            className="w-full border border-at-border rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-at-accent"
-          >
-            {Object.entries(TASK_PRIORITY_LABELS).map(([key, label]) => (
-              <option key={key} value={key}>{label}</option>
-            ))}
-          </select>
+        {/* 우선순위 + 업무 분류 */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-at-text-secondary mb-2">
+              우선순위
+            </label>
+            <select
+              value={formData.priority}
+              onChange={(e) => setFormData({ ...formData, priority: e.target.value as TaskPriority })}
+              className="w-full border border-at-border rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-at-accent"
+            >
+              {Object.entries(TASK_PRIORITY_LABELS).map(([key, label]) => (
+                <option key={key} value={key}>{label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* 일회성 업무 또는 편집 모드에서만 노출 — 반복 업무는 recurrence_type을 따라감 */}
+          {(!recurrence.enabled || isEditing) && (
+            <div>
+              <label className="block text-sm font-medium text-at-text-secondary mb-2">
+                업무 분류
+              </label>
+              <select
+                value={formData.task_period || 'general'}
+                onChange={(e) => setFormData({ ...formData, task_period: e.target.value as TaskPeriod })}
+                className="w-full border border-at-border rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-at-accent"
+              >
+                {Object.entries(TASK_PERIOD_LABELS).map(([key, label]) => (
+                  <option key={key} value={key}>{label}</option>
+                ))}
+              </select>
+            </div>
+          )}
         </div>
 
         {/* 마감일 (일회성 업무용) */}

--- a/dental-clinic-manager/src/components/Bulletin/TaskList.tsx
+++ b/dental-clinic-manager/src/components/Bulletin/TaskList.tsx
@@ -13,20 +13,25 @@ import {
   CalendarDays,
   Users,
   Repeat,
+  CheckSquare,
+  X,
+  Tag,
 } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { taskService } from '@/lib/bulletinService'
-import type { Task, TaskStatus, TaskPriority } from '@/types/bulletin'
+import type { Task, TaskStatus, TaskPriority, TaskPeriod } from '@/types/bulletin'
 import {
   TASK_STATUS_LABELS,
   TASK_PRIORITY_LABELS,
+  TASK_PERIOD_LABELS,
 } from '@/types/bulletin'
 import TaskDetail from './TaskDetail'
 import TaskForm from './TaskForm'
 import TaskCardView from './TaskCardView'
 import RecurringTaskTemplateList from './RecurringTaskTemplateList'
+import BulkAssigneeChangeModal from './BulkAssigneeChangeModal'
 import { appConfirm, appAlert } from '@/components/ui/AppDialog'
 
 type ViewTab = 'active' | 'completed' | 'recurring'
@@ -70,14 +75,29 @@ const getCurrentUserId = (): string | null => {
   }
 }
 
+// 현재 사용자 role 가져오기 (대표 원장 일괄 변경 권한 체크용)
+const getCurrentUserRole = (): string | null => {
+  if (typeof window === 'undefined') return null
+  const userStr = sessionStorage.getItem('dental_user') || localStorage.getItem('dental_user')
+  if (!userStr) return null
+  try {
+    return JSON.parse(userStr).role || null
+  } catch {
+    return null
+  }
+}
+
 export default function TaskList({ canCreate = false, showMyTasksOnly = false }: TaskListProps) {
   const searchParams = useSearchParams()
   const [allTasks, setAllTasks] = useState<Task[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const currentUserId = getCurrentUserId()
+  const currentUserRole = getCurrentUserRole()
+  const canBulkReassign = currentUserRole === 'owner' || currentUserRole === 'master_admin'
   const autoOpenedRef = useRef(false)
   const [selectedPriority, setSelectedPriority] = useState<TaskPriority | ''>('')
+  const [periodFilter, setPeriodFilter] = useState<TaskPeriod | ''>('')
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedTask, setSelectedTask] = useState<Task | null>(null)
   const [showForm, setShowForm] = useState(false)
@@ -87,6 +107,10 @@ export default function TaskList({ canCreate = false, showMyTasksOnly = false }:
   const [completedPeriod, setCompletedPeriod] = useState<CompletedPeriod>('all')
   const [assigneeFilter, setAssigneeFilter] = useState<string>('')
   const [completedSearchQuery, setCompletedSearchQuery] = useState('')
+  // 일괄 선택 모드 (대표 원장만 사용)
+  const [selectionMode, setSelectionMode] = useState(false)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [showBulkAssigneeModal, setShowBulkAssigneeModal] = useState(false)
   const [stats, setStats] = useState<{
     total: number
     pending: number
@@ -275,16 +299,52 @@ export default function TaskList({ canCreate = false, showMyTasksOnly = false }:
 
   // 상태 필터 적용
   const displayedTasks = useMemo(() => {
+    let base: Task[]
     if (statusFilter === 'overdue') {
-      return allTasks.filter(t => isOverdue(t))
+      base = allTasks.filter(t => isOverdue(t))
     } else if (statusFilter === 'completed') {
-      return filteredCompletedTasks
+      base = filteredCompletedTasks
     } else if (statusFilter) {
-      return allTasks.filter(t => t.status === statusFilter)
+      base = allTasks.filter(t => t.status === statusFilter)
     } else {
-      return activeTab === 'active' ? activeTasks : filteredCompletedTasks
+      base = activeTab === 'active' ? activeTasks : filteredCompletedTasks
     }
-  }, [allTasks, activeTasks, filteredCompletedTasks, statusFilter, activeTab])
+    // 분류(주간/월간/분기/연간/일반) 필터
+    if (periodFilter) {
+      base = base.filter(t => (t.task_period || 'general') === periodFilter)
+    }
+    return base
+  }, [allTasks, activeTasks, filteredCompletedTasks, statusFilter, activeTab, periodFilter])
+
+  const toggleSelect = useCallback((taskId: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(taskId)) next.delete(taskId)
+      else next.add(taskId)
+      return next
+    })
+  }, [])
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedIds(prev => {
+      if (prev.size === displayedTasks.length && displayedTasks.length > 0) {
+        return new Set()
+      }
+      return new Set(displayedTasks.map(t => t.id))
+    })
+  }, [displayedTasks])
+
+  const exitSelectionMode = useCallback(() => {
+    setSelectionMode(false)
+    setSelectedIds(new Set())
+  }, [])
+
+  const handleBulkAssigneeSuccess = useCallback(async (updatedCount: number) => {
+    setShowBulkAssigneeModal(false)
+    exitSelectionMode()
+    await Promise.all([fetchTasks(), fetchStats()])
+    await appAlert(`${updatedCount}건의 담당자가 변경되었습니다.`)
+  }, [exitSelectionMode, fetchTasks, fetchStats])
 
   // TaskForm 표시
   if (showForm) {
@@ -325,13 +385,59 @@ export default function TaskList({ canCreate = false, showMyTasksOnly = false }:
             <span className="text-xs text-at-text-weak font-normal ml-1">총 {allTasks.length}건</span>
           )}
         </div>
-        {canCreate && (
-          <Button onClick={() => setShowForm(true)} className="flex items-center gap-2">
-            <Plus className="w-4 h-4" />
-            새 업무 할당
-          </Button>
-        )}
+        <div className="flex items-center gap-2">
+          {canBulkReassign && activeTab !== 'recurring' && !selectionMode && (
+            <Button
+              variant="outline"
+              onClick={() => setSelectionMode(true)}
+              className="flex items-center gap-2"
+            >
+              <CheckSquare className="w-4 h-4" />
+              일괄 선택
+            </Button>
+          )}
+          {canCreate && (
+            <Button onClick={() => setShowForm(true)} className="flex items-center gap-2">
+              <Plus className="w-4 h-4" />
+              새 업무 할당
+            </Button>
+          )}
+        </div>
       </div>
+
+      {/* 일괄 선택 모드 액션바 */}
+      {selectionMode && (
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-3 bg-at-accent-light border border-at-accent rounded-xl">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={toggleSelectAll}
+              className="text-sm font-medium text-at-accent hover:underline"
+            >
+              {selectedIds.size === displayedTasks.length && displayedTasks.length > 0
+                ? '전체 해제'
+                : '현재 보이는 업무 전체 선택'}
+            </button>
+            <span className="text-sm text-at-text-secondary">
+              {selectedIds.size}건 선택됨
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={() => setShowBulkAssigneeModal(true)}
+              disabled={selectedIds.size === 0}
+              className="flex items-center gap-2"
+            >
+              <Users className="w-4 h-4" />
+              담당자 일괄 변경
+            </Button>
+            <Button variant="outline" onClick={exitSelectionMode} className="flex items-center gap-2">
+              <X className="w-4 h-4" />
+              취소
+            </Button>
+          </div>
+        </div>
+      )}
 
       {/* 통계 (클릭하면 해당 상태 필터링) */}
       {stats && (
@@ -435,9 +541,9 @@ export default function TaskList({ canCreate = false, showMyTasksOnly = false }:
         <RecurringTaskTemplateList />
       )}
 
-      {/* 진행 업무 탭: 검색 및 우선순위 필터 */}
+      {/* 진행 업무 탭: 검색 및 우선순위 + 분류 필터 */}
       {activeTab === 'active' && !statusFilter && (
-        <div className="flex flex-col sm:flex-row gap-3">
+        <div className="flex flex-col sm:flex-row gap-3 flex-wrap">
           <div className="flex items-center gap-2">
             <Filter className="w-4 h-4 text-at-text-weak" />
             <select
@@ -451,7 +557,20 @@ export default function TaskList({ canCreate = false, showMyTasksOnly = false }:
               ))}
             </select>
           </div>
-          <form onSubmit={handleSearch} className="flex-1 flex gap-2">
+          <div className="flex items-center gap-2">
+            <Tag className="w-4 h-4 text-at-text-weak" />
+            <select
+              value={periodFilter}
+              onChange={(e) => setPeriodFilter(e.target.value as TaskPeriod | '')}
+              className="border border-at-border rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-at-accent"
+            >
+              <option value="">전체 분류</option>
+              {Object.entries(TASK_PERIOD_LABELS).map(([key, label]) => (
+                <option key={key} value={key}>{label}</option>
+              ))}
+            </select>
+          </div>
+          <form onSubmit={handleSearch} className="flex-1 flex gap-2 min-w-[200px]">
             <div className="relative flex-1">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-at-text-weak" />
               <Input
@@ -606,8 +725,24 @@ export default function TaskList({ canCreate = false, showMyTasksOnly = false }:
           </p>
         </div>
       ) : (
-        <TaskCardView tasks={displayedTasks} onTaskClick={handleTaskClick} />
+        <TaskCardView
+          tasks={displayedTasks}
+          onTaskClick={handleTaskClick}
+          selectionMode={selectionMode}
+          selectedIds={selectedIds}
+          onToggleSelect={toggleSelect}
+        />
       ))}
+
+      {/* 담당자 일괄 변경 모달 */}
+      {showBulkAssigneeModal && (
+        <BulkAssigneeChangeModal
+          selectedCount={selectedIds.size}
+          selectedTaskIds={Array.from(selectedIds)}
+          onClose={() => setShowBulkAssigneeModal(false)}
+          onSuccess={handleBulkAssigneeSuccess}
+        />
+      )}
     </div>
   )
 }

--- a/dental-clinic-manager/src/lib/bulletinService.ts
+++ b/dental-clinic-manager/src/lib/bulletinService.ts
@@ -736,6 +736,7 @@ export const taskService = {
           title: input.title,
           description: input.description || null,
           priority: input.priority || 'medium',
+          task_period: input.task_period || 'general',
           assignee_id: input.assignee_id,
           assigner_id: userId,
           due_date: input.due_date || null,
@@ -782,6 +783,7 @@ export const taskService = {
         }
       }
       if (input.priority !== undefined) updateData.priority = input.priority
+      if (input.task_period !== undefined) updateData.task_period = input.task_period
       if (input.assignee_id !== undefined) updateData.assignee_id = input.assignee_id
       if (input.due_date !== undefined) updateData.due_date = input.due_date || null
       if (input.progress !== undefined) updateData.progress = input.progress
@@ -832,6 +834,62 @@ export const taskService = {
     } catch (error) {
       console.error('[taskService.updateTask] Error:', error)
       return { data: null, error: extractErrorMessage(error) }
+    }
+  },
+
+  /**
+   * 다수 업무의 담당자 일괄 변경 (대표 원장 권한)
+   * - 각 업무에 대해 새 담당자에게 알림 전송
+   * - 권한은 RLS UPDATE 정책 + 페이지의 owner 체크로 이중 보호됨
+   */
+  async bulkUpdateAssignee(
+    taskIds: string[],
+    newAssigneeId: string
+  ): Promise<{ success: boolean; updatedCount: number; error: string | null }> {
+    try {
+      if (!taskIds.length) return { success: true, updatedCount: 0, error: null }
+
+      const supabase = await ensureConnection()
+      if (!supabase) throw new Error('Database connection failed')
+
+      const clinicId = getCurrentClinicId()
+      if (!clinicId) throw new Error('Clinic not found')
+
+      const { data: existing, error: fetchErr } = await (supabase as any)
+        .from('tasks')
+        .select('id, title, assignee_id')
+        .in('id', taskIds)
+        .eq('clinic_id', clinicId)
+
+      if (fetchErr) throw fetchErr
+
+      const targetIds = (existing || [])
+        .filter((t: any) => t.assignee_id !== newAssigneeId)
+        .map((t: any) => t.id)
+
+      if (!targetIds.length) {
+        return { success: true, updatedCount: 0, error: null }
+      }
+
+      const { error: updateErr } = await (supabase as any)
+        .from('tasks')
+        .update({ assignee_id: newAssigneeId })
+        .in('id', targetIds)
+
+      if (updateErr) throw updateErr
+
+      const userName = getCurrentUserName()
+      const tasksToNotify = (existing || []).filter((t: any) => targetIds.includes(t.id))
+      tasksToNotify.forEach((t: any) => {
+        userNotificationService
+          .notifyTaskAssigned(newAssigneeId, userName || '관리자', t.title, t.id)
+          .catch((err) => console.error('[taskService.bulkUpdateAssignee] Notify error:', err))
+      })
+
+      return { success: true, updatedCount: targetIds.length, error: null }
+    } catch (error) {
+      console.error('[taskService.bulkUpdateAssignee] Error:', error)
+      return { success: false, updatedCount: 0, error: extractErrorMessage(error) }
     }
   },
 

--- a/dental-clinic-manager/src/types/bulletin.ts
+++ b/dental-clinic-manager/src/types/bulletin.ts
@@ -114,6 +114,14 @@ export type TaskPriority =
   | 'high'          // 높음
   | 'urgent'        // 긴급
 
+// 업무 분류 (주간/월간/분기별/연간/일반)
+export type TaskPeriod =
+  | 'general'       // 일반 (분류 없음)
+  | 'weekly'        // 주간 업무
+  | 'monthly'       // 월간 업무
+  | 'quarterly'     // 분기별 업무
+  | 'yearly'        // 연간 업무
+
 // 업무 할당
 export interface Task {
   id: string
@@ -122,6 +130,7 @@ export interface Task {
   description?: string
   status: TaskStatus
   priority: TaskPriority
+  task_period?: TaskPeriod     // 업무 분류 (주간/월간/분기/연간/일반)
   assignee_id: string          // 담당자 ID
   assignee_name?: string       // 담당자 이름
   assigner_id: string          // 할당자 ID
@@ -140,6 +149,7 @@ export interface CreateTaskDto {
   title: string
   description?: string
   priority?: TaskPriority
+  task_period?: TaskPeriod
   assignee_id: string
   due_date?: string
 }
@@ -150,6 +160,7 @@ export interface UpdateTaskDto {
   description?: string
   status?: TaskStatus
   priority?: TaskPriority
+  task_period?: TaskPeriod
   assignee_id?: string
   due_date?: string
   progress?: number
@@ -226,12 +237,30 @@ export const TASK_PRIORITY_COLORS: Record<TaskPriority, string> = {
   urgent: 'bg-red-100 text-red-600'
 }
 
+// 업무 분류 라벨
+export const TASK_PERIOD_LABELS: Record<TaskPeriod, string> = {
+  general: '일반',
+  weekly: '주간',
+  monthly: '월간',
+  quarterly: '분기',
+  yearly: '연간',
+}
+
+// 업무 분류 색상 (배지용)
+export const TASK_PERIOD_COLORS: Record<TaskPeriod, string> = {
+  general: 'bg-gray-100 text-gray-600 border-gray-200',
+  weekly: 'bg-sky-50 text-sky-700 border-sky-200',
+  monthly: 'bg-indigo-50 text-indigo-700 border-indigo-200',
+  quarterly: 'bg-amber-50 text-amber-700 border-amber-200',
+  yearly: 'bg-rose-50 text-rose-700 border-rose-200',
+}
+
 // =====================================================
 // 반복 업무 템플릿
 // =====================================================
 
 // 반복 주기 유형
-export type RecurrenceType = 'weekly' | 'monthly' | 'yearly'
+export type RecurrenceType = 'weekly' | 'monthly' | 'quarterly' | 'yearly'
 
 // 반복 업무 템플릿
 export interface RecurringTaskTemplate {
@@ -299,7 +328,15 @@ export const WEEKDAY_LABELS: Record<number, string> = {
 export const RECURRENCE_TYPE_LABELS: Record<RecurrenceType, string> = {
   weekly: '주간',
   monthly: '월간',
+  quarterly: '분기',
   yearly: '연간',
+}
+
+// 분기별 반복: recurrence_month는 분기 내 몇 번째 달인지(1=첫 달, 2=둘째 달, 3=셋째 달)
+const QUARTER_OFFSET_LABELS: Record<number, string> = {
+  1: '첫째 달',
+  2: '둘째 달',
+  3: '셋째 달',
 }
 
 // 반복 설정을 사람이 읽을 수 있는 문구로 변환
@@ -309,6 +346,8 @@ export const formatRecurrenceRule = (template: Pick<RecurringTaskTemplate, 'recu
       return `매주 ${WEEKDAY_LABELS[template.recurrence_weekday ?? 0]}요일`
     case 'monthly':
       return `매월 ${template.recurrence_day_of_month ?? 1}일`
+    case 'quarterly':
+      return `매분기 ${QUARTER_OFFSET_LABELS[template.recurrence_month ?? 1] ?? '첫째 달'} ${template.recurrence_day_of_month ?? 1}일`
     case 'yearly':
       return `매년 ${template.recurrence_month ?? 1}월 ${template.recurrence_day_of_month ?? 1}일`
     default:

--- a/dental-clinic-manager/supabase/migrations/20260430_add_task_period_and_quarterly.sql
+++ b/dental-clinic-manager/supabase/migrations/20260430_add_task_period_and_quarterly.sql
@@ -1,0 +1,37 @@
+-- ============================================
+-- 업무 분류(task_period) 추가 + 분기별(quarterly) 반복 지원
+-- Migration: 20260430_add_task_period_and_quarterly.sql
+-- Created: 2026-04-30
+-- ============================================
+
+-- 1. tasks 테이블에 task_period 컬럼 추가
+--    weekly, monthly, quarterly, yearly, general(분류 없음)
+ALTER TABLE tasks
+  ADD COLUMN IF NOT EXISTS task_period TEXT
+    CHECK (task_period IN ('weekly', 'monthly', 'quarterly', 'yearly', 'general'))
+    DEFAULT 'general';
+
+CREATE INDEX IF NOT EXISTS idx_tasks_task_period
+  ON tasks(clinic_id, task_period);
+
+-- 2. recurring_task_templates에 quarterly 추가
+--    기존 CHECK 제약을 교체하여 'quarterly'를 허용
+ALTER TABLE recurring_task_templates
+  DROP CONSTRAINT IF EXISTS recurring_task_templates_recurrence_type_check;
+
+ALTER TABLE recurring_task_templates
+  ADD CONSTRAINT recurring_task_templates_recurrence_type_check
+    CHECK (recurrence_type IN ('weekly', 'monthly', 'quarterly', 'yearly'));
+
+-- 3. 분기별 반복은 recurrence_month(분기 시작 월: 1~3 중 하나) +
+--    recurrence_day_of_month(해당 월의 일자)로 표현
+--    예) recurrence_month=1, recurrence_day_of_month=15 →
+--        매분기 첫 달 15일 (1·4·7·10월 15일)
+--    별도 컬럼 추가 없이 기존 컬럼 재사용
+
+-- 4. 기존 반복 템플릿이 자동 생성한 task의 task_period를 동기화
+UPDATE tasks t
+SET task_period = rt.recurrence_type
+FROM recurring_task_templates rt
+WHERE t.recurring_template_id = rt.id
+  AND (t.task_period IS NULL OR t.task_period = 'general');


### PR DESCRIPTION
## Summary

- **업무지시**: 대표 원장이 기존 업무 담당자를 단건/일괄 변경 가능. 주간/월간/분기/연간 업무 분류 추가 및 분기별 반복 템플릿 지원
- **월간 성과 보고서**: 매출 차트 연도별 겹쳐보기, 3개년(36개월) 확장, 덴트웹 내원경로/연령대 매핑 개선
- **스케줄/계약서/투자**: 일정 위젯 디자인 통일 및 위치 이동, 안드로이드 크롬 근로계약서 회색 텍스트 수정 (#418), HistoryCompareView 추가

## Commits

- feat(tasks): 담당자 일괄 변경 + 주간/월간/분기/연간 업무 분류 추가
- fix(monthly-report): 연령대 변화 차트 스택/범례 정렬
- fix(monthly-report): 연도별 겹쳐보기 라인 색상 강화 + 올해 라인 강조
- feat(monthly-report): 매출 차트 연도별 겹쳐보기 + 과거 매출 backfill
- refactor(schedule-widget): 디자인 시스템 통일 + 내 업무 옆 가로 배치
- feat(monthly-report): 매출 차트 최근 3개년 확장 (보험/비보험 라인 제거)
- feat(monthly-report): 덴트웹 내원경로 매핑 + 연령대 색상/순서 개선
- feat(schedule-widget): 연속 일정 단일 병합 + 오늘 현황 가로 배치
- fix: 안드로이드 크롬에서 근로계약서 회색 텍스트 (#418)
- feat(compare-history): HistoryCompareView (matrix + equity overlay)

## Test plan

- [x] 업무지시: 일괄 선택 모드 → 체크박스 → 일괄 담당자 변경 모달 동작 (Chrome DevTools)
- [x] 업무지시: 분류 필터 (주간/월간/분기/연간/일반) 동작 확인
- [x] 업무지시: 새 업무 폼에서 분기별 반복(첫째/둘째/셋째 달) 옵션 노출 확인
- [x] DB 마이그레이션 적용 (Supabase MCP, 17개 클리닉 영향 없음)
- [x] `npm run build` 통과 / 콘솔 에러 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)