### PR TITLE
feat(smart-money): 시장 구조 카드 HH/HL/LH/LL 해석 + 용어 가이드

### DIFF
--- a/dental-clinic-manager/src/components/Investment/SmartMoney/MarketStructureBadge.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/MarketStructureBadge.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import { useState } from 'react'
-import { TrendingUp, TrendingDown, Activity, Info, X } from 'lucide-react'
+import { TrendingUp, TrendingDown, Activity, Info, X, ChevronDown, ChevronUp } from 'lucide-react'
 import type { MarketStructureResult, SwingPoint } from '@/types/smartMoney'
 
 const HELP = {
@@ -15,6 +15,8 @@ const HELP = {
 
 interface Props {
   structure: MarketStructureResult
+  /** LLM 카드별 한 문장 해석 (옵션) */
+  comment?: string | null
 }
 
 const SWING_LABEL: Record<SwingPoint['kind'], string> = {
@@ -31,8 +33,91 @@ const SWING_COLOR: Record<SwingPoint['kind'], string> = {
   LL: 'text-rose-600',
 }
 
-export function MarketStructureBadge({ structure }: Props) {
+interface SwingDef {
+  full: string
+  short: string
+  meaning: string
+  bias: 'bull' | 'bear'
+}
+
+const SWING_DEFS: Record<SwingPoint['kind'], SwingDef> = {
+  HH: {
+    full: 'Higher High',
+    short: '고점 상승',
+    meaning: '직전 고점보다 높은 새 고점 — 매수세 우위, 상승 추세 지속',
+    bias: 'bull',
+  },
+  HL: {
+    full: 'Higher Low',
+    short: '저점 상승',
+    meaning: '직전 저점보다 높은 새 저점 — 조정 후 매수세 재개',
+    bias: 'bull',
+  },
+  LH: {
+    full: 'Lower High',
+    short: '고점 하락',
+    meaning: '직전 고점보다 낮은 새 고점 — 매도 압력 등장, 상승세 약화',
+    bias: 'bear',
+  },
+  LL: {
+    full: 'Lower Low',
+    short: '저점 하락',
+    meaning: '직전 저점보다 낮은 새 저점 — 매도세 우위, 하락 추세 지속',
+    bias: 'bear',
+  },
+}
+
+const EVENT_DEFS = {
+  BOS: {
+    full: 'Break of Structure',
+    desc: '직전 스윙을 같은 방향으로 돌파 — 현재 추세 지속 확인',
+  },
+  CHoCH: {
+    full: 'Change of Character',
+    desc: '반대 방향으로 직전 스윙을 돌파 — 추세 전환 가능 신호',
+  },
+}
+
+/** 현재 추세 + 최근 이벤트에 맞춘 1~2 문장 자동 해석 */
+function buildInterpretation(structure: MarketStructureResult): string {
+  const { trend, lastEvent, lastEventDirection, swings } = structure
+  const trendLabel = trend === 'bullish' ? '상승 추세' : trend === 'bearish' ? '하락 추세' : '횡보'
+  const lastTwo = swings.slice(-2).map((s) => s.kind)
+  const seq = lastTwo.length > 0 ? ` (최근 스윙 ${lastTwo.join(' → ')})` : ''
+
+  let trendInsight = ''
+  if (trend === 'bullish') {
+    trendInsight = 'HH·HL 배열로 매수세가 우위. 눌림목(HL 형성)은 매수 진입 후보.'
+  } else if (trend === 'bearish') {
+    trendInsight = 'LH·LL 배열로 매도세가 우위. 반등(LH 형성)은 매도 진입 후보.'
+  } else {
+    trendInsight = '뚜렷한 방향성 없음 — 박스권 상하단 돌파 여부를 관찰.'
+  }
+
+  let eventInsight = ''
+  if (lastEvent === 'BOS') {
+    eventInsight =
+      lastEventDirection === 'bullish'
+        ? ' 최근 BOS(상방)로 추세 지속이 확인됨.'
+        : lastEventDirection === 'bearish'
+          ? ' 최근 BOS(하방)로 약세 지속이 확인됨.'
+          : ''
+  } else if (lastEvent === 'CHoCH') {
+    eventInsight =
+      lastEventDirection === 'bullish'
+        ? ' 최근 CHoCH(상방)는 하락에서 상승으로 전환 시그널 — 단기 매수세 진입 가능.'
+        : lastEventDirection === 'bearish'
+          ? ' 최근 CHoCH(하방)는 상승에서 하락으로 전환 시그널 — 추세 약화·차익실현 주의.'
+          : ''
+  }
+
+  return `${trendLabel}${seq}. ${trendInsight}${eventInsight}`
+}
+
+export function MarketStructureBadge({ structure, comment }: Props) {
   const [helpOpen, setHelpOpen] = useState(false)
+  const [glossaryOpen, setGlossaryOpen] = useState(false)
+  const interpretation = buildInterpretation(structure)
   const trendBadge =
     structure.trend === 'bullish'
       ? 'bg-emerald-100 text-emerald-700'
@@ -112,26 +197,88 @@ export function MarketStructureBadge({ structure }: Props) {
           </span>
         </div>
 
+        {/* 자동 해석 — 현재 추세 + 최근 이벤트 의미 */}
+        <div className="pt-2 border-t border-slate-100">
+          <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wide mb-1">현재 해석</p>
+          <p className="text-[11px] leading-relaxed text-slate-700">{interpretation}</p>
+        </div>
+
         {lastSwings.length > 0 ? (
           <div className="pt-2 border-t border-slate-100">
             <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wide mb-1">최근 스윙</p>
             <div className="space-y-1">
-              {lastSwings.map((s, i) => (
-                <div
-                  key={`${s.kind}-${s.barIndex}-${i}`}
-                  className="flex items-center justify-between text-[11px]"
-                >
-                  <span className={`font-bold ${SWING_COLOR[s.kind]}`}>
-                    {s.kind}
-                    <span className="ml-1 text-[9px] text-slate-500 font-normal">{SWING_LABEL[s.kind]}</span>
-                  </span>
-                  <span className="font-mono text-slate-700">{s.price.toLocaleString()}</span>
-                </div>
-              ))}
+              {lastSwings.map((s, i) => {
+                const def = SWING_DEFS[s.kind]
+                return (
+                  <div
+                    key={`${s.kind}-${s.barIndex}-${i}`}
+                    className="flex items-center justify-between text-[11px]"
+                    title={`${def.full} — ${def.meaning}`}
+                  >
+                    <span className={`font-bold ${SWING_COLOR[s.kind]}`}>
+                      {s.kind}
+                      <span className="ml-1 text-[9px] text-slate-500 font-normal">{SWING_LABEL[s.kind]}</span>
+                    </span>
+                    <span className="font-mono text-slate-700">{s.price.toLocaleString()}</span>
+                  </div>
+                )
+              })}
             </div>
           </div>
         ) : (
           <p className="text-[11px] text-slate-500 leading-relaxed pt-1">스윙 포인트 데이터 없음</p>
+        )}
+
+        {/* 용어 가이드 토글 — HH/HL/LH/LL/BOS/CHoCH 의미 */}
+        <div className="pt-2 border-t border-slate-100">
+          <button
+            type="button"
+            onClick={() => setGlossaryOpen((o) => !o)}
+            className="w-full flex items-center justify-between text-[10px] font-semibold text-slate-500 uppercase tracking-wide hover:text-slate-700"
+          >
+            <span>용어 가이드</span>
+            {glossaryOpen ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+          </button>
+          {glossaryOpen && (
+            <div className="mt-2 space-y-2">
+              <div className="grid grid-cols-1 gap-1.5">
+                {(Object.keys(SWING_DEFS) as SwingPoint['kind'][]).map((k) => {
+                  const def = SWING_DEFS[k]
+                  return (
+                    <div key={k} className="flex items-start gap-2 text-[10.5px] leading-relaxed">
+                      <span className={`font-bold whitespace-nowrap ${SWING_COLOR[k]}`}>{k}</span>
+                      <div className="flex-1 min-w-0">
+                        <span className="text-slate-700 font-medium">{def.full}</span>
+                        <span className="text-slate-400 mx-1">·</span>
+                        <span className="text-slate-500">{def.meaning}</span>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+              <div className="pt-1.5 border-t border-slate-100 grid grid-cols-1 gap-1.5">
+                {(Object.keys(EVENT_DEFS) as Array<keyof typeof EVENT_DEFS>).map((k) => {
+                  const def = EVENT_DEFS[k]
+                  return (
+                    <div key={k} className="flex items-start gap-2 text-[10.5px] leading-relaxed">
+                      <span className="font-bold whitespace-nowrap text-slate-700">{k}</span>
+                      <div className="flex-1 min-w-0">
+                        <span className="text-slate-700 font-medium">{def.full}</span>
+                        <span className="text-slate-400 mx-1">·</span>
+                        <span className="text-slate-500">{def.desc}</span>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {comment && (
+          <p className="text-[11px] leading-relaxed text-blue-700 bg-blue-50 rounded-md px-2 py-1.5 mt-1">
+            🤖 {comment}
+          </p>
         )}
 
         {structure.description && (


### PR DESCRIPTION
## Summary
- 시장 구조 카드에 현재 추세/최근 스윙 배열/BOS·CHoCH 이벤트 종합 자동 해석 한 문장 추가
- 용어 가이드 토글로 HH/HL/LH/LL 4종 + BOS/CHoCH 정의·의미 노출
- 스윙 리스트 hover title로 풀네임·의미 표시

## Test plan
- [ ] /investment/smart-money 분석 → 시장 구조 카드에 "현재 해석" 한 문장 자동 표시
- [ ] 용어 가이드 토글 펼치면 HH/HL/LH/LL/BOS/CHoCH 의미 표시
- [ ] develop → main 머지 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)