### PR TITLE
feat(smart-money): 미국 주식 Pre-Market 분석 옵션 + 별도 탭

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
@@ -100,7 +100,7 @@ export async function POST(request: NextRequest) {
   const userId = auth.user.id
 
   // 2. 입력 파싱
-  let body: { ticker?: unknown; market?: unknown; includeLLM?: unknown }
+  let body: { ticker?: unknown; market?: unknown; includeLLM?: unknown; includePreMarket?: unknown }
   try {
     body = await request.json()
   } catch {
@@ -110,6 +110,8 @@ export async function POST(request: NextRequest) {
   const ticker = typeof body.ticker === 'string' ? body.ticker.trim().toUpperCase() : ''
   const market = body.market === 'KR' || body.market === 'US' ? (body.market as Market) : null
   const includeLLM = Boolean(body.includeLLM)
+  // US 종목에서 pre-market(ET 04:00~09:30) 봉도 분석에 포함 + 별도 byDay entry 추가
+  const includePreMarket = Boolean(body.includePreMarket) && market === 'US'
 
   if (!ticker) {
     return NextResponse.json({ error: 'ticker는 필수입니다.' }, { status: 400 })
@@ -297,11 +299,13 @@ export async function POST(request: NextRequest) {
     bars = dailyBars
   }
 
-  // 정규장 시간만 필터 — 프리/포스트마켓 봉은 거래량 분포·시·종가 식별에 노이즈
-  // (US: ET 09:30~16:00, KR: KST 09:00~15:30)
+  // 정규장(+옵션 pre-market) 시간만 필터 — post-market은 항상 제외
   // dailyBars로 fallback된 경우는 시간 정보가 없으므로 그대로 유지
   if (bars !== dailyBars && bars.length > 0) {
-    const filtered = bars.filter((b) => isRegularTradingHours(b.datetime, market))
+    const filterFn = (b: NormalizedBar) =>
+      isRegularTradingHours(b.datetime, market) ||
+      (includePreMarket && isPreMarketUS(b.datetime))
+    const filtered = bars.filter(filterFn)
     if (filtered.length >= 30) bars = filtered
   }
 
@@ -567,6 +571,78 @@ export async function POST(request: NextRequest) {
       lastDay.overallScore = scoreResult.overallScore
       lastDay.interpretation = scoreResult.interpretation
       lastDay.signalDetails = scoreResult.signalDetails
+    }
+
+    // ===== Pre-Market 별도 entry (US 옵션) =====
+    // 가장 최근 일자의 pre-market 봉만 분리해 분석 → byDay에 추가
+    if (includePreMarket && market === 'US') {
+      const latestDayKey = recentDayKeys[recentDayKeys.length - 1]
+      if (latestDayKey) {
+        const preBars = bars.filter(
+          (b) => dayKeyOf(b.datetime) === latestDayKey && isPreMarketUS(b.datetime),
+        )
+        if (preBars.length >= 10) {
+          const closePrice = preBars[preBars.length - 1].close
+          const dVwapBars: VWAPInputBar[] = preBars.map((b) => ({
+            high: b.high, low: b.low, close: b.close, volume: b.volume,
+          }))
+          const dVwap = calculateVWAP(dVwapBars, closePrice)
+
+          const dAlgoBars: AlgoBar[] = preBars.map((b) => ({
+            datetime: b.datetime, open: b.open, high: b.high, low: b.low, close: b.close, volume: b.volume,
+          }))
+          const dAlgoFootprint = analyzeAlgoFootprint(dAlgoBars, dAlgoBars)
+
+          const dWyckoffBars: WyckoffBar[] = preBars.map((b) => ({
+            open: b.open, high: b.high, low: b.low, close: b.close, volume: b.volume,
+          }))
+          const dWyckoffIntraday = detectWyckoff(dWyckoffBars, { timeframe: 'minute' })
+
+          const dSessionBars: SessionBar[] = preBars.map((b) => ({ ...b }))
+          const dSession = analyzeSession(dSessionBars, market)
+
+          const dNewsBars: NewsBar[] = preBars.map((b) => ({ ...b }))
+          const dNewsContext = analyzeNewsContext({ bars: dNewsBars, signalDetails: [], newsEvents: [] })
+
+          const dScore = computeSmartMoneyScore({
+            vwap: dVwap,
+            investorFlow,
+            wyckoff,
+            algoFootprint: dAlgoFootprint,
+            wyckoffPhase,
+            liquidity,
+            marketStructure,
+            orderBlocksFvg,
+            traps,
+            vsa,
+            session: dSession,
+            newsContext: dNewsContext,
+          })
+
+          byDay.push({
+            ticker,
+            market,
+            asOfDate: `${latestDayKey} (Pre)`,
+            closePrice,
+            vwap: dVwap,
+            wyckoff,
+            wyckoffIntraday: dWyckoffIntraday,
+            algoFootprint: dAlgoFootprint,
+            wyckoffPhase,
+            liquidity,
+            marketStructure,
+            orderBlocksFvg,
+            traps,
+            vsa,
+            session: dSession,
+            newsContext: dNewsContext,
+            manipulationRiskScore: dScore.manipulationRiskScore,
+            overallScore: dScore.overallScore,
+            interpretation: dScore.interpretation,
+            signalDetails: dScore.signalDetails,
+          })
+        }
+      }
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : '분석 엔진 실패'
@@ -942,28 +1018,34 @@ function toKisDateString(d: Date): string {
  * 프리/포스트마켓 봉은 거래량 분포 분석에 노이즈가 되므로 분석 입력에서 제외용.
  */
 function isRegularTradingHours(dt: string, market: Market): boolean {
-  if (!dt) return false
+  const m = tzMinutesOf(dt, market)
+  if (m === null) return true
+  if (market === 'US') return m >= 9 * 60 + 30 && m < 16 * 60
+  return m >= 9 * 60 && m < 15 * 60 + 30
+}
+
+/** US pre-market: ET 04:00 ~ 09:30 (09:30 미포함) */
+function isPreMarketUS(dt: string): boolean {
+  const m = tzMinutesOf(dt, 'US')
+  if (m === null) return false
+  return m >= 4 * 60 && m < 9 * 60 + 30
+}
+
+function tzMinutesOf(dt: string, market: Market): number | null {
+  if (!dt) return null
   const hasTz = /Z$|[+-]\d{2}:?\d{2}$/.test(dt)
   const d = new Date(hasTz ? dt : dt + 'Z')
-  if (isNaN(d.getTime())) return true
+  if (isNaN(d.getTime())) return null
   const tz = market === 'US' ? 'America/New_York' : 'Asia/Seoul'
-  let hh = 0
-  let mm = 0
   try {
     const fmt = new Intl.DateTimeFormat('en-GB', {
       timeZone: tz, hour: '2-digit', minute: '2-digit', hour12: false,
     })
     const parts = fmt.formatToParts(d)
-    const hourPart = parts.find((p) => p.type === 'hour')?.value ?? '00'
-    const minutePart = parts.find((p) => p.type === 'minute')?.value ?? '00'
-    hh = parseInt(hourPart, 10)
-    mm = parseInt(minutePart, 10)
+    const hh = parseInt(parts.find((p) => p.type === 'hour')?.value ?? '00', 10)
+    const mm = parseInt(parts.find((p) => p.type === 'minute')?.value ?? '00', 10)
+    return hh * 60 + mm
   } catch {
-    return true
+    return null
   }
-  const minutes = hh * 60 + mm
-  if (market === 'US') {
-    return minutes >= 9 * 60 + 30 && minutes < 16 * 60
-  }
-  return minutes >= 9 * 60 && minutes < 15 * 60 + 30
 }

--- a/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
@@ -113,19 +113,23 @@ function todayKey() {
   return new Date().toISOString().slice(0, 10)
 }
 
-/** YYYY-MM-DD → "MM/DD (요일)" — timezone에 영향받지 않도록 UTC로 명시 파싱 */
+/** YYYY-MM-DD 또는 'YYYY-MM-DD (Pre)' → "MM/DD (요일)" — pre-market suffix는 분리 표기 */
 function formatDayLabel(date: string): string {
-  const [y, m, d] = date.split('-').map(Number)
+  const isPre = / \(Pre\)$/.test(date)
+  const dateOnly = date.replace(/ \(Pre\)$/, '')
+  const [y, m, d] = dateOnly.split('-').map(Number)
   if (!y || !m || !d) return date
   const dt = new Date(Date.UTC(y, m - 1, d))
   const day = dt.getUTCDay()
   const dayLabel = ['일', '월', '화', '수', '목', '금', '토'][day]
-  return `${m}/${d} (${dayLabel})`
+  return `${m}/${d} (${dayLabel})${isPre ? ' Pre' : ''}`
 }
 
-/** "오늘" / "어제" / "그제" 라벨 — 가장 최근(마지막)이 오늘 */
-function formatDayRelative(_date: string, total: number, idx: number): string {
-  const offset = total - 1 - idx // 마지막=0(오늘), 그 앞=1(어제), ...
+/** "오늘" / "어제" / "Pre-Market" 라벨 — hasPre 시 정규장 인덱스 보정 */
+function formatDayRelative(date: string, total: number, idx: number, hasPre = false): string {
+  if (/ \(Pre\)$/.test(date)) return 'Pre-Market'
+  const regularTotal = hasPre ? total - 1 : total
+  const offset = regularTotal - 1 - idx
   if (offset === 0) return '오늘'
   if (offset === 1) return '전 거래일'
   if (offset === 2) return '그 전'
@@ -139,6 +143,7 @@ export function SmartMoneyContent() {
   const [error, setError] = useState<string | null>(null)
   const [errorCode, setErrorCode] = useState<string | null>(null)
   const [llmLoading, setLlmLoading] = useState(false)
+  const [includePreMarket, setIncludePreMarket] = useState(false)
 
   // 알림 모달
   const [alertModalOpen, setAlertModalOpen] = useState(false)
@@ -179,6 +184,7 @@ export function SmartMoneyContent() {
           ticker: selected.ticker,
           market: selected.market,
           includeLLM: true,
+          includePreMarket: includePreMarket && selected.market === 'US',
         }),
       })
       const json = await res.json().catch(() => ({}))
@@ -207,7 +213,7 @@ export function SmartMoneyContent() {
     } finally {
       setLoading(false)
     }
-  }, [selected])
+  }, [selected, includePreMarket])
 
   const fetchLlmComment = useCallback(async (base: SmartMoneyAnalysis) => {
     setLlmLoading(true)
@@ -331,6 +337,24 @@ export function SmartMoneyContent() {
             )}
           </button>
         </div>
+        {/* Pre-Market 옵션 — US 종목 선택 시만 활성 */}
+        {selected?.market === 'US' && (
+          <label className="mt-2 inline-flex items-center gap-2 text-[12px] text-slate-700 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={includePreMarket}
+              onChange={(e) => setIncludePreMarket(e.target.checked)}
+              disabled={loading}
+              className="w-3.5 h-3.5 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+            />
+            <span>
+              <span className="font-semibold">Pre-Market 포함</span>
+              <span className="text-[11px] text-slate-500 ml-1">
+                (ET 04:00~09:30 봉 + 별도 분석 탭 추가)
+              </span>
+            </span>
+          </label>
+        )}
         {selected && !loading && !analysis && !error && (
           <p className="mt-2 text-[11px] text-slate-500">
             선택됨: <span className="font-mono font-semibold text-blue-600">{selected.ticker}</span>{' '}
@@ -386,7 +410,14 @@ export function SmartMoneyContent() {
                             : 'bg-slate-50 text-slate-700 hover:bg-slate-100'
                         }`}
                       >
-                        <span className="block text-[10px] opacity-75">{formatDayRelative(day.asOfDate, analysis.byDay!.length, i)}</span>
+                        <span className="block text-[10px] opacity-75">
+                          {formatDayRelative(
+                            day.asOfDate,
+                            analysis.byDay!.length,
+                            i,
+                            analysis.byDay!.some((d) => / \(Pre\)$/.test(d.asOfDate)),
+                          )}
+                        </span>
                         <span>{formatDayLabel(day.asOfDate)}</span>
                       </button>
                     )


### PR DESCRIPTION
## Summary
- US 종목 분석에 Pre-Market(ET 04:00~09:30) 옵션 추가
- 토글 활성 시: 정규장 + pre-market 봉을 함께 분석에 포함
- 가장 최근 일자의 pre-market 데이터를 별도 byDay 탭(라벨 "Pre")로 추가 — VWAP/알고풋프린트/Wyckoff/세션 모두 그 시간대 기반 재계산

## Test plan
- [ ] 미국 종목 선택 → Pre-Market 토글 노출 확인
- [ ] 토글 ON 분석 → 탭에 "Pre-Market" 항목 추가 확인
- [ ] Pre 탭의 VWAP/Algo Footprint가 정규장 탭과 다른 값
- [ ] 한국 종목은 토글 미노출
- [ ] develop → main 머지 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)