### PR TITLE
chore: 진단 로그 제거 + payroll/subscription fix 일괄

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
@@ -299,7 +299,6 @@ export async function POST(request: NextRequest) {
   if (bars !== dailyBars && bars.length > 0) {
     const filtered = bars.filter((b) => isRegularTradingHours(b.datetime, market))
     if (filtered.length >= 30) bars = filtered
-    // 필터 후 너무 적으면(예: 데이터 형식 문제) 원본 유지
   }
 
   // 5. 엔진 호출

--- a/dental-clinic-manager/src/components/Payroll/PayrollForm.tsx
+++ b/dental-clinic-manager/src/components/Payroll/PayrollForm.tsx
@@ -501,16 +501,15 @@ export default function PayrollForm() {
             savedPayroll.payments?.bonus !== adjustedBonus
 
           if (settingsChanged && isOwner) {
-            // 설정이 변경되었으면 새로운 값으로 저장
+            // 이미 저장된 명세서의 설정이 변경되었으면 새로운 값으로 갱신
             await autoSavePayroll(employee, newFormState, result, currentAttendanceSummary, currentAttendanceDeduction)
           }
           setHasSavedPayroll(true)
         } else {
-          // 저장된 명세서가 없으면 자동 저장 (owner만)
-          if (isOwner) {
-            await autoSavePayroll(employee, newFormState, result, currentAttendanceSummary, currentAttendanceDeduction)
-          }
-          setHasSavedPayroll(true)
+          // 저장된 명세서가 없으면 화면에는 자동 계산만 표시하고 DB 저장은 하지 않음
+          // (원장이 단순히 화면을 열어보기만 해도 자동 저장돼서 인건비가 잡히던 버그 방지)
+          // 사용자가 폼을 직접 수정하거나 명시적으로 저장 액션을 했을 때만 저장됨
+          setHasSavedPayroll(false)
         }
       } catch (error) {
         console.error('Error loading payroll:', error)

--- a/dental-clinic-manager/src/components/Subscription/BasicPlansSection.tsx
+++ b/dental-clinic-manager/src/components/Subscription/BasicPlansSection.tsx
@@ -47,11 +47,11 @@ export default function BasicPlansSection({ plans, current, activeCount, onSelec
               title={isDisabled ? `현재 ${activeCount}명 재직 중` : undefined}
             >
               {isCurrent && <span className="text-[10px] font-semibold text-blue-700">현재 이용 중</span>}
-              <div className="text-sm font-semibold">{plan.display_name}</div>
-              <div className="text-xs text-muted-foreground">
+              <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{plan.display_name}</div>
+              <div className="text-xs text-gray-600 dark:text-gray-300">
                 {plan.min_users}~{plan.max_users}인
               </div>
-              <div className="mt-1 text-sm font-bold">{formatPlanPrice(plan)}</div>
+              <div className="mt-1 text-sm font-bold text-gray-900 dark:text-gray-100">{formatPlanPrice(plan)}</div>
             </button>
           )
         })}

--- a/dental-clinic-manager/src/components/Subscription/PerformanceSection.tsx
+++ b/dental-clinic-manager/src/components/Subscription/PerformanceSection.tsx
@@ -57,9 +57,9 @@ export default function PerformanceSection({ plans, onSelect }: Props) {
       <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-5 dark:border-emerald-800 dark:bg-emerald-950/30">
         <div className="flex items-start justify-between">
           <div>
-            <div className="text-base font-semibold">주식 자동매매</div>
-            <div className="mt-1 text-sm font-bold">구독료 0원 · 수익의 5%</div>
-            <div className="text-xs text-muted-foreground">매월 실현 수익이 있을 때만 정산됩니다.</div>
+            <div className="text-base font-semibold text-gray-900 dark:text-gray-100">주식 자동매매</div>
+            <div className="mt-1 text-sm font-bold text-gray-900 dark:text-gray-100">구독료 0원 · 수익의 5%</div>
+            <div className="text-xs text-gray-600 dark:text-gray-300">매월 실현 수익이 있을 때만 정산됩니다.</div>
           </div>
           <button type="button" onClick={() => onSelect(investment)}
             className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700">

--- a/dental-clinic-manager/src/components/Subscription/PremiumBundleSection.tsx
+++ b/dental-clinic-manager/src/components/Subscription/PremiumBundleSection.tsx
@@ -48,15 +48,15 @@ function BundleCard({ plan, isCurrent, onSelect, variant }: BundleCardProps) {
       {isCurrent && (
         <div className={`mb-1 text-[10px] font-semibold ${styles.currentText}`}>현재 이용 중</div>
       )}
-      <div className="text-base font-semibold">{plan.display_name}</div>
+      <div className="text-base font-semibold text-gray-900 dark:text-gray-100">{plan.display_name}</div>
       {plan.features?.length > 0 && (
-        <ul className="mt-2 list-inside list-disc text-xs text-muted-foreground">
+        <ul className="mt-2 list-inside list-disc text-xs text-gray-700 dark:text-gray-300">
           {plan.features.map((feature) => (
             <li key={feature}>{feature}</li>
           ))}
         </ul>
       )}
-      <div className="mt-3 text-sm font-bold">{formatPlanPrice(plan)}</div>
+      <div className="mt-3 text-sm font-bold text-gray-900 dark:text-gray-100">{formatPlanPrice(plan)}</div>
     </button>
   )
 }

--- a/dental-clinic-manager/src/components/Subscription/UpgradeRequiredModal.tsx
+++ b/dental-clinic-manager/src/components/Subscription/UpgradeRequiredModal.tsx
@@ -53,8 +53,8 @@ export default function UpgradeRequiredModal({ open, onClose, onPayNow, context 
         <div className="space-y-3 text-sm">
           {plan ? (
             <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950/30">
-              <div className="text-base font-semibold">{plan.display_name}</div>
-              <div className="text-sm text-muted-foreground">
+              <div className="text-base font-semibold text-gray-900 dark:text-gray-100">{plan.display_name}</div>
+              <div className="text-sm text-gray-600 dark:text-gray-300">
                 {plan.min_users}~{plan.max_users}인 · {formatPlanPrice(plan)}
               </div>
             </div>


### PR DESCRIPTION
## Summary

develop의 신규 3개 커밋을 main으로:
- \`ac59ec49\`: chore(smart-money): 진단 로그 제거 (PR #450 검증 완료)
- \`d5583538\`: fix(payroll): 원장이 화면 열어보기만 해도 명세서가 자동 저장되던 버그
- \`c2c422fd\`: fix(subscription): 안드로이드/다크모드 가독성

🤖 Generated with [Claude Code](https://claude.com/claude-code)