### PR TITLE
feat: 업무지시 일괄 삭제

### DIFF
--- a/dental-clinic-manager/src/components/Bulletin/TaskList.tsx
+++ b/dental-clinic-manager/src/components/Bulletin/TaskList.tsx
@@ -15,6 +15,7 @@ import {
   Repeat,
   X,
   Tag,
+  Trash2,
 } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/Button'
@@ -343,6 +344,23 @@ export default function TaskList({ canCreate = false, showMyTasksOnly = false }:
     await appAlert(`${updatedCount}건의 담당자가 변경되었습니다.`)
   }, [clearSelection, fetchTasks, fetchStats])
 
+  const handleBulkDelete = useCallback(async () => {
+    if (selectedIds.size === 0) return
+    const ok = await appConfirm(
+      `선택한 ${selectedIds.size}건의 업무를 삭제하시겠습니까?\n삭제된 업무는 복구할 수 없습니다.`
+    )
+    if (!ok) return
+    const ids = Array.from(selectedIds)
+    const { success, deletedCount, error } = await taskService.bulkDeleteTasks(ids)
+    if (!success) {
+      await appAlert(error || '삭제에 실패했습니다.')
+      return
+    }
+    clearSelection()
+    await Promise.all([fetchTasks(), fetchStats()])
+    await appAlert(`${deletedCount}건의 업무가 삭제되었습니다.`)
+  }, [selectedIds, clearSelection, fetchTasks, fetchStats])
+
   // TaskForm 표시
   if (showForm) {
     return (
@@ -409,13 +427,21 @@ export default function TaskList({ canCreate = false, showMyTasksOnly = false }:
                 : '현재 보이는 업무 전체 선택'}
             </button>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
             <Button
               onClick={() => setShowBulkAssigneeModal(true)}
               className="flex items-center gap-2"
             >
               <Users className="w-4 h-4" />
               담당자 일괄 변경
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handleBulkDelete}
+              className="flex items-center gap-2 text-at-error hover:text-at-error hover:bg-at-error-bg border-red-200"
+            >
+              <Trash2 className="w-4 h-4" />
+              일괄 삭제
             </Button>
             <Button variant="outline" onClick={clearSelection} className="flex items-center gap-2">
               <X className="w-4 h-4" />

--- a/dental-clinic-manager/src/lib/bulletinService.ts
+++ b/dental-clinic-manager/src/lib/bulletinService.ts
@@ -894,6 +894,37 @@ export const taskService = {
   },
 
   /**
+   * 다수 업무 일괄 삭제 (대표 원장 권한)
+   * - 같은 clinic의 업무만 삭제 (RLS + clinic_id 이중 가드)
+   */
+  async bulkDeleteTasks(
+    taskIds: string[]
+  ): Promise<{ success: boolean; deletedCount: number; error: string | null }> {
+    try {
+      if (!taskIds.length) return { success: true, deletedCount: 0, error: null }
+
+      const supabase = await ensureConnection()
+      if (!supabase) throw new Error('Database connection failed')
+
+      const clinicId = getCurrentClinicId()
+      if (!clinicId) throw new Error('Clinic not found')
+
+      const { error, count } = await (supabase as any)
+        .from('tasks')
+        .delete({ count: 'exact' })
+        .in('id', taskIds)
+        .eq('clinic_id', clinicId)
+
+      if (error) throw error
+
+      return { success: true, deletedCount: count || taskIds.length, error: null }
+    } catch (error) {
+      console.error('[taskService.bulkDeleteTasks] Error:', error)
+      return { success: false, deletedCount: 0, error: extractErrorMessage(error) }
+    }
+  },
+
+  /**
    * 업무 삭제
    */
   async deleteTask(id: string): Promise<{ success: boolean; error: string | null }> {


### PR DESCRIPTION
## Summary

선택된 업무를 한 번에 삭제할 수 있는 "일괄 삭제" 버튼을 액션바에 추가.

- `taskService.bulkDeleteTasks(taskIds)`: clinic_id 가드 + `DELETE ... IN (ids)` 단일 쿼리
- 확인 다이얼로그(N건 삭제) → 성공 시 선택 해제 + 목록 갱신 + 결과 알림

## Test plan

- [x] 빌드 통과
- [x] Chrome DevTools: 체크박스 선택 → 액션바에 "일괄 삭제" 버튼 노출, 콘솔 에러 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)