### PR TITLE
feat(smart-money): 최근 3일 일별 분석 탭 + LLM 코멘트 일반인 친화

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
@@ -53,6 +53,7 @@ import type {
   SmartMoneyAlert,
   InvestorTrendRow,
   InvestorFlowResult,
+  DailyAnalysis,
 } from '@/types/smartMoney'
 
 export const dynamic = 'force-dynamic'
@@ -161,14 +162,13 @@ export async function POST(request: NextRequest) {
       currentPrice = quote.price
       // KRRealtimeQuote에는 name이 없으므로 ticker 그대로 사용
 
-      // 분봉 (1분봉 780개 ≈ 2거래일치 — 알고리즘 풋프린트 정밀도 ↑)
-      // 1분봉이 5분봉보다 패턴 인식(VWAP U-shape, Iceberg 클러스터, MOO/MOC)에 정교함
+      // 분봉 (1분봉 2400개 ≈ 4거래일치 — 첫·끝 일자 잘림 여유분 포함, byDay에 최신 3일 사용)
       const krBars: KRMinuteBar[] = await getKRMinutePrices({
         credentialId: kisCredential.credentialId,
         credential: krCredential,
         ticker,
         intervalMinutes: 1,
-        count: 780,
+        count: 2400,
       })
       bars = krBars.map((b) => ({
         datetime: b.datetime,
@@ -227,14 +227,13 @@ export async function POST(request: NextRequest) {
       const quote = await fetchCurrentQuote(ticker, 'US')
       currentPrice = quote.price ?? 0
 
-      // 1분봉으로 변경 — 알고리즘 풋프린트 정밀도 ↑ (yahoo 1m은 7일까지 제공)
-      // 마지막 780봉(≈2거래일치) 사용
+      // 1분봉 — 마지막 2400봉(≈4거래일치) 사용 (byDay에 최신 3일 + 여유분)
       const usBars: OHLCV[] = await fetchIntradayPrices({
         ticker,
         market: 'US',
         timeframe: '1m',
       })
-      const recent = usBars.slice(-780)
+      const recent = usBars.slice(-2400)
       bars = recent.map((b) => ({
         datetime: b.date,
         open: b.open,
@@ -296,6 +295,7 @@ export async function POST(request: NextRequest) {
   // 5. 엔진 호출
   let vwap, wyckoff, algoFootprint, investorFlow: InvestorFlowResult | null, scoreResult
   let wyckoffPhase, liquidity, marketStructure, orderBlocksFvg, traps, vsa, session, newsContext
+  let byDay: DailyAnalysis[] = []
   try {
     // ================================================================
     // 데이터 윈도우 라우팅 — 각 엔진의 자연스러운 데이터 타입에 맞춤
@@ -428,6 +428,99 @@ export async function POST(request: NextRequest) {
       session,
       newsContext,
     })
+
+    // ===== byDay: 최근 3 거래일치 일자별 분석 =====
+    // 다일 기반 엔진(wyckoffPhase, liquidity, marketStructure, orderBlocksFvg, traps, vsa)은
+    // 본질적으로 N일 컨텍스트가 필요하므로 모든 일자에 동일하게 표시.
+    // intraday 엔진(vwap, wyckoff(단일봉), algoFootprint, session, newsContext)은 일자별로 다르게 계산.
+    const dayKeys = Array.from(new Set(bars.map((b) => (b.datetime ?? '').slice(0, 10)).filter(Boolean))).sort()
+    // 봉 수가 너무 적은(잘린) 일자는 제외하고 가장 최근 3 거래일만 사용
+    const MIN_BARS_PER_DAY = 200
+    const fullDays = dayKeys.filter(
+      (k) => bars.filter((b) => (b.datetime ?? '').startsWith(k)).length >= MIN_BARS_PER_DAY
+        || k === dayKeys[dayKeys.length - 1], // 진행 중 오늘은 항상 포함
+    )
+    const recentDayKeys = fullDays.slice(-3)
+    for (const dayKey of recentDayKeys) {
+      const dayBars = bars.filter((b) => (b.datetime ?? '').startsWith(dayKey))
+      if (dayBars.length < 5) continue
+      const closePrice = dayBars[dayBars.length - 1].close
+
+      const dVwapBars: VWAPInputBar[] = dayBars.map((b) => ({
+        high: b.high, low: b.low, close: b.close, volume: b.volume,
+      }))
+      const dVwap = calculateVWAP(dVwapBars, closePrice)
+
+      const dAlgoBars: AlgoBar[] = dayBars.map((b) => ({
+        datetime: b.datetime, open: b.open, high: b.high, low: b.low, close: b.close, volume: b.volume,
+      }))
+      const dAlgoFootprint = analyzeAlgoFootprint(dAlgoBars, dAlgoBars)
+
+      const dWyckoffBars: WyckoffBar[] = dayBars.map((b) => ({
+        open: b.open, high: b.high, low: b.low, close: b.close, volume: b.volume,
+      }))
+      const dWyckoff = detectWyckoff(dWyckoffBars)
+
+      const dSessionBars: SessionBar[] = dayBars.map((b) => ({ ...b }))
+      const dSession = analyzeSession(dSessionBars, market)
+
+      const dNewsBars: NewsBar[] = dayBars.map((b) => ({ ...b }))
+      const dNewsContext = analyzeNewsContext({
+        bars: dNewsBars,
+        signalDetails: [],
+        newsEvents: [],
+      })
+
+      const dScore = computeSmartMoneyScore({
+        vwap: dVwap,
+        investorFlow,
+        wyckoff: dWyckoff,
+        algoFootprint: dAlgoFootprint,
+        wyckoffPhase,
+        liquidity,
+        marketStructure,
+        orderBlocksFvg,
+        traps,
+        vsa,
+        session: dSession,
+        newsContext: dNewsContext,
+      })
+
+      byDay.push({
+        ticker,
+        market,
+        asOfDate: dayKey,
+        closePrice,
+        vwap: dVwap,
+        wyckoff: dWyckoff,
+        algoFootprint: dAlgoFootprint,
+        wyckoffPhase,
+        liquidity,
+        marketStructure,
+        orderBlocksFvg,
+        traps,
+        vsa,
+        session: dSession,
+        newsContext: dNewsContext,
+        manipulationRiskScore: dScore.manipulationRiskScore,
+        overallScore: dScore.overallScore,
+        interpretation: dScore.interpretation,
+        signalDetails: dScore.signalDetails,
+      })
+    }
+    // 가장 최근 일자(byDay 마지막)는 메인 분석과 정렬되도록 메인 결과를 덮어씌움
+    if (byDay.length > 0) {
+      const lastDay = byDay[byDay.length - 1]
+      lastDay.vwap = vwap
+      lastDay.wyckoff = wyckoff
+      lastDay.algoFootprint = algoFootprint
+      lastDay.session = session
+      lastDay.newsContext = newsContext
+      lastDay.manipulationRiskScore = scoreResult.manipulationRiskScore
+      lastDay.overallScore = scoreResult.overallScore
+      lastDay.interpretation = scoreResult.interpretation
+      lastDay.signalDetails = scoreResult.signalDetails
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : '분석 엔진 실패'
     console.error('[smart-money/analyze] 엔진 실행 실패:', err)
@@ -461,12 +554,17 @@ export async function POST(request: NextRequest) {
     interpretation: scoreResult.interpretation,
     signalDetails: scoreResult.signalDetails,
     generatedAt: new Date().toISOString(),
+    byDay,
   }
 
-  // 6. LLM 코멘트 (옵션)
+  // 6. LLM 코멘트 (옵션) — 가장 최근 일자(byDay 마지막 = 메인 분석)에만 생성
   if (includeLLM) {
     try {
       analysis.naturalLanguageComment = await generateLLMComment(analysis)
+      // byDay가 있으면 마지막 일자에도 같은 코멘트 노출
+      if (byDay.length > 0) {
+        byDay[byDay.length - 1].naturalLanguageComment = analysis.naturalLanguageComment
+      }
     } catch (err) {
       console.warn('[smart-money/analyze] LLM 코멘트 생성 스킵:', err)
     }

--- a/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
@@ -113,6 +113,23 @@ function todayKey() {
   return new Date().toISOString().slice(0, 10)
 }
 
+/** YYYY-MM-DD → "MM/DD (요일)" */
+function formatDayLabel(date: string): string {
+  const [, m, d] = date.split('-')
+  const day = new Date(date).getDay()
+  const dayLabel = ['일', '월', '화', '수', '목', '금', '토'][day]
+  return `${parseInt(m, 10)}/${parseInt(d, 10)} (${dayLabel})`
+}
+
+/** "오늘" / "어제" / "그제" 라벨 — 가장 최근(마지막)이 오늘 */
+function formatDayRelative(_date: string, total: number, idx: number): string {
+  const offset = total - 1 - idx // 마지막=0(오늘), 그 앞=1(어제), ...
+  if (offset === 0) return '오늘'
+  if (offset === 1) return '전 거래일'
+  if (offset === 2) return '그 전'
+  return `${offset}일 전`
+}
+
 export function SmartMoneyContent() {
   const [selected, setSelected] = useState<Selected | null>(null)
   const [analysis, setAnalysis] = useState<SmartMoneyAnalysis | null>(null)
@@ -126,6 +143,9 @@ export function SmartMoneyContent() {
   const [editingAlert, setEditingAlert] = useState<{ ticker: string; market: Market; name: string | null } | null>(null)
   const [alertListRefresh, setAlertListRefresh] = useState(0)
 
+  // 일자별 탭 — null이면 가장 최근 일자(byDay 마지막) 또는 메인 분석
+  const [activeDayIdx, setActiveDayIdx] = useState<number | null>(null)
+
   // 메모리 캐시 (ticker:market:date → analysis)
   const cacheRef = useRef<Map<string, SmartMoneyAnalysis>>(new Map())
 
@@ -137,6 +157,7 @@ export function SmartMoneyContent() {
     setSelected(next)
     setError(null)
     setErrorCode(null)
+    setActiveDayIdx(null)
     // 캐시에 있으면 즉시 표시
     const cached = cacheRef.current.get(`${next.market}:${next.ticker}:${todayKey()}`)
     if (cached) setAnalysis(cached)
@@ -171,6 +192,7 @@ export function SmartMoneyContent() {
         return
       }
       setAnalysis(data)
+      setActiveDayIdx(null) // 가장 최근 일자 default
       cacheRef.current.set(cacheKey(selected), data)
 
       // LLM 코멘트가 비어 있으면 별도 호출
@@ -207,18 +229,52 @@ export function SmartMoneyContent() {
     }
   }, [selected])
 
+  // 활성 일자 분석 객체 — byDay에서 선택된 일자가 있으면 그 항목으로 SmartMoneyAnalysis를 합성.
+  // 일자별 탭이 클릭됐을 때 표시 데이터(점수/시그널/패널/LLM)가 모두 그 일자 기준으로 전환됨.
+  const viewAnalysis = useMemo<SmartMoneyAnalysis | null>(() => {
+    if (!analysis) return null
+    const byDay = analysis.byDay ?? []
+    if (byDay.length === 0) return analysis
+    const idx = activeDayIdx ?? byDay.length - 1
+    const day = byDay[Math.max(0, Math.min(byDay.length - 1, idx))]
+    if (!day) return analysis
+    // byDay 마지막 일자(가장 최근)는 메인 분석과 동일 — 효율을 위해 메인을 그대로 사용
+    if (idx === byDay.length - 1) return analysis
+    return {
+      ...analysis,
+      asOfDate: day.asOfDate,
+      currentPrice: day.closePrice,
+      vwap: day.vwap,
+      wyckoff: day.wyckoff,
+      algoFootprint: day.algoFootprint,
+      wyckoffPhase: day.wyckoffPhase,
+      liquidity: day.liquidity,
+      marketStructure: day.marketStructure,
+      orderBlocksFvg: day.orderBlocksFvg,
+      traps: day.traps,
+      vsa: day.vsa,
+      session: day.session,
+      newsContext: day.newsContext,
+      manipulationRiskScore: day.manipulationRiskScore,
+      overallScore: day.overallScore,
+      interpretation: day.interpretation,
+      signalDetails: day.signalDetails,
+      naturalLanguageComment: day.naturalLanguageComment,
+    }
+  }, [analysis, activeDayIdx])
+
   const topSignals = useMemo(() => {
-    if (!analysis) return []
-    return [...analysis.signalDetails]
+    if (!viewAnalysis) return []
+    return [...viewAnalysis.signalDetails]
       .sort((a, b) => {
         const at = a.triggeredAt ? new Date(a.triggeredAt).getTime() : 0
         const bt = b.triggeredAt ? new Date(b.triggeredAt).getTime() : 0
         return bt - at || b.confidence - a.confidence
       })
       .slice(0, 5)
-  }, [analysis])
+  }, [viewAnalysis])
 
-  const overallScore = analysis?.overallScore ?? 0
+  const overallScore = viewAnalysis?.overallScore ?? 0
   const scorePct = Math.max(0, Math.min(100, (overallScore + 100) / 2))
   const scoreColor =
     overallScore > 30 ? 'bg-emerald-500' : overallScore < -30 ? 'bg-rose-500' : 'bg-slate-400'
@@ -302,31 +358,59 @@ export function SmartMoneyContent() {
       </section>
 
       {/* 분석 결과 */}
-      {analysis && (
+      {analysis && viewAnalysis && (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
           <div className="lg:col-span-2 space-y-4">
+            {/* 일자별 탭 (byDay 2개 이상일 때만) */}
+            {analysis.byDay && analysis.byDay.length > 1 && (
+              <section className="bg-white rounded-2xl border border-slate-200 p-2 shadow-sm">
+                <div role="tablist" className="flex gap-1">
+                  {analysis.byDay.map((day, i) => {
+                    const isActive = (activeDayIdx ?? analysis.byDay!.length - 1) === i
+                    return (
+                      <button
+                        key={day.asOfDate}
+                        role="tab"
+                        type="button"
+                        onClick={() => setActiveDayIdx(i)}
+                        aria-selected={isActive}
+                        className={`flex-1 px-3 py-2 rounded-xl text-xs font-semibold transition-colors ${
+                          isActive
+                            ? 'bg-blue-600 text-white shadow-sm'
+                            : 'bg-slate-50 text-slate-700 hover:bg-slate-100'
+                        }`}
+                      >
+                        <span className="block text-[10px] opacity-75">{formatDayRelative(day.asOfDate, analysis.byDay!.length, i)}</span>
+                        <span>{formatDayLabel(day.asOfDate)}</span>
+                      </button>
+                    )
+                  })}
+                </div>
+              </section>
+            )}
+
             {/* 결과 헤더 */}
             <section className="bg-white rounded-2xl border border-slate-200 p-5 shadow-sm">
               <div className="flex items-start justify-between flex-wrap gap-3">
                 <div className="min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
-                    <span className="font-mono text-sm font-bold text-blue-600">{analysis.ticker}</span>
-                    <span className="text-base font-bold text-slate-900">{analysis.name}</span>
+                    <span className="font-mono text-sm font-bold text-blue-600">{viewAnalysis.ticker}</span>
+                    <span className="text-base font-bold text-slate-900">{viewAnalysis.name}</span>
                     <span
                       className={`text-[10px] px-1.5 py-0.5 rounded font-bold ${
-                        analysis.market === 'KR' ? 'bg-blue-100 text-blue-700' : 'bg-purple-100 text-purple-700'
+                        viewAnalysis.market === 'KR' ? 'bg-blue-100 text-blue-700' : 'bg-purple-100 text-purple-700'
                       }`}
                     >
-                      {analysis.market === 'KR' ? '국내' : '미국'}
+                      {viewAnalysis.market === 'KR' ? '국내' : '미국'}
                     </span>
                   </div>
                   <div className="mt-1 text-2xl font-bold text-slate-900">
-                    {analysis.market === 'KR'
-                      ? `${Math.round(analysis.currentPrice).toLocaleString()}원`
-                      : `$${analysis.currentPrice.toFixed(2)}`}
+                    {viewAnalysis.market === 'KR'
+                      ? `${Math.round(viewAnalysis.currentPrice).toLocaleString()}원`
+                      : `$${viewAnalysis.currentPrice.toFixed(2)}`}
                   </div>
                   <p className="text-[11px] text-slate-500 mt-0.5">
-                    기준일 {analysis.asOfDate} · 생성 {new Date(analysis.generatedAt).toLocaleTimeString('ko-KR')}
+                    기준일 {viewAnalysis.asOfDate} · 생성 {new Date(analysis.generatedAt).toLocaleTimeString('ko-KR')}
                   </p>
                 </div>
 
@@ -369,10 +453,10 @@ export function SmartMoneyContent() {
                     </span>
                     <span
                       className={`text-[10px] px-2 py-0.5 rounded-full font-bold ${
-                        INTERPRETATION_COLOR[analysis.interpretation]
+                        INTERPRETATION_COLOR[viewAnalysis.interpretation]
                       }`}
                     >
-                      {INTERPRETATION_LABEL[analysis.interpretation]}
+                      {INTERPRETATION_LABEL[viewAnalysis.interpretation]}
                     </span>
                   </div>
                 </div>
@@ -397,16 +481,16 @@ export function SmartMoneyContent() {
                 <Sparkles className="w-4 h-4 text-purple-600 flex-shrink-0 mt-0.5" />
                 <div className="min-w-0 flex-1">
                   <p className="text-xs font-semibold text-purple-900 mb-1">AI 분석 코멘트</p>
-                  {analysis.naturalLanguageComment ? (
+                  {viewAnalysis.naturalLanguageComment ? (
                     <p className="text-sm text-slate-800 leading-relaxed whitespace-pre-line">
-                      {analysis.naturalLanguageComment}
+                      {viewAnalysis.naturalLanguageComment}
                     </p>
                   ) : llmLoading ? (
                     <p className="text-xs text-slate-500 inline-flex items-center gap-1.5">
                       <Loader2 className="w-3 h-3 animate-spin" />
                       분석 코멘트 생성 중...
                     </p>
-                  ) : (
+                  ) : viewAnalysis.asOfDate === analysis.asOfDate ? (
                     <button
                       type="button"
                       onClick={() => analysis && fetchLlmComment(analysis)}
@@ -414,13 +498,17 @@ export function SmartMoneyContent() {
                     >
                       AI 코멘트 생성하기
                     </button>
+                  ) : (
+                    <p className="text-[11px] text-slate-500">
+                      AI 코멘트는 가장 최근 일자에서만 제공됩니다.
+                    </p>
                   )}
                 </div>
               </div>
             </section>
 
             {/* 시그널 패널 (4개 카드) */}
-            <SignalPanel analysis={analysis} />
+            <SignalPanel analysis={viewAnalysis} />
 
             {/* VWAP 차트 placeholder */}
             <section className="bg-white rounded-2xl border border-dashed border-slate-300 p-6 text-center">

--- a/dental-clinic-manager/src/lib/smartMoney/llmAnalyzer.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/llmAnalyzer.ts
@@ -14,7 +14,7 @@ const MODEL_ID = 'claude-haiku-4-5-20251001'
 const MAX_TOKENS = 600
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24h
 /** 캐시 키에 포함되는 프롬프트 버전 — 프롬프트 구조 변경 시 무효화 */
-const PROMPT_VERSION = 'v2'
+const PROMPT_VERSION = 'v3-plain'
 
 interface CacheEntry {
   comment: string
@@ -47,21 +47,40 @@ function setCached(key: string, comment: string): void {
   llmCache.set(key, { comment, expiresAt: Date.now() + CACHE_TTL_MS })
 }
 
-const SYSTEM_PROMPT = `당신은 한국 주식시장 전문 트레이더입니다. 주어진 다층 분석 데이터(VWAP, 단일봉 Wyckoff, 알고리즘 풋프린트, 외국인/기관 매매, 와이코프 페이즈 A~E, 시장구조 BOS/CHoCH, 유동성 풀과 sweep, 오더블록·FVG, Bull/Bear Trap, VSA effort-vs-result, 세션·PO3, 뉴스 컨텍스트, 조작 위험도)를 종합 해석하여 오늘 이 종목에서 스마트머니의 의도와 일반 투자자가 취할 수 있는 대응 전략을 작성하세요.
+const SYSTEM_PROMPT = `당신은 일반 개인 투자자에게 주식시장의 큰손(기관·외국인) 움직임을 쉽게 풀어 설명해주는 친절한 가이드입니다. 다양한 분석 데이터를 받지만, 답변에는 전문용어를 가급적 쓰지 말고 **일반인이 처음 들어도 이해할 수 있는 평범한 한국어**로 설명하세요.
 
 반드시 아래 두 섹션을 모두 포함해야 합니다:
 
-[스마트머니 의도]
-- 2~3문장. 매집/분배/중립 중 어느 단계로 보이는지, 어떤 시그널이 그 판단을 뒷받침하는지 구체적으로 언급(예: 와이코프 Phase C Spring, CHoCH 강세 전환, 유동성 사냥, 매수 클라이맥스 등).
+[큰손의 의도]
+- 2~3문장. 기관·외국인 같은 "큰손"이 지금 이 종목을 사 모으는 중인지, 팔아 치우는 중인지, 아니면 관망 중인지를 일반인 눈높이에서 설명. 그렇게 판단한 이유를 비유나 쉬운 풀이로.
 
-[일반 투자자 대응 전략]
-- 2~3문장. 위 의도 분석을 바탕으로 일반 개인 투자자가 어떻게 행동/관망/주의해야 하는지 구체적 가이드. 트랩이 감지되면 "추격 매수 자제", 매집 후기 페이즈면 "분할 진입 고려" 같이 행동 지침 제시. 조작 위험도가 50 이상이면 반드시 경고 문구 포함.
+[일반 투자자 행동 가이드]
+- 2~3문장. 위 분석을 토대로 평범한 개인이 지금 어떻게 행동하는 게 안전한지(추격 매수를 자제할지, 천천히 나눠서 살지, 일단 지켜볼지). 위험한 함정 신호가 있으면 분명히 경고.
 
-규칙:
-- 위 두 섹션 헤더([스마트머니 의도] / [일반 투자자 대응 전략])는 반드시 그대로 출력.
-- 단정적 표현 대신 "~로 보입니다", "~의심됩니다" 같은 톤 사용.
-- 절대 특정 가격대의 매수/매도 추천이나 목표가/손절가 명시 금지.
-- 단순한 데이터 나열 금지 — 반드시 종합 해석.`
+전문용어 사용 규칙 (매우 중요):
+- 다음 단어들은 **사용하지 말고** 쉬운 표현으로 바꿔 쓰세요:
+  · "VWAP 위/아래" → "오늘 평균 거래가격보다 비싸게/싸게"
+  · "BOS / CHoCH / Break of Structure" → "추세가 위로/아래로 꺾이는 신호" 또는 "상승 흐름이 새로 만들어졌다"
+  · "유동성 풀 / 유동성 사냥 / sweep" → "많은 손절가가 몰린 가격대를 큰손이 일부러 건드린 흔적"
+  · "오더블록 / FVG" → "큰손이 매수/매도 의사를 남긴 가격대" 또는 "되돌아올 가능성이 있는 가격구간"
+  · "Wyckoff Spring" → "공포로 잠깐 떨어뜨려 매물을 흔들어낸 뒤 다시 끌어올린 흔적"
+  · "Wyckoff Upthrust" → "환호로 잠깐 끌어올려 매수세를 끌어들인 뒤 다시 내린 흔적"
+  · "Iceberg" → "큰 주문을 잘게 쪼개 티 안 나게 사 모으는 방식"
+  · "TWAP / VWAP 알고" → "기관이 시간을 두고 일정하게 분할 매매하는 방식"
+  · "Sniper" → "조용하다가 한순간에 빠르게 들어오는 매매 방식"
+  · "MOO / MOC" → "장 시작 동시호가 / 장 마감 동시호가에 큰 거래량이 몰린 흔적"
+  · "Bull/Bear Trap" → "사라고/팔라고 유혹하는 함정"
+  · "VSA / Effort vs Result / No-Demand" → "거래량은 많은데 가격이 안 움직임 → 지친 기색" / "사려는 사람이 거의 없음 → 약한 신호"
+  · "PO3 / Judas Swing" → "장 초반 일부러 반대로 움직여 개미를 흔드는 패턴"
+- 영어 약자는 절대 그대로 쓰지 말 것. 꼭 필요하면 풀어 쓴 뒤 괄호로 한 번만 표기.
+- 비유 적극 사용 (예: "도매상이 물건을 조용히 들이는 모습", "큰 식당이 평일에 손님 적은 시간을 노려 재고를 채우는 느낌").
+
+기타 규칙:
+- 섹션 헤더([큰손의 의도] / [일반 투자자 행동 가이드])는 그대로 출력.
+- 단정 표현 대신 "~인 듯 합니다", "~로 보입니다" 같은 부드러운 톤 사용.
+- 특정 가격대의 매수/매도 추천, 목표가/손절가 명시 절대 금지.
+- 점수나 숫자를 그대로 나열하지 말고 한국어 풀이로(예: "100점 만점에 80점" 대신 "꽤 강한 신호").
+- 조작 위험도가 50 이상이면 반드시 "함정일 수 있으니 추격 자제" 식 경고를 포함.`
 
 let anthropicClient: Anthropic | null = null
 
@@ -195,7 +214,7 @@ export async function generateLLMComment(analysis: SmartMoneyAnalysis): Promise<
   try {
     const client = getAnthropic()
     const summary = summarizeAnalysis(analysis)
-    const userMessage = `다음은 오늘 (${analysis.asOfDate}) ${analysis.name}(${analysis.ticker}) 종목의 스마트머니 분석 결과입니다.\n\n${JSON.stringify(summary, null, 2)}\n\n위 데이터를 바탕으로 스마트머니의 의도와 일반 투자자의 대응 전략을 2~3문장으로 작성해주세요.`
+    const userMessage = `다음은 오늘 (${analysis.asOfDate}) ${analysis.name}(${analysis.ticker}) 종목에 대한 큰손(기관·외국인) 움직임 분석 결과입니다.\n\n${JSON.stringify(summary, null, 2)}\n\n위 데이터를 바탕으로 [큰손의 의도]와 [일반 투자자 행동 가이드]를 작성해주세요. 전문용어는 절대 그대로 쓰지 말고 평범한 한국어로 풀어 설명해주세요.`
 
     const response = await client.messages.create({
       model: MODEL_ID,

--- a/dental-clinic-manager/src/types/smartMoney.ts
+++ b/dental-clinic-manager/src/types/smartMoney.ts
@@ -279,6 +279,38 @@ export interface SmartMoneyAnalysis {
   naturalLanguageComment?: string
   /** ISO timestamp */
   generatedAt: string
+  /** 최근 N일치 일자별 분석 (오래된 → 최신 순). 가장 최근 일자(마지막 항목)는 본 객체와 동일. */
+  byDay?: DailyAnalysis[]
+}
+
+/**
+ * 일자별 단일일 분석 — byDay 항목.
+ * SmartMoneyAnalysis의 일자별 부분집합(LLM 코멘트는 가장 최근 일자만 포함되므로 옵션).
+ */
+export interface DailyAnalysis {
+  ticker: string
+  market: Market
+  /** YYYY-MM-DD — 이 분석이 대상으로 하는 거래일 */
+  asOfDate: string
+  /** 그 거래일의 종가(가장 최근 일자라면 진행 중 가격) */
+  closePrice: number
+  vwap: VWAPResult
+  wyckoff: WyckoffResult
+  algoFootprint: AlgoFootprintResult
+  wyckoffPhase?: WyckoffPhaseResult
+  liquidity?: LiquidityResult
+  marketStructure?: MarketStructureResult
+  orderBlocksFvg?: OrderBlockFvgResult
+  traps?: TrapResult
+  vsa?: VSAResult
+  session?: SessionResult
+  newsContext?: NewsContextResult
+  manipulationRiskScore?: number
+  overallScore: number
+  interpretation: Interpretation
+  signalDetails: SignalDetail[]
+  /** 가장 최근 일자에만 포함됨 (비용 절감) */
+  naturalLanguageComment?: string
 }
 
 // ============================================


### PR DESCRIPTION
## 변경

### 1. 일별 분석 탭 (최근 3거래일)

스마트머니 분석 페이지에 **일자별 탭** 을 추가하여 가장 최근 3 거래일의 분석을 비교 가능하게.

- 분봉 1170 → **2400봉(≈4일치)** 확장하여 가장 최근 3거래일 모두 풀 데이터 보장
- \`SmartMoneyAnalysis.byDay: DailyAnalysis[]\` 추가
  - 각 일자별 \`vwap / wyckoff(단일봉) / algoFootprint / session / newsContext / score\` 분리 계산
  - 다일 기반 엔진(\`wyckoffPhase / marketStructure / liquidity / orderBlocksFvg / traps / vsa\`)은 공유
  - 봉 200개 미만 부분 일자는 byDay에서 제외 (진행 중인 오늘은 항상 포함)
- UI: 일자별 탭 N개. 탭 클릭 시 \`viewAnalysis\`가 그 일자로 라우팅 → 점수/SignalPanel/시그널 디테일 모두 전환
- 가장 최근(오늘) 탭에만 LLM 코멘트, 다른 탭은 안내 문구

### 2. LLM 코멘트 일반인 친화 (v2 → v3-plain)

시스템 프롬프트 전면 재작성하여 일반 투자자가 처음 들어도 이해할 수 있는 평범한 한국어로:

- 섹션 헤더: \`[스마트머니 의도] / [일반 투자자 대응 전략]\` → **\`[큰손의 의도] / [일반 투자자 행동 가이드]\`**
- 전문용어 일상어로 변환 (예시):
  - \"VWAP 위\" → \"오늘 평균 거래가격보다 비싸게\"
  - \"유동성 사냥\" → \"많은 손절가가 몰린 가격대를 큰손이 일부러 건드린 흔적\"
  - \"Iceberg\" → \"큰 주문을 잘게 쪼개 티 안 나게 사 모으는 방식\"
  - \"BOS\" → \"상승 흐름이 새로 만들어진 신호\"
  - \"Wyckoff Spring\" → \"공포로 잠깐 떨어뜨려 매물을 흔들어낸 뒤 다시 끌어올린 흔적\"
- 비유 적극 사용 (\"도매상이 평일에 재고를 채우는 모습\")
- 영어 약자 그대로 출력 금지

## 검증 (AAPL, 미국장 진행 중)

- 탭 2개 표시: \"전 거래일 4/29 (수)\" / \"오늘 4/30 (목)\"
- LLM 코멘트 일반인 친화 확인 (\"큰손들이 꾸준히 사 모으는 중인 듯\")
- 탭 전환 시 점수/패널/날짜 모두 그 일자 기준으로 전환
- 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)