### PR TITLE
fix(worker): Chromium 미번들 시 사용자 데이터 경로로 폴백

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/src/main.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/main.ts
@@ -66,18 +66,41 @@ async function autoRegister(): Promise<boolean> {
  * 시스템 기본 경로(`AppData\Local\ms-playwright`)에 의존하지 않도록 명시 설정
  */
 function setupPlaywrightBrowsersPath(): string {
+  // 번들된 browsers 폴더에 실제 chromium 실행 파일이 있는지 검증.
+  // Program Files 하위는 일반 사용자 권한으로 쓰기 불가 → 자동 설치도 실패하므로,
+  // 비어 있으면 사용자 데이터 폴더로 폴백한다.
   if (app.isPackaged) {
     const bundledPath = path.join(process.resourcesPath, 'browsers');
-    if (fs.existsSync(bundledPath)) {
+    if (fs.existsSync(bundledPath) && hasPlaywrightChromium(bundledPath)) {
       process.env.PLAYWRIGHT_BROWSERS_PATH = bundledPath;
       log('info', `[Playwright] 번들된 브라우저 사용: ${bundledPath}`);
       return bundledPath;
     }
+    log('warn', `[Playwright] 번들된 browsers 폴더에 chromium 실행 파일 없음 → 사용자 데이터 경로로 폴백`);
   }
   const userPath = path.join(app.getPath('userData'), 'playwright-browsers');
   process.env.PLAYWRIGHT_BROWSERS_PATH = userPath;
   log('info', `[Playwright] 사용자 데이터 경로 사용: ${userPath}`);
   return userPath;
+}
+
+/** browsers 디렉토리 내에 chromium 또는 chromium_headless_shell 실제 실행 파일이 있는지 검증 */
+function hasPlaywrightChromium(browsersPath: string): boolean {
+  try {
+    const entries = fs.readdirSync(browsersPath);
+    return entries.some((entry) => {
+      if (!entry.startsWith('chromium')) return false;
+      const candidates = [
+        path.join(browsersPath, entry, 'chrome-win', 'chrome.exe'),
+        path.join(browsersPath, entry, 'chrome-headless-shell-win64', 'chrome-headless-shell.exe'),
+        path.join(browsersPath, entry, 'chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium'),
+        path.join(browsersPath, entry, 'chrome-linux', 'chrome'),
+      ];
+      return candidates.some((p) => fs.existsSync(p));
+    });
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
실제 워커 동작 테스트에서 발견된 두 번째 이슈 해결.

## 문제
1차 수정(credentials API) 후 워커가 작업을 정상으로 잡았으나 chromium launch에서 실패:

```
[Scraping] 폴링 오류: Error: browserType.launch: Executable doesn't exist at
C:\Program Files\hayan-marketing-worker\resources\browsers\chromium_headless_shell-1208\chrome-headless-shell-win64\chrome-headless-shell.exe
```

원인:
- `setupPlaywrightBrowsersPath()`가 번들 `browsers/` 폴더의 존재만 확인하고 안에 실제 chromium이 있는지 검증하지 않음
- 1.1.91 빌드에 chromium이 빠진 채로 폴더만 만들어진 상태
- `C:\Program Files\` 경로는 일반 사용자 권한으로 자동 설치 불가 → ensureChromiumInstalled도 실패

## 수정
- `hasPlaywrightChromium()` 헬퍼로 실제 chrome.exe / chrome-headless-shell.exe 존재 검증
- 번들 폴더가 비어 있으면 `userData/playwright-browsers`로 폴백
- 폴백 경로는 사용자 권한으로 쓰기 가능 → ensureChromiumInstalled 정상 동작

## Test plan
- [x] TypeScript 타입체크 통과
- [ ] 새 워커 빌드(1.1.92) 자동 패키징
- [ ] 사용자 PC 자동 업데이트 후 chromium 자동 설치 확인
- [ ] manual_sync job 정상 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)