### PR TITLE
refactor(permissions): 유료 기능 기본 권한을 대표원장 전용으로 한정

### DIFF
--- a/dental-clinic-manager/src/components/Investment/ScreenerContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/ScreenerContent.tsx
@@ -17,11 +17,24 @@ import FavoritesButtons from './FavoritesButtons'
 import { PRESET_STRATEGIES } from '@/components/Investment/StrategyBuilder/presets'
 import PresetDetailView from '@/components/Investment/PresetDetailView'
 import { getUniverse, type UniverseId } from '@/lib/screenerUniverses'
+import { topByMarketCap as topUSByMarketCap } from '@/lib/usTickerCatalog'
+import { getKRMarketCapRank } from '@/lib/krTickerCatalog'
 import { useScanner, type StrategyPayload } from '@/contexts/ScannerContext'
 import type { InvestmentStrategy, ConditionGroup, IndicatorConfig } from '@/types/investment'
 
 const DAYTRADING_PRESET_IDS = new Set(['day-vwap-bounce', 'day-orb-breakout', 'day-closing-pressure'])
 const MAX_STRATEGIES = 10
+
+// 시총 순위 조회 — US는 lazy 인덱스 빌드, KR은 모듈 캐시 사용
+let _usRankIndex: Map<string, number> | null = null
+function getMarketCapRank(ticker: string, market: 'KR' | 'US'): number | null {
+  if (market === 'KR') return getKRMarketCapRank(ticker)
+  if (!_usRankIndex) {
+    const list = topUSByMarketCap(10000)
+    _usRankIndex = new Map(list.map((e, i) => [e.ticker, i + 1]))
+  }
+  return _usRankIndex.get((ticker ?? '').toUpperCase()) ?? null
+}
 
 interface SelectableItem {
   key: string  // 'user:<id>' or 'preset:<id>'
@@ -408,7 +421,15 @@ export default function ScreenerContent() {
 
           <div className="space-y-4">
             {job.strategyKeys.map(strategyKey => {
-              const matches = job.matchesByStrategy[strategyKey] || []
+              const rawMatches = job.matchesByStrategy[strategyKey] || []
+              // 시총 순위 오름차순 정렬 (rank null은 뒤로)
+              const matches = rawMatches
+                .map((m) => ({ ...m, _rank: getMarketCapRank(m.ticker, m.market) }))
+                .sort((a, b) => {
+                  const ra = a._rank ?? Number.POSITIVE_INFINITY
+                  const rb = b._rank ?? Number.POSITIVE_INFINITY
+                  return ra - rb
+                })
               const failed = job.failedByStrategy[strategyKey] || []
               const strategyName = job.strategyNames[strategyKey] || strategyKey
               const isCollapsed = collapsedStrategies.has(strategyKey)
@@ -444,6 +465,7 @@ export default function ScreenerContent() {
                           <table className="w-full text-xs">
                             <thead className="bg-at-surface-alt/40 border-t border-at-border/60">
                               <tr>
+                                <th className="px-3 py-2 text-left font-medium text-at-text-secondary w-16">시총 순위</th>
                                 <th className="px-3 py-2 text-left font-medium text-at-text-secondary">시장</th>
                                 <th className="px-3 py-2 text-left font-medium text-at-text-secondary">종목</th>
                                 <th className="px-3 py-2 text-left font-medium text-at-text-secondary">이름</th>
@@ -460,6 +482,9 @@ export default function ScreenerContent() {
                                     className="border-t border-at-border hover:bg-at-surface-alt cursor-pointer"
                                     onClick={() => setInfoTicker({ ticker: m.ticker, market: m.market, name: m.name })}
                                   >
+                                    <td className="px-3 py-2 font-mono text-at-text-secondary">
+                                      {m._rank == null ? '—' : `#${m._rank}`}
+                                    </td>
                                     <td className="px-3 py-2">
                                       <span className={`text-[10px] px-1.5 py-0.5 rounded font-bold ${
                                         m.market === 'KR' ? 'bg-blue-100 text-blue-700' : 'bg-purple-100 text-purple-700'

--- a/dental-clinic-manager/src/types/permissions.ts
+++ b/dental-clinic-manager/src/types/permissions.ts
@@ -158,6 +158,7 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
   ],
   vice_director: [
     // 부원장은 직원 관리와 병원 설정, 프로토콜 삭제 제외한 모든 권한
+    // 유료 기능(리콜/AI/경영현황/월간보고서/소개환자/마케팅/투자)은 기본 제외 — 대표원장만 보유
     'daily_report_view', 'daily_report_create', 'daily_report_edit', 'daily_report_delete',
     'stats_weekly_view', 'stats_monthly_view', 'stats_annual_view',
     'logs_view', 'inventory_view', 'inventory_manage',
@@ -188,22 +189,11 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     // 병원 게시판 (조회/관리)
     'bulletin_view', 'bulletin_manage',
     // 커뮤니티 (조회/작성)
-    'community_view', 'community_post',
-    // 리콜 관리 (조회/관리)
-    'recall_view', 'recall_manage',
-    // AI 데이터 분석 (조회)
-    'ai_analysis_view',
-    // 경영 현황 (조회)
-    'financial_view',
-    // 마케팅 자동화 (조회)
-    'marketing_view',
-    // 월간 성과 보고서 (조회)
-    'monthly_report_view',
-    // 소개환자 관리 (모든 권한)
-    'referral_view', 'referral_manage', 'referral_sms_send', 'referral_points_adjust'
+    'community_view', 'community_post'
   ],
   manager: [
     // 실장은 프로토콜 조회와 히스토리, 1차 승인만 가능
+    // 유료 기능(리콜/AI/경영현황/월간보고서/소개환자/마케팅/투자)은 기본 제외 — 대표원장만 보유
     'daily_report_view', 'daily_report_create', 'daily_report_edit', 'daily_report_delete',
     'stats_weekly_view', 'stats_monthly_view', 'stats_annual_view',
     'logs_view', 'inventory_view', 'inventory_manage',
@@ -231,18 +221,11 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     // 병원 게시판 (조회/관리)
     'bulletin_view', 'bulletin_manage',
     // 커뮤니티 (조회/작성)
-    'community_view', 'community_post',
-    // 리콜 관리 (조회/관리)
-    'recall_view', 'recall_manage',
-    // 경영 현황 (조회)
-    'financial_view',
-    // 월간 성과 보고서 (조회)
-    'monthly_report_view',
-    // 소개환자 관리 (모든 권한)
-    'referral_view', 'referral_manage', 'referral_sms_send', 'referral_points_adjust'
+    'community_view', 'community_post'
   ],
   team_leader: [
     // 팀장은 프로토콜 조회와 히스토리만 가능, 자신의 계약서 조회 및 서명만 가능
+    // 유료 기능(리콜/AI/경영현황/월간보고서/소개환자/마케팅/투자)은 기본 제외 — 대표원장만 보유
     'daily_report_view', 'daily_report_create', 'daily_report_edit',
     'stats_weekly_view', 'stats_monthly_view',
     'logs_view', 'inventory_view', 'guide_view',
@@ -268,12 +251,11 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     // 병원 게시판 (조회)
     'bulletin_view',
     // 커뮤니티 (조회/작성)
-    'community_view', 'community_post',
-    // 리콜 관리 (조회)
-    'recall_view'
+    'community_view', 'community_post'
   ],
   staff: [
     // 일반 직원은 프로토콜 조회, 본인 출퇴근, 본인 연차만 가능
+    // 유료 기능(리콜/AI/경영현황/월간보고서/소개환자/마케팅/투자)은 기본 제외 — 대표원장만 보유
     'daily_report_view', 'daily_report_create',
     'stats_weekly_view',
     'inventory_view', 'guide_view',
@@ -299,9 +281,7 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     // 병원 게시판 (조회)
     'bulletin_view',
     // 커뮤니티 (조회/작성)
-    'community_view', 'community_post',
-    // 리콜 관리 (조회)
-    'recall_view'
+    'community_view', 'community_post'
   ]
 }
 


### PR DESCRIPTION
## Summary

- 유료 기능(리콜/AI 데이터 분석/경영 현황/월간 성과 보고서/소개환자/마케팅 자동화/주식 자동매매) 기본 권한을 owner만 보유하도록 제한
- 부원장/실장/팀장/직원 기본값에서 해당 권한 제거 → 대표원장이 권한 관리에서 직급별/개별로 위임
- 기존 커스텀 권한이 저장된 직원에는 영향 없음 (DEFAULT_PERMISSIONS만 변경)
- 추가: 스크리너 결과 표에 시총 순위 컬럼/정렬 기능

## Test plan

- [x] `npm run build` + `npm run check:permissions` 통과
- [ ] main 머지 후 신규 가입 직원이 기본 권한으로 승인될 때 유료 메뉴가 보이지 않는지 확인
- [ ] 대표원장 권한 모달에서 유료 기능 권한 위임 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)