### PR TITLE
feat(smart-money): 유동성 존·VSA 용어 가이드 추가

### DIFF
--- a/dental-clinic-manager/src/components/Investment/SmartMoney/LiquidityZonePanel.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/LiquidityZonePanel.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import { useState } from 'react'
-import { ArrowUp, ArrowDown, Info, X, Sparkles } from 'lucide-react'
+import { ArrowUp, ArrowDown, Info, X, Sparkles, ChevronDown, ChevronUp } from 'lucide-react'
 import type { LiquidityPool, LiquidityResult } from '@/types/smartMoney'
 
 const HELP = {
@@ -37,8 +37,41 @@ const POOL_TYPE_COLOR: Record<LiquidityPool['type'], string> = {
   'swing-low': 'bg-emerald-50 text-emerald-700 border-emerald-200',
 }
 
+interface PoolDef {
+  full: string
+  meaning: string
+}
+
+const POOL_DEFS: Record<LiquidityPool['type'], PoolDef> = {
+  'equal-highs': {
+    full: 'Equal Highs',
+    meaning: '같은 가격대에서 여러 번 막힌 고점 — 위쪽에 매도(매수자 손절) 주문이 밀집. 기관이 돌파시켜 사냥할 가능성',
+  },
+  'equal-lows': {
+    full: 'Equal Lows',
+    meaning: '같은 가격대에서 여러 번 받쳐진 저점 — 아래쪽에 매수(매도자 손절) 주문이 밀집. 기관이 깨뜨려 사냥할 가능성',
+  },
+  pdh: {
+    full: 'Previous Day High',
+    meaning: '전일 고가 — 데이트레이더의 손절매·역지정가가 자주 걸리는 가격대',
+  },
+  pdl: {
+    full: 'Previous Day Low',
+    meaning: '전일 저가 — 매수자 손절매가 밀집되는 가격대',
+  },
+  'swing-high': {
+    full: 'Swing High',
+    meaning: '명확한 단기 고점 — 매도세가 한 번 등장한 자리. 돌파 시 손절 주문이 트리거됨',
+  },
+  'swing-low': {
+    full: 'Swing Low',
+    meaning: '명확한 단기 저점 — 매수세가 한 번 등장한 자리. 이탈 시 손절 주문이 트리거됨',
+  },
+}
+
 export function LiquidityZonePanel({ liquidity, comment }: Props) {
   const [helpOpen, setHelpOpen] = useState(false)
+  const [glossaryOpen, setGlossaryOpen] = useState(false)
   const noPools = liquidity.pools.length === 0
   const noSweeps = liquidity.recentSweeps.length === 0
 
@@ -96,24 +129,30 @@ export function LiquidityZonePanel({ liquidity, comment }: Props) {
         <div className="space-y-3">
           {sortedPools.length > 0 && (
             <div>
-              <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wide mb-1">활성 풀</p>
+              <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wide mb-1">
+                활성 풀 <span className="font-normal normal-case text-slate-400">(×N = 닿은 횟수, 많을수록 유동성 강함)</span>
+              </p>
               <div className="space-y-1">
-                {sortedPools.map((p, i) => (
-                  <div
-                    key={`${p.type}-${p.level}-${i}`}
-                    className="flex items-center justify-between text-[11px] gap-2"
-                  >
-                    <span
-                      className={`flex-shrink-0 text-[9px] px-1.5 py-0.5 rounded border font-bold ${POOL_TYPE_COLOR[p.type]} ${
-                        p.swept ? 'opacity-50 line-through' : ''
-                      }`}
+                {sortedPools.map((p, i) => {
+                  const def = POOL_DEFS[p.type]
+                  return (
+                    <div
+                      key={`${p.type}-${p.level}-${i}`}
+                      className="flex items-center justify-between text-[11px] gap-2"
+                      title={`${def.full} — ${def.meaning}${p.swept ? ' · 이미 사냥됨' : ''}`}
                     >
-                      {POOL_TYPE_LABEL[p.type]}
-                    </span>
-                    <span className="font-mono text-slate-700 flex-1 text-right">{p.level.toLocaleString()}</span>
-                    <span className="text-[9px] text-slate-500 font-mono w-10 text-right">×{p.hits}</span>
-                  </div>
-                ))}
+                      <span
+                        className={`flex-shrink-0 text-[9px] px-1.5 py-0.5 rounded border font-bold ${POOL_TYPE_COLOR[p.type]} ${
+                          p.swept ? 'opacity-50 line-through' : ''
+                        }`}
+                      >
+                        {POOL_TYPE_LABEL[p.type]}
+                      </span>
+                      <span className="font-mono text-slate-700 flex-1 text-right">{p.level.toLocaleString()}</span>
+                      <span className="text-[9px] text-slate-500 font-mono w-10 text-right">×{p.hits}</span>
+                    </div>
+                  )
+                })}
               </div>
             </div>
           )}
@@ -153,6 +192,41 @@ export function LiquidityZonePanel({ liquidity, comment }: Props) {
           )}
         </div>
       )}
