### PR TITLE
feat(payroll): 세무사무실 PDF 총급여 자동 인식 → 총 지출 반영

### DIFF
--- a/dental-clinic-manager/package-lock.json
+++ b/dental-clinic-manager/package-lock.json
@@ -68,6 +68,7 @@
         "lucide-react": "^0.544.0",
         "next": "15.5.7",
         "openai": "^6.17.0",
+        "pdf-parse": "^1.1.1",
         "pdfjs-dist": "^5.4.624",
         "pg": "^8.16.3",
         "qrcode": "^1.5.4",
@@ -196,7 +197,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -812,7 +812,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
       "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -3842,7 +3841,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
       "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.71.1",
         "@supabase/functions-js": "2.4.6",
@@ -4169,7 +4167,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.9.0.tgz",
       "integrity": "sha512-2f460x1yMJ2vXctrbFw6m4/uZk7g5BgsxsJCJtDDjpyasMk5f+BdJTDCb0dwewWb75U+cbdH88AF7NXtLEs6XQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4418,7 +4415,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.7.2.tgz",
       "integrity": "sha512-/tYHmEkOGcVweAc9ZgnAXkzua5aJfu7TjZcKTq5fmDt6x9MY1eY1+egS7D9hVR2sUSAC10VgXmYdYPDsKF3p2g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4511,7 +4507,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.7.2.tgz",
       "integrity": "sha512-1sBOrYHoMDcygPSuBfunp/bw21rea/r7L8AQaeZ/NIo2RZ6GXWxI9sRzTkLWijZ4xC3md0O/ylmvxvLL4V0SVA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4617,7 +4612,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.9.0.tgz",
       "integrity": "sha512-by/GH4A5kaiQqujA2KtXI1ZfQLMuFbb5tylAupPq+Pv6qzEU+Engx7vwUxb/dYvFHh+pxQPJeG6zxWf+WiGPQw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4657,7 +4651,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.7.2.tgz",
       "integrity": "sha512-FaToSdU9fhQk2swkaXrAQNgdaE0dwLbUHcvilW5F4xTpQfZ3J535u5U2TUYf+f9KKSV5fTmD4QGNY9qxY7ihTg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4672,7 +4665,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.9.0.tgz",
       "integrity": "sha512-MN1gL1OZWD489a/OmwV+InyNoRY+nKMKZ2EuZGL5ouQRdi5qSTvtMCmqzBHqrDzJCDPNCaY4NWW5DiKqIiJ2Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4940,7 +4932,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4950,7 +4941,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -5034,7 +5024,6 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -5694,7 +5683,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7268,7 +7256,6 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7443,7 +7430,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9874,6 +9860,12 @@
         "node": ">=10.5.0"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/node-fetch": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
@@ -10301,6 +10293,28 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/pdfjs-dist": {
       "version": "5.4.624",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.624.tgz",
@@ -10326,7 +10340,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -10666,7 +10679,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
       "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -10696,7 +10708,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -10745,7 +10756,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
       "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -10865,7 +10875,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.2.tgz",
       "integrity": "sha512-MdWVitvLbQULD+4DP8GYjZUrepGW7d+GQkNVqJEzNxE+e9WIa4egVFE/RDfVb1u9u/Jw7dNMmPB4IqxzbFYJ0w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10875,7 +10884,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.2.tgz",
       "integrity": "sha512-dEoydsCp50i7kS1xHOmPXq4zQYoGWedUsvqv9H6zdif2r7yLHygyfP9qou71TulRN0d6ng9EbRVsQhSqfUc19g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10920,15 +10928,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -11087,8 +11093,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -12278,7 +12283,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12548,7 +12552,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/dental-clinic-manager/package.json
+++ b/dental-clinic-manager/package.json
@@ -73,6 +73,7 @@
     "lucide-react": "^0.544.0",
     "next": "15.5.7",
     "openai": "^6.17.0",
+    "pdf-parse": "^1.1.1",
     "pdfjs-dist": "^5.4.624",
     "pg": "^8.16.3",
     "qrcode": "^1.5.4",
@@ -91,7 +92,6 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
-    "vitest": "^2.1.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
@@ -100,6 +100,7 @@
     "eslint-config-next": "15.5.7",
     "supabase": "^2.92.1",
     "tailwindcss": "^4",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^2.1.0"
   }
 }

--- a/dental-clinic-manager/src/app/api/payroll/tax-office-files/route.ts
+++ b/dental-clinic-manager/src/app/api/payroll/tax-office-files/route.ts
@@ -7,6 +7,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import JSZip from 'jszip'
 import type { TaxOfficeFileMatch, TaxOfficeUploadResult } from '@/types/payroll'
