### PR TITLE
fix(smart-money/KR): 502 timeout — maxDuration + rate limit 안전장치

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
@@ -57,6 +57,9 @@ import type {
 } from '@/types/smartMoney'
 
 export const dynamic = 'force-dynamic'
+// KIS 분봉 페이지네이션 + 멀티 엔진 + LLM 병렬 호출 시간 확보
+// 기본 10초로는 KR 종목 분석 시 KIS 60 req 페이지네이션이 timeout
+export const maxDuration = 60
 
 // ============================================
 // 내부 타입
@@ -162,13 +165,14 @@ export async function POST(request: NextRequest) {
       currentPrice = quote.price
       // KRRealtimeQuote에는 name이 없으므로 ticker 그대로 사용
 
-      // 분봉 (1분봉 2400개 ≈ 4거래일치 — 첫·끝 일자 잘림 여유분 포함, byDay에 최신 3일 사용)
+      // 분봉 (1분봉 1200개 ≈ 정규장 3거래일치 — KIS 페이지네이션 40 req로 ~3초 소요)
+      // KIS rate limit + Vercel function timeout(60s) 안에서 안정적으로 받을 수 있는 양
       const krBars: KRMinuteBar[] = await getKRMinutePrices({
         credentialId: kisCredential.credentialId,
         credential: krCredential,
         ticker,
         intervalMinutes: 1,
-        count: 2400,
+        count: 1200,
       })
       bars = krBars.map((b) => ({
         datetime: b.datetime,

--- a/dental-clinic-manager/src/lib/kisApiService.ts
+++ b/dental-clinic-manager/src/lib/kisApiService.ts
@@ -556,9 +556,14 @@ export async function getKRMinutePrices(params: MinutePriceParams): Promise<KRMi
   // count <= 30이라도 페이지네이션 경로 통과 (1번만 호출되고 종료)
   const accumulated = new Map<string, KRMinuteBar>()
   let cursor: string | undefined = undefined
-  const MAX_REQUESTS = 60 // 안전장치 (1800봉 = 정규장 4.6일)
+  // 안전장치 — 호출 빈도 + Vercel timeout(60s) 안에서 가능한 봉 수
+  // KIS rate limit 20 req/sec, 호출당 응답 200~400ms → 50ms 간격으로 안전하게
+  // MAX_REQUESTS 40 = 약 30봉 × 40 = 1200봉 (정규장 ≈ 3거래일치) — 충분
+  const MAX_REQUESTS = 40
+  const REQUEST_DELAY_MS = 60 // KIS rate limit 회피
 
   for (let i = 0; i < MAX_REQUESTS; i++) {
+    if (i > 0) await new Promise((r) => setTimeout(r, REQUEST_DELAY_MS))
     const chunk = await fetchKRMinutesAtCursor(credentialId, credential, ticker, cursor, 1, 30)
     if (chunk.length === 0) break
 


### PR DESCRIPTION
## 문제

한국 주식 분석 시 \`502 [smart-money/analyze] 데이터 수집 실패\` 에러.

## 근본 원인

1. **Vercel function timeout**: 기본 10초. KIS 페이지네이션 60 req × ~200ms = 12초+ → 초과
2. **KIS rate limit**: 호출 간 대기 없으면 20 req/sec 초과 가능

## 수정

- \`analyze\` route에 \`export const maxDuration = 60\` 추가 (Pro 플랜 한도)
- \`getKRMinutePrices\` 페이지네이션:
  - \`MAX_REQUESTS\` 60 → 40 (3일치 1200봉으로 충분)
  - 호출 간 60ms 대기 (KIS rate limit 회피)
- KR \`count\` 2400 → 1200 (3일치 적정)

## 결과

40 req × (응답 + 대기) ≈ 12~15초 → \`maxDuration 60s\` 안에 충분히 완료, byDay 3일치 안정적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)