### PR TITLE
feat(investment): 전략 카드에 백테스트 통계 표시

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/strategies/stats/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/strategies/stats/route.ts
@@ -1,0 +1,111 @@
+/**
+ * 전략별 백테스트 통계 집계
+ *
+ * GET /api/investment/strategies/stats
+ * 사용자의 모든 전략에 대해 backtest_runs 집계 — 전략 카드에 통계 표시용.
+ *
+ * Response: {
+ *   data: [{
+ *     strategyId, runs, tickerCount,
+ *     avgReturn, bestReturn, worstReturn,
+ *     avgWinRate, avgMDD, avgSharpe,
+ *     totalTrades, lastRunAt
+ *   }]
+ * }
+ */
+
+import { NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+export const dynamic = 'force-dynamic'
+
+interface StrategyStats {
+  strategyId: string
+  runs: number
+  tickerCount: number
+  avgReturn: number
+  bestReturn: number
+  worstReturn: number
+  avgWinRate: number
+  avgMDD: number
+  avgSharpe: number
+  totalTrades: number
+  lastRunAt: string | null
+}
+
+export async function GET() {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 실패' }, { status: auth.status })
+  }
+
+  const supabase = getSupabaseAdmin()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+
+  // 모든 사용자 backtest run의 핵심 지표만 조회 — 클라이언트보다 더 큰 limit 허용
+  const { data: runs, error } = await supabase
+    .from('backtest_runs')
+    .select('strategy_id, ticker, total_return, win_rate, max_drawdown, sharpe_ratio, total_trades, executed_at')
+    .eq('user_id', auth.user.id)
+    .eq('status', 'completed')
+    .limit(2000)
+
+  if (error) {
+    console.error('[strategies/stats] 조회 실패:', error)
+    return NextResponse.json({ error: '통계 조회 실패' }, { status: 500 })
+  }
+
+  // strategy_id별 집계
+  type RunRow = {
+    strategy_id: string
+    ticker: string
+    total_return: number | null
+    win_rate: number | null
+    max_drawdown: number | null
+    sharpe_ratio: number | null
+    total_trades: number | null
+    executed_at: string | null
+  }
+
+  const grouped = new Map<string, RunRow[]>()
+  for (const r of (runs ?? []) as RunRow[]) {
+    if (!r.strategy_id) continue
+    const arr = grouped.get(r.strategy_id) ?? []
+    arr.push(r)
+    grouped.set(r.strategy_id, arr)
+  }
+
+  const stats: StrategyStats[] = []
+  for (const [sid, group] of grouped) {
+    const returns = group.map((g) => Number(g.total_return ?? 0))
+    const winRates = group.map((g) => Number(g.win_rate ?? 0))
+    const mdds = group.map((g) => Number(g.max_drawdown ?? 0))
+    const sharpes = group.map((g) => Number(g.sharpe_ratio ?? 0))
+    const trades = group.reduce((s, g) => s + Number(g.total_trades ?? 0), 0)
+    const tickers = new Set(group.map((g) => g.ticker))
+    const lastRunAt = group
+      .map((g) => g.executed_at)
+      .filter((x): x is string => Boolean(x))
+      .sort()
+      .pop() ?? null
+
+    stats.push({
+      strategyId: sid,
+      runs: group.length,
+      tickerCount: tickers.size,
+      avgReturn: returns.reduce((s, v) => s + v, 0) / Math.max(returns.length, 1),
+      bestReturn: returns.length > 0 ? Math.max(...returns) : 0,
+      worstReturn: returns.length > 0 ? Math.min(...returns) : 0,
+      avgWinRate: winRates.reduce((s, v) => s + v, 0) / Math.max(winRates.length, 1),
+      avgMDD: mdds.reduce((s, v) => s + v, 0) / Math.max(mdds.length, 1),
+      avgSharpe: sharpes.reduce((s, v) => s + v, 0) / Math.max(sharpes.length, 1),
+      totalTrades: trades,
+      lastRunAt,
+    })
+  }
+
+  return NextResponse.json({ data: stats })
+}

--- a/dental-clinic-manager/src/components/Investment/CompareContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/CompareContent.tsx
@@ -14,6 +14,7 @@ import TickerSearch from '@/components/Investment/TickerSearch'
 import { PRESET_STRATEGIES } from '@/components/Investment/StrategyBuilder/presets'
 import PresetDetailView from '@/components/Investment/PresetDetailView'
 import DateRangePicker from '@/components/Investment/DateRangePicker'
