### PR TITLE
feat(scraping-worker): worker_control.disabled 플래그로 Mac mini 영구 비활성화 지원

### DIFF
--- a/dental-clinic-manager/scraping-worker/src/index.ts
+++ b/dental-clinic-manager/scraping-worker/src/index.ts
@@ -46,6 +46,23 @@ async function shutdown(signal: string): Promise<void> {
   process.exit(0);
 }
 
+/** worker_control.disabled 플래그 체크 — true이면 즉시 종료 */
+async function checkDisabledFlag(): Promise<boolean> {
+  try {
+    const { getSupabaseClient } = await import('./db/supabaseClient.js');
+    const supabase = getSupabaseClient();
+    const { data } = await supabase
+      .from('worker_control')
+      .select('disabled')
+      .eq('id', 'main')
+      .single();
+    return data?.disabled === true;
+  } catch (err) {
+    log.warn({ err }, 'disabled 플래그 조회 실패 — 정상 진행');
+    return false;
+  }
+}
+
 /** 메인 엔트리 포인트 */
 async function main(): Promise<void> {
   log.info({
@@ -54,6 +71,12 @@ async function main(): Promise<void> {
     heartbeatInterval: config.worker.heartbeatIntervalMs,
     maxConcurrent: config.worker.maxConcurrent,
   }, '홈택스 스크래핑 워커 시작');
+
+  // 0. 비활성화 플래그 체크 (사용자 PC marketing-worker로 이전된 경우)
+  if (await checkDisabledFlag()) {
+    log.warn('worker_control.disabled=true → 즉시 종료 (PM2가 max_restarts 후 stopped 상태로 전환)');
+    process.exit(0);
+  }
 
   // 1. Supabase 연결 테스트
   const connected = await testConnection();

--- a/dental-clinic-manager/scraping-worker/src/watchdog.ts
+++ b/dental-clinic-manager/scraping-worker/src/watchdog.ts
@@ -82,12 +82,22 @@ async function updateStatus(): Promise<void> {
 async function poll(): Promise<void> {
   const { data, error } = await supabase
     .from('worker_control')
-    .select('start_requested')
+    .select('start_requested, disabled')
     .eq('id', CONTROL_ID)
     .single();
 
   if (error) {
     console.warn('[Watchdog] 폴링 오류:', error.message);
+    return;
+  }
+
+  // 비활성화 플래그: Mac mini 워커가 사용자 PC로 이전된 경우 워커를 시작하지 않고
+  // 실행 중이면 종료시킨다.
+  if (data?.disabled) {
+    if (isWorkerRunning()) {
+      console.log('[Watchdog] worker_control.disabled=true → 실행 중인 워커 종료');
+      try { workerProcess?.kill('SIGTERM'); } catch { /* ignore */ }
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
사용자 PC marketing-worker가 hometax 스크래핑을 처리하도록 이전됐으나, Mac mini scraping-worker가 PM2 autorestart로 항상 살아 있어서 작업을 먼저 가로챕니다. SSH 접근 없이 DB 한 줄로 영구 비활성화 가능하도록 합니다.

## 변경
- `worker_control.disabled` 컬럼 추가 (마이그레이션 적용 완료)
- `src/index.ts`: main() 진입 시 disabled 체크 → true면 즉시 `exit(0)`
- `src/watchdog.ts`: poll() 시 disabled 체크 → true면 워커 spawn 차단 + 실행 중이면 SIGTERM
- PM2 `max_restarts: 10` + `min_uptime: 60s` 설정으로 약 10번 재시작 후 stopped 상태 전환
- 사용자 PC marketing-worker는 별도 코드 경로(scraping-bridge)이므로 이 플래그 영향 없음

## 사용법
```sql
-- Mac mini 비활성화
UPDATE worker_control SET disabled = true WHERE id = 'main';
-- 다시 활성화
UPDATE worker_control SET disabled = false WHERE id = 'main';
```

## Test plan
- [x] TypeScript 타입체크 통과
- [ ] Mac mini PM2가 새 코드로 갱신 후 disabled=true 적용 시 즉시 종료 확인
- [ ] 사용자 PC 워커가 작업을 잡아가는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)