+
+      {/* 용어 가이드 토글 */}
+      <div className="mt-3 pt-2 border-t border-slate-100">
+        <button
+          type="button"
+          onClick={() => setGlossaryOpen((o) => !o)}
+          className="w-full flex items-center justify-between text-[10px] font-semibold text-slate-500 uppercase tracking-wide hover:text-slate-700"
+        >
+          <span>용어 가이드</span>
+          {glossaryOpen ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        </button>
+        {glossaryOpen && (
+          <div className="mt-2 space-y-1.5">
+            {(Object.keys(POOL_DEFS) as LiquidityPool['type'][]).map((k) => {
+              const def = POOL_DEFS[k]
+              return (
+                <div key={k} className="flex items-start gap-2 text-[10.5px] leading-relaxed">
+                  <span className={`flex-shrink-0 text-[9px] px-1.5 py-0.5 rounded border font-bold ${POOL_TYPE_COLOR[k]}`}>
+                    {POOL_TYPE_LABEL[k]}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <span className="text-slate-700 font-medium">{def.full}</span>
+                    <span className="text-slate-400 mx-1">·</span>
+                    <span className="text-slate-500">{def.meaning}</span>
+                  </div>
+                </div>
+              )
+            })}
+            <div className="pt-1.5 mt-1.5 border-t border-slate-100 space-y-1 text-[10.5px] leading-relaxed text-slate-500">
+              <p><span className="font-semibold text-slate-700">사냥(Sweep)</span> · 가격이 풀을 일시적으로 돌파해 손절 주문을 트리거하고 다시 반대 방향으로 움직이는 패턴. 강세 사냥(저점 사냥)은 매수 신호, 약세 사냥(고점 사냥)은 매도 신호로 해석.</p>
+              <p><span className="font-semibold text-slate-700">×N (Hits)</span> · 해당 가격대에 가격이 닿은 횟수. 많을수록 유동성이 강하게 모여 있음.</p>
+            </div>
+          </div>
+        )}
+      </div>
 
       {comment && (
         <div className="mt-3 pt-3 border-t border-dashed border-slate-200">

--- a/dental-clinic-manager/src/components/Investment/SmartMoney/VSASignalList.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/VSASignalList.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Info, X } from 'lucide-react'
+import { Info, X, ChevronDown, ChevronUp } from 'lucide-react'
 import type { VSAResult, VSASignalEntry } from '@/types/smartMoney'
 
 const HELP = {
@@ -34,8 +34,50 @@ const VSA_TYPE_COLOR: Record<VSASignalEntry['type'], string> = {
   'stopping-volume': 'bg-emerald-100 text-emerald-700',
 }
 
+interface VSADef {
+  full: string
+  meaning: string
+  bias: 'bull' | 'bear' | 'neutral'
+}
+
+const VSA_DEFS: Record<VSASignalEntry['type'], VSADef> = {
+  'no-demand': {
+    full: 'No Demand (수요 부재)',
+    meaning: '상승 양봉이지만 거래량이 평소보다 부진 — 추격 매수가 약함. 상승 동력 소진, 단기 약세 전환 가능',
+    bias: 'bear',
+  },
+  'no-supply': {
+    full: 'No Supply (공급 부재)',
+    meaning: '하락 음봉이지만 거래량이 평소보다 부진 — 매도 압력이 약함. 하락 동력 소진, 단기 강세 전환 가능',
+    bias: 'bull',
+  },
+  'buying-climax': {
+    full: 'Buying Climax (매수 클라이맥스)',
+    meaning: '거래량 폭증 + 윗꼬리 긴 양봉 — 마지막 매수자의 추격 진입 직후 기관 분배. 고점 반전 임박',
+    bias: 'bear',
+  },
+  'selling-climax': {
+    full: 'Selling Climax (매도 클라이맥스)',
+    meaning: '거래량 폭증 + 아랫꼬리 긴 음봉 — 공포 매도 절정 + 기관 흡수. 저점 반전 임박',
+    bias: 'bull',
+  },
+  'stopping-volume': {
+    full: 'Stopping Volume (멈춤 거래량)',
+    meaning: '하락 중 갑자기 큰 거래량으로 하락이 멈춤 — 기관이 매도 물량을 흡수. 하락 추세 정지 신호',
+    bias: 'bull',
+  },
+}
+
+function confidenceBucket(c: number): { label: string; color: string } {
+  if (c >= 80) return { label: '매우 강함', color: 'text-emerald-600' }
+  if (c >= 60) return { label: '강함', color: 'text-emerald-500' }
+  if (c >= 40) return { label: '보통', color: 'text-amber-500' }
+  return { label: '약함', color: 'text-slate-500' }
+}
+
 export function VSASignalList({ vsa }: Props) {
   const [helpOpen, setHelpOpen] = useState(false)
+  const [glossaryOpen, setGlossaryOpen] = useState(false)
   const effortBadge =
     vsa.effortVsResult === 'bullish'
       ? 'bg-emerald-100 text-emerald-700'
@@ -87,24 +129,29 @@ export function VSASignalList({ vsa }: Props) {
         <p className="text-[11px] text-slate-500 leading-relaxed py-2">VSA 시그널 미감지</p>
       ) : (
         <div className="space-y-1.5">
-          {signals.map((s, i) => (
-            <div
-              key={`${s.type}-${s.barIndex}-${i}`}
-              className="flex items-start justify-between gap-2 text-[11px]"
-            >
-              <div className="flex items-start gap-2 flex-1 min-w-0">
-                <span
-                  className={`flex-shrink-0 text-[9px] px-1.5 py-0.5 rounded-full font-bold ${VSA_TYPE_COLOR[s.type]}`}
-                >
-                  {VSA_TYPE_LABEL[s.type]}
+          {signals.map((s, i) => {
+            const def = VSA_DEFS[s.type]
+            const conf = confidenceBucket(s.confidence)
+            return (
+              <div
+                key={`${s.type}-${s.barIndex}-${i}`}
+                className="flex items-start justify-between gap-2 text-[11px]"
+                title={`${def.full} — ${def.meaning} · 신뢰도 ${s.confidence.toFixed(0)}% (${conf.label})`}
+              >
+                <div className="flex items-start gap-2 flex-1 min-w-0">
+                  <span
+                    className={`flex-shrink-0 text-[9px] px-1.5 py-0.5 rounded-full font-bold ${VSA_TYPE_COLOR[s.type]}`}
+                  >
+                    {VSA_TYPE_LABEL[s.type]}
+                  </span>
+                  <span className="text-[10px] text-slate-500 font-mono" title="감지된 분봉의 인덱스 (0=가장 최근)">#{s.barIndex}</span>
+                </div>
+                <span className={`flex-shrink-0 font-mono text-[10px] font-bold ${conf.color}`}>
+                  {s.confidence.toFixed(0)}%
                 </span>
-                <span className="text-[10px] text-slate-500 font-mono">#{s.barIndex}</span>
               </div>
-              <span className="flex-shrink-0 font-mono text-[10px] text-slate-700 font-bold">
-                {s.confidence.toFixed(0)}%
-              </span>
-            </div>
-          ))}
+            )
+          })}
           {vsa.description && (
             <p className="text-[11px] text-slate-500 leading-relaxed pt-1 line-clamp-2 border-t border-slate-100">
               {vsa.description}
@@ -112,6 +159,51 @@ export function VSASignalList({ vsa }: Props) {
           )}
         </div>
       )}
+
+      {/* 용어 가이드 토글 */}
+      <div className="mt-3 pt-2 border-t border-slate-100">
+        <button
+          type="button"
+          onClick={() => setGlossaryOpen((o) => !o)}
+          className="w-full flex items-center justify-between text-[10px] font-semibold text-slate-500 uppercase tracking-wide hover:text-slate-700"
+        >
+          <span>용어 가이드</span>
+          {glossaryOpen ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        </button>
+        {glossaryOpen && (
+          <div className="mt-2 space-y-1.5">
+            {(Object.keys(VSA_DEFS) as VSASignalEntry['type'][]).map((k) => {
+              const def = VSA_DEFS[k]
+              return (
+                <div key={k} className="flex items-start gap-2 text-[10.5px] leading-relaxed">
+                  <span className={`flex-shrink-0 text-[9px] px-1.5 py-0.5 rounded-full font-bold ${VSA_TYPE_COLOR[k]}`}>
+                    {VSA_TYPE_LABEL[k]}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <span className="text-slate-700 font-medium">{def.full}</span>
+                    <span className="text-slate-400 mx-1">·</span>
+                    <span className="text-slate-500">{def.meaning}</span>
+                  </div>
+                </div>
+              )
+            })}
+            <div className="pt-1.5 mt-1.5 border-t border-slate-100 space-y-1 text-[10.5px] leading-relaxed text-slate-500">
+              <p>
+                <span className="font-semibold text-slate-700">신뢰도 (%)</span> · 시그널 강도.
+                <span className="ml-1">80↑ 매우 강함, 60↑ 강함, 40↑ 보통, 미만 약함.</span>
+                평소 거래량 대비 편차·꼬리 비율·종가 위치를 합산해 산출.
+              </p>
+              <p>
+                <span className="font-semibold text-slate-700">#N (Bar Index)</span> · 시그널이 감지된 분봉 번호. 0이 가장 최근 봉이며 숫자가 클수록 더 과거.
+              </p>
+              <p>
+                <span className="font-semibold text-slate-700">노력 vs 결과</span> · 거래량(노력) 대비 가격 변동(결과)이 일치하는지의 종합 평가.
+                강세=매수 동력 우세, 약세=매도 동력 우세, 중립=균형.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- 유동성 존: 동일고점/동일저점/PDH/PDL/스윙고저 6종 풀네임·의미, ×N(Hits) 설명, 사냥(Sweep) 정의
- VSA: 공급/수요 부재·클라이맥스·멈춤거래량 5종 풀네임·의미·편향, 신뢰도(%) 색상 구간, #N 인덱스 의미

## Test plan
- [ ] /investment/smart-money 분석 → 유동성 존 카드 용어 가이드 토글 펼침
- [ ] VSA 시그널 카드 신뢰도 색상 (강함=초록, 보통=주황, 약함=회색)
- [ ] 풀/시그널 항목 hover 시 풀네임·의미 툴팁
- [ ] develop → main 머지 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)