### PR TITLE
release: permissions auto-validation + investment favorites/ticker info

### DIFF
--- a/dental-clinic-manager/.claude/WORK_LOG.md
+++ b/dental-clinic-manager/.claude/WORK_LOG.md
@@ -10,6 +10,34 @@
 
 ---
 
+## 2026-05-06 [기능 개발] 종목 상세 모달 + 즐겨찾기 시스템
+
+**키워드:** #investment #favorites #ticker-info #screener #yahoo-finance2 #broadcast-channel
+
+### 📋 작업 내용
+- 신규 테이블 `investment_favorites` (user_id, ticker, market UNIQUE) + RLS
+- `/api/investment/ticker-info` — yahoo-finance2 quoteSummary + chart로 펀더멘털(PER/PBR/ROE/영업이익률 등) + 시총 순위 + 가격 차트 통합 (30분 캐시)
+- `/api/investment/favorites` GET/POST/DELETE — requireAuth 패턴
+- `useFavorites` 훅 — 낙관적 업데이트 + BroadcastChannel cross-tab 동기화
+- `TickerInfoModal` 컴포넌트 — 가격 카드 + 12셀 펀더멘털 그리드 + 1M/3M/1Y 차트 토글 + 즐겨찾기 버튼
+- `FavoritesButtons` 컴포넌트 — RecentTickersButtons와 동일 외형, 별표 prefix
+- KR 시총 스냅샷: `scripts/fetch-kr-marketcap.mjs` + `src/data/kr-tickers-marketcap.json` + `src/lib/krTickerCatalog.ts`
+- 4개 페이지에 즐겨찾기 행 통합: SmartMoneyContent, CompareContent, DayTradingContent, StrategyCard
+- ScreenerContent: 결과 행 클릭 = TickerInfoModal 오픈으로 통일 (인라인 펼침 제거), 매치 정보는 모달 extra에 표시
+
+### ✅ 검증
+- `npm run build` 통과 (모든 task 종료 후 최종 빌드 clean)
+- yahoo-finance2 v3 dynamic-import 패턴 준수 (코드베이스 기존 관례)
+- AAPL/005930 ticker-info API 응답 정상 (marketCapRank 포함)
+- Spec compliance + code quality review 모든 task 통과
+
+### 💡 배운 점
+- yahoo-finance2 v3는 default export가 클래스, `new YahooFinance()`로 인스턴스화 필요
+- recharts v3 Tooltip `labelFormatter`의 1번째 인자는 `ReactNode` 타입이라 `string` 캐스팅 필요
+- Supabase 타입 자동 생성 파일에 새 테이블이 없으면 `(supabase as any).from()` 캐스팅이 임시 해결책
+
+---
+
 ## 2026-03-23 [버그 수정] 스크래핑 워커 인증정보 읽기 실패 (stale 프로세스)
 
 **키워드:** #스크래핑워커 #tsx모듈캐싱 #stale프로세스 #워커재시작