+import StrategyStatsBlock, { type StrategyBacktestStats } from '@/components/Investment/StrategyStatsBlock'
 import type {
   InvestmentStrategy, Market, BacktestMetrics, EquityCurvePoint, BacktestTrade,
   PresetStrategy, IndicatorConfig, ConditionGroup, RiskSettings,
@@ -128,6 +129,7 @@ type ViewMode = 'matrix' | 'list'
 function LiveCompareSection() {
   const [strategies, setStrategies] = useState<InvestmentStrategy[]>([])
   const [loadingStrategies, setLoadingStrategies] = useState(true)
+  const [statsByStrategy, setStatsByStrategy] = useState<Map<string, StrategyBacktestStats>>(new Map())
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [tickers, setTickers] = useState<SelectedTicker[]>([{ ticker: 'AAPL', name: 'Apple Inc.' }])
   const [market, setMarket] = useState<Market>('US')
@@ -181,7 +183,22 @@ function LiveCompareSection() {
     }
   }, [])
 
-  useEffect(() => { loadStrategies() }, [loadStrategies])
+  const loadStrategyStats = useCallback(async () => {
+    try {
+      const res = await fetch('/api/investment/strategies/stats')
+      const json = await res.json()
+      if (res.ok && Array.isArray(json.data)) {
+        const map = new Map<string, StrategyBacktestStats>()
+        for (const s of json.data as StrategyBacktestStats[]) map.set(s.strategyId, s)
+        setStatsByStrategy(map)
+      }
+    } catch { /* ignore */ }
+  }, [])
+
+  useEffect(() => {
+    loadStrategies()
+    loadStrategyStats()
+  }, [loadStrategies, loadStrategyStats])
 
   // 사용자 저장 전략 (시장 일치)
   const userItems = useMemo<SelectableItem[]>(
@@ -626,6 +643,7 @@ function LiveCompareSection() {
                   selectedIds={selectedIds}
                   onToggle={toggleStrategy}
                   onOpenDetail={setDetailPresetId}
+                  stats={item.strategyId ? statsByStrategy.get(item.strategyId) ?? null : null}
                 />
               ))}
             </div>
@@ -1232,11 +1250,12 @@ function formatNum(n: number): string {
   return n.toFixed(4)
 }
 
