### PR TITLE
feat(payroll): 모바일 PDF 인라인 미리보기 (react-pdf)

### DIFF
--- a/dental-clinic-manager/package-lock.json
+++ b/dental-clinic-manager/package-lock.json
@@ -76,6 +76,7 @@
         "react-dom": "19.1.2",
         "react-dropzone": "^14.3.8",
         "react-hook-form": "^7.72.1",
+        "react-pdf": "^10.4.1",
         "recharts": "^3.8.1",
         "resend": "^6.4.2",
         "simple-statistics": "^7.8.9",
@@ -6804,6 +6805,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
@@ -9611,6 +9621,24 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-cancellable-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-2.0.0.tgz",
+      "integrity": "sha512-3SEQqTpV9oqVsIWqAcmDuaNeo7yBO3tqPtqGRcKkEo0lrzD3wqbKG9mkxO65KoOgXqj+zH2phJ2LiAsdzlogSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-cancellable-promise?sponsor=1"
+      }
+    },
+    "node_modules/make-event-props": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-2.0.0.tgz",
+      "integrity": "sha512-G/hncXrl4Qt7mauJEXSg3AcdYzmpkIITTNl5I+rH9sog5Yw0kK6vseJjCaPfOXqOqQuPUP89Rkhfz5kPS8ijtw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
+      }
+    },
     "node_modules/markdown-it": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -9643,6 +9671,23 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "license": "MIT"
+    },
+    "node_modules/merge-refs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-2.0.0.tgz",
+      "integrity": "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/merge-refs?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -10929,6 +10974,47 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-pdf": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-10.4.1.tgz",
+      "integrity": "sha512-kS/35staVCBqS29verTQJQZXw7RfsRCPO3fdJoW1KXylcv7A9dw6DZ3vJXC2w+bIBgLw5FN4pOFvKSQtkQhPfA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "dequal": "^2.0.3",
+        "make-cancellable-promise": "^2.0.0",
+        "make-event-props": "^2.0.0",
+        "merge-refs": "^2.0.0",
+        "pdfjs-dist": "5.4.296",
+        "tiny-invariant": "^1.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-pdf/node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -12920,6 +13006,15 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",

--- a/dental-clinic-manager/package.json
+++ b/dental-clinic-manager/package.json
@@ -81,6 +81,7 @@
     "react-dom": "19.1.2",
     "react-dropzone": "^14.3.8",
     "react-hook-form": "^7.72.1",
+    "react-pdf": "^10.4.1",
     "recharts": "^3.8.1",
     "resend": "^6.4.2",
     "simple-statistics": "^7.8.9",