+import { extractPayslipTotalPayment } from '@/utils/payslipPdfParser'
 
 const STORAGE_BUCKET = 'payroll-documents'
 
@@ -188,6 +189,17 @@ export async function POST(request: NextRequest) {
           continue
         }
 
+        // PDF에서 총 지급액 자동 추출 (실패 시 null — 후속 동기화 스킵)
+        let totalPayment: number | null = null
+        try {
+          totalPayment = await extractPayslipTotalPayment(Buffer.from(pdfArrayBuffer))
+        } catch (parseErr) {
+          console.error(`[tax-office-files] PDF 파싱 오류 (${match.fileName}):`, parseErr)
+        }
+        if (totalPayment == null) {
+          result.errors.push(`총 지급액 인식 실패: ${match.fileName} (수동 입력이 필요할 수 있습니다)`)
+        }
+
         // DB에 메타데이터 저장 (upsert)
         const dbRecord = {
           clinic_id: clinicId,
@@ -197,6 +209,7 @@ export async function POST(request: NextRequest) {
           file_name: displayFileName,
           storage_path: storagePath,
           uploaded_by: uploadedBy,
+          total_payment: totalPayment,
           created_at: new Date().toISOString()
         }
 
@@ -207,6 +220,7 @@ export async function POST(request: NextRequest) {
               file_name: displayFileName,
               storage_path: storagePath,
               uploaded_by: uploadedBy,
+              total_payment: totalPayment,
               created_at: new Date().toISOString()
             })
             .eq('id', existingRecord.id)

--- a/dental-clinic-manager/src/utils/payslipPdfParser.ts
+++ b/dental-clinic-manager/src/utils/payslipPdfParser.ts
@@ -1,0 +1,85 @@
+// ============================================
+// 세무사무실 급여명세서 PDF 파싱 유틸
+// "지 급 액 계" 라벨 다음의 총 지급액(=총급여) 추출
+// ============================================
+import path from 'path'
+
+let cachedPdfjs: typeof import('pdfjs-dist/legacy/build/pdf.mjs') | null = null
+
+async function getPdfjs() {
+  if (!cachedPdfjs) {
+    cachedPdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs')
+  }
+  return cachedPdfjs
+}
+
+function nodeModulesPath(sub: string): string {
+  // process.cwd()는 Next.js 실행 시 프로젝트 루트
+  return path.join(process.cwd(), 'node_modules', 'pdfjs-dist', sub)
+}
+
+/**
+ * PDF 버퍼에서 텍스트 전체를 추출.
+ * 한국어 폰트(cMap) 지원 포함.
+ */
+async function extractPdfText(buffer: Buffer | Uint8Array): Promise<string> {
+  const pdfjs = await getPdfjs()
+  const data = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer)
+  const doc = await pdfjs.getDocument({
+    data,
+    cMapUrl: nodeModulesPath('cmaps') + '/',
+    cMapPacked: true,
+    disableFontFace: true,
+    standardFontDataUrl: nodeModulesPath('standard_fonts') + '/',
+  }).promise
+
+  let text = ''
+  try {
+    for (let i = 1; i <= doc.numPages; i++) {
+      const page = await doc.getPage(i)
+      const content = await page.getTextContent()
+      text += content.items
+        .map(item => ('str' in item ? (item as { str: string }).str : ''))
+        .join(' ') + '\n'
+    }
+  } finally {
+    await doc.destroy()
+  }
+  return text
+}
+
+/**
+ * 정규화된 텍스트에서 "지 급 액 계" 다음 첫 숫자 시퀀스를 추출하여 정수로 변환.
+ * 한국 세무사무실 급여명세서 표준 양식 기준.
+ */
+function parseTotalPaymentFromText(text: string): number | null {
+  const normalized = text.replace(/\s+/g, ' ')
+
+  // 1순위: "지 급 액 계" 라벨
+  const labels = ['지 급 액 계', '지급액계', '지급 총액', '총 지급액', '총지급액']
+  for (const label of labels) {
+    const idx = normalized.indexOf(label)
+    if (idx < 0) continue
+    const after = normalized.slice(idx + label.length)
+    // 라벨 직후의 첫 숫자/콤마/공백 시퀀스 (한글이 나오면 종료)
+    const m = after.match(/^\s*([\d][\d,\s]*\d|\d)/)
+    if (!m) continue
+    const num = parseInt(m[1].replace(/[,\s]/g, ''), 10)
+    if (!isNaN(num) && num > 0) return num
+  }
+  return null
+}
+
+/**
+ * PDF 버퍼에서 총 지급액(=총급여) 추출.
+ * @returns 인식된 금액(원). 인식 실패 시 null.
+ */
+export async function extractPayslipTotalPayment(buffer: Buffer | Uint8Array): Promise<number | null> {
+  try {
+    const text = await extractPdfText(buffer)
+    return parseTotalPaymentFromText(text)
+  } catch (err) {
+    console.error('[payslipPdfParser] 추출 실패:', err)
+    return null
+  }
+}

