### PR TITLE
feat(smart-money): 분봉 1분봉 변경 + Iceberg 임계값 비례 조정

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
@@ -161,13 +161,14 @@ export async function POST(request: NextRequest) {
       currentPrice = quote.price
       // KRRealtimeQuote에는 name이 없으므로 ticker 그대로 사용
 
-      // 분봉 (5분봉 390개 ≈ 5거래일치 — 와이코프 페이즈 탐지용)
+      // 분봉 (1분봉 780개 ≈ 2거래일치 — 알고리즘 풋프린트 정밀도 ↑)
+      // 1분봉이 5분봉보다 패턴 인식(VWAP U-shape, Iceberg 클러스터, MOO/MOC)에 정교함
       const krBars: KRMinuteBar[] = await getKRMinutePrices({
         credentialId: kisCredential.credentialId,
         credential: krCredential,
         ticker,
-        intervalMinutes: 5,
-        count: 390,
+        intervalMinutes: 1,
+        count: 780,
       })
       bars = krBars.map((b) => ({
         datetime: b.datetime,
@@ -226,14 +227,14 @@ export async function POST(request: NextRequest) {
       const quote = await fetchCurrentQuote(ticker, 'US')
       currentPrice = quote.price ?? 0
 
-      // fetchIntradayPrices는 default로 30일치(≈2340봉)를 반환.
-      // 정교화 엔진(와이코프 페이즈/유동성)을 위해 5거래일치(≈390봉)로 확장.
+      // 1분봉으로 변경 — 알고리즘 풋프린트 정밀도 ↑ (yahoo 1m은 7일까지 제공)
+      // 마지막 780봉(≈2거래일치) 사용
       const usBars: OHLCV[] = await fetchIntradayPrices({
         ticker,
         market: 'US',
-        timeframe: '5m',
+        timeframe: '1m',
       })
-      const recent = usBars.slice(-390)
+      const recent = usBars.slice(-780)
       bars = recent.map((b) => ({
         datetime: b.date,
         open: b.open,
@@ -316,8 +317,8 @@ export async function POST(request: NextRequest) {
     const multiDayBars: NormalizedBar[] = dailyBars.length >= 30 ? dailyBars : bars
 
     // 진행 중인 거래일이 짧으면(장 시작 직후) 알고리즘/VWAP 패턴 인식이 부족함
-    // → 60봉(≈5시간) 미만이면 2거래일치로 fallback (어제 풀 거래일 + 오늘 진행분)
-    const MIN_INTRADAY_BARS = 60
+    // → 300봉(1분봉 ≈ 5시간) 미만이면 2거래일치로 fallback (어제 풀 거래일 + 오늘 진행분)
+    const MIN_INTRADAY_BARS = 300
     const intradayForAlgo =
       intradayLast1Day.length >= MIN_INTRADAY_BARS ? intradayLast1Day : intradayLast2Days
 

--- a/dental-clinic-manager/src/lib/smartMoney/algoFootprintEngine.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/algoFootprintEngine.ts
@@ -122,9 +122,13 @@ function scoreIceberg(bars: AlgoBar[]): number {
     }
   }
 
-  // 4 클러스터 → 0점, 8 → ~50점, 12 이상 → 100점
-  if (bestCluster < 4) return 0
-  return Math.max(0, Math.min(100, ((bestCluster - 4) / 8) * 100))
+  // 데이터 양에 비례한 임계값 — 봉 수의 5%(min 4) → 0점, 15%(min 12) → 100점
+  // (5분봉 78봉: 4~12, 1분봉 780봉: 39~117)
+  const minCluster = Math.max(4, Math.ceil(bars.length * 0.05))
+  const maxCluster = Math.max(12, Math.ceil(bars.length * 0.15))
+  if (bestCluster < minCluster) return 0
+  const range = Math.max(1, maxCluster - minCluster)
+  return Math.max(0, Math.min(100, ((bestCluster - minCluster) / range) * 100))
 }
 
 // ============================================


### PR DESCRIPTION
## 변경

스마트머니 분석의 분봉 데이터를 **5분봉 → 1분봉** 으로 변경하여 알고리즘 풋프린트 패턴 인식 정밀도 향상.

### 데이터 소스
- KR \`getKRMinutePrices\`: \`intervalMinutes 5 → 1\`, \`count 390 → 780\`
- US \`fetchIntradayPrices\`: \`timeframe '5m' → '1m'\`, \`slice -390 → -780\`
- yahoo 1m은 7일까지 제공 → 780봉(≈2거래일) 안전하게 커버

### 임계값 재조정
- \`MIN_INTRADAY_BARS\` 60 → 300 (1분봉 ≈ 5시간 기준)
- \`scoreIceberg\` 임계값을 **데이터 양 비례**로 변경
  - 기존: 4 클러스터 → 0점, 12 → 100점 (절대값)
  - 변경: 봉수의 5%(min 4) → 0점, 15%(min 12) → 100점
  - 1분봉 780봉에서는 절대 임계 12로 항상 100점 발생 → 비례 임계가 일관성 보장

## 검증 (AAPL 1분봉 780봉)

| | TWAP | VWAP | Iceberg | Sniper | MOO | MOC |
|---|---|---|---|---|---|---|
| 이전(절대) | 0 | 52 | **★ 100** | 66 | 0 | 0 |
| 수정 후 | 0 | 52 | 0 | **★ 66** | 0 | 0 |

콘솔 에러 0, 빌드 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)