-function SelectableCard({ item, selectedIds, onToggle, onOpenDetail }: {
+function SelectableCard({ item, selectedIds, onToggle, onOpenDetail, stats }: {
   item: SelectableItem
   selectedIds: Set<string>
   onToggle: (key: string) => void
   onOpenDetail: (presetId: string) => void
+  stats?: StrategyBacktestStats | null
 }) {
   const isSelected = selectedIds.has(item.key)
   const orderIndex = isSelected ? Array.from(selectedIds).indexOf(item.key) : -1
@@ -1269,6 +1288,13 @@ function SelectableCard({ item, selectedIds, onToggle, onOpenDetail }: {
                 <span className="text-[10px] px-1.5 py-0.5 rounded bg-green-100 text-green-700">활성</span>
               )}
             </div>
+
+            {/* 백테스트 통계 (사용자 저장 전략만 — 프리셋은 backtest_runs에 저장 안 됨) */}
+            {item.source === 'user' && (
+              <div className="mt-2">
+                <StrategyStatsBlock stats={stats} compact />
+              </div>
+            )}
           </div>
           {isSelected && color && (
             <span className={`flex-shrink-0 w-6 h-6 rounded-full ${color.bg} text-white text-xs font-bold flex items-center justify-center`}>

--- a/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
@@ -13,6 +13,7 @@ import ConnectContent from './ConnectContent'
 import TradingContent from './TradingContent'
 import BacktestPanel from './BacktestPanel'
 import StrategyCard from './StrategyCard'
+import type { StrategyBacktestStats } from './StrategyStatsBlock'
 import DayTradingContent from './DayTradingContent'
 import CompareContent from './CompareContent'
 import ScreenerContent from './ScreenerContent'
@@ -46,6 +47,7 @@ export default function InvestmentTab() {
   const [balance, setBalance] = useState<{ totalEvaluation: number; totalPnl: number; holdingsCount: number } | null>(null)
   const [balanceLoading, setBalanceLoading] = useState(false)
   const [balanceError, setBalanceError] = useState<string | null>(null)
+  const [statsByStrategy, setStatsByStrategy] = useState<Map<string, StrategyBacktestStats>>(new Map())
 
   const loadBalance = useCallback(async () => {
     setBalanceLoading(true)
@@ -85,6 +87,19 @@ export default function InvestmentTab() {
       const res = await fetch('/api/investment/strategies')
       const json = await res.json()
       if (json.data) setStrategies(json.data)
+
+      // 전략별 백테스트 통계 (병렬)
+      try {
+        const statsRes = await fetch('/api/investment/strategies/stats')
+        const statsJson = await statsRes.json()
+        if (statsRes.ok && Array.isArray(statsJson.data)) {
+          const map = new Map<string, StrategyBacktestStats>()
+          for (const s of statsJson.data as StrategyBacktestStats[]) {
+            map.set(s.strategyId, s)
+          }
+          setStatsByStrategy(map)
+        }
+      } catch { /* ignore */ }
 
       // 계좌 연결된 경우 잔고도 로드
       if (connected) {
@@ -201,6 +216,7 @@ export default function InvestmentTab() {
         {!inInlineView && subTab === 'strategy' && (
           <StrategySubTab
             strategies={strategies}
+            statsByStrategy={statsByStrategy}
             onRefresh={loadData}
             onBacktest={setBacktestStrategyId}
             hasCredential={!!hasCredential}
@@ -530,7 +546,7 @@ function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergenc
   )
 }
 
-function StrategySubTab({ strategies, onRefresh, onBacktest, hasCredential, onCreateNew }: { strategies: InvestmentStrategy[]; onRefresh: () => void; onBacktest: (id: string) => void; hasCredential: boolean; onCreateNew: () => void }) {
+function StrategySubTab({ strategies, statsByStrategy, onRefresh, onBacktest, hasCredential, onCreateNew }: { strategies: InvestmentStrategy[]; statsByStrategy: Map<string, StrategyBacktestStats>; onRefresh: () => void; onBacktest: (id: string) => void; hasCredential: boolean; onCreateNew: () => void }) {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -563,6 +579,7 @@ function StrategySubTab({ strategies, onRefresh, onBacktest, hasCredential, onCr
               hasCredential={hasCredential}
               onRefresh={onRefresh}
               onBacktest={onBacktest}
+              stats={statsByStrategy.get(s.id) ?? null}
             />
           ))}
         </div>

--- a/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
@@ -7,6 +7,7 @@ import {
   X, CheckCircle2, AlertCircle, Target, Eye,
 } from 'lucide-react'
 import TickerSearch from './TickerSearch'
+import StrategyStatsBlock, { type StrategyBacktestStats } from './StrategyStatsBlock'
 import type { InvestmentStrategy, Market } from '@/types/investment'
 
 interface WatchlistItem {
@@ -22,11 +23,13 @@ interface Props {
   hasCredential: boolean
   onRefresh: () => void
   onBacktest: (id: string) => void
+  /** 전략별 백테스트 집계 통계 (없으면 통계 블록 비표시) */
+  stats?: StrategyBacktestStats | null
 }
 
 const MARKET_LABELS: Record<string, string> = { KR: '국내', US: '미국' }
 
-export default function StrategyCard({ strategy, hasCredential, onRefresh, onBacktest }: Props) {
+export default function StrategyCard({ strategy, hasCredential, onRefresh, onBacktest, stats }: Props) {
   const [expanded, setExpanded] = useState(false)
   const [watchlist, setWatchlist] = useState<WatchlistItem[]>([])
   const [watchlistLoading, setWatchlistLoading] = useState(false)
@@ -163,6 +166,13 @@ export default function StrategyCard({ strategy, hasCredential, onRefresh, onBac
           </button>
         </div>
       </div>
+
+      {/* 백테스트 통계 — stats가 전달된 경우만 표시 */}
+      {stats !== undefined && (
+        <div className="mt-3">
+          <StrategyStatsBlock stats={stats} />
+        </div>
+      )}
 
       {/* 활성화 체크리스트 (비활성 상태일 때만) */}
       {!strategy.is_active && (

--- a/dental-clinic-manager/src/components/Investment/StrategyStatsBlock.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyStatsBlock.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+/**
+ * 전략 카드용 백테스트 통계 블록.
+ * 전략 선택/조회 페이지의 카드에 공통으로 표시.
+ */
+
+import { TrendingUp, TrendingDown, BarChart3 } from 'lucide-react'
+
+export interface StrategyBacktestStats {
+  strategyId: string
+  runs: number
+  tickerCount: number
+  avgReturn: number
+  bestReturn: number
+  worstReturn: number
+  avgWinRate: number
+  avgMDD: number
+  avgSharpe: number
+  totalTrades: number
+  lastRunAt: string | null
+}
+
+interface Props {
+  stats?: StrategyBacktestStats | null
+  /** 작은 카드용 컴팩트 모드 (한 줄 요약) */
+  compact?: boolean
+}
+
+const fmtPct = (v: number) => `${v >= 0 ? '+' : ''}${v.toFixed(2)}%`
+const colorPnl = (v: number) =>
+  v > 0 ? 'text-red-600' : v < 0 ? 'text-blue-600' : 'text-at-text-secondary'
+
+export default function StrategyStatsBlock({ stats, compact = false }: Props) {
+  if (!stats || stats.runs === 0) {
+    return (
+      <div className="text-[11px] text-at-text-weak inline-flex items-center gap-1">
+        <BarChart3 className="w-3 h-3" />
+        백테스트 이력 없음
+      </div>
+    )
+  }
+
+  if (compact) {
+    return (
+      <div className="flex flex-wrap items-center gap-1.5 text-[10px]">
+        <span className="px-1.5 py-0.5 rounded bg-slate-50 text-slate-700 inline-flex items-center gap-0.5">
+          <BarChart3 className="w-2.5 h-2.5" />
+          {stats.runs}회
+        </span>
+        <span className={`px-1.5 py-0.5 rounded font-mono font-semibold ${stats.avgReturn >= 0 ? 'bg-red-50 text-red-700' : 'bg-blue-50 text-blue-700'}`}>
+          평균 {fmtPct(stats.avgReturn)}
+        </span>
+        {stats.bestReturn !== stats.avgReturn && (
+          <span className="px-1.5 py-0.5 rounded bg-emerald-50 text-emerald-700 font-mono">
+            최고 {fmtPct(stats.bestReturn)}
+          </span>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-lg bg-slate-50 border border-slate-200 p-2.5 space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="text-[10px] font-semibold text-slate-600 uppercase tracking-wide inline-flex items-center gap-1">
+          <BarChart3 className="w-3 h-3" />
+          백테스트 통계
+        </div>
+        <div className="text-[10px] text-slate-500">
+          {stats.runs}회 · {stats.tickerCount}종목
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-1.5">
+        <Stat label="평균 수익률" value={fmtPct(stats.avgReturn)} colorClass={colorPnl(stats.avgReturn)} icon={stats.avgReturn >= 0 ? TrendingUp : TrendingDown} />
+        <Stat label="최고" value={fmtPct(stats.bestReturn)} colorClass="text-emerald-600" />
+        <Stat label="최저" value={fmtPct(stats.worstReturn)} colorClass="text-rose-600" />
+        <Stat label="평균 승률" value={`${stats.avgWinRate.toFixed(0)}%`} />
+        <Stat label="평균 MDD" value={fmtPct(-Math.abs(stats.avgMDD))} colorClass="text-blue-600" />
+        <Stat label="평균 Sharpe" value={stats.avgSharpe.toFixed(2)} />
+      </div>
+
+      <div className="text-[10px] text-slate-500 flex items-center justify-between pt-1 border-t border-slate-200">
+        <span>총 매매 {stats.totalTrades.toLocaleString()}건</span>
+        {stats.lastRunAt && (
+          <span>최근 {new Date(stats.lastRunAt).toLocaleDateString('ko-KR', { month: '2-digit', day: '2-digit' })}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Stat({
+  label,
+  value,
+  colorClass,
+  icon: Icon,
+}: {
+  label: string
+  value: string
+  colorClass?: string
+  icon?: React.ComponentType<{ className?: string }>
+}) {
+  return (
+    <div className="bg-white rounded px-1.5 py-1 border border-slate-100">
+      <p className="text-[9px] text-slate-500 leading-tight">{label}</p>
+      <p className={`text-[11px] font-mono font-semibold inline-flex items-center gap-0.5 ${colorClass ?? 'text-slate-900'}`}>
+        {Icon && <Icon className="w-2.5 h-2.5" />}
+        {value}
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- 새 endpoint /api/investment/strategies/stats — 전략별 backtest_runs 집계 한 번에 반환
- StrategyStatsBlock 공통 컴포넌트 (full/compact)
- StrategyCard(전략 관리)에 full 통계, 비교 페이지 SelectableCard에 compact 통계

## Test plan
- [ ] 전략 관리 페이지(/investment, 전략 탭)에서 카드별 백테스트 통계 표시
- [ ] 비교 페이지(/investment/compare)의 사용자 전략 카드에 compact 통계 표시
- [ ] 백테스트 이력 없는 전략은 "백테스트 이력 없음"
- [ ] 프리셋 카드는 통계 미표시
- [ ] develop → main 머지 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)