### PR TITLE
fix(investment/backtest): 프리셋 백테스트도 히스토리에 저장

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/backtest/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/backtest/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: '잘못된 요청 형식입니다' }, { status: 400 })
   }
 
-  const { strategyId, preset, ticker, market, startDate, endDate, initialCapital, useFullCapital } = body
+  const { strategyId, preset, presetId, presetName, ticker, market, startDate, endDate, initialCapital, useFullCapital } = body
 
   if (!ticker || typeof ticker !== 'string') {
     return NextResponse.json({ error: '종목 코드가 필요합니다' }, { status: 400 })
@@ -57,7 +57,7 @@ export async function POST(request: NextRequest) {
   let buyConditions: ConditionGroup
   let sellConditions: ConditionGroup
   let riskSettings: RiskSettings
-  let saveResult = true  // strategyId 모드에선 결과 저장, preset 모드에선 미저장
+  // 모든 백테스트는 backtest_runs에 저장 (사용자 전략·프리셋 모두) — 프리셋은 strategy_id NULL + preset_id 채움
 
   const DEFAULT_RISK: RiskSettings = {
     maxDailyLossPercent: 2,
@@ -166,13 +166,12 @@ export async function POST(request: NextRequest) {
     buyConditions = p.buyConditions
     sellConditions = p.sellConditions
     riskSettings = { ...DEFAULT_RISK, ...(p.riskSettings || {}) }
-    saveResult = false
   } else {
     return NextResponse.json({ error: 'strategyId 또는 preset 중 하나가 필요합니다' }, { status: 400 })
   }
 
-  // 동시 백테스트 제한 (저장된 전략에만 적용)
-  if (saveResult) {
+  // 동시 백테스트 제한 (사용자별 전체)
+  {
     const { count } = await supabase
       .from('backtest_runs')
       .select('id', { count: 'exact', head: true })
@@ -215,17 +214,21 @@ export async function POST(request: NextRequest) {
 
     clearTimeout(timeout)
 
-    // preset 모드는 결과 저장 안 함 (즉석 비교용)
-    if (!saveResult) {
-      return NextResponse.json({ data: { ...result, saved: false } })
-    }
-
-    // 저장된 전략 모드: backtest_runs에 결과 저장
+    // 사용자 전략 + 프리셋 모두 backtest_runs에 저장 — 프리셋은 strategy_id NULL + preset_id 채움
     const nowIso = new Date().toISOString()
+    const isPresetMode = !strategyId
+    const finalPresetId = isPresetMode
+      ? (typeof presetId === 'string' && presetId ? presetId : 'custom')
+      : null
+    const finalPresetName = isPresetMode
+      ? (typeof presetName === 'string' && presetName ? presetName : '프리셋 백테스트')
+      : null
     const { data: run, error } = await supabase
       .from('backtest_runs')
       .insert({
-        strategy_id: strategyId,
+        strategy_id: isPresetMode ? null : (strategyId as string),
+        preset_id: finalPresetId,
+        preset_name: finalPresetName,
         user_id: userId,
         ticker: ticker as string,
         market: market as string,

--- a/dental-clinic-manager/src/components/Investment/AutoTradeFromBacktest.tsx
+++ b/dental-clinic-manager/src/components/Investment/AutoTradeFromBacktest.tsx
@@ -18,7 +18,10 @@ import type { InvestmentStrategy, Market } from '@/types/investment'
 
 interface BacktestRun {
   id: string
-  strategy_id: string
+  /** 프리셋 백테스트면 NULL */
+  strategy_id: string | null
+  preset_id: string | null
+  preset_name: string | null
   ticker: string
   market: Market
   total_return: number | null
@@ -156,14 +159,19 @@ export default function AutoTradeFromBacktest() {
 
     let bestRuns: BacktestRun[] = []
 
+    /** run의 그룹 키 — 사용자 전략은 strategy_id, 프리셋은 preset:<id> */
+    const groupKeyOf = (r: BacktestRun) =>
+      r.strategy_id ?? `preset:${r.preset_id ?? 'custom'}`
+
     if (isPickedMode) {
-      // strategy_id별 best totalReturn 1개
+      // strategy(또는 preset)별 best totalReturn 1개
       const bestPerStrategy = new Map<string, BacktestRun>()
       for (const r of runs) {
-        const cur = bestPerStrategy.get(r.strategy_id)
+        const k = groupKeyOf(r)
+        const cur = bestPerStrategy.get(k)
         const tr = Number(r.total_return ?? -Infinity)
         const curTr = cur ? Number(cur.total_return ?? -Infinity) : -Infinity
-        if (!cur || tr > curTr) bestPerStrategy.set(r.strategy_id, r)
+        if (!cur || tr > curTr) bestPerStrategy.set(k, r)
       }
       bestRuns = Array.from(bestPerStrategy.values())
     } else {
@@ -181,19 +189,30 @@ export default function AutoTradeFromBacktest() {
 
     const rows: RankedRow[] = []
     for (const run of bestRuns) {
-      const strat = stratMap.get(run.strategy_id)
-      // 삭제됐거나 stratMap에 없는 경우 backend join 정보로 fallback
-      const joinedName = run.investment_strategies?.name
-      const joinedLevel = run.investment_strategies?.automation_level
-      const strategyName = strat?.name ?? joinedName ?? `전략 #${run.strategy_id.slice(0, 8)}`
-      const automationLevel = strat?.automation_level ?? joinedLevel ?? 1
-      const canAdd = Boolean(strat) // 자동매매 추가는 현재 active 사용자 전략만 가능
+      const isPreset = !run.strategy_id
+      const strat = run.strategy_id ? stratMap.get(run.strategy_id) : undefined
 
-      const wlKey = `${run.strategy_id}::${run.market}::${run.ticker.toUpperCase()}`
+      let strategyName: string
+      let canAdd: boolean
+      if (isPreset) {
+        strategyName = run.preset_name ?? `프리셋 #${run.preset_id ?? 'custom'}`
+        canAdd = false // 프리셋은 자동매매 추가 불가 (저장 전략 없음)
+      } else {
+        const joinedName = run.investment_strategies?.name
+        strategyName = strat?.name ?? joinedName ?? `전략 #${(run.strategy_id ?? '').slice(0, 8)}`
+        canAdd = Boolean(strat) // 자동매매 추가는 현재 사용자 보유 전략만
+      }
+
+      const automationLevel =
+        strat?.automation_level ?? run.investment_strategies?.automation_level ?? 1
+
+      const groupId = run.strategy_id ?? `preset:${run.preset_id ?? 'custom'}`
+      const wlKey = `${groupId}::${run.market}::${run.ticker.toUpperCase()}`
       const inWatchlist = watchlistMap.get(wlKey) === true
-      const alreadyActive = automationLevel === 2 && inWatchlist
+      const alreadyActive = !isPreset && automationLevel === 2 && inWatchlist
+
       rows.push({
-        strategyId: run.strategy_id,
+        strategyId: groupId,
         strategyName,
         totalReturn: Number(run.total_return ?? 0),
         winRate: Number(run.win_rate ?? 0),
@@ -211,11 +230,13 @@ export default function AutoTradeFromBacktest() {
     return rows.sort((a, b) => b.totalReturn - a.totalReturn)
   }, [runs, strategies, watchlistMap, isPickedMode])
 
-  // ranked 변화 시 → watchlist 조합 조회
+  // ranked 변화 시 → watchlist 조합 조회 (프리셋 group은 제외)
   useEffect(() => {
     if (ranked.length === 0) return
-    const combos = ranked.map((r) => ({ sid: r.strategyId, ticker: r.ticker, market: r.market }))
-    loadWatchlistForCombos(combos)
+    const combos = ranked
+      .filter((r) => r.canAdd) // 프리셋·삭제 전략은 watchlist 조회 의미 없음
+      .map((r) => ({ sid: r.strategyId, ticker: r.ticker, market: r.market }))
+    if (combos.length > 0) loadWatchlistForCombos(combos)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runs])
 

--- a/dental-clinic-manager/src/components/Investment/CompareContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/CompareContent.tsx
@@ -314,7 +314,11 @@ function LiveCompareSection() {
             useFullCapital: true,
           }
           if (item?.source === 'user') body.strategyId = item.strategyId
-          else if (item?.source === 'preset') body.preset = item.preset
+          else if (item?.source === 'preset') {
+            body.preset = item.preset
+            body.presetId = item.key.replace(/^preset:/, '')
+            body.presetName = item.name
+          }
 
           try {
             const res = await fetch('/api/investment/backtest', {


### PR DESCRIPTION
## Summary
- 비교 페이지 프리셋 백테스트가 backtest_runs에 저장 안 되던 문제 수정 (saveResult=false 분기 제거)
- DB 마이그레이션: strategy_id nullable, preset_id/preset_name 컬럼 + CHECK 제약 추가 (적용 완료)
- AutoTradeFromBacktest: strategy_id NULL run 처리, 프리셋은 canAdd=false로 표시만

## Test plan
- [ ] 비교 페이지에서 프리셋 + 종목 선택 → 백테스트 실행 → DB에 row 생성 확인
- [ ] 자동매매 카드(미선택 모드)에 프리셋 백테스트 결과도 노출 (canAdd=false)
- [ ] 사용자 저장 전략 백테스트는 기존대로 저장
- [ ] develop → main 머지 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)