--- a/dental-clinic-manager/scripts/fetch-kr-marketcap.mjs
+++ b/dental-clinic-manager/scripts/fetch-kr-marketcap.mjs
@@ -10,7 +10,7 @@ import { writeFileSync, mkdirSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import YahooFinance from 'yahoo-finance2'
 
-const yahooFinance = new YahooFinance({ suppressNotices: ['yahooSurvey'] })
+const yahooFinance = new YahooFinance()
 
 const DICT_PATH = resolve(process.cwd(), 'src/lib/krTickerDict.ts')
 const OUT_PATH = resolve(process.cwd(), 'src/data/kr-tickers-marketcap.json')

--- a/dental-clinic-manager/src/app/api/investment/favorites/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/favorites/route.ts
@@ -8,6 +8,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
 
 interface Row {
   ticker: string
@@ -22,10 +23,12 @@ function isMarket(v: unknown): v is 'KR' | 'US' {
 }
 
 export async function GET() {
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return NextResponse.json({ error: '인증 필요' }, { status: 401 })
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 필요' }, { status: auth.status || 401 })
+  }
 
+  const supabase = await createClient()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data, error } = await (supabase as any)
     .from('investment_favorites')
@@ -33,7 +36,10 @@ export async function GET() {
     .order('sort_order', { ascending: false })
     .order('created_at', { ascending: false })
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  if (error) {
+    console.error('[favorites] GET error:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
 
   const items = ((data ?? []) as Row[]).map((r) => ({
     ticker: r.ticker,
@@ -45,9 +51,10 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return NextResponse.json({ error: '인증 필요' }, { status: 401 })
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 필요' }, { status: auth.status || 401 })
+  }
 
   let body: { ticker?: string; market?: string; ticker_name?: string | null }
   try {
@@ -61,17 +68,21 @@ export async function POST(req: NextRequest) {
   if (!ticker) return NextResponse.json({ error: 'ticker 누락' }, { status: 400 })
   if (!isMarket(market)) return NextResponse.json({ error: 'market 잘못됨' }, { status: 400 })
 
+  const supabase = await createClient()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data, error } = await (supabase as any)
     .from('investment_favorites')
     .upsert(
-      { user_id: user.id, ticker, market, ticker_name: body.ticker_name ?? null },
+      { user_id: auth.user.id, ticker, market, ticker_name: body.ticker_name ?? null },
       { onConflict: 'user_id,ticker,market', ignoreDuplicates: false },
     )
     .select('ticker, market, ticker_name, created_at')
     .single()
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  if (error) {
+    console.error('[favorites] POST error:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
 
   return NextResponse.json({
     ok: true,
@@ -85,9 +96,10 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return NextResponse.json({ error: '인증 필요' }, { status: 401 })
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 필요' }, { status: auth.status || 401 })
+  }
 
   const { searchParams } = new URL(req.url)
   const ticker = (searchParams.get('ticker') ?? '').trim().toUpperCase()
@@ -95,14 +107,18 @@ export async function DELETE(req: NextRequest) {
   if (!ticker) return NextResponse.json({ error: 'ticker 누락' }, { status: 400 })
   if (!isMarket(market)) return NextResponse.json({ error: 'market 잘못됨' }, { status: 400 })
 
+  const supabase = await createClient()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { error } = await (supabase as any)
     .from('investment_favorites')
     .delete()
-    .eq('user_id', user.id)
+    .eq('user_id', auth.user.id)
     .eq('ticker', ticker)
     .eq('market', market)
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  if (error) {
+    console.error('[favorites] DELETE error:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
   return NextResponse.json({ ok: true })
 }

--- a/dental-clinic-manager/src/app/api/investment/favorites/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/favorites/route.ts
@@ -1,0 +1,108 @@
+/**
+ * 사용자 즐겨찾기 종목 CRUD.
+ *
+ *   GET    /api/investment/favorites
+ *   POST   /api/investment/favorites          { ticker, market, ticker_name? }
+ *   DELETE /api/investment/favorites?ticker=...&market=KR|US
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+interface Row {
+  ticker: string
+  market: 'KR' | 'US'
+  ticker_name: string | null
+  created_at: string
+  sort_order: number
+}
+
+function isMarket(v: unknown): v is 'KR' | 'US' {
+  return v === 'KR' || v === 'US'
+}
+
+export async function GET() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: '인증 필요' }, { status: 401 })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase as any)
+    .from('investment_favorites')
+    .select('ticker, market, ticker_name, created_at, sort_order')
+    .order('sort_order', { ascending: false })
+    .order('created_at', { ascending: false })
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  const items = ((data ?? []) as Row[]).map((r) => ({
+    ticker: r.ticker,
+    market: r.market,
+    tickerName: r.ticker_name,
+    createdAt: r.created_at,
+  }))
+  return NextResponse.json({ items })
+}
+
+export async function POST(req: NextRequest) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: '인증 필요' }, { status: 401 })
+
+  let body: { ticker?: string; market?: string; ticker_name?: string | null }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: '본문 파싱 실패' }, { status: 400 })
+  }
+
+  const ticker = (body.ticker ?? '').trim().toUpperCase()
+  const market = body.market
+  if (!ticker) return NextResponse.json({ error: 'ticker 누락' }, { status: 400 })
+  if (!isMarket(market)) return NextResponse.json({ error: 'market 잘못됨' }, { status: 400 })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase as any)
+    .from('investment_favorites')
+    .upsert(
+      { user_id: user.id, ticker, market, ticker_name: body.ticker_name ?? null },
+      { onConflict: 'user_id,ticker,market', ignoreDuplicates: false },
+    )
+    .select('ticker, market, ticker_name, created_at')
+    .single()
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  return NextResponse.json({
+    ok: true,
+    item: {
+      ticker: data.ticker,
+      market: data.market,
+      tickerName: data.ticker_name,
+      createdAt: data.created_at,
+    },
+  })
+}
+
+export async function DELETE(req: NextRequest) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: '인증 필요' }, { status: 401 })
+
+  const { searchParams } = new URL(req.url)
+  const ticker = (searchParams.get('ticker') ?? '').trim().toUpperCase()
+  const market = searchParams.get('market')
+  if (!ticker) return NextResponse.json({ error: 'ticker 누락' }, { status: 400 })
+  if (!isMarket(market)) return NextResponse.json({ error: 'market 잘못됨' }, { status: 400 })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase as any)
+    .from('investment_favorites')
+    .delete()
+    .eq('user_id', user.id)
+    .eq('ticker', ticker)
+    .eq('market', market)
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ ok: true })
+}

--- a/dental-clinic-manager/src/app/api/investment/ticker-info/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/ticker-info/route.ts
@@ -1,0 +1,165 @@
+/**
+ * 종목 펀더멘털 + 가격 차트 + 시총 순위 통합 조회.
+ *
+ *   GET /api/investment/ticker-info?ticker=AAPL&market=US&range=1mo
+ *   GET /api/investment/ticker-info?ticker=005930&market=KR&range=3mo
+ *
+ * - yahoo-finance2 quoteSummary로 펀더멘털 + 시총 + price
+ * - yahoo-finance2 chart로 가격 시계열
+ * - 시총 순위: usTickerCatalog / krTickerCatalog 정렬 인덱스
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getUSCatalogEntry, topByMarketCap as topUSByMarketCap } from '@/lib/usTickerCatalog'
+import { getKRMarketCapRank } from '@/lib/krTickerCatalog'
+
+export const revalidate = 1800 // 30분 캐시
+
+type Range = '1mo' | '3mo' | '1y'
+
+function parseRange(v: string | null): Range {
+  if (v === '3mo' || v === '1y') return v
+  return '1mo'
+}
+
+function rangeToInterval(range: Range): { period: number; interval: '1d' | '1wk' } {
+  const now = Date.now()
+  const day = 24 * 60 * 60 * 1000
+  switch (range) {
+    case '1mo': return { period: now - 35 * day, interval: '1d' }
+    case '3mo': return { period: now - 100 * day, interval: '1d' }
+    case '1y':  return { period: now - 380 * day, interval: '1wk' }
+  }
+}
+
+async function getYahoo() {
+  const YahooFinance = (await import('yahoo-finance2')).default
+  return new YahooFinance()
+}
+
+async function resolveSymbol(yahoo: any, ticker: string, market: 'KR' | 'US'): Promise<string | null> {
+  const t = ticker.toUpperCase().trim()
+  if (!t) return null
+  if (market === 'US') return t
+  for (const suffix of ['.KS', '.KQ']) {
+    try {
+      await yahoo.quoteSummary(t + suffix, { modules: ['price'] })
+      return t + suffix
+    } catch {
+      // 다음 suffix
+    }
+  }
+  return null
+}
+
+let _us_rank: Map<string, number> | null = null
+function getUSMarketCapRank(ticker: string): number | null {
+  if (!_us_rank) {
+    const list = topUSByMarketCap(10000)
+    const m = new Map<string, number>()
+    list.forEach((e, i) => m.set(e.ticker, i + 1))
+    _us_rank = m
+  }
+  return _us_rank.get(ticker.toUpperCase()) ?? null
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const ticker = (searchParams.get('ticker') ?? '').trim()
+  const market = searchParams.get('market') as 'KR' | 'US' | null
+  const range = parseRange(searchParams.get('range'))
+
+  if (!ticker) return NextResponse.json({ error: '종목 코드가 비어있습니다' }, { status: 400 })
+  if (market !== 'KR' && market !== 'US') {
+    return NextResponse.json({ error: '올바르지 않은 시장 코드' }, { status: 400 })
+  }
+
+  const yahoo = await getYahoo()
+  const symbol = await resolveSymbol(yahoo, ticker, market)
+  if (!symbol) {
+    return NextResponse.json({ error: '종목 정보를 찾을 수 없습니다' }, { status: 404 })
+  }
+
+  try {
+    const sum = await yahoo.quoteSummary(symbol, {
+      modules: ['price', 'summaryDetail', 'defaultKeyStatistics', 'financialData'],
+    })
+
+    const price = sum?.price ?? {}
+    const detail = sum?.summaryDetail ?? {}
+    const stats = sum?.defaultKeyStatistics ?? {}
+    const fin = sum?.financialData ?? {}
+
+    const rank = market === 'US'
+      ? getUSMarketCapRank(ticker)
+      : getKRMarketCapRank(ticker)
+
+    const { period, interval } = rangeToInterval(range)
+    let chartPoints: Array<{ date: string; close: number }> = []
+    try {
+      const chart = await yahoo.chart(symbol, {
+        period1: new Date(period),
+        interval,
+      })
+      chartPoints = (chart?.quotes ?? [])
+        .filter((q: any) => q?.date && typeof q?.close === 'number')
+        .map((q: any) => ({
+          date: new Date(q.date).toISOString().slice(0, 10),
+          close: Number(q.close),
+        }))
+    } catch {
+      // 차트 실패해도 본문은 응답
+    }
+
+    const usEntry = market === 'US' ? getUSCatalogEntry(ticker) : null
+    const name = usEntry?.name ?? (price as any)?.shortName ?? (price as any)?.longName ?? ticker
+
+    const body = {
+      ticker: ticker.toUpperCase(),
+      market,
+      name,
+      price: {
+        current: numOrNull((price as any)?.regularMarketPrice),
+        change: numOrNull((price as any)?.regularMarketChange),
+        changePercent: numOrNull((price as any)?.regularMarketChangePercent),
+        volume: numOrNull((price as any)?.regularMarketVolume),
+        currency: (price as any)?.currency ?? (market === 'KR' ? 'KRW' : 'USD'),
+      },
+      range52w: {
+        high: numOrNull((detail as any)?.fiftyTwoWeekHigh),
+        low: numOrNull((detail as any)?.fiftyTwoWeekLow),
+      },
+      marketCap: numOrNull((price as any)?.marketCap ?? (detail as any)?.marketCap),
+      marketCapRank: rank,
+      fundamentals: {
+        per: numOrNull((detail as any)?.trailingPE ?? (stats as any)?.trailingPE),
+        pbr: numOrNull((stats as any)?.priceToBook),
+        roe: numOrNull((fin as any)?.returnOnEquity),
+        eps: numOrNull((stats as any)?.trailingEps ?? (fin as any)?.epsTrailingTwelveMonths),
+        dividendYield: numOrNull((detail as any)?.dividendYield),
+        revenue: numOrNull((fin as any)?.totalRevenue),
+        operatingIncome: numOrNull((fin as any)?.operatingIncome),
+        netIncome: numOrNull((fin as any)?.netIncomeToCommon ?? (stats as any)?.netIncomeToCommon),
+        operatingMargin: numOrNull((fin as any)?.operatingMargins),
+        profitMargin: numOrNull((fin as any)?.profitMargins),
+        debtToEquity: numOrNull((fin as any)?.debtToEquity),
+      },
+      chart: { range, points: chartPoints },
+      asOf: new Date().toISOString(),
+    }
+
+    return NextResponse.json(body, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=1800, stale-while-revalidate=600',
+      },
+    })
+  } catch (err: any) {
+    console.error('[ticker-info] yahoo error:', err?.message)
+    return NextResponse.json({ error: '종목 정보를 가져오지 못했습니다' }, { status: 502 })
+  }
+}
+
+function numOrNull(v: unknown): number | null {
+  if (typeof v !== 'number' || !Number.isFinite(v)) return null
+  return v
+}

--- a/dental-clinic-manager/src/components/Investment/CompareContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/CompareContent.tsx
@@ -16,6 +16,7 @@ import PresetDetailView from '@/components/Investment/PresetDetailView'
 import DateRangePicker from '@/components/Investment/DateRangePicker'
 import StrategyStatsBlock, { type StrategyBacktestStats } from '@/components/Investment/StrategyStatsBlock'
 import RecentTickersButtons from '@/components/Investment/RecentTickersButtons'
+import FavoritesButtons from '@/components/Investment/FavoritesButtons'
 import { useRecentTickers } from '@/hooks/useRecentTickers'
 import type {
   InvestmentStrategy, Market, BacktestMetrics, EquityCurvePoint, BacktestTrade,
@@ -512,6 +513,11 @@ function LiveCompareSection() {
               placeholder="종목 검색 후 선택하면 칩으로 추가됩니다"
             />
             <div className="mt-2">
+              <FavoritesButtons
+                market="ALL"
+                onSelect={(t, name, m) => handleTickerSelect(t, name, m)}
+                excludeKeys={new Set(tickers.map((tk) => `${market}:${tk.ticker}`))}
+              />
               <RecentTickersButtons
                 market="ALL"
                 onSelect={(t, name, m) => handleTickerSelect(t, name, m)}

--- a/dental-clinic-manager/src/components/Investment/DayTradingContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/DayTradingContent.tsx
@@ -14,6 +14,7 @@ import { useState, useMemo } from 'react'
 import { Zap, Play, Loader2, Target, TrendingDown, TrendingUp, AlertCircle, CheckCircle2, X } from 'lucide-react'
 import TickerSearch from '@/components/Investment/TickerSearch'
 import RecentTickersButtons from '@/components/Investment/RecentTickersButtons'
+import FavoritesButtons from '@/components/Investment/FavoritesButtons'
 import { useRecentTickers } from '@/hooks/useRecentTickers'
 import { PRESET_STRATEGIES } from '@/components/Investment/StrategyBuilder/presets'
 import type { Market, BacktestMetrics, BacktestTrade, EquityCurvePoint, PresetStrategy } from '@/types/investment'
@@ -219,6 +220,10 @@ export default function DayTradingContent() {
               </p>
             )}
             <div className="mt-2">
+              <FavoritesButtons
+                market={market}
+                onSelect={(t, name, m) => handleTickerSelect(t, name, m)}
+              />
               <RecentTickersButtons
                 market={market}
                 onSelect={(t, name, m) => handleTickerSelect(t, name, m)}

--- a/dental-clinic-manager/src/components/Investment/FavoritesButtons.tsx
+++ b/dental-clinic-manager/src/components/Investment/FavoritesButtons.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+/**
+ * 즐겨찾기 종목을 버튼으로 노출 — RecentTickersButtons 위에 배치.
+ * 클릭 시 onSelect 호출 (자동 검색/추가는 호출자 책임).
+ */
+
+import { Plus, Star, X } from 'lucide-react'
+import { useFavorites } from '@/hooks/useFavorites'
+import type { Market } from '@/types/investment'
+
+interface Props {
+  /** 'ALL' = KR/US 모두, 'KR' / 'US' = 해당 시장만 */
+  market?: 'KR' | 'US' | 'ALL'
+  /** 클릭 시 호출 — 부모가 폼 입력란에 채움 */
+  onSelect: (ticker: string, name: string, market: Market) => void
+  /** 이미 추가된 항목 키 (`${market}:${ticker}` 형식) — disabled 처리 */
+  excludeKeys?: Set<string>
+  /** 노출 최대 개수 (default 24) */
+  limit?: number
+  /** 작은 버튼 모드 */
+  compact?: boolean
+  /** 라벨 */
+  label?: string
+}
+
+export default function FavoritesButtons({
+  market = 'ALL',
+  onSelect,
+  excludeKeys,
+  limit = 24,
+  compact = false,
+  label = '즐겨찾기',
+}: Props) {
+  const { favorites, loading, remove } = useFavorites()
+
+  const filtered = favorites
+    .filter((f) => market === 'ALL' || f.market === market)
+    .slice(0, limit)
+
+  if (loading && favorites.length === 0) return null
+  if (filtered.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-1.5 items-center">
+      <span className="text-xs text-at-text-weak inline-flex items-center gap-1 mr-1">
+        <Star className="w-3 h-3 text-amber-500" />
+        {label}:
+      </span>
+      {filtered.map((it) => {
+        const key = `${it.market}:${it.ticker}`
+        const already = excludeKeys?.has(key) === true
+        const display = it.tickerName ?? it.ticker
+        return (
+          <span
+            key={key}
+            className={`inline-flex items-center rounded text-xs ${
+              compact
+                ? 'px-1.5 py-0.5 bg-amber-50 text-at-text-secondary border border-amber-200/60'
+                : 'px-2 py-1 bg-amber-50 text-at-text-secondary border border-amber-200/60'
+            } ${already ? 'opacity-40' : ''}`}
+          >
+            <button
+              type="button"
+              onClick={() => { if (!already) onSelect(it.ticker, display, it.market) }}
+              disabled={already}
+              title={`${display} (${it.ticker})${already ? ' · 이미 추가됨' : ''}`}
+              className={`inline-flex items-center gap-1 ${already ? 'cursor-not-allowed' : 'hover:text-at-accent'}`}
+            >
+              <Plus className="w-3 h-3" />
+              <span className={`text-[9px] px-1 rounded font-bold ${it.market === 'KR' ? 'bg-blue-100 text-blue-700' : 'bg-purple-100 text-purple-700'}`}>
+                {it.market}
+              </span>
+              <span className="truncate max-w-[110px]">{display}</span>
+            </button>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); remove(it.ticker, it.market) }}
+              title="즐겨찾기에서 제거"
+              className="ml-1 text-at-text-weak hover:text-rose-500"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </span>
+        )
+      })}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/ScreenerContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/ScreenerContent.tsx
@@ -10,8 +10,10 @@
  * 사용자가 다른 메뉴로 이동해도 진행률이 floating 위젯으로 표시됨.
  */
 
-import { useState, useEffect, useCallback, useMemo, Fragment } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Search, Loader2, AlertCircle, Sparkles, User, X, CheckCircle2, ChevronDown, ChevronRight, Info, Zap } from 'lucide-react'
+import TickerInfoModal from './TickerInfoModal'
+import FavoritesButtons from './FavoritesButtons'
 import { PRESET_STRATEGIES } from '@/components/Investment/StrategyBuilder/presets'
 import PresetDetailView from '@/components/Investment/PresetDetailView'
 import { getUniverse, type UniverseId } from '@/lib/screenerUniverses'
@@ -50,7 +52,7 @@ export default function ScreenerContent() {
   const [realtime, setRealtime] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [detailPresetId, setDetailPresetId] = useState<string | null>(null)
-  const [expandedTickers, setExpandedTickers] = useState<Set<string>>(new Set())
+  const [infoTicker, setInfoTicker] = useState<{ ticker: string; market: 'KR' | 'US'; name: string } | null>(null)
   const [collapsedStrategies, setCollapsedStrategies] = useState<Set<string>>(new Set())
 
   const loadStrategies = useCallback(async () => {
@@ -133,7 +135,6 @@ export default function ScreenerContent() {
     }))
 
     setCollapsedStrategies(new Set())
-    setExpandedTickers(new Set())
 
     try {
       await startScan({
@@ -148,15 +149,6 @@ export default function ScreenerContent() {
     } catch (err) {
       setError(err instanceof Error ? err.message : '스캔 실행 실패')
     }
-  }
-
-  const toggleExpand = (key: string) => {
-    setExpandedTickers(prev => {
-      const next = new Set(prev)
-      if (next.has(key)) next.delete(key)
-      else next.add(key)
-      return next
-    })
   }
 
   const toggleStrategyCollapse = (key: string) => {
@@ -191,6 +183,14 @@ export default function ScreenerContent() {
           여러 전략을 동시에 선택하면 전략별로 분리된 결과를 한 번에 확인할 수 있습니다.
         </p>
       </div>
+
+      {/* 즐겨찾기 종목 바로가기 */}
+      <FavoritesButtons
+        market="ALL"
+        onSelect={(ticker, name, market) => {
+          setInfoTicker({ ticker, market, name })
+        }}
+      />
 
       {/* 1. 전략 선택 */}
       <section className="bg-white rounded-2xl shadow-sm border border-at-border p-5">
@@ -444,7 +444,6 @@ export default function ScreenerContent() {
                           <table className="w-full text-xs">
                             <thead className="bg-at-surface-alt/40 border-t border-at-border/60">
                               <tr>
-                                <th className="px-2 py-2 w-8"></th>
                                 <th className="px-3 py-2 text-left font-medium text-at-text-secondary">시장</th>
                                 <th className="px-3 py-2 text-left font-medium text-at-text-secondary">종목</th>
                                 <th className="px-3 py-2 text-left font-medium text-at-text-secondary">이름</th>
@@ -455,64 +454,30 @@ export default function ScreenerContent() {
                             <tbody>
                               {matches.map(m => {
                                 const rowKey = `${strategyKey}|${m.market}:${m.ticker}`
-                                const expanded = expandedTickers.has(rowKey)
                                 return (
-                                  <Fragment key={rowKey}>
-                                    <tr
-                                      className="border-t border-at-border hover:bg-at-surface-alt cursor-pointer"
-                                      onClick={() => toggleExpand(rowKey)}
-                                    >
-                                      <td className="px-2 py-2 text-at-text-weak">
-                                        {expanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
-                                      </td>
-                                      <td className="px-3 py-2">
-                                        <span className={`text-[10px] px-1.5 py-0.5 rounded font-bold ${
-                                          m.market === 'KR' ? 'bg-blue-100 text-blue-700' : 'bg-purple-100 text-purple-700'
-                                        }`}>
-                                          {m.market === 'KR' ? '국내' : '미국'}
-                                        </span>
-                                      </td>
-                                      <td className="px-3 py-2 font-mono font-semibold text-at-accent">{m.ticker}</td>
-                                      <td className="px-3 py-2 text-at-text">{m.name}</td>
-                                      <td className="px-3 py-2 text-right font-mono">
-                                        {m.market === 'KR' ? `${Math.round(m.price).toLocaleString()}원` : `$${m.price.toFixed(2)}`}
-                                      </td>
-                                      <td className="px-3 py-2 text-at-text-secondary text-[11px]">
-                                        {m.matchedConditions.length === 0 ? '—' :
-                                          m.matchedConditions.length === 1 ? m.matchedConditions[0] :
-                                          `${m.matchedConditions[0]} 외 ${m.matchedConditions.length - 1}건`}
-                                      </td>
-                                    </tr>
-                                    {expanded && (
-                                      <tr className="border-t border-at-border bg-blue-50/30">
-                                        <td colSpan={6} className="p-3">
-                                          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                                            <div className="bg-white rounded-lg border border-at-border p-3">
-                                              <p className="text-xs font-semibold text-at-text mb-1.5">충족 조건</p>
-                                              <ul className="space-y-1">
-                                                {m.matchedConditions.map((c, i) => (
-                                                  <li key={i} className="text-[11px] font-mono bg-at-surface-alt rounded px-2 py-1">{c}</li>
-                                                ))}
-                                              </ul>
-                                            </div>
-                                            <div className="bg-white rounded-lg border border-at-border p-3">
-                                              <p className="text-xs font-semibold text-at-text mb-1.5">지표값</p>
-                                              <div className="flex flex-wrap gap-1">
-                                                {Object.entries(m.indicators).map(([id, val]) => (
-                                                  <span key={id} className="text-[10px] font-mono bg-at-surface-alt rounded px-2 py-1">
-                                                    <span className="text-at-text-secondary">{id}:</span>{' '}
-                                                    {typeof val === 'number'
-                                                      ? val.toFixed(Math.abs(val) >= 100 ? 1 : 2)
-                                                      : Object.entries(val).map(([k, v]) => `${k}=${v.toFixed(2)}`).join(', ')}
-                                                  </span>
-                                                ))}
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </td>
-                                      </tr>
-                                    )}
-                                  </Fragment>
+                                  <tr
+                                    key={rowKey}
+                                    className="border-t border-at-border hover:bg-at-surface-alt cursor-pointer"
+                                    onClick={() => setInfoTicker({ ticker: m.ticker, market: m.market, name: m.name })}
+                                  >
+                                    <td className="px-3 py-2">
+                                      <span className={`text-[10px] px-1.5 py-0.5 rounded font-bold ${
+                                        m.market === 'KR' ? 'bg-blue-100 text-blue-700' : 'bg-purple-100 text-purple-700'
+                                      }`}>
+                                        {m.market === 'KR' ? '국내' : '미국'}
+                                      </span>
+                                    </td>
+                                    <td className="px-3 py-2 font-mono font-semibold text-at-accent">{m.ticker}</td>
+                                    <td className="px-3 py-2 text-at-text">{m.name}</td>
+                                    <td className="px-3 py-2 text-right font-mono">
+                                      {m.market === 'KR' ? `${Math.round(m.price).toLocaleString()}원` : `$${m.price.toFixed(2)}`}
+                                    </td>
+                                    <td className="px-3 py-2 text-at-text-secondary text-[11px]">
+                                      {m.matchedConditions.length === 0 ? '—' :
+                                        m.matchedConditions.length === 1 ? m.matchedConditions[0] :
+                                        `${m.matchedConditions[0]} 외 ${m.matchedConditions.length - 1}건`}
+                                    </td>
+                                  </tr>
                                 )
                               })}
                             </tbody>
@@ -543,7 +508,7 @@ export default function ScreenerContent() {
 
           <div className="mt-3 flex items-center gap-2 text-[11px] text-at-text-weak">
             <Info className="w-3 h-3" />
-            <span>각 종목 행 클릭 시 충족 조건과 지표값 상세 펼침. 전략 헤더 클릭으로 섹션 접기/펼치기.</span>
+            <span>각 종목 행 클릭 시 펀더멘털·차트·충족 조건 상세 모달 오픈. 전략 헤더 클릭으로 섹션 접기/펼치기.</span>
           </div>
         </section>
       )}
@@ -571,6 +536,52 @@ export default function ScreenerContent() {
           </div>
         </div>
       )}
+
+      {/* 종목 상세 모달 */}
+      {infoTicker && (() => {
+        const matchData = job
+          ? Object.entries(job.matchesByStrategy).flatMap(([strategyKey, ms]) =>
+              ms
+                .filter((m) => m.ticker === infoTicker.ticker && m.market === infoTicker.market)
+                .map((m) => ({ ...m, _strategyKey: strategyKey, _strategyName: job.strategyNames[strategyKey] || strategyKey })),
+            )
+          : []
+        const match = matchData[0]
+        return (
+          <TickerInfoModal
+            ticker={infoTicker.ticker}
+            market={infoTicker.market}
+            tickerName={infoTicker.name}
+            onClose={() => setInfoTicker(null)}
+            extra={match ? (
+              <div className="bg-blue-50/30 border border-blue-200/60 rounded-lg p-3 space-y-2">
+                <p className="text-xs font-semibold text-at-text">스크리너 매치 ({match._strategyName})</p>
+                <div>
+                  <p className="text-[11px] text-at-text-weak mb-1">충족 조건</p>
+                  <ul className="space-y-0.5">
+                    {match.matchedConditions.map((c: string, i: number) => (
+                      <li key={i} className="text-[11px] font-mono bg-white rounded px-2 py-1">{c}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <p className="text-[11px] text-at-text-weak mb-1">지표값</p>
+                  <div className="flex flex-wrap gap-1">
+                    {Object.entries(match.indicators).map(([id, val]) => (
+                      <span key={id} className="text-[10px] font-mono bg-white border border-at-border rounded px-2 py-1">
+                        <span className="text-at-text-secondary">{id}:</span>{' '}
+                        {typeof val === 'number'
+                          ? val.toFixed(Math.abs(val) >= 100 ? 1 : 2)
+                          : Object.entries(val as Record<string, number>).map(([k, v]) => `${k}=${(v as number).toFixed(2)}`).join(', ')}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ) : null}
+          />
+        )
+      })()}
     </div>
   )
 }

--- a/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lucide-react'
 import TickerSearch from '@/components/Investment/TickerSearch'
 import RecentTickersButtons from '@/components/Investment/RecentTickersButtons'
+import FavoritesButtons from '@/components/Investment/FavoritesButtons'
 import { useRecentTickers } from '@/hooks/useRecentTickers'
 import { SignalPanel } from './SignalPanel'
 import { AlertSettingsModal } from './AlertSettingsModal'
@@ -348,6 +349,10 @@ export function SmartMoneyContent() {
           </button>
         </div>
         <div className="mt-2">
+          <FavoritesButtons
+            market="ALL"
+            onSelect={(t, name, m) => handleSelectTicker(t, name, m)}
+          />
           <RecentTickersButtons
             market="ALL"
             onSelect={(t, name, m) => handleSelectTicker(t, name, m)}

--- a/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
@@ -8,6 +8,7 @@ import {
 } from 'lucide-react'
 import TickerSearch from './TickerSearch'
 import RecentTickersButtons from './RecentTickersButtons'
+import FavoritesButtons from './FavoritesButtons'
 import StrategyStatsBlock, { type StrategyBacktestStats } from './StrategyStatsBlock'
 import { useRecentTickers } from '@/hooks/useRecentTickers'
 import type { InvestmentStrategy, Market } from '@/types/investment'
@@ -253,6 +254,11 @@ export default function StrategyCard({ strategy, hasCredential, onRefresh, onBac
                 className="w-full sm:flex-1"
               />
             </div>
+            <FavoritesButtons
+              market={addingMarket}
+              onSelect={(t, name, m) => addTicker(t, name, m)}
+              excludeKeys={new Set(watchlist.map((w) => `${w.market}:${w.ticker}`))}
+            />
             <RecentTickersButtons
               market={addingMarket}
               onSelect={(t, name, m) => addTicker(t, name, m)}

--- a/dental-clinic-manager/src/components/Investment/TickerInfoModal.tsx
+++ b/dental-clinic-manager/src/components/Investment/TickerInfoModal.tsx
@@ -1,0 +1,326 @@
+'use client'
+
+/**
+ * 종목 상세 모달 — 펀더멘털 + 시총 순위 + 가격 차트 + 즐겨찾기 토글.
+ * 호출자: ScreenerContent (행 클릭), 추후 다른 페이지에서도 재사용 가능.
+ */
+
+import { useEffect, useState } from 'react'
+import { Star, X, BarChart3, ExternalLink, Loader2 } from 'lucide-react'
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+import { useFavorites } from '@/hooks/useFavorites'
+import type { Market } from '@/types/investment'
+
+type Range = '1mo' | '3mo' | '1y'
+
+interface ApiResponse {
+  ticker: string
+  market: Market
+  name: string
+  price: {
+    current: number | null
+    change: number | null
+    changePercent: number | null
+    volume: number | null
+    currency: string
+  }
+  range52w: { high: number | null; low: number | null }
+  marketCap: number | null
+  marketCapRank: number | null
+  fundamentals: {
+    per: number | null
+    pbr: number | null
+    roe: number | null
+    eps: number | null
+    dividendYield: number | null
+    revenue: number | null
+    operatingIncome: number | null
+    netIncome: number | null
+    operatingMargin: number | null
+    profitMargin: number | null
+    debtToEquity: number | null
+  }
+  chart: { range: Range; points: Array<{ date: string; close: number }> }
+  asOf: string
+}
+
+interface Props {
+  ticker: string
+  market: Market
+  tickerName?: string
+  onClose: () => void
+  onAnalyze?: (ticker: string, market: Market) => void
+  extra?: React.ReactNode
+}
+
+export default function TickerInfoModal({ ticker, market, tickerName, onClose, onAnalyze, extra }: Props) {
+  const [range, setRange] = useState<Range>('1mo')
+  const [data, setData] = useState<ApiResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const { isFavorite, add, remove } = useFavorites()
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    const url = `/api/investment/ticker-info?ticker=${encodeURIComponent(ticker)}&market=${market}&range=${range}`
+    fetch(url)
+      .then(async (r) => {
+        if (!r.ok) {
+          const j = await r.json().catch(() => ({}))
+          throw new Error(j?.error ?? `HTTP ${r.status}`)
+        }
+        return r.json() as Promise<ApiResponse>
+      })
+      .then((d) => { if (!cancelled) setData(d) })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          const msg = e instanceof Error ? e.message : '오류'
+          setError(msg)
+        }
+      })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [ticker, market, range])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const fav = isFavorite(ticker, market)
+  const displayName = data?.name ?? tickerName ?? ticker
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center p-4 sm:p-6 overflow-y-auto bg-black/50 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-3xl bg-at-surface rounded-2xl shadow-2xl border border-at-border my-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-3 px-5 py-3 border-b border-at-border">
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="font-mono font-bold text-at-text">{ticker}</span>
+            <span className="text-at-text-secondary truncate">{displayName}</span>
+            <span className={`text-[10px] px-1.5 py-0.5 rounded font-bold ${market === 'KR' ? 'bg-blue-100 text-blue-700' : 'bg-purple-100 text-purple-700'}`}>
+              {market === 'KR' ? '국내' : '미국'}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => fav ? remove(ticker, market) : add(ticker, market, displayName)}
+              className={`inline-flex items-center gap-1 text-xs px-2 py-1 rounded border ${fav ? 'bg-amber-50 border-amber-300 text-amber-700' : 'bg-white border-at-border text-at-text-secondary hover:text-amber-600'}`}
+              title={fav ? '즐겨찾기에서 제거' : '즐겨찾기에 추가'}
+            >
+              <Star className={`w-3.5 h-3.5 ${fav ? 'fill-amber-400 text-amber-500' : ''}`} />
+              {fav ? '즐겨찾기됨' : '즐겨찾기'}
+            </button>
+            <button onClick={onClose} className="text-at-text-weak hover:text-at-text">
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+
+        <div className="p-5 space-y-4">
+          {loading && (
+            <div className="flex items-center gap-2 text-at-text-secondary text-sm">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              종목 정보를 불러오는 중...
+            </div>
+          )}
+          {error && !loading && (
+            <div className="text-rose-600 text-sm bg-rose-50 border border-rose-200 rounded-lg px-3 py-2">
+              {error}
+            </div>
+          )}
+
+          {data && !loading && (
+            <>
+              <PriceCard data={data} />
+              <FundamentalGrid data={data} />
+              <ChartBlock data={data} range={range} setRange={setRange} />
+            </>
+          )}
+
+          {extra}
+        </div>
+
+        <div className="px-5 py-3 border-t border-at-border flex items-center justify-end gap-2">
+          {onAnalyze && (
+            <button
+              type="button"
+              onClick={() => onAnalyze(ticker, market)}
+              className="text-xs px-3 py-1.5 rounded border border-at-border text-at-text hover:bg-at-surface-alt inline-flex items-center gap-1"
+            >
+              <BarChart3 className="w-3.5 h-3.5" />
+              스마트머니 분석
+            </button>
+          )}
+          <a
+            href={market === 'KR'
+              ? `https://finance.yahoo.com/quote/${ticker}.KS`
+              : `https://finance.yahoo.com/quote/${ticker}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs px-3 py-1.5 rounded border border-at-border text-at-text-secondary hover:bg-at-surface-alt inline-flex items-center gap-1"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            yahoo
+          </a>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-xs px-3 py-1.5 rounded bg-at-accent text-white hover:opacity-90"
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function PriceCard({ data }: { data: ApiResponse }) {
+  const c = data.price.current
+  const chg = data.price.change ?? 0
+  const chgPct = data.price.changePercent ?? 0
+  const positive = chg >= 0
+  const color = positive ? 'text-rose-600' : 'text-blue-600'
+  return (
+    <div className="bg-at-surface-alt/40 rounded-xl p-4 grid grid-cols-1 md:grid-cols-3 gap-3">
+      <div>
+        <p className="text-[11px] text-at-text-weak">현재가</p>
+        <p className="text-2xl font-bold text-at-text font-mono">
+          {c == null ? '—' : data.market === 'KR'
+            ? `${Math.round(c).toLocaleString()}원`
+            : `$${c.toFixed(2)}`}
+        </p>
+        <p className={`text-xs ${color} font-mono`}>
+          {chg == null ? '' : `${positive ? '+' : ''}${chg.toFixed(2)} (${positive ? '+' : ''}${(chgPct).toFixed(2)}%)`}
+        </p>
+      </div>
+      <div className="text-xs space-y-1">
+        <Row k="52주 최고" v={fmtPrice(data.range52w.high, data.market)} />
+        <Row k="52주 최저" v={fmtPrice(data.range52w.low, data.market)} />
+        <Row k="거래량" v={data.price.volume == null ? '—' : data.price.volume.toLocaleString()} />
+      </div>
+      <div className="text-xs space-y-1">
+        <Row k="시가총액" v={fmtMarketCap(data.marketCap, data.market)} />
+        <Row k="시총 순위" v={data.marketCapRank == null ? '—' : `${data.market === 'KR' ? 'KR' : 'US'} #${data.marketCapRank}`} />
+      </div>
+    </div>
+  )
+}
+
+function FundamentalGrid({ data }: { data: ApiResponse }) {
+  const f = data.fundamentals
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+      <Cell k="PER" v={fmtNum(f.per, 1)} />
+      <Cell k="PBR" v={fmtNum(f.pbr, 2)} />
+      <Cell k="ROE" v={fmtPct(f.roe, 1)} />
+      <Cell k="영업이익률" v={fmtPct(f.operatingMargin, 1)} />
+      <Cell k="순이익률" v={fmtPct(f.profitMargin, 1)} />
+      <Cell k="EPS" v={fmtNum(f.eps, 2)} />
+      <Cell k="배당수익률" v={fmtPct(f.dividendYield, 2)} />
+      <Cell k="부채비율" v={fmtNum(f.debtToEquity, 2)} />
+      <Cell k="매출" v={fmtBigMoney(f.revenue, data.market)} />
+      <Cell k="영업이익" v={fmtBigMoney(f.operatingIncome, data.market)} />
+      <Cell k="순이익" v={fmtBigMoney(f.netIncome, data.market)} />
+      <Cell k="기준일" v={data.asOf.slice(0, 10)} />
+    </div>
+  )
+}
+
+function ChartBlock({ data, range, setRange }: { data: ApiResponse; range: Range; setRange: (r: Range) => void }) {
+  const points = data.chart.points
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs font-semibold text-at-text">최근 주가 흐름</p>
+        <div className="inline-flex rounded border border-at-border overflow-hidden text-[11px]">
+          {(['1mo', '3mo', '1y'] as Range[]).map((r) => (
+            <button
+              key={r}
+              type="button"
+              onClick={() => setRange(r)}
+              className={`px-2 py-0.5 ${range === r ? 'bg-at-accent text-white' : 'bg-white text-at-text-secondary hover:bg-at-surface-alt'}`}
+            >
+              {r === '1mo' ? '1개월' : r === '3mo' ? '3개월' : '1년'}
+            </button>
+          ))}
+        </div>
+      </div>
+      {points.length === 0 ? (
+        <div className="text-xs text-at-text-weak bg-at-surface-alt/40 rounded-lg px-3 py-6 text-center">
+          차트 데이터가 없습니다.
+        </div>
+      ) : (
+        <div className="h-48">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={points}>
+              <XAxis dataKey="date" hide />
+              <YAxis domain={['dataMin', 'dataMax']} hide />
+              <Tooltip
+                formatter={(v: unknown) => [
+                  data.market === 'KR'
+                    ? `${Math.round(v as number).toLocaleString()}원`
+                    : `$${(v as number).toFixed(2)}`,
+                  '종가',
+                ]}
+                labelFormatter={(l: unknown) => String(l)}
+              />
+              <Line type="monotone" dataKey="close" stroke="#2563eb" strokeWidth={2} dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Row({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="flex justify-between gap-2"><span className="text-at-text-weak">{k}</span><span className="font-mono">{v}</span></div>
+  )
+}
+function Cell({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="bg-white border border-at-border rounded px-2 py-1.5">
+      <p className="text-[10px] text-at-text-weak">{k}</p>
+      <p className="text-sm font-semibold font-mono text-at-text">{v}</p>
+    </div>
+  )
+}
+function fmtNum(v: number | null, digits = 2): string {
+  if (v == null) return '—'
+  return v.toFixed(digits)
+}
+function fmtPct(v: number | null, digits = 2): string {
+  if (v == null) return '—'
+  return `${(v * 100).toFixed(digits)}%`
+}
+function fmtPrice(v: number | null, market: Market): string {
+  if (v == null) return '—'
+  return market === 'KR' ? `${Math.round(v).toLocaleString()}원` : `$${v.toFixed(2)}`
+}
+function fmtMarketCap(v: number | null, market: Market): string {
+  if (v == null) return '—'
+  if (market === 'KR') {
+    if (v >= 1e12) return `${(v / 1e12).toFixed(2)}조원`
+    if (v >= 1e8) return `${(v / 1e8).toFixed(0)}억원`
+    return v.toLocaleString()
+  }
+  if (v >= 1e12) return `$${(v / 1e12).toFixed(2)}T`
+  if (v >= 1e9) return `$${(v / 1e9).toFixed(2)}B`
+  if (v >= 1e6) return `$${(v / 1e6).toFixed(2)}M`
+  return `$${v.toLocaleString()}`
+}
+function fmtBigMoney(v: number | null, market: Market): string {
+  return fmtMarketCap(v, market)
+}

--- a/dental-clinic-manager/src/hooks/useFavorites.ts
+++ b/dental-clinic-manager/src/hooks/useFavorites.ts
@@ -1,0 +1,142 @@
+'use client'
+
+/**
+ * 사용자 즐겨찾기 종목 — 서버(Supabase)에 영속.
+ * 5개 페이지(전략관리/단타/전략비교/스크리너/스마트머니)와 TickerInfoModal에서 공통 사용.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { Market } from '@/types/investment'
+
+export interface Favorite {
+  ticker: string
+  market: Market
+  tickerName: string | null
+  createdAt: string
+}
+
+const BROADCAST_CHANNEL = 'dcm-favorites-v1'
+
+interface ListResponse {
+  items?: Favorite[]
+  error?: string
+}
+
+export function useFavorites(): {
+  favorites: Favorite[]
+  loading: boolean
+  error: string | null
+  add: (ticker: string, market: Market, tickerName?: string | null) => Promise<void>
+  remove: (ticker: string, market: Market) => Promise<void>
+  isFavorite: (ticker: string, market: Market) => boolean
+  refresh: () => Promise<void>
+} {
+  const [favorites, setFavorites] = useState<Favorite[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+  const channelRef = useRef<BroadcastChannel | null>(null)
+
+  const refresh = useCallback(async () => {
+    try {
+      setError(null)
+      const res = await fetch('/api/investment/favorites', { cache: 'no-store' })
+      if (!res.ok) {
+        if (res.status === 401) {
+          setFavorites([])
+          return
+        }
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j?.error ?? 'fetch failed')
+      }
+      const data: ListResponse = await res.json()
+      setFavorites(data.items ?? [])
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : '오류'
+      setError(msg)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+    if (typeof window === 'undefined' || typeof BroadcastChannel === 'undefined') return
+    const ch = new BroadcastChannel(BROADCAST_CHANNEL)
+    channelRef.current = ch
+    ch.onmessage = (ev) => {
+      if (ev?.data === 'changed') refresh()
+    }
+    return () => {
+      ch.close()
+      channelRef.current = null
+    }
+  }, [refresh])
+
+  const broadcast = useCallback(() => {
+    try {
+      channelRef.current?.postMessage('changed')
+    } catch { /* noop */ }
+  }, [])
+
+  const add = useCallback(async (ticker: string, market: Market, tickerName?: string | null) => {
+    const t = (ticker ?? '').trim().toUpperCase()
+    if (!t || (market !== 'KR' && market !== 'US')) return
+    const already = favorites.some((f) => f.ticker === t && f.market === market)
+    if (already) return
+    const optimistic: Favorite = {
+      ticker: t,
+      market,
+      tickerName: tickerName ?? t,
+      createdAt: new Date().toISOString(),
+    }
+    setFavorites((prev) => [optimistic, ...prev])
+    try {
+      const res = await fetch('/api/investment/favorites', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ticker: t, market, ticker_name: tickerName ?? null }),
+      })
+      if (!res.ok) {
+        setFavorites((prev) => prev.filter((f) => !(f.ticker === t && f.market === market)))
+        const j = await res.json().catch(() => ({}))
+        setError(j?.error ?? '저장 실패')
+        return
+      }
+      broadcast()
+    } catch (e: unknown) {
+      setFavorites((prev) => prev.filter((f) => !(f.ticker === t && f.market === market)))
+      const msg = e instanceof Error ? e.message : '저장 실패'
+      setError(msg)
+    }
+  }, [favorites, broadcast])
+
+  const remove = useCallback(async (ticker: string, market: Market) => {
+    const t = (ticker ?? '').trim().toUpperCase()
+    if (!t || (market !== 'KR' && market !== 'US')) return
+    const before = favorites
+    setFavorites((prev) => prev.filter((f) => !(f.ticker === t && f.market === market)))
+    try {
+      const res = await fetch(`/api/investment/favorites?ticker=${encodeURIComponent(t)}&market=${market}`, {
+        method: 'DELETE',
+      })
+      if (!res.ok) {
+        setFavorites(before)
+        const j = await res.json().catch(() => ({}))
+        setError(j?.error ?? '삭제 실패')
+        return
+      }
+      broadcast()
+    } catch (e: unknown) {
+      setFavorites(before)
+      const msg = e instanceof Error ? e.message : '삭제 실패'
+      setError(msg)
+    }
+  }, [favorites, broadcast])
+
+  const isFavorite = useCallback((ticker: string, market: Market) => {
+    const t = (ticker ?? '').trim().toUpperCase()
+    return favorites.some((f) => f.ticker === t && f.market === market)
+  }, [favorites])
+
+  return { favorites, loading, error, add, remove, isFavorite, refresh }
+}

--- a/dental-clinic-manager/src/lib/krTickerCatalog.ts
+++ b/dental-clinic-manager/src/lib/krTickerCatalog.ts
@@ -17,6 +17,13 @@ export interface KRMarketCapEntry {
 
 const ALL: KRMarketCapEntry[] = catalog as KRMarketCapEntry[]
 
+/** ticker → entry 직접 조회 (eager) — usTickerCatalog의 BY_TICKER와 동일 패턴 */
+const BY_TICKER: Map<string, KRMarketCapEntry> = (() => {
+  const m = new Map<string, KRMarketCapEntry>()
+  for (const e of ALL) m.set(e.ticker, e)
+  return m
+})()
+
 /** marketCap > 0 인 종목만 시총 내림차순 정렬한 인덱스 */
 let _ranked: KRMarketCapEntry[] | null = null
 function rankedList(): KRMarketCapEntry[] {
@@ -44,7 +51,9 @@ export function getKRMarketCapRank(ticker: string): number | null {
 
 /** 시총 (없으면 null) */
 export function getKRMarketCap(ticker: string): number | null {
-  const e = ALL.find((x) => x.ticker === ticker)
+  const t = (ticker ?? '').trim()
+  if (!t) return null
+  const e = BY_TICKER.get(t)
   if (!e || e.marketCap <= 0) return null
   return e.marketCap
 }

--- a/dental-clinic-manager/src/lib/krTickerCatalog.ts
+++ b/dental-clinic-manager/src/lib/krTickerCatalog.ts
@@ -1,0 +1,60 @@
+/**
+ * KR 종목 시가총액 정적 카탈로그.
+ *
+ * 데이터: src/data/kr-tickers-marketcap.json (scripts/fetch-kr-marketcap.mjs 산출물)
+ *
+ * 갱신: yahoo-finance2 시총은 변동이 크지 않아 분기별 1회 정도 수동 실행 권장.
+ */
+
+import catalog from '@/data/kr-tickers-marketcap.json'
+
+export interface KRMarketCapEntry {
+  ticker: string
+  name: string
+  market: 'KR'
+  marketCap: number
+}
+
+const ALL: KRMarketCapEntry[] = catalog as KRMarketCapEntry[]
+
+/** marketCap > 0 인 종목만 시총 내림차순 정렬한 인덱스 */
+let _ranked: KRMarketCapEntry[] | null = null
+function rankedList(): KRMarketCapEntry[] {
+  if (_ranked) return _ranked
+  _ranked = ALL.filter((e) => e.marketCap > 0)
+    .sort((a, b) => b.marketCap - a.marketCap)
+  return _ranked
+}
+
+let _rankByTicker: Map<string, number> | null = null
+function rankIndex(): Map<string, number> {
+  if (_rankByTicker) return _rankByTicker
+  const m = new Map<string, number>()
+  rankedList().forEach((e, i) => m.set(e.ticker, i + 1))
+  _rankByTicker = m
+  return m
+}
+
+/** 1-based 시가총액 순위 (없으면 null) */
+export function getKRMarketCapRank(ticker: string): number | null {
+  const t = (ticker ?? '').trim()
+  if (!t) return null
+  return rankIndex().get(t) ?? null
+}
+
+/** 시총 (없으면 null) */
+export function getKRMarketCap(ticker: string): number | null {
+  const e = ALL.find((x) => x.ticker === ticker)
+  if (!e || e.marketCap <= 0) return null
+  return e.marketCap
+}
+
+/** 카탈로그 전체 크기 */
+export function getKRCatalogSize(): number {
+  return ALL.length
+}
+
+/** 시총 상위 N개 (스크리너 universe 등 용도) */
+export function topKRByMarketCap(n: number): KRMarketCapEntry[] {
+  return rankedList().slice(0, Math.max(0, n))
+}


### PR DESCRIPTION
## Summary

- **권한 관리**: 신규 기능 권한 자동 노출 + 정합성 검증 스크립트
  - PermissionSelector가 기존 직원 권한 로딩 시 신규 기능 권한 자동 보충 (월간 성과 보고서/소개환자 관리 등 사전 체크됨)
  - `npm run check:permissions` + prebuild 결합 → 메뉴/권한 누락 시 빌드 실패
  - CLAUDE.md에 신규 기능 권한 등록 가이드 추가
- **투자 즐겨찾기**: 종목 즐겨찾기 시스템 (서버 영속 + BroadcastChannel 동기화)
  - 전략 관리 / 단타 / 비교 / 스마트머니 / 스크리너 전체에 즐겨찾기 빠른 추가 버튼
  - TickerInfoModal: 펀더멘털 + 시총 순위 + 차트
- **카탈로그**: KR 시총 카탈로그 헬퍼 + krTickerCatalog BY_TICKER 인덱스

## Test plan

- [x] `npm run build` 통과 (prebuild의 check:permissions 통과 포함)
- [x] develop 단계 검증 완료
- [ ] main 머지 후 Vercel 프로덕션 배포 확인
- [ ] 직원 권한 관리 모달에서 신규 기능 그룹 사전 체크 확인
- [ ] 투자 메뉴 즐겨찾기 추가/삭제 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)