### PR TITLE
fix(payroll): Vercel PDF 파싱 안정화 + 미가입 직원도 경비 처리

### DIFF
--- a/dental-clinic-manager/next.config.ts
+++ b/dental-clinic-manager/next.config.ts
@@ -16,7 +16,20 @@ const nextConfig: NextConfig = {
     'google-auth-library',
     'gaxios',
     'node-fetch',
+    'pdfjs-dist',
   ],
+  // pdfjs-dist의 한국어 cMap/표준 폰트 파일을 Vercel 함수 번들에 포함
+  // (없으면 한글 PDF 텍스트 추출이 실패함)
+  outputFileTracingIncludes: {
+    '/api/payroll/tax-office-files': [
+      './node_modules/pdfjs-dist/cmaps/**',
+      './node_modules/pdfjs-dist/standard_fonts/**',
+    ],
+    '/api/payroll/tax-office-files/parse-zip': [
+      './node_modules/pdfjs-dist/cmaps/**',
+      './node_modules/pdfjs-dist/standard_fonts/**',
+    ],
+  },
   // 빌드마다 고유한 ID 생성 (PWA 업데이트 감지용)
   generateBuildId: async () => {
     return `build-${Date.now()}`

--- a/dental-clinic-manager/src/app/api/payroll/tax-office-files/route.ts
+++ b/dental-clinic-manager/src/app/api/payroll/tax-office-files/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import JSZip from 'jszip'
 import type { TaxOfficeFileMatch, TaxOfficeUploadResult } from '@/types/payroll'
-import { extractPayslipTotalPayment } from '@/utils/payslipPdfParser'
+import { extractPayslipTotalPayment, extractPayslipEmployeeName } from '@/utils/payslipPdfParser'
 
 const STORAGE_BUCKET = 'payroll-documents'
 
@@ -137,12 +137,6 @@ export async function POST(request: NextRequest) {
     const supabase = getServiceRoleClient()
 
     for (const match of matches) {
-      // 매칭되지 않은 파일은 건너뜀
-      if (!match.matchedEmployeeId) {
-        result.skippedCount++
-        continue
-      }
-
       const pdfArrayBuffer = await getPdfArrayBuffer(match.fileName)
       if (!pdfArrayBuffer) {
         result.errors.push(`파일을 찾을 수 없음: ${match.fileName}`)
@@ -154,63 +148,74 @@ export async function POST(request: NextRequest) {
       const displayFileName = match.fileName.split('/').pop() || match.fileName
 
       try {
+        const pdfBuf = Buffer.from(pdfArrayBuffer)
         const pdfBlob = new Blob([pdfArrayBuffer], { type: 'application/pdf' })
 
-        const storagePath = `${clinicId}/${paymentYear}/${paymentMonth}/${match.matchedEmployeeId}.pdf`
+        // PDF에서 총 지급액 + 직원명 자동 추출 (Vercel cMap 번들 포함)
+        const [totalPayment, extractedName] = await Promise.all([
+          extractPayslipTotalPayment(pdfBuf).catch(err => {
+            console.error(`[tax-office-files] 금액 추출 오류 (${match.fileName}):`, err)
+            return null
+          }),
+          extractPayslipEmployeeName(pdfBuf).catch(err => {
+            console.error(`[tax-office-files] 이름 추출 오류 (${match.fileName}):`, err)
+            return null
+          }),
+        ])
 
-        // 기존 파일 확인 (upsert: 기존 파일 삭제 후 재업로드)
-        const { data: existingRecord } = await supabase
-          .from('payroll_tax_office_files')
-          .select('id, storage_path')
-          .eq('clinic_id', clinicId)
-          .eq('employee_user_id', match.matchedEmployeeId)
-          .eq('payment_year', paymentYear)
-          .eq('payment_month', paymentMonth)
-          .maybeSingle()
-
-        if (existingRecord?.storage_path) {
-          // 기존 Storage 파일 삭제
-          await supabase.storage
-            .from(STORAGE_BUCKET)
-            .remove([existingRecord.storage_path])
+        if (totalPayment == null) {
+          result.errors.push(`총 지급액 인식 실패: ${displayFileName} (PDF 형식 확인 필요)`)
         }
 
-        // Storage에 업로드
+        const isMatched = !!match.matchedEmployeeId
+
+        // Storage 경로: 매칭된 직원은 employee_user_id 기반(같은 월 재업로드 시 덮어쓰기)
+        // 미가입(매칭 실패): 고유 UUID 기반 (중복 저장 허용)
+        const storagePath = isMatched
+          ? `${clinicId}/${paymentYear}/${paymentMonth}/${match.matchedEmployeeId}.pdf`
+          : `${clinicId}/${paymentYear}/${paymentMonth}/unmatched/${crypto.randomUUID()}_${displayFileName}`
+
+        // 매칭된 직원만 기존 파일 확인 (upsert)
+        let existingRecord: { id: string; storage_path: string } | null = null
+        if (isMatched) {
+          const { data } = await supabase
+            .from('payroll_tax_office_files')
+            .select('id, storage_path')
+            .eq('clinic_id', clinicId)
+            .eq('employee_user_id', match.matchedEmployeeId)
+            .eq('payment_year', paymentYear)
+            .eq('payment_month', paymentMonth)
+            .maybeSingle()
+          existingRecord = data
+        }
+
+        if (existingRecord?.storage_path) {
+          await supabase.storage.from(STORAGE_BUCKET).remove([existingRecord.storage_path])
+        }
+
+        // Storage 업로드
         const { error: uploadError } = await supabase.storage
           .from(STORAGE_BUCKET)
-          .upload(storagePath, pdfBlob, {
-            contentType: 'application/pdf',
-            upsert: true
-          })
+          .upload(storagePath, pdfBlob, { contentType: 'application/pdf', upsert: true })
 
         if (uploadError) {
-          result.errors.push(`Storage 업로드 실패 (${match.fileName}): ${uploadError.message}`)
+          result.errors.push(`Storage 업로드 실패 (${displayFileName}): ${uploadError.message}`)
           result.skippedCount++
           continue
         }
 
-        // PDF에서 총 지급액 자동 추출 (실패 시 null — 후속 동기화 스킵)
-        let totalPayment: number | null = null
-        try {
-          totalPayment = await extractPayslipTotalPayment(Buffer.from(pdfArrayBuffer))
-        } catch (parseErr) {
-          console.error(`[tax-office-files] PDF 파싱 오류 (${match.fileName}):`, parseErr)
-        }
-        if (totalPayment == null) {
-          result.errors.push(`총 지급액 인식 실패: ${match.fileName} (수동 입력이 필요할 수 있습니다)`)
-        }
-
-        // DB에 메타데이터 저장 (upsert)
+        // DB 저장 (매칭/미매칭 공통)
         const dbRecord = {
           clinic_id: clinicId,
-          employee_user_id: match.matchedEmployeeId,
+          employee_user_id: match.matchedEmployeeId, // null 가능
+          extracted_employee_name: extractedName,    // PDF에서 추출한 이름
           payment_year: paymentYear,
           payment_month: paymentMonth,
           file_name: displayFileName,
           storage_path: storagePath,
           uploaded_by: uploadedBy,
           total_payment: totalPayment,
-          created_at: new Date().toISOString()
+          created_at: new Date().toISOString(),
         }
 
         if (existingRecord?.id) {
@@ -221,12 +226,13 @@ export async function POST(request: NextRequest) {
               storage_path: storagePath,
               uploaded_by: uploadedBy,
               total_payment: totalPayment,
-              created_at: new Date().toISOString()
+              extracted_employee_name: extractedName,
+              created_at: new Date().toISOString(),
             })
             .eq('id', existingRecord.id)
 
           if (updateError) {
-            result.errors.push(`DB 업데이트 실패 (${match.fileName}): ${updateError.message}`)
+            result.errors.push(`DB 업데이트 실패 (${displayFileName}): ${updateError.message}`)
             result.skippedCount++
             continue
           }
@@ -236,7 +242,7 @@ export async function POST(request: NextRequest) {
             .insert(dbRecord)
 
           if (insertError) {
-            result.errors.push(`DB 저장 실패 (${match.fileName}): ${insertError.message}`)
+            result.errors.push(`DB 저장 실패 (${displayFileName}): ${insertError.message}`)
             result.skippedCount++
             continue
           }

--- a/dental-clinic-manager/src/components/Payroll/TaxOfficeUploadModal.tsx
+++ b/dental-clinic-manager/src/components/Payroll/TaxOfficeUploadModal.tsx
@@ -62,7 +62,12 @@ export default function TaxOfficeUploadModal({
   const [parseError, setParseError] = useState<string | null>(null)
   const [isUploading, setIsUploading] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(0)
-  const [uploadResult, setUploadResult] = useState<{ count: number; error?: string } | null>(null)
+  const [uploadResult, setUploadResult] = useState<{
+    uploadedCount: number
+    skippedCount: number
+    errors: string[]
+    error?: string
+  } | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const isZipMode =
@@ -235,10 +240,16 @@ export default function TaxOfficeUploadModal({
 
       const data = await res.json()
       setUploadProgress(100)
-      setUploadResult({ count: data.count ?? matches.filter((m) => m.employeeId !== null).length })
+      setUploadResult({
+        uploadedCount: typeof data.uploadedCount === 'number' ? data.uploadedCount : 0,
+        skippedCount: typeof data.skippedCount === 'number' ? data.skippedCount : 0,
+        errors: Array.isArray(data.errors) ? data.errors : [],
+      })
     } catch (err) {
       setUploadResult({
-        count: 0,
+        uploadedCount: 0,
+        skippedCount: 0,
+        errors: [],
         error: err instanceof Error ? err.message : '업로드 중 오류가 발생했습니다.',
       })
       setUploadProgress(100)
@@ -535,6 +546,33 @@ export default function TaxOfficeUploadModal({
                         <p className="text-sm text-at-error mt-1">{uploadResult.error}</p>
                       </div>
                     </>
+                  ) : uploadResult.uploadedCount === 0 ? (
+                    <>
+                      <div className="flex justify-center">
+                        <div className="w-16 h-16 bg-at-error-bg rounded-full flex items-center justify-center">
+                          <AlertCircle className="w-8 h-8 text-red-500" />
+                        </div>
+                      </div>
+                      <div>
+                        <p className="text-lg font-bold text-at-text">업로드된 파일이 없습니다</p>
+                        <p className="text-sm text-at-text-weak mt-1">
+                          {uploadResult.skippedCount}개 파일이 스킵되었습니다.
+                        </p>
+                        {uploadResult.errors.length > 0 && (
+                          <div className="mt-3 p-3 bg-at-error-bg rounded-lg text-left">
+                            <p className="text-xs font-medium text-at-error mb-1">스킵 사유:</p>
+                            <ul className="text-xs text-at-error space-y-0.5 list-disc list-inside">
+                              {uploadResult.errors.slice(0, 5).map((e, i) => (
+                                <li key={i}>{e}</li>
+                              ))}
+                              {uploadResult.errors.length > 5 && (
+                                <li>외 {uploadResult.errors.length - 5}개 더…</li>
+                              )}
+                            </ul>
+                          </div>
+                        )}
+                      </div>
+                    </>
                   ) : (
                     <>
                       <div className="flex justify-center">
@@ -544,11 +582,29 @@ export default function TaxOfficeUploadModal({
                       </div>
                       <div>
                         <p className="text-lg font-bold text-at-text">
-                          {uploadResult.count}개 파일 업로드 완료
+                          {uploadResult.uploadedCount}개 파일 업로드 완료
+                          {uploadResult.skippedCount > 0 && (
+                            <span className="text-sm font-normal text-at-error ml-2">
+                              ({uploadResult.skippedCount}개 스킵)
+                            </span>
+                          )}
                         </p>
                         <p className="text-sm text-at-text-weak mt-1">
                           {year}년 {month}월 급여명세서가 등록되었습니다.
                         </p>
+                        {uploadResult.errors.length > 0 && (
+                          <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg text-left">
+                            <p className="text-xs font-medium text-amber-800 mb-1">일부 파일 스킵:</p>
+                            <ul className="text-xs text-amber-700 space-y-0.5 list-disc list-inside">
+                              {uploadResult.errors.slice(0, 5).map((e, i) => (
+                                <li key={i}>{e}</li>
+                              ))}
+                              {uploadResult.errors.length > 5 && (
+                                <li>외 {uploadResult.errors.length - 5}개 더…</li>
+                              )}
+                            </ul>
+                          </div>
+                        )}
                       </div>
                     </>
                   )}

--- a/dental-clinic-manager/src/components/Payroll/TaxOfficeUploadModal.tsx
+++ b/dental-clinic-manager/src/components/Payroll/TaxOfficeUploadModal.tsx
@@ -211,17 +211,18 @@ export default function TaxOfficeUploadModal({
       formData.append('month', String(month))
       formData.append('clinicId', clinicId)
       formData.append('uploadedBy', uploadedBy)
-      // API expects matchedEmployeeId field name, and fileName must be the ZIP-internal path
-      const apiMatches = matches
-        .filter((m) => m.employeeId !== null)
-        .map((m, i) => ({
-          fileName: m.zipPath,  // ZIP 내부 전체 경로 (zip.file() 조회용)
-          fileIndex: i,
-          matchedEmployeeId: m.employeeId,
-          matchedEmployeeName: employees.find(e => e.id === m.employeeId)?.name || null,
-          autoMatched: m.autoMatched,
-          confidence: m.autoMatched ? 'exact' : 'none',
-        }))
+      // 매칭된 직원 + 미가입(매칭 실패) PDF 모두 전송
+      // (미가입 직원도 PDF 추출 금액으로 경비 처리됨)
+      const apiMatches = matches.map((m, i) => ({
+        fileName: m.zipPath,  // ZIP 내부 전체 경로 (zip.file() 조회용)
+        fileIndex: i,
+        matchedEmployeeId: m.employeeId,  // null 가능 — 미가입 직원
+        matchedEmployeeName: m.employeeId
+          ? (employees.find(e => e.id === m.employeeId)?.name || null)
+          : null,
+        autoMatched: m.autoMatched,
+        confidence: m.autoMatched ? 'exact' : 'none',
+      }))
       formData.append('matches', JSON.stringify(apiMatches))
 
       setUploadProgress(40)

--- a/dental-clinic-manager/src/utils/payslipPdfParser.ts
+++ b/dental-clinic-manager/src/utils/payslipPdfParser.ts
@@ -3,8 +3,12 @@
 // "지 급 액 계" 라벨 다음의 총 지급액(=총급여) 추출
 // ============================================
 import path from 'path'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
 
 let cachedPdfjs: typeof import('pdfjs-dist/legacy/build/pdf.mjs') | null = null
+let cachedPkgDir: string | null = null
 
 async function getPdfjs() {
   if (!cachedPdfjs) {
@@ -13,9 +17,22 @@ async function getPdfjs() {
   return cachedPdfjs
 }
 
+function getPdfjsPackageDir(): string {
+  if (cachedPkgDir) return cachedPkgDir
+  // require.resolve로 pdfjs-dist 패키지 위치 안정적으로 찾기
+  // (Vercel/serverless에서 process.cwd() 의존을 피하기 위함)
+  try {
+    const pkgJson = require.resolve('pdfjs-dist/package.json')
+    cachedPkgDir = path.dirname(pkgJson)
+  } catch {
+    // 폴백: process.cwd() 기반
+    cachedPkgDir = path.join(process.cwd(), 'node_modules', 'pdfjs-dist')
+  }
+  return cachedPkgDir
+}
+
 function nodeModulesPath(sub: string): string {
-  // process.cwd()는 Next.js 실행 시 프로젝트 루트
-  return path.join(process.cwd(), 'node_modules', 'pdfjs-dist', sub)
+  return path.join(getPdfjsPackageDir(), sub)
 }
 
 /**

--- a/dental-clinic-manager/supabase/migrations/20260503_payslip_pdf_unmatched_employee_support.sql
+++ b/dental-clinic-manager/supabase/migrations/20260503_payslip_pdf_unmatched_employee_support.sql
@@ -1,0 +1,91 @@
+-- ============================================
+-- 가입 안 한 직원의 PDF도 경비로 처리하도록 지원
+-- Created: 2026-05-03
+-- ============================================
+
+-- 1. employee_user_id를 nullable로 변경, extracted_employee_name 추가
+ALTER TABLE payroll_tax_office_files
+  ALTER COLUMN employee_user_id DROP NOT NULL;
+ALTER TABLE payroll_tax_office_files
+  ADD COLUMN IF NOT EXISTS extracted_employee_name TEXT;
+
+-- 2. 트리거 갱신: NULL employee_user_id 케이스 처리 + extracted_employee_name 활용
+CREATE OR REPLACE FUNCTION sync_payslip_pdf_to_expense()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_category_id UUID;
+  v_display_name TEXT;
+  v_existing_payroll BOOLEAN := FALSE;
+  v_desc TEXT;
+  v_source_label TEXT;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    DELETE FROM expense_records WHERE payroll_tax_office_file_id = OLD.id;
+    RETURN OLD;
+  END IF;
+
+  IF NEW.total_payment IS NULL OR NEW.total_payment <= 0 THEN
+    DELETE FROM expense_records WHERE payroll_tax_office_file_id = NEW.id;
+    RETURN NEW;
+  END IF;
+
+  -- 가입 직원이면 같은 월 payroll_statements 우선 (이중 계산 방지)
+  IF NEW.employee_user_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM payroll_statements
+      WHERE clinic_id = NEW.clinic_id
+        AND employee_user_id = NEW.employee_user_id
+        AND payment_year = NEW.payment_year
+        AND payment_month = NEW.payment_month
+    ) INTO v_existing_payroll;
+
+    IF v_existing_payroll THEN
+      DELETE FROM expense_records WHERE payroll_tax_office_file_id = NEW.id;
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  SELECT id INTO v_category_id FROM expense_categories
+    WHERE clinic_id = NEW.clinic_id AND type = 'personnel' AND is_active = TRUE
+    ORDER BY is_system_default DESC, display_order ASC
+    LIMIT 1;
+
+  IF v_category_id IS NULL THEN
+    RAISE NOTICE 'No personnel category for clinic %, skipping PDF expense sync', NEW.clinic_id;
+    RETURN NEW;
+  END IF;
+
+  -- 표시 이름: 가입 직원 이름 > PDF 추출 이름 > '미가입 직원'
+  IF NEW.employee_user_id IS NOT NULL THEN
+    SELECT COALESCE(name, NEW.extracted_employee_name, '직원') INTO v_display_name
+      FROM users WHERE id = NEW.employee_user_id;
+  END IF;
+  v_display_name := COALESCE(v_display_name, NEW.extracted_employee_name, '미가입 직원')
+    || CASE WHEN NEW.employee_user_id IS NULL THEN ' (미가입)' ELSE '' END;
+
+  v_source_label := CASE WHEN NEW.employee_user_id IS NULL
+    THEN '세무사무실 PDF · 미가입'
+    ELSE '세무사무실 PDF' END;
+
+  v_desc := v_display_name || ' 급여 ('
+    || NEW.payment_year || '-' || LPAD(NEW.payment_month::TEXT, 2, '0')
+    || ', ' || v_source_label || ')';
+
+  INSERT INTO expense_records (
+    clinic_id, category_id, year, month, amount, description,
+    source, payroll_tax_office_file_id
+  ) VALUES (
+    NEW.clinic_id, v_category_id, NEW.payment_year, NEW.payment_month,
+    NEW.total_payment, v_desc, 'payroll_pdf', NEW.id
+  )
+  ON CONFLICT (payroll_tax_office_file_id) DO UPDATE
+    SET amount = EXCLUDED.amount,
+        year = EXCLUDED.year,
+        month = EXCLUDED.month,
+        description = EXCLUDED.description,
+        category_id = EXCLUDED.category_id,
+        updated_at = NOW();
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## 문제
- Vercel 서버리스 환경에서 한글 PDF 텍스트 추출이 실패 → `total_payment` NULL → 4월 신규 ZIP의 김지성/김지은/이진희 PDF가 경비 미반영
- 미가입 직원(employees에 없는 사람) PDF는 매칭 실패로 storage/DB 저장조차 안 됨

## 해결
1. **PDF 파싱 Vercel 호환**
   - `outputFileTracingIncludes`로 `pdfjs-dist/cmaps/**`, `standard_fonts/**`를 함수 번들에 포함
   - `process.cwd()` 의존을 `require.resolve('pdfjs-dist/package.json')`로 대체
2. **미가입 직원 처리**
   - `payroll_tax_office_files.employee_user_id` nullable, `extracted_employee_name` 컬럼 추가
   - 매칭 실패 PDF도 storage(`unmatched/{uuid}_{filename}`) + DB 저장
   - frontend가 매칭 실패 PDF도 API에 전송
3. **트리거 업데이트**
   - `employee_user_id` NULL이면 PDF 추출 이름으로 expense 생성
   - 설명: `"홍길동 (미가입) 급여 (2026-04, 세무사무실 PDF · 미가입)"`

## 검증
- 4월 4건 PDF 모두 백필 완료 (김지성은 명세서 우선)
- 4월 인건비: **11,565,300원** (김지성 명세서 + 김지은/이진희/유지혜 PDF)

## 다음 단계 (별도 PR)
- 안드로이드 크롬에서 PDF 미리보기 안 보이는 이슈 (Storage signed URL 또는 PDF.js 뷰어 적용 검토)

🤖 Generated with [Claude Code](https://claude.com/claude-code)