### PR TITLE
feat(investment/backtest): 빠른 추가에 이전 백테스트 종목 노출

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/backtest/recent-tickers/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/backtest/recent-tickers/route.ts
@@ -1,0 +1,102 @@
+/**
+ * 최근 백테스트 종목 조회
+ *
+ * GET /api/investment/backtest/recent-tickers?limit=12
+ * 사용자가 직전에 백테스트했던 종목 distinct 목록을 최신순으로 반환.
+ * BacktestPanel "이전 백테스트 종목" 섹션의 빠른 추가용.
+ *
+ * Response: { data: [{ ticker, market, tickerName, lastRunAt }] }
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+export const dynamic = 'force-dynamic'
+
+interface RecentTicker {
+  ticker: string
+  market: 'KR' | 'US'
+  tickerName: string
+  lastRunAt: string
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 실패' }, { status: auth.status })
+  }
+
+  const supabase = getSupabaseAdmin()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+
+  const url = new URL(request.url)
+  const limit = Math.min(Math.max(parseInt(url.searchParams.get('limit') ?? '12', 10) || 12, 1), 50)
+
+  // 1) 최근 백테스트에서 ticker+market 추출 (충분히 받아서 distinct 처리)
+  const { data: runs, error } = await supabase
+    .from('backtest_runs')
+    .select('ticker, market, created_at, completed_at')
+    .eq('user_id', auth.user.id)
+    .order('created_at', { ascending: false })
+    .limit(200)
+
+  if (error) {
+    console.error('[recent-tickers] backtest_runs 조회 실패:', error)
+    return NextResponse.json({ error: '조회 실패' }, { status: 500 })
+  }
+
+  // distinct (ticker, market) — 가장 최근 실행만 유지
+  const distinct = new Map<string, RecentTicker>()
+  for (const r of runs ?? []) {
+    const ticker = (r as { ticker: string }).ticker
+    const market = (r as { market: string }).market
+    if (!ticker || (market !== 'KR' && market !== 'US')) continue
+    const key = `${market}:${ticker}`
+    if (distinct.has(key)) continue
+    const lastRunAt = (r as { completed_at: string | null; created_at: string }).completed_at
+      ?? (r as { created_at: string }).created_at
+    distinct.set(key, {
+      ticker,
+      market: market as 'KR' | 'US',
+      tickerName: ticker,
+      lastRunAt,
+    })
+    if (distinct.size >= limit) break
+  }
+
+  // 2) strategy_watchlist를 사용자의 strategy 기반으로 조회하여 ticker_name 매핑
+  const tickers = Array.from(distinct.values())
+  if (tickers.length > 0) {
+    const tickerKeys = Array.from(new Set(tickers.map((t) => t.ticker)))
+    const { data: strategies } = await supabase
+      .from('investment_strategies')
+      .select('id')
+      .eq('user_id', auth.user.id)
+
+    const strategyIds = (strategies ?? []).map((s) => (s as { id: string }).id)
+    if (strategyIds.length > 0) {
+      const { data: watchItems } = await supabase
+        .from('strategy_watchlist')
+        .select('ticker, market, ticker_name')
+        .in('strategy_id', strategyIds)
+        .in('ticker', tickerKeys)
+
+      if (watchItems) {
+        const nameMap = new Map<string, string>()
+        for (const w of watchItems as Array<{ ticker: string; market: string; ticker_name: string | null }>) {
+          if (!w.ticker_name) continue
+          nameMap.set(`${w.market}:${w.ticker}`, w.ticker_name)
+        }
+        for (const t of tickers) {
+          const name = nameMap.get(`${t.market}:${t.ticker}`)
+          if (name) t.tickerName = name
+        }
+      }
+    }
+  }
+
+  return NextResponse.json({ data: tickers })
+}

--- a/dental-clinic-manager/src/components/Investment/BacktestPanel.tsx
+++ b/dental-clinic-manager/src/components/Investment/BacktestPanel.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from 'react'
 import {
   Play, Loader2, TrendingUp, TrendingDown,
-  BarChart3, Award, Clock, Plus, X, Trophy, ArrowLeft,
+  BarChart3, Award, Clock, Plus, X, Trophy, ArrowLeft, History,
 } from 'lucide-react'
 import TickerSearch from '@/components/Investment/TickerSearch'
 import DateRangePicker from '@/components/Investment/DateRangePicker'
@@ -46,6 +46,7 @@ export default function BacktestPanel({ strategyId, onBack }: BacktestPanelProps
 
   const [tickers, setTickers] = useState<TickerEntry[]>([])
   const [addingMarket, setAddingMarket] = useState<Market>('KR')
+  const [recentTickers, setRecentTickers] = useState<TickerEntry[]>([])
 
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
@@ -70,6 +71,24 @@ export default function BacktestPanel({ strategyId, onBack }: BacktestPanelProps
     }
   }, [strategyId])
 
+  // 사용자가 직전에 백테스트했던 종목 목록 (빠른 추가용)
+  const loadRecentTickers = useCallback(async () => {
+    try {
+      const res = await fetch('/api/investment/backtest/recent-tickers?limit=12')
+      const json = await res.json()
+      if (res.ok && Array.isArray(json.data)) {
+        const list: TickerEntry[] = json.data
+          .filter((t: { market: string }) => t.market === 'KR' || t.market === 'US')
+          .map((t: { ticker: string; market: Market; tickerName: string }) => ({
+            ticker: t.ticker,
+            name: t.tickerName || t.ticker,
+            market: t.market,
+          }))
+        setRecentTickers(list)
+      }
+    } catch { /* ignore */ }
+  }, [])
+
   // 전략의 감시 종목을 자동으로 불러와서 초기 선택으로 설정
   const loadWatchlist = useCallback(async () => {
     try {
@@ -93,12 +112,13 @@ export default function BacktestPanel({ strategyId, onBack }: BacktestPanelProps
   useEffect(() => {
     loadStrategy()
     loadWatchlist()
+    loadRecentTickers()
     const end = new Date()
     const start = new Date()
     start.setFullYear(start.getFullYear() - 1)
     setEndDate(end.toISOString().split('T')[0])
     setStartDate(start.toISOString().split('T')[0])
-  }, [loadStrategy, loadWatchlist])
+  }, [loadStrategy, loadWatchlist, loadRecentTickers])
 
   const addTicker = (ticker: string, name?: string, market?: Market) => {
     if (!ticker.trim()) return
@@ -235,25 +255,34 @@ export default function BacktestPanel({ strategyId, onBack }: BacktestPanelProps
           </div>
         )}
 
-        <div className="flex flex-wrap gap-1.5">
-          <span className="text-xs text-at-text-weak mr-1">빠른 추가:</span>
-          {[
+        <div className="flex flex-wrap gap-1.5 items-center">
+          <span className="text-xs text-at-text-weak mr-1 inline-flex items-center gap-1">
+            {recentTickers.length > 0 && <History className="w-3 h-3" />}
+            {recentTickers.length > 0 ? '이전 백테스트 종목' : '빠른 추가'}:
+          </span>
+          {(recentTickers.length > 0 ? recentTickers : [
             { ticker: '005930', name: '삼성전자', market: 'KR' as Market },
             { ticker: '000660', name: 'SK하이닉스', market: 'KR' as Market },
             { ticker: '035420', name: 'NAVER', market: 'KR' as Market },
             { ticker: 'AAPL', name: 'Apple', market: 'US' as Market },
             { ticker: 'MSFT', name: 'Microsoft', market: 'US' as Market },
             { ticker: 'NVDA', name: 'NVIDIA', market: 'US' as Market },
-          ].map(q => (
-            <button
-              key={`${q.ticker}-${q.market}`}
-              onClick={() => { if (!tickers.some(t => t.ticker === q.ticker && t.market === q.market)) setTickers(prev => [...prev, q]) }}
-              disabled={tickers.some(t => t.ticker === q.ticker && t.market === q.market)}
-              className="px-2 py-0.5 rounded text-xs bg-at-bg text-at-text-secondary hover:bg-at-accent-light hover:text-at-accent transition-colors disabled:opacity-30"
-            >
-              <Plus className="w-3 h-3 inline mr-0.5" />{q.name}
-            </button>
-          ))}
+          ]).map(q => {
+            const already = tickers.some(t => t.ticker === q.ticker && t.market === q.market)
+            return (
+              <button
+                key={`${q.ticker}-${q.market}`}
+                onClick={() => { if (!already) setTickers(prev => [...prev, q]) }}
+                disabled={already}
+                title={`${q.name} (${q.ticker})`}
+                className="px-2 py-0.5 rounded text-xs bg-at-bg text-at-text-secondary hover:bg-at-accent-light hover:text-at-accent transition-colors disabled:opacity-30 inline-flex items-center gap-0.5"
+              >
+                <Plus className="w-3 h-3" />
+                <span className={`text-[9px] px-1 rounded font-bold ${q.market === 'KR' ? 'bg-blue-100 text-blue-700' : 'bg-purple-100 text-purple-700'}`}>{q.market}</span>
+                <span>{q.name}</span>
+              </button>
+            )
+          })}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- /api/investment/backtest/recent-tickers 신규 — 사용자의 백테스트 이력에서 distinct (ticker, market) 최신순 12개
- BacktestPanel "빠른 추가" 버튼이 사용자 이력 기반 동적 버튼으로 교체 (이력 없으면 기본 6개 fallback)
- KR/US 시장 배지 + 종목명 표시

## Test plan
- [ ] /investment/strategy/<id>/backtest 진입 시 "이전 백테스트 종목" 라벨 + 동적 버튼 표시
- [ ] 백테스트 이력 없는 신규 사용자는 기본 6개 fallback
- [ ] 클릭 시 종목 추가, 이미 추가된 종목은 disabled
- [ ] develop → main 머지 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)