### PR TITLE
fix(smart-money): 알고리즘 풋프린트 0점 문제 — 진행 중 거래일 짧을 때 2일치 fallback

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
@@ -315,6 +315,12 @@ export async function POST(request: NextRequest) {
     const intradayLast2Days = extractLastNTradingDays(bars, 2)
     const multiDayBars: NormalizedBar[] = dailyBars.length >= 30 ? dailyBars : bars
 
+    // 진행 중인 거래일이 짧으면(장 시작 직후) 알고리즘/VWAP 패턴 인식이 부족함
+    // → 60봉(≈5시간) 미만이면 2거래일치로 fallback (어제 풀 거래일 + 오늘 진행분)
+    const MIN_INTRADAY_BARS = 60
+    const intradayForAlgo =
+      intradayLast1Day.length >= MIN_INTRADAY_BARS ? intradayLast1Day : intradayLast2Days
+
     // 디버그 로그 — 각 윈도우별 봉 수
     console.log('[smart-money/analyze] 데이터 윈도우:', {
       ticker,
@@ -322,12 +328,13 @@ export async function POST(request: NextRequest) {
       total_intraday: bars.length,
       intraday_1day: intradayLast1Day.length,
       intraday_2days: intradayLast2Days.length,
+      intraday_for_algo: intradayForAlgo.length,
       daily: dailyBars.length,
       multiDay: multiDayBars.length,
     })
 
-    // ===== Intraday 1-day 엔진 =====
-    const vwapBars: VWAPInputBar[] = intradayLast1Day.map((b) => ({
+    // ===== Intraday 엔진 (1~2일치 적응) =====
+    const vwapBars: VWAPInputBar[] = intradayForAlgo.map((b) => ({
       high: b.high,
       low: b.low,
       close: b.close,
@@ -335,7 +342,7 @@ export async function POST(request: NextRequest) {
     }))
     vwap = calculateVWAP(vwapBars, currentPrice)
 
-    const algoBars: AlgoBar[] = intradayLast1Day.map((b) => ({
+    const algoBars: AlgoBar[] = intradayForAlgo.map((b) => ({
       datetime: b.datetime,
       open: b.open,
       high: b.high,
@@ -343,8 +350,18 @@ export async function POST(request: NextRequest) {
       close: b.close,
       volume: b.volume,
     }))
-    algoFootprint = analyzeAlgoFootprint(algoBars)
+    // MOO/MOC는 반드시 단일 거래일 기준 — 시·종가 봉이 양 끝에 정확히 있어야 함
+    const auctionBars: AlgoBar[] = intradayLast1Day.map((b) => ({
+      datetime: b.datetime,
+      open: b.open,
+      high: b.high,
+      low: b.low,
+      close: b.close,
+      volume: b.volume,
+    }))
+    algoFootprint = analyzeAlgoFootprint(algoBars, auctionBars)
 
+    // session은 항상 "현재" 시간대 분류이므로 1일치 유지
     const sessionBars: SessionBar[] = intradayLast1Day.map((b) => ({ ...b }))
     session = analyzeSession(sessionBars, market)
 

--- a/dental-clinic-manager/src/lib/smartMoney/algoFootprintEngine.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/algoFootprintEngine.ts
@@ -272,8 +272,16 @@ function detectDirection(bars: AlgoBar[]): 'accumulation' | 'distribution' | 'ne
 
 // ============================================
 // 메인 엔트리
+//
+// bars        : TWAP / VWAP / Iceberg / Sniper 점수 계산용 (1~2 거래일치 권장)
+// auctionBars : MOO / MOC 점수 계산용 (반드시 단일 거래일치 — 시·종가 봉이 양 끝)
+//               생략 시 bars 전체로 계산 (단일 거래일이라 가정).
+//               2일치 이상이면 첫·마지막 봉이 어제·오늘에 걸쳐있어 MOO/MOC가 왜곡됨.
 // ============================================
-export function analyzeAlgoFootprint(bars: AlgoBar[]): AlgoFootprintResult {
+export function analyzeAlgoFootprint(
+  bars: AlgoBar[],
+  auctionBars?: AlgoBar[],
+): AlgoFootprintResult {
   if (!bars || bars.length === 0) {
     return {
       twapScore: 0,
@@ -292,7 +300,9 @@ export function analyzeAlgoFootprint(bars: AlgoBar[]): AlgoFootprintResult {
   const vwapScore = scoreVwap(bars)
   const icebergScore = scoreIceberg(bars)
   const sniperScore = scoreSniper(bars)
-  const { mooScore, mocScore, auctionDirection } = detectAuctionFootprint(bars)
+  const { mooScore, mocScore, auctionDirection } = detectAuctionFootprint(
+    auctionBars && auctionBars.length > 0 ? auctionBars : bars,
+  )
 
   type AlgoLabel = 'TWAP' | 'VWAP' | 'Iceberg' | 'Sniper' | 'MOO' | 'MOC'
   const scores: { algo: AlgoLabel; score: number }[] = [


### PR DESCRIPTION
## 문제

미국 장 진행 중(예: 시작 후 3시간) AAPL 분석 시 알고리즘 풋프린트 6개 항목 모두 0점, VWAP 표준편차 0.00.

## 근본 원인

\`analyze\` route가 \`intradayLast1Day\`(1거래일치)를 algo/VWAP 입력으로 사용. 미국 장 시작 후 1~3시간이면 약 12~36봉만 존재 (서버 로그: \`intraday_1day=40\`). 패턴 인식에 데이터 부족 → 모두 낮은 점수.

## 수정

1. **2일치 fallback**: \`intradayLast1Day < 60봉\`이면 \`intradayLast2Days\`로 fallback (어제 풀 거래일 + 오늘 진행분 ≈ 100~150봉)
2. **MOO/MOC 분리**: \`analyzeAlgoFootprint\`에 \`auctionBars\` 옵션 추가 — MOO/MOC만 단일 거래일 첫·마지막 봉 사용 (2일치로 호출하면 어제 시작/오늘 진행 봉이 양 끝에 배치되어 부정확)

## 검증 (AAPL 미국 장 시작 후 ~3시간)

| 항목 | 이전 | 수정 후 |
|---|---|---|
| TWAP | 0 | 0 |
| VWAP | 0 | 40 |
| Iceberg | 0 | 25 |
| Sniper | 0 | **49 (dominant)** |
| MOO/MOC | 0 | 0 (예상대로) |
| VWAP std | 0.00 | 2.07 |
| intraday_for_algo | 40 | 232 |

콘솔 에러 0건. 빌드 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)