--- a/dental-clinic-manager/supabase/migrations/20260501_payslip_pdf_total_payment_sync.sql
+++ b/dental-clinic-manager/supabase/migrations/20260501_payslip_pdf_total_payment_sync.sql
@@ -1,0 +1,152 @@
+-- ============================================
+-- 세무사무실 PDF total_payment → expense_records 자동 동기화
+-- Created: 2026-05-01
+-- ============================================
+
+-- 1. payroll_tax_office_files에 total_payment 컬럼 추가
+ALTER TABLE payroll_tax_office_files
+  ADD COLUMN IF NOT EXISTS total_payment INTEGER;
+
+-- 2. expense_records에 payroll_tax_office_file_id 컬럼 + unique index
+ALTER TABLE expense_records
+  ADD COLUMN IF NOT EXISTS payroll_tax_office_file_id UUID
+    REFERENCES payroll_tax_office_files(id) ON DELETE CASCADE;
+
+DROP INDEX IF EXISTS idx_expense_records_tax_office_file;
+CREATE UNIQUE INDEX idx_expense_records_tax_office_file
+  ON expense_records(payroll_tax_office_file_id);
+
+-- 3. expense_records.source CHECK 갱신 ('payroll_pdf' 추가)
+ALTER TABLE expense_records DROP CONSTRAINT IF EXISTS expense_records_source_check;
+ALTER TABLE expense_records ADD CONSTRAINT expense_records_source_check
+  CHECK (source IN ('manual','payroll','payroll_pdf'));
+
+-- 4. PDF → expense_records 동기화 트리거
+CREATE OR REPLACE FUNCTION sync_payslip_pdf_to_expense()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_category_id UUID;
+  v_employee_name TEXT;
+  v_existing_payroll BOOLEAN;
+  v_desc TEXT;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    DELETE FROM expense_records WHERE payroll_tax_office_file_id = OLD.id;
+    RETURN OLD;
+  END IF;
+
+  IF NEW.total_payment IS NULL OR NEW.total_payment <= 0 THEN
+    DELETE FROM expense_records WHERE payroll_tax_office_file_id = NEW.id;
+    RETURN NEW;
+  END IF;
+
+  -- 같은 (clinic, employee, year, month) payroll_statements 우선 — PDF 동기화 스킵
+  SELECT EXISTS (
+    SELECT 1 FROM payroll_statements
+    WHERE clinic_id = NEW.clinic_id
+      AND employee_user_id = NEW.employee_user_id
+      AND payment_year = NEW.payment_year
+      AND payment_month = NEW.payment_month
+  ) INTO v_existing_payroll;
+
+  IF v_existing_payroll THEN
+    DELETE FROM expense_records WHERE payroll_tax_office_file_id = NEW.id;
+    RETURN NEW;
+  END IF;
+
+  SELECT id INTO v_category_id FROM expense_categories
+    WHERE clinic_id = NEW.clinic_id AND type = 'personnel' AND is_active = TRUE
+    ORDER BY is_system_default DESC, display_order ASC
+    LIMIT 1;
+
+  IF v_category_id IS NULL THEN
+    RAISE NOTICE 'No personnel category for clinic %, skipping PDF expense sync', NEW.clinic_id;
+    RETURN NEW;
+  END IF;
+
+  SELECT COALESCE(name, '직원') INTO v_employee_name
+    FROM users WHERE id = NEW.employee_user_id;
+  v_employee_name := COALESCE(v_employee_name, '직원');
+
+  v_desc := v_employee_name || ' 급여 ('
+    || NEW.payment_year || '-' || LPAD(NEW.payment_month::TEXT, 2, '0')
+    || ', 세무사무실)';
+
+  INSERT INTO expense_records (
+    clinic_id, category_id, year, month, amount, description,
+    source, payroll_tax_office_file_id
+  ) VALUES (
+    NEW.clinic_id, v_category_id, NEW.payment_year, NEW.payment_month,
+    NEW.total_payment, v_desc, 'payroll_pdf', NEW.id
+  )
+  ON CONFLICT (payroll_tax_office_file_id) DO UPDATE
+    SET amount = EXCLUDED.amount,
+        year = EXCLUDED.year,
+        month = EXCLUDED.month,
+        description = EXCLUDED.description,
+        category_id = EXCLUDED.category_id,
+        updated_at = NOW();
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_sync_payslip_pdf_to_expense ON payroll_tax_office_files;
+CREATE TRIGGER trg_sync_payslip_pdf_to_expense
+  AFTER INSERT OR UPDATE OR DELETE ON payroll_tax_office_files
+  FOR EACH ROW EXECUTE FUNCTION sync_payslip_pdf_to_expense();
+
+-- 5. payroll_statements 추가 시 같은 (clinic,employee,year,month)의 PDF expense 제거
+CREATE OR REPLACE FUNCTION sync_payroll_to_expense()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_category_id UUID;
+  v_amount INTEGER;
+  v_desc TEXT;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    DELETE FROM expense_records WHERE payroll_statement_id = OLD.id;
+    RETURN OLD;
+  END IF;
+
+  SELECT id INTO v_category_id FROM expense_categories
+    WHERE clinic_id = NEW.clinic_id AND type = 'personnel' AND is_active = TRUE
+    ORDER BY is_system_default DESC, display_order ASC
+    LIMIT 1;
+
+  IF v_category_id IS NULL THEN
+    RAISE NOTICE 'No personnel category for clinic %, skipping expense sync', NEW.clinic_id;
+    RETURN NEW;
+  END IF;
+
+  v_amount := COALESCE(NEW.total_payment, NEW.total_earnings, 0);
+  v_desc := COALESCE(NEW.employee_name, '직원') || ' 급여 ('
+    || NEW.payment_year || '-' || LPAD(NEW.payment_month::TEXT, 2, '0') || ')';
+
+  INSERT INTO expense_records (
+    clinic_id, category_id, year, month, amount, description,
+    source, payroll_statement_id
+  ) VALUES (
+    NEW.clinic_id, v_category_id, NEW.payment_year, NEW.payment_month,
+    v_amount, v_desc, 'payroll', NEW.id
+  )
+  ON CONFLICT (payroll_statement_id) DO UPDATE
+    SET amount = EXCLUDED.amount,
+        year = EXCLUDED.year,
+        month = EXCLUDED.month,
+        description = EXCLUDED.description,
+        category_id = EXCLUDED.category_id,
+        updated_at = NOW();
+
+  -- 같은 (clinic,employee,year,month) PDF expense 제거 (중복 방지)
+  DELETE FROM expense_records er
+  USING payroll_tax_office_files f
+  WHERE er.payroll_tax_office_file_id = f.id
+    AND f.clinic_id = NEW.clinic_id
+    AND f.employee_user_id = NEW.employee_user_id
+    AND f.payment_year = NEW.payment_year
+    AND f.payment_month = NEW.payment_month;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- 세무사무실 급여명세서 PDF를 업로드하면 PDF에서 총 지급액(=총급여)을 자동 인식하여 `payroll_tax_office_files.total_payment`에 저장
- 새 트리거 `sync_payslip_pdf_to_expense`로 expense_records에 인건비로 자동 등록 → 총 지출 카드에 반영
- 같은 직원의 같은 월에 직접 입력된 급여 명세서가 이미 있으면 PDF는 스킵(명세서 우선) — 이중 계산 방지
- 기존 4건 PDF는 backfill 완료. 유지혜 4월 645,810원이 4월 총 지출에 정상 반영됨 (4월 인건비: 3,068,130 + 645,810 = 3,713,940원)

## Implementation
- `src/utils/payslipPdfParser.ts`: pdfjs-dist legacy build + 한국어 cMap 지원, "지 급 액 계" 라벨 인식
- `src/app/api/payroll/tax-office-files/route.ts`: 업로드 시 PDF 파싱 → `total_payment` 저장
- `supabase/migrations/20260501_payslip_pdf_total_payment_sync.sql`: 컬럼 추가 + 트리거 + CHECK 갱신
- pdf-parse 1.1.1 의존성 추가 (사실상 미사용 — 향후 정리 가능, 현재는 pdfjs-dist만 사용)

## Test plan
- [x] `npm run build` 통과
- [x] 4건 PDF 텍스트 추출 검증 (김지성 2,882,832 / 김지은 3,765,320 / 이진희 4,203,130 / 유지혜 645,810)
- [x] backfill 완료 후 financial_summary_view 확인 (하얀치과 4월 인건비 3,713,940원)
- [ ] 배포 후 PDF 업로드 시 자동 반영 확인
- [ ] 인식 실패 PDF 케이스 — errors 메시지 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)