### PR TITLE
release: 2026-04-30 develop → main 통합 (84 commits)

### DIFF
--- a/dental-clinic-manager/src/components/Admin/ClinicsManagement.tsx
+++ b/dental-clinic-manager/src/components/Admin/ClinicsManagement.tsx
@@ -26,7 +26,7 @@ export default function ClinicsManagement() {
   const [loading, setLoading] = useState(true)
   const [searchQuery, setSearchQuery] = useState('')
   const [filterStatus, setFilterStatus] = useState<'all' | 'active' | 'suspended' | 'cancelled'>('all')
-  const [filterTier, setFilterTier] = useState<'all' | 'basic' | 'professional' | 'enterprise'>('all')
+  const [filterTier, setFilterTier] = useState<'all' | 'basic' | 'professional'>('all')
   const [selectedClinic, setSelectedClinic] = useState<ExtendedClinic | null>(null)
   const [showDetails, setShowDetails] = useState(false)
   const [error, setError] = useState('')
@@ -96,7 +96,7 @@ export default function ClinicsManagement() {
               phone: '02-2072-2114',
               email: 'info@snudh.org',
               business_number: '234-56-78901',
-              subscription_tier: 'enterprise',
+              subscription_tier: 'professional',
               subscription_expires_at: '2025-03-31',
               max_users: 50,
               status: 'active',
@@ -217,8 +217,7 @@ export default function ClinicsManagement() {
       if (!revenueError && clinicsForRevenue) {
         const tierPrices = {
           basic: 50000,
-          professional: 150000,
-          enterprise: 500000
+          professional: 150000
         }
 
         monthlyRevenue = clinicsForRevenue.reduce((total: number, clinic: any) => {
@@ -345,13 +344,11 @@ export default function ClinicsManagement() {
   const getTierBadge = (tier: string) => {
     const badges = {
       basic: 'bg-at-surface-alt text-at-text',
-      professional: 'bg-at-tag text-at-accent',
-      enterprise: 'bg-purple-100 text-purple-800'
+      professional: 'bg-at-tag text-at-accent'
     }
     const labels = {
       basic: '기본',
-      professional: '프로페셔널',
-      enterprise: '엔터프라이즈'
+      professional: '프로페셔널'
     }
     return (
       <span className={`inline-flex px-2.5 py-0.5 rounded-full text-xs font-medium ${badges[tier as keyof typeof badges] || 'bg-at-surface-alt text-at-text'}`}>
@@ -453,7 +450,6 @@ export default function ClinicsManagement() {
                 <option value="all">모든 플랜</option>
                 <option value="basic">기본</option>
                 <option value="professional">프로페셔널</option>
-                <option value="enterprise">엔터프라이즈</option>
               </select>
             </div>
           </div>
@@ -610,7 +606,6 @@ export default function ClinicsManagement() {
                     >
                       <option value="basic">기본</option>
                       <option value="professional">프로페셔널</option>
-                      <option value="enterprise">엔터프라이즈</option>
                     </select>
                   </div>
                   <div>

--- a/dental-clinic-manager/src/components/Management/ClinicSettings.tsx
+++ b/dental-clinic-manager/src/components/Management/ClinicSettings.tsx
@@ -198,8 +198,7 @@ const [formData, setFormData] = useState<ClinicFormData>({
   const getSubscriptionTierLabel = (tier: string) => {
     const labels = {
       basic: '기본',
-      professional: '프로페셔널',
-      enterprise: '엔터프라이즈'
+      professional: '프로페셔널'
     }
     return labels[tier as keyof typeof labels] || tier
   }

--- a/dental-clinic-manager/src/components/Subscription/BasicPlansSection.tsx
+++ b/dental-clinic-manager/src/components/Subscription/BasicPlansSection.tsx
@@ -28,7 +28,7 @@ export default function BasicPlansSection({ plans, current, activeCount, onSelec
         </div>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         {headcountPlans.map((plan) => {
           const isCurrent = plan.id === currentId
           const isDisabled = plan.max_users != null && plan.max_users < activeCount

--- a/dental-clinic-manager/src/components/Subscription/UpgradeRequiredModal.tsx
+++ b/dental-clinic-manager/src/components/Subscription/UpgradeRequiredModal.tsx
@@ -51,12 +51,7 @@ export default function UpgradeRequiredModal({ open, onClose, onPayNow, context 
         </DialogHeader>
 
         <div className="space-y-3 text-sm">
-          {plan && plan.name === 'enterprise' ? (
-            <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950/30">
-              <div className="text-base font-semibold">{plan.display_name}</div>
-              <div className="text-sm text-muted-foreground">{formatPlanPrice(plan)}</div>
-            </div>
-          ) : plan ? (
+          {plan ? (
             <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950/30">
               <div className="text-base font-semibold">{plan.display_name}</div>
               <div className="text-sm text-muted-foreground">
@@ -68,9 +63,7 @@ export default function UpgradeRequiredModal({ open, onClose, onPayNow, context 
 
         <DialogFooter className="flex justify-end gap-2">
           <Button variant="outline" onClick={onClose}>나중에 결제</Button>
-          <Button onClick={onPayNow}>
-            {plan?.name === 'enterprise' ? '문의하기' : '지금 결제하기'}
-          </Button>
+          <Button onClick={onPayNow}>지금 결제하기</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/dental-clinic-manager/src/lib/subscriptionPlans.ts
+++ b/dental-clinic-manager/src/lib/subscriptionPlans.ts
@@ -1,30 +1,27 @@
 // src/lib/subscriptionPlans.ts
 import type { SubscriptionPlan } from '@/types/subscription'
 
-export type HeadcountPlanName = 'free' | 'starter' | 'growth' | 'pro' | 'enterprise'
+export type HeadcountPlanName = 'free' | 'starter' | 'growth' | 'pro'
 
 /**
  * 총 재직자 수에 맞는 헤드카운트 플랜 이름을 반환한다.
- * 경계: Free 1~4, Starter 5~10, Growth 11~20, Pro 21~50, Enterprise 51+
+ * 경계: Free 1~4, Starter 5~10, Growth 11~20, Pro 21+
  */
 export function findPlanByHeadcount(total: number): HeadcountPlanName {
   if (total <= 4) return 'free'
   if (total <= 10) return 'starter'
   if (total <= 20) return 'growth'
-  if (total <= 50) return 'pro'
-  return 'enterprise'
+  return 'pro'
 }
 
 /**
  * 플랜 가격을 일관된 문구로 포맷한다.
  * - 주식 자동매매(feature_id='investment'): "수익의 5%"
- * - Enterprise: "맞춤 문의"
  * - price=0: "무료"
  * - 그 외: "월 N,NNN원"
  */
 export function formatPlanPrice(plan: Pick<SubscriptionPlan, 'name' | 'price' | 'feature_id'>): string {
   if (plan.feature_id === 'investment') return '수익의 5%'
-  if (plan.name === 'enterprise') return '맞춤 문의'
   if (plan.price === 0) return '무료'
   return `월 ${plan.price.toLocaleString()}원`
 }

--- a/dental-clinic-manager/src/lib/subscriptionService.ts
+++ b/dental-clinic-manager/src/lib/subscriptionService.ts
@@ -492,7 +492,7 @@ export async function getSubscriptionStatus(clinicId: string): Promise<Subscript
     plan,
     payments,
     isFreePlan,
-    canUpgrade: isFreePlan || (plan?.type === 'headcount' && plan.name !== 'enterprise'),
+    canUpgrade: isFreePlan || plan?.type === 'headcount',
     daysUntilExpiry,
   }
 }

--- a/dental-clinic-manager/src/types/auth.ts
+++ b/dental-clinic-manager/src/types/auth.ts
@@ -1,5 +1,5 @@
 export type UserRole = 'master_admin' | 'owner' | 'vice_director' | 'manager' | 'team_leader' | 'staff'
-export type SubscriptionTier = 'basic' | 'professional' | 'enterprise'
+export type SubscriptionTier = 'basic' | 'professional'
 export type ClinicStatus = 'active' | 'suspended' | 'cancelled'
 
 export interface User {

--- a/dental-clinic-manager/supabase/migrations/20260418_subscription_system.sql
+++ b/dental-clinic-manager/supabase/migrations/20260418_subscription_system.sql
@@ -136,14 +136,10 @@ INSERT INTO subscription_plans (name, display_name, type, min_users, max_users, 
    '11~20인 사업장',
    '["기본 대시보드", "직원 관리", "출퇴근 관리", "게시판", "스케줄 관리", "리콜 관리"]',
    2),
-  ('pro', 'Pro', 'headcount', 21, 50, 149000,
-   '21~50인 사업장',
+  ('pro', 'Pro', 'headcount', 21, 9999, 149000,
+   '21인 이상 사업장',
    '["기본 대시보드", "직원 관리", "출퇴근 관리", "게시판", "스케줄 관리", "리콜 관리", "급여 관리"]',
-   3),
-  ('enterprise', 'Enterprise', 'headcount', 51, 9999, 0,
-   '51인 이상 맞춤 계약',
-   '["Pro 플랜 전체 기능", "전담 지원", "맞춤 계약"]',
-   4)
+   3)
 ON CONFLICT (name) DO NOTHING;
 
 -- 11. 기본 기능별 프리미엄 플랜 데이터

--- a/dental-clinic-manager/supabase/migrations/20260430_remove_enterprise_plan.sql
+++ b/dental-clinic-manager/supabase/migrations/20260430_remove_enterprise_plan.sql
@@ -1,0 +1,17 @@
+-- ============================================
+-- Enterprise 플랜 제거 + Pro 플랜 범위 확장
+-- Migration: 20260430_remove_enterprise_plan.sql
+-- Created: 2026-04-30
+--
+-- 변경 사항
+-- 1) Pro 플랜 max_users 50 → 9999 (21인 이상 모두 Pro로 통합)
+-- 2) Enterprise 플랜 행 삭제
+-- ============================================
+
+UPDATE subscription_plans
+SET max_users = 9999,
+    description = '21인 이상 사업장'
+WHERE name = 'pro' AND type = 'headcount';
+
+DELETE FROM subscription_plans
+WHERE name = 'enterprise' AND type = 'headcount';


### PR DESCRIPTION
## Summary

develop 브랜치 누적 84 커밋을 main으로 통합합니다.

### 주요 변경 사항
- **구독 시스템**: Enterprise 플랜 제거 + Pro 범위 21인 이상으로 확장
- **소개환자 관리 Phase 2**: 가족 묶음 / 전환율 차트 / 자동 감사문자 / 대시보드 위젯
- **월간 성과 보고서**: 연령대 차트 / 매출 차트 3개년 + 연도별 겹쳐보기 + backfill
- **백테스트 비교 히스토리**: live/history 탭, 필터·선택·정렬·상세·매트릭스 비교
- **RL 트레이딩 서버**: 자체 학습 파이프라인(Dow 30 PPO + yfinance) / env v2 / ensemble / benchmark / walk-forward CV / hyperparameter sweep / n_envs 병렬
- **업무 관리**: 담당자 일괄 변경, 주간/월간/분기/연간 분류, 일괄 삭제, 체크박스 상시 노출
- **급여**: 세무사무실 명세서 업로드 PDF 지원
- **계약서**: 대표 원장 권한 타이밍 버그 수정
- **메뉴**: 사용자 메뉴 설정 DB 기반(계정 종속) 전환
- **스케줄 위젯**: 디자인 시스템 통일 + 연속 일정 병합 + 오늘의 현황 옆 가로 배치
- **모바일 안드로이드 크롬 근로계약서 텍스트 회색 표시 버그 수정 (#418)**

### DB 마이그레이션
- `20260430_remove_enterprise_plan.sql` (Enterprise 행 삭제, Pro max_users 9999)
- 기타 referral / monthly-report / dentweb 관련 마이그레이션 포함

## Test plan

- [x] `npm run build` 통과
- [x] develop 브랜치 정상 동작 검증 완료 (각 feature 커밋 시점에 검증)
- [ ] main 머지 후 Vercel 프로덕션 배포 확인
- [ ] 구독 플랜 페이지에서 enterprise 미노출 확인
- [ ] 월간 보고서 / 소개환자 위젯 / 업무 일괄 처리 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)