### PR TITLE
fix(monthly-report): 연령대 차트 범례를 어린 나이 순으로 강제 정렬

### DIFF
--- a/dental-clinic-manager/src/components/MonthlyReport/AgeDistributionChart.tsx
+++ b/dental-clinic-manager/src/components/MonthlyReport/AgeDistributionChart.tsx
@@ -108,7 +108,25 @@ export default function AgeDistributionChart({ data, targetYear, targetMonth }: 
                     }}
                     contentStyle={{ borderRadius: 12, border: '1px solid #e5e7eb' }}
                   />
-                  <Legend formatter={(value: string) => AGE_GROUP_LABELS[value as keyof typeof AGE_GROUP_LABELS] ?? value} />
+                  {/*
+                    recharts Legend 기본 정렬이 dataKey 알파벳 순이라 어린 → 높은 연령 순서가 깨진다.
+                    content 커스텀 렌더로 AGE_GROUP_ORDER 그대로 표시.
+                  */}
+                  <Legend
+                    content={() => (
+                      <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 pt-2 text-xs text-at-text-secondary">
+                        {AGE_GROUP_ORDER.map((g) => (
+                          <span key={g} className="inline-flex items-center gap-1.5">
+                            <span
+                              className="inline-block w-3 h-3 rounded-sm"
+                              style={{ backgroundColor: AGE_GROUP_COLORS[g] }}
+                            />
+                            {AGE_GROUP_LABELS[g]}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  />
                   {AGE_GROUP_ORDER.map((g) => (
                     <Bar
                       key={g}


### PR DESCRIPTION
## Summary

연령대 차트 범례가 알파벳 순(50대→40대→60대+→10대→...)으로 표시되던 문제를 수정.

## 원인
- recharts Legend는 dataKey 알파벳 순으로 자동 정렬
  - fifties(f) → forties(f) → sixties_plus(s) → teens(t) → thirties(t) → twenties(t) → under_10(u) → unknown(u)

## 해결
- Legend `content` 커스텀 렌더러로 AGE_GROUP_ORDER 순서를 강제
- 10세 미만 → 10대 → 20대 → 30대 → 40대 → 50대 → 60대+ → 미상

🤖 Generated with [Claude Code](https://claude.com/claude-code)