### PR TITLE
fix(investment): FinRL 백테스트 'fetch failed' 정상화

### DIFF
--- a/dental-clinic-manager/src/components/Investment/BacktestPanel.tsx
+++ b/dental-clinic-manager/src/components/Investment/BacktestPanel.tsx
@@ -142,8 +142,9 @@ export default function BacktestPanel({ strategyId, onBack }: BacktestPanelProps
           equityCurve: data.equityCurve || data.equity_curve || [],
           buyHold: data.buyHold || data.buy_hold || undefined,
         }
-      } catch {
-        return { ticker: entry.ticker, error: '네트워크 오류' }
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : '네트워크 오류'
+        return { ticker: entry.ticker, error: reason }
       } finally {
         setRunningTickers(prev => { const next = new Set(prev); next.delete(entry.ticker); return next })
       }

--- a/dental-clinic-manager/src/lib/rlBacktestService.ts
+++ b/dental-clinic-manager/src/lib/rlBacktestService.ts
@@ -60,16 +60,39 @@ export async function runRLBacktest(params: RLBacktestParams): Promise<RLBacktes
     initial_capital: initialCapital,
   }
 
+  if (!RL_API_KEY) {
+    throw new Error(
+      `RL_API_KEY 환경변수가 설정되지 않았습니다. .env.local 또는 배포 환경의 환경변수에 ` +
+      `RL_SERVER_URL과 RL_API_KEY를 추가하고 서버를 재시작하세요. (서버: ${RL_SERVER_URL})`
+    )
+  }
+
   const ctrl = new AbortController()
   const timer = setTimeout(() => ctrl.abort(), 120_000)  // 2 min — yfinance fetch + simulation
 
   try {
-    const resp = await fetch(`${RL_SERVER_URL}/backtest_universe`, {
-      method: 'POST',
-      headers: { 'X-RL-API-KEY': RL_API_KEY, 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-      signal: ctrl.signal,
-    })
+    let resp: Response
+    try {
+      resp = await fetch(`${RL_SERVER_URL}/backtest_universe`, {
+        method: 'POST',
+        headers: { 'X-RL-API-KEY': RL_API_KEY, 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: ctrl.signal,
+      })
+    } catch (fetchErr) {
+      // Node native fetch는 ECONNREFUSED/DNS 실패 등에서 "fetch failed" (cause 포함) 던진다.
+      // 사용자에게 원인을 명확히 전달하기 위해 cause 정보를 풀어 메시지로 노출한다.
+      if (fetchErr instanceof Error && fetchErr.name === 'AbortError') {
+        throw new Error('RL 백테스트가 120초 안에 완료되지 않아 중단되었습니다. 기간을 줄이거나 종목 수를 줄여 다시 시도하세요.')
+      }
+      const cause = (fetchErr as { cause?: { code?: string; message?: string } } | undefined)?.cause
+      const reason = cause?.code ?? cause?.message ?? (fetchErr instanceof Error ? fetchErr.message : String(fetchErr))
+      throw new Error(
+        `RL 추론 서버에 연결할 수 없습니다 (${RL_SERVER_URL}, ${reason}). ` +
+        `로컬에서는 rl-inference-server가 실행 중인지(\`uvicorn src.main:app --port 8001\`), ` +
+        `배포 환경에서는 RL_SERVER_URL이 외부에서 접근 가능한 주소인지 확인하세요.`
+      )
+    }
     if (!resp.ok) {
       const text = await resp.text().catch(() => '')
       throw new Error(`rl-inference-server /backtest_universe ${resp.status}: ${text.slice(0, 300)}`)


### PR DESCRIPTION
## Summary

전략관리에서 FinRL 백테스트 실행 시 "fetch failed" 메시지가 발생하던 문제를 수정.

## 근본 원인
- `.env.local`에 `RL_API_KEY` 미설정 → 빈 키로 요청 → 401
- `RL_SERVER_URL` 미설정 시 기본값 `127.0.0.1:8001`로 연결 → production 환경에서는 ECONNREFUSED 발생
- BacktestPanel의 catch가 모든 에러를 "네트워크 오류"로 흡수해 사용자가 원인 파악 불가

## 수정
- `.env.local`에 `RL_SERVER_URL` / `RL_API_KEY` 추가 (rl-inference-server/.env와 동기화, git 미추적)
- `rlBacktestService.runRLBacktest`:
  - API 키 누락 시 사전 차단 + 명확한 안내
  - fetch 실패 시 cause(ECONNREFUSED 등) + 서버 URL + 재현 명령을 포함한 메시지
  - AbortError(120초 타임아웃) 분리 처리
- `BacktestPanel`: catch에서 `error.message`를 사용자에게 그대로 노출

## 검증
- [x] tsc --noEmit 통과
- [x] RL 서버 직접 호출 200 (AAPL/MSFT 3개월, total_return 2.67%, Sharpe 0.59, 24초)
- [x] dev 서버 재시작 후 새 환경변수 로드

## 배포 환경 메모
Vercel 등 배포 환경에서 사용하려면 `RL_SERVER_URL`(외부에서 접근 가능한 주소)과 `RL_API_KEY`를 환경변수로 등록해야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)