### PR TITLE
fix(smart-money): 날짜 시간대 + 탭 3개 + 알고풋프린트 6개 가시성

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
@@ -227,13 +227,14 @@ export async function POST(request: NextRequest) {
       const quote = await fetchCurrentQuote(ticker, 'US')
       currentPrice = quote.price ?? 0
 
-      // 1분봉 — 마지막 2400봉(≈4거래일치) 사용 (byDay에 최신 3일 + 여유분)
+      // 1분봉 — yahoo가 주는 6일치 데이터를 모두 사용 (캐시 우회로 fresh 데이터 보장)
       const usBars: OHLCV[] = await fetchIntradayPrices({
         ticker,
         market: 'US',
         timeframe: '1m',
+        forceRefresh: true,
       })
-      const recent = usBars.slice(-2400)
+      const recent = usBars
       bars = recent.map((b) => ({
         datetime: b.date,
         open: b.open,
@@ -433,16 +434,41 @@ export async function POST(request: NextRequest) {
     // 다일 기반 엔진(wyckoffPhase, liquidity, marketStructure, orderBlocksFvg, traps, vsa)은
     // 본질적으로 N일 컨텍스트가 필요하므로 모든 일자에 동일하게 표시.
     // intraday 엔진(vwap, wyckoff(단일봉), algoFootprint, session, newsContext)은 일자별로 다르게 계산.
-    const dayKeys = Array.from(new Set(bars.map((b) => (b.datetime ?? '').slice(0, 10)).filter(Boolean))).sort()
-    // 봉 수가 너무 적은(잘린) 일자는 제외하고 가장 최근 3 거래일만 사용
-    const MIN_BARS_PER_DAY = 200
+    // datetime → 시장의 거래일 기준 YYYY-MM-DD 키
+    // yahoo/KIS 분봉이 UTC ISO이면 한 거래일이 UTC 2일에 걸쳐 분리되어 잘못 묶임
+    // → 미국=America/New_York, 한국=Asia/Seoul timezone으로 normalize
+    const tz = market === 'US' ? 'America/New_York' : 'Asia/Seoul'
+    const dayKeyOf = (dt: string): string => {
+      if (!dt) return ''
+      // ISO에 timezone offset(Z 또는 ±HH:MM)이 없으면 UTC로 가정
+      const hasTz = /Z$|[+-]\d{2}:?\d{2}$/.test(dt)
+      const d = new Date(hasTz ? dt : dt + 'Z')
+      if (isNaN(d.getTime())) return dt.slice(0, 10)
+      try {
+        const fmt = new Intl.DateTimeFormat('en-CA', { timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit' })
+        return fmt.format(d) // YYYY-MM-DD
+      } catch {
+        return dt.slice(0, 10)
+      }
+    }
+    const dayKeys = Array.from(new Set(bars.map((b) => dayKeyOf(b.datetime)).filter(Boolean))).sort()
+    // 일자별 봉 수 (timezone normalized)
+    const dayBarCounts = new Map<string, number>()
+    for (const b of bars) {
+      const k = dayKeyOf(b.datetime)
+      if (!k) continue
+      dayBarCounts.set(k, (dayBarCounts.get(k) ?? 0) + 1)
+    }
+    console.log('[smart-money/analyze] 일자별 봉 수:', Array.from(dayBarCounts.entries()))
+    // 가장 최근 3 거래일을 보장하도록 — 임계값(>=100)을 완화하여 부분 일자도 가능하면 포함
+    const MIN_BARS_PER_DAY = 100
     const fullDays = dayKeys.filter(
-      (k) => bars.filter((b) => (b.datetime ?? '').startsWith(k)).length >= MIN_BARS_PER_DAY
-        || k === dayKeys[dayKeys.length - 1], // 진행 중 오늘은 항상 포함
+      (k) => (dayBarCounts.get(k) ?? 0) >= MIN_BARS_PER_DAY
+        || k === dayKeys[dayKeys.length - 1],
     )
     const recentDayKeys = fullDays.slice(-3)
     for (const dayKey of recentDayKeys) {
-      const dayBars = bars.filter((b) => (b.datetime ?? '').startsWith(dayKey))
+      const dayBars = bars.filter((b) => dayKeyOf(b.datetime) === dayKey)
       if (dayBars.length < 5) continue
       const closePrice = dayBars[dayBars.length - 1].close
 

--- a/dental-clinic-manager/src/components/Investment/SmartMoney/SignalPanel.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/SignalPanel.tsx
@@ -225,6 +225,7 @@ export function SignalPanel({ analysis }: Props) {
           {algoBars.map(b => {
             const isDominant = algoFootprint.dominantAlgo === b.label
             const pct = Math.max(0, Math.min(100, b.score))
+            const isZero = b.score === 0
             return (
               <div key={b.label}>
                 <div className="flex items-center justify-between text-[11px] mb-0.5">
@@ -232,13 +233,21 @@ export function SignalPanel({ analysis }: Props) {
                     {b.label}
                     {isDominant && <span className="ml-1 text-[9px]">★</span>}
                   </span>
-                  <span className="font-mono text-slate-600">{b.score.toFixed(0)}</span>
+                  <span className={`font-mono ${isZero ? 'text-slate-400' : 'text-slate-600'}`}>
+                    {isZero ? '신호 없음' : b.score.toFixed(0)}
+                  </span>
                 </div>
-                <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
-                  <div
-                    className={`h-full transition-all ${isDominant ? 'bg-blue-600' : 'bg-slate-400'}`}
-                    style={{ width: `${pct}%` }}
-                  />
+                <div
+                  className={`w-full h-1.5 rounded-full overflow-hidden ${
+                    isZero ? 'bg-slate-200/40 border border-dashed border-slate-300' : 'bg-slate-100'
+                  }`}
+                >
+                  {!isZero && (
+                    <div
+                      className={`h-full transition-all ${isDominant ? 'bg-blue-600' : 'bg-slate-400'}`}
+                      style={{ width: `${pct}%` }}
+                    />
+                  )}
                 </div>
               </div>
             )

--- a/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
@@ -113,12 +113,14 @@ function todayKey() {
   return new Date().toISOString().slice(0, 10)
 }
 
-/** YYYY-MM-DD → "MM/DD (요일)" */
+/** YYYY-MM-DD → "MM/DD (요일)" — timezone에 영향받지 않도록 UTC로 명시 파싱 */
 function formatDayLabel(date: string): string {
-  const [, m, d] = date.split('-')
-  const day = new Date(date).getDay()
+  const [y, m, d] = date.split('-').map(Number)
+  if (!y || !m || !d) return date
+  const dt = new Date(Date.UTC(y, m - 1, d))
+  const day = dt.getUTCDay()
   const dayLabel = ['일', '월', '화', '수', '목', '금', '토'][day]
-  return `${parseInt(m, 10)}/${parseInt(d, 10)} (${dayLabel})`
+  return `${m}/${d} (${dayLabel})`
 }
 
 /** "오늘" / "어제" / "그제" 라벨 — 가장 최근(마지막)이 오늘 */

--- a/dental-clinic-manager/src/lib/intradayDataService.ts
+++ b/dental-clinic-manager/src/lib/intradayDataService.ts
@@ -29,6 +29,8 @@ export interface FetchIntradayParams {
   startDate?: string
   /** 종료 날짜 (YYYY-MM-DD). 미지정 시 오늘 */
   endDate?: string
+  /** true면 DB 캐시를 무시하고 yahoo에서 직접 받아와 캐시 갱신 */
+  forceRefresh?: boolean
 }
 
 // ============================================
@@ -43,13 +45,15 @@ export interface FetchIntradayParams {
  * - 한국 종목이 yahoo에서 미지원이면 빈 배열 반환
  */
 export async function fetchIntradayPrices(params: FetchIntradayParams): Promise<OHLCV[]> {
-  const { ticker, market, timeframe } = params
+  const { ticker, market, timeframe, forceRefresh } = params
   const endDate = params.endDate ?? toDateString(new Date())
   const startDate = params.startDate ?? defaultStartDate(timeframe)
 
-  // 1. DB 캐시 조회
-  const cached = await getCachedIntraday(ticker, market, timeframe, startDate, endDate)
-  if (cached.length > 0) {
+  // 1. DB 캐시 조회 (forceRefresh=true면 스킵)
+  const cached = forceRefresh
+    ? []
+    : await getCachedIntraday(ticker, market, timeframe, startDate, endDate)
+  if (!forceRefresh && cached.length > 0) {
     // 분봉 데이터 자체는 외부에서 가져오는 게 비싸므로 캐시가 어느 정도 있으면 사용
     // 하루 단위로 신선도가 다르므로 보수적으로 (요청 일수 * 일봉 60% 수준 이상이면 캐시 사용)
     const requestDays = daysBetween(startDate, endDate)

--- a/dental-clinic-manager/src/lib/smartMoney/algoFootprintEngine.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/algoFootprintEngine.ts
@@ -37,8 +37,8 @@ function scoreTwap(bars: AlgoBar[]): number {
   for (const v of volumes) varSum += (v - mean) ** 2
   const std = Math.sqrt(varSum / n)
   const cv = std / mean  // 변동계수
-  // cv=0 → 100, cv=1 → 0 (대략)
-  return Math.max(0, Math.min(100, (1 - cv) * 100))
+  // cv=0 → 100, cv=2 → 0 (인트라데이는 보통 cv≈1이라 종전 매핑은 항상 0)
+  return Math.max(0, Math.min(100, ((2 - cv) / 2) * 100))
 }
 
 // ============================================
@@ -122,10 +122,10 @@ function scoreIceberg(bars: AlgoBar[]): number {
     }
   }
 
-  // 데이터 양에 비례한 임계값 — 봉 수의 5%(min 4) → 0점, 15%(min 12) → 100점
-  // (5분봉 78봉: 4~12, 1분봉 780봉: 39~117)
-  const minCluster = Math.max(4, Math.ceil(bars.length * 0.05))
-  const maxCluster = Math.max(12, Math.ceil(bars.length * 0.15))
+  // 데이터 양에 비례한 임계값 — 봉 수의 3%(min 4) → 0점, 10%(min 12) → 100점
+  // 1분봉이 5분봉보다 봉당 거래량 작아 클러스터 형성 더 어려움 → 임계 완화
+  const minCluster = Math.max(4, Math.ceil(bars.length * 0.03))
+  const maxCluster = Math.max(12, Math.ceil(bars.length * 0.10))
   if (bestCluster < minCluster) return 0
   const range = Math.max(1, maxCluster - minCluster)
   return Math.max(0, Math.min(100, ((bestCluster - minCluster) / range) * 100))
@@ -181,12 +181,12 @@ function median(arr: number[]): number {
 
 /**
  * 봉 거래량이 중앙값 대비 ratio일 때 점수:
- * ratio ≤ 1.5 → 0 / ratio = 3 → 60 / ratio = 5 → 100 / 그 이상 클램프
+ * ratio ≤ 1.2 → 0 / ratio = 4 → 100
+ * (1분봉은 봉당 거래량이 작아 정규장 시초/종가 봉도 baseline 1.2~3배 정도라 종전 1.5~5 매핑은 항상 0)
  */
 function ratioToScore(ratio: number): number {
-  if (ratio <= 1.5) return 0
-  // 1.5 → 0, 5 → 100 선형
-  return Math.max(0, Math.min(100, ((ratio - 1.5) / 3.5) * 100))
+  if (ratio <= 1.2) return 0
+  return Math.max(0, Math.min(100, ((ratio - 1.2) / 2.8) * 100))
 }
 
 interface AuctionResult {


### PR DESCRIPTION
## 수정 내역

### 1. 날짜 표시 시간대 일관성
- analyze route: datetime을 **시장 timezone**(US: America/New_York, KR: Asia/Seoul)으로 변환 후 dayKey 추출
- yahoo가 UTC ISO를 반환 → UTC slice는 ET 거래일과 어긋남 (프리/포스트마켓이 UTC 2일에 걸침)
- \`+00:00\` offset 형식까지 정규식으로 정확 처리
- \`formatDayLabel\` UTC 기반으로 명시 (시스템 timezone 영향 제거)

### 2. 탭 3개 보장
- \`fetchIntradayPrices\`에 \`forceRefresh\` 옵션 추가 — 캐시 stale로 4/29~4/30 데이터 누락 해결
- smart-money는 항상 fresh fetch
- \`slice(-2400)\` 제거하여 yahoo 6일치 모두 사용
- byDay 부분 일자 임계 200 → 100 완화

### 3. 알고풋프린트 6개 가시성
- 임계값 완화:
  - \`scoreTwap\`: cv=0→100 / cv=2→0 (이전: cv=1→0이라 인트라데이 거의 항상 0)
  - \`scoreIceberg\`: 봉수의 5%/15% → 3%/10%
  - \`ratioToScore\` (MOO/MOC): 1.5/5 → 1.2/4
- SignalPanel UI: **0점 항목 "신호 없음" + 점선 막대**로 시각적 명확화
  - 이전: 0점 막대가 0%라 안 보여 "VWAP/Sniper만 표시" 보임

## 검증 (AAPL 1분봉, 한국 5/1)

- 탭 3개: \"그 전 4/28 (화)\" / \"전 거래일 4/29 (수)\" / \"오늘 4/30 (목)\"
- 알고풋프린트 6개 모두 명시: TWAP/Iceberg/MOO/MOC = 신호 없음(점선), VWAP=37, Sniper=27
- 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)