--- a/dental-clinic-manager/src/components/Payroll/PayrollForm.tsx
+++ b/dental-clinic-manager/src/components/Payroll/PayrollForm.tsx
@@ -30,7 +30,18 @@ import {
 import { formatCurrency } from '@/utils/taxCalculationUtils'
 import { getPublicHolidaySet } from '@/lib/holidayService'
 import PayrollPreview from './PayrollPreview'
+import dynamic from 'next/dynamic'
 import { AlertCircle, FileText, Settings, Clock, Calendar, AlertTriangle, Lock, UserPlus, Coins, Calculator } from 'lucide-react'
+
+// 모바일 PDF 뷰어는 client-side에서만 로드 (react-pdf는 SSR 비호환)
+const PayslipMobileViewer = dynamic(() => import('./PayslipMobileViewer'), {
+  ssr: false,
+  loading: () => (
+    <div className="border border-at-border rounded-xl p-8 text-center text-at-text-weak text-xs">
+      PDF 뷰어 로드 중...
+    </div>
+  ),
+})
 import type { WorkSchedule } from '@/types/workSchedule'
 import { workScheduleService } from '@/lib/workScheduleService'
 
@@ -766,33 +777,9 @@ export default function PayrollForm() {
                 />
               </div>
 
-              {/* 모바일: 다운로드/새 탭 카드 (PDF inline 미지원 환경 대응) */}
-              <div className="md:hidden border border-at-border rounded-xl p-6 bg-at-surface-alt/40 text-center space-y-4">
-                <FileText className="w-12 h-12 mx-auto text-at-accent" />
-                <div>
-                  <p className="text-sm font-medium text-at-text break-all">{taxOfficeFileName}</p>
-                  <p className="text-xs text-at-text-weak mt-1">
-                    모바일 브라우저에서는 미리보기가 지원되지 않을 수 있습니다.
-                  </p>
-                </div>
-                <div className="flex flex-col gap-2">
-                  <a
-                    href={taxOfficeFileUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center justify-center gap-2 px-4 py-3 bg-at-accent text-white font-medium rounded-xl text-sm"
-                  >
-                    <FileText className="w-4 h-4" />
-                    PDF 새 탭에서 열기
-                  </a>
-                  <a
-                    href={taxOfficeFileUrl}
-                    download={taxOfficeFileName || 'payslip.pdf'}
-                    className="inline-flex items-center justify-center gap-2 px-4 py-3 bg-white border border-at-border text-at-text font-medium rounded-xl text-sm"
-                  >
-                    PDF 다운로드
-                  </a>
-                </div>
+              {/* 모바일: react-pdf 인라인 뷰어 (안드로이드 크롬에서도 작동) */}
+              <div className="md:hidden">
+                <PayslipMobileViewer fileUrl={taxOfficeFileUrl} fileName={taxOfficeFileName} />
               </div>
             </div>
           ) : (

--- a/dental-clinic-manager/src/components/Payroll/PayslipMobileViewer.tsx
+++ b/dental-clinic-manager/src/components/Payroll/PayslipMobileViewer.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { Document, Page, pdfjs } from 'react-pdf'
+import { ChevronLeft, ChevronRight, Loader2, AlertCircle } from 'lucide-react'
+import 'react-pdf/dist/Page/AnnotationLayer.css'
+import 'react-pdf/dist/Page/TextLayer.css'
+
+// pdfjs worker (jsDelivr CDN — react-pdf 내장 pdfjs-dist 버전과 일치)
+const PDFJS_VERSION = pdfjs.version
+pdfjs.GlobalWorkerOptions.workerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/build/pdf.worker.min.mjs`
+
+const PDF_OPTIONS = {
+  cMapUrl: `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/cmaps/`,
+  cMapPacked: true,
+  standardFontDataUrl: `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/standard_fonts/`,
+}
+
+interface Props {
+  fileUrl: string
+  fileName?: string | null
+}
+
+export default function PayslipMobileViewer({ fileUrl, fileName }: Props) {
+  const [numPages, setNumPages] = useState<number | null>(null)
+  const [pageNumber, setPageNumber] = useState(1)
+  const [width, setWidth] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // 컨테이너 폭에 맞춰 PDF 자동 스케일
+  useEffect(() => {
+    const updateWidth = () => {
+      if (containerRef.current) {
+        const w = containerRef.current.clientWidth
+        if (w > 0) setWidth(w)
+      }
+    }
+    updateWidth()
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(updateWidth) : null
+    if (ro && containerRef.current) ro.observe(containerRef.current)
+    window.addEventListener('resize', updateWidth)
+    return () => {
+      window.removeEventListener('resize', updateWidth)
+      ro?.disconnect()
+    }
+  }, [])
+
+  return (
+    <div className="border border-at-border rounded-xl overflow-hidden bg-white">
+      <div ref={containerRef} className="overflow-x-auto">
+        {error ? (
+          <div className="p-8 text-center space-y-2">
+            <AlertCircle className="w-10 h-10 mx-auto text-at-error" />
+            <p className="text-sm font-medium text-at-text">PDF를 표시할 수 없습니다</p>
+            <p className="text-xs text-at-text-weak">{error}</p>
+            <a
+              href={fileUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block mt-2 text-sm text-at-accent underline"
+            >
+              새 탭에서 열기
+            </a>
+          </div>
+        ) : (
+          <Document
+            file={fileUrl}
+            options={PDF_OPTIONS}
+            onLoadSuccess={({ numPages: n }) => {
+              setNumPages(n)
+              setPageNumber(1)
+              setError(null)
+            }}
+            onLoadError={(e) => {
+              console.error('[PayslipMobileViewer] PDF 로드 실패:', e)
+              setError(e.message || 'PDF 로드 중 오류가 발생했습니다.')
+            }}
+            loading={
+              <div className="p-8 flex flex-col items-center gap-2 text-at-text-weak">
+                <Loader2 className="w-6 h-6 animate-spin" />
+                <span className="text-xs">PDF 불러오는 중...</span>
+              </div>
+            }
+          >
+            {width && (
+              <Page
+                pageNumber={pageNumber}
+                width={width}
+                renderTextLayer={false}
+                renderAnnotationLayer={false}
+              />
+            )}
+          </Document>
+        )}
+      </div>
+
+      {numPages && numPages > 1 && (
+        <div className="flex items-center justify-between p-3 border-t border-at-border bg-at-surface-alt/40">
+          <button
+            onClick={() => setPageNumber((p) => Math.max(1, p - 1))}
+            disabled={pageNumber <= 1}
+            className="flex items-center gap-1 px-3 py-1.5 text-sm rounded-lg bg-white border border-at-border disabled:opacity-40"
+          >
+            <ChevronLeft className="w-4 h-4" /> 이전
+          </button>
+          <span className="text-xs text-at-text-secondary">
+            {pageNumber} / {numPages}
+          </span>
+          <button
+            onClick={() => setPageNumber((p) => Math.min(numPages, p + 1))}
+            disabled={pageNumber >= numPages}
+            className="flex items-center gap-1 px-3 py-1.5 text-sm rounded-lg bg-white border border-at-border disabled:opacity-40"
+          >
+            다음 <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+
+      <div className="p-3 border-t border-at-border bg-white flex flex-col sm:flex-row gap-2">
+        <a
+          href={fileUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex-1 inline-flex items-center justify-center gap-1.5 px-4 py-2 bg-at-accent text-white text-sm font-medium rounded-lg"
+        >
+          새 탭에서 열기
+        </a>
+        <a
+          href={fileUrl}
+          download={fileName || 'payslip.pdf'}
+          className="flex-1 inline-flex items-center justify-center gap-1.5 px-4 py-2 bg-white border border-at-border text-at-text text-sm font-medium rounded-lg"
+        >
+          PDF 다운로드
+        </a>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
안드로이드 크롬 등 모바일 브라우저에서 \`<iframe>\` 내 PDF가 표시되지 않던 문제 해결. react-pdf(pdfjs-dist 기반) canvas 렌더링으로 모든 모바일 환경에서 인라인 미리보기 가능.

- \`PayslipMobileViewer\` (client only, dynamic import)
- 컨테이너 폭 자동 맞춤 + 페이지 네비게이션
- worker/cMap/standardFonts는 jsDelivr CDN
- 데스크톱은 기존 iframe 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)