### PR TITLE
feat: 종목 모달·즐겨찾기·KR PER fix·스크리너 히스토리·AI 분석/추천·비교 모달

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/screener-recommend/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/screener-recommend/route.ts
@@ -1,0 +1,189 @@
+/**
+ * 스크리너 결과 상위 3개 추천 (전략별).
+ *
+ *   POST /api/investment/screener-recommend
+ *   body: { strategyKey, strategyName, market, matches: [{ticker, market, name, price, matchedConditions, indicators }] }
+ *
+ * 정량 1차 후보 선정 (시총 순위 + 매치 조건 수) → Claude haiku가 상위 3개 + 이유 작성.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import Anthropic from '@anthropic-ai/sdk'
+import { topByMarketCap as topUSByMarketCap } from '@/lib/usTickerCatalog'
+import { getKRMarketCapRank } from '@/lib/krTickerCatalog'
+
+export const runtime = 'nodejs'
+export const maxDuration = 30
+
+const MODEL_ID = 'claude-haiku-4-5-20251001'
+const MAX_CANDIDATES = 10
+
+interface MatchInput {
+  ticker: string
+  market: 'KR' | 'US'
+  name: string
+  price: number
+  matchedConditions: string[]
+  indicators: Record<string, unknown>
+}
+
+interface RecommendBody {
+  strategyKey: string
+  strategyName: string
+  matches: MatchInput[]
+}
+
+interface Recommendation {
+  ticker: string
+  market: 'KR' | 'US'
+  name: string
+  score: number
+  reasoning: string
+}
+
+interface RecommendResponse {
+  strategyKey: string
+  strategyName: string
+  criteria: string  // 평가 기준 설명
+  rankings: Recommendation[]
+}
+
+let _usRankIndex: Map<string, number> | null = null
+function getMarketCapRank(ticker: string, market: 'KR' | 'US'): number | null {
+  if (market === 'KR') return getKRMarketCapRank(ticker)
+  if (!_usRankIndex) {
+    const list = topUSByMarketCap(10000)
+    _usRankIndex = new Map(list.map((e, i) => [e.ticker, i + 1]))
+  }
+  return _usRankIndex.get(ticker.toUpperCase()) ?? null
+}
+
+let anthropicClient: Anthropic | null = null
+function getAnthropic(): Anthropic {
+  if (!anthropicClient) {
+    const apiKey = process.env.ANTHROPIC_API_KEY
+    if (!apiKey) throw new Error('ANTHROPIC_API_KEY 미설정')
+    anthropicClient = new Anthropic({ apiKey })
+  }
+  return anthropicClient
+}
+
+export async function POST(req: NextRequest) {
+  let body: RecommendBody
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: '본문 파싱 실패' }, { status: 400 })
+  }
+
+  if (!body.strategyKey || !Array.isArray(body.matches) || body.matches.length === 0) {
+    return NextResponse.json({ error: '유효한 매치 데이터가 필요합니다' }, { status: 400 })
+  }
+
+  // 1. 정량 후보 선정 — 시총 순위(낮음=대형주) + 매칭 조건 수 기준 점수
+  const scored = body.matches.map((m) => {
+    const rank = getMarketCapRank(m.ticker, m.market) ?? 9999
+    // 시총 순위가 낮을수록(대형주일수록) 안정성 가산. 0~1 정규화: rank=1 → 1.0, rank=1000 → 0.0 근사.
+    const sizeScore = Math.max(0, 1 - rank / 1000)
+    // 매칭 조건이 많을수록 신호 강도 가산
+    const conditionScore = Math.min(1, m.matchedConditions.length / 5)
+    const score = sizeScore * 0.6 + conditionScore * 0.4
+    return { ...m, _rank: rank, _score: score }
+  })
+  scored.sort((a, b) => b._score - a._score)
+  const candidates = scored.slice(0, MAX_CANDIDATES)
+
+  if (candidates.length === 0) {
+    return NextResponse.json({ error: '추천 가능한 후보가 없습니다' }, { status: 400 })
+  }
+
+  // 2. Claude에게 상위 3개 + 이유 요청
+  const anthropic = getAnthropic()
+  const candidateLines = candidates.map((c, i) => {
+    const conds = c.matchedConditions.slice(0, 3).join(', ') + (c.matchedConditions.length > 3 ? ` 외 ${c.matchedConditions.length - 3}` : '')
+    const indKeys = Object.keys(c.indicators).slice(0, 5).map((k) => {
+      const v = c.indicators[k]
+      if (typeof v === 'number') return `${k}=${v.toFixed(2)}`
+      return `${k}=${JSON.stringify(v).slice(0, 30)}`
+    }).join(', ')
+    const rankStr = c._rank < 9999 ? `${c.market} 시총 #${c._rank}` : '시총 미상'
+    return `${i + 1}. ${c.ticker} (${c.name}, ${rankStr}) — 충족조건: ${conds}; 지표: ${indKeys}`
+  }).join('\n')
+
+  // 후보의 시장 분포 — 우세한 시장으로 표시
+  const krCount = candidates.filter((c) => c.market === 'KR').length
+  const dominantMarket = krCount > candidates.length / 2 ? '한국' : krCount === 0 ? '미국' : '한국+미국 혼합'
+
+  const prompt = `다음은 "${body.strategyName}" 전략에 부합한 ${dominantMarket} 종목 후보 ${candidates.length}개입니다. 이 중 향후 6-12개월 동안 가장 큰 수익률이 기대되는 상위 3개를 골라주세요.
+
+## 후보 종목
+${candidateLines}
+
+## 평가 기준 (반드시 출력에 명시)
+- 시가총액 안정성 (대형주 우선)
+- 충족된 매수 조건의 강도/개수
+- 전략 의도와의 부합도 (전략명·매치 조건 기반 추론)
+- 산업/섹터 환경 (종목명에서 추정 가능한 범위)
+
+## 출력 형식 (JSON only, 코드 블록 없이, 쌍따옴표 사용)
+{
+  "criteria": "어떤 기준으로 골랐는지 1-2문장",
+  "rankings": [
+    { "ticker": "...", "name": "...", "score": 8.5, "reasoning": "이 종목을 선택한 이유 3-5문장. 매치 조건과 전략 의도를 연결지어 설명." },
+    { "ticker": "...", "name": "...", "score": 7.8, "reasoning": "..." },
+    { "ticker": "...", "name": "...", "score": 7.2, "reasoning": "..." }
+  ]
+}
+
+규칙:
+- 정확히 3개 선정 (후보가 3개 미만이면 그만큼만)
+- score는 0-10점 (10이 가장 유망)
+- reasoning은 단정 대신 "~로 보입니다" 톤
+- 매수/매도 추천이나 목표가/손절가 명시 금지
+- 영어 약자는 한국어 풀이로 (예: "주가수익비율(PER)")`
+
+  let parsed: { criteria: string; rankings: Array<{ ticker: string; name?: string; score?: number; reasoning?: string }> }
+  try {
+    const res = await anthropic.messages.create({
+      model: MODEL_ID,
+      max_tokens: 2000,
+      messages: [{ role: 'user', content: prompt }],
+    })
+    const text = res.content
+      .filter((b) => b.type === 'text')
+      .map((b) => (b as { text: string }).text)
+      .join('\n')
+      .trim()
+    const start = text.indexOf('{')
+    const end = text.lastIndexOf('}')
+    if (start < 0 || end < 0) throw new Error('LLM 응답에서 JSON을 찾지 못함')
+    parsed = JSON.parse(text.slice(start, end + 1))
+  } catch (err) {
+    console.error('[screener-recommend] LLM 실패:', err instanceof Error ? err.message : err)
+    return NextResponse.json({ error: '추천 생성 실패' }, { status: 502 })
+  }
+
+  // ticker로 후보 매칭 (LLM이 ticker를 정확히 출력해야 함)
+  const candByTicker = new Map(candidates.map((c) => [c.ticker.toUpperCase(), c]))
+  const rankings: Recommendation[] = []
+  for (const r of parsed.rankings ?? []) {
+    const cand = candByTicker.get((r.ticker || '').toUpperCase())
+    if (!cand) continue
+    rankings.push({
+      ticker: cand.ticker,
+      market: cand.market,
+      name: cand.name,
+      score: typeof r.score === 'number' ? r.score : 0,
+      reasoning: typeof r.reasoning === 'string' ? r.reasoning : '',
+    })
+  }
+
+  const body_out: RecommendResponse = {
+    strategyKey: body.strategyKey,
+    strategyName: body.strategyName,
+    criteria: typeof parsed.criteria === 'string' ? parsed.criteria : '',
+    rankings: rankings.slice(0, 3),
+  }
+
+  return NextResponse.json(body_out)
+}

--- a/dental-clinic-manager/src/app/api/investment/screener-runs/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/screener-runs/route.ts
@@ -1,0 +1,159 @@
+/**
+ * 종목 스크리너 실행 히스토리 CRUD.
+ *
+ *   GET    /api/investment/screener-runs              → 목록 (직전 100개)
+ *   GET    /api/investment/screener-runs?id=...       → 단건
+ *   POST   /api/investment/screener-runs              → 저장
+ *   DELETE /api/investment/screener-runs?id=...       → 삭제
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+
+interface MatchEntry {
+  ticker: string
+  market: 'KR' | 'US'
+  name: string
+  price: number
+  asOfDate: string
+  matchedConditions: string[]
+  indicators: Record<string, unknown>
+}
+
+interface FailedEntry {
+  ticker: string
+  market: 'KR' | 'US'
+  reason: string
+}
+
+interface RunBody {
+  started_at?: string
+  finished_at?: string
+  status?: 'completed' | 'cancelled' | 'error'
+  as_of_date: string
+  universe: string
+  universe_label?: string | null
+  realtime?: boolean
+  total_tickers?: number
+  total_matches?: number
+  strategy_keys: string[]
+  strategy_names: Record<string, string>
+  matches_by_strategy: Record<string, MatchEntry[]>
+  failed_by_strategy: Record<string, FailedEntry[]>
+  error_message?: string | null
+}
+
+const LIST_LIMIT = 100
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 필요' }, { status: auth.status || 401 })
+  }
+  const { searchParams } = new URL(req.url)
+  const id = searchParams.get('id')
+  const supabase = await createClient()
+
+  if (id) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (supabase as any)
+      .from('screener_runs')
+      .select('*')
+      .eq('id', id)
+      .single()
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return NextResponse.json({ error: '존재하지 않습니다' }, { status: 404 })
+      }
+      console.error('[screener-runs] GET single error:', error)
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+    return NextResponse.json({ item: data })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase as any)
+    .from('screener_runs')
+    .select('id, started_at, finished_at, status, as_of_date, universe, universe_label, realtime, total_tickers, total_matches, strategy_keys, strategy_names')
+    .order('started_at', { ascending: false })
+    .limit(LIST_LIMIT)
+
+  if (error) {
+    console.error('[screener-runs] GET list error:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ items: data ?? [] })
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 필요' }, { status: auth.status || 401 })
+  }
+
+  let body: RunBody
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: '본문 파싱 실패' }, { status: 400 })
+  }
+
+  if (!body.as_of_date || !body.universe || !Array.isArray(body.strategy_keys)) {
+    return NextResponse.json({ error: '필수 필드 누락 (as_of_date / universe / strategy_keys)' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase as any)
+    .from('screener_runs')
+    .insert({
+      user_id: auth.user.id,
+      started_at: body.started_at ?? new Date().toISOString(),
+      finished_at: body.finished_at ?? new Date().toISOString(),
+      status: body.status ?? 'completed',
+      as_of_date: body.as_of_date,
+      universe: body.universe,
+      universe_label: body.universe_label ?? null,
+      realtime: body.realtime ?? false,
+      total_tickers: body.total_tickers ?? 0,
+      total_matches: body.total_matches ?? 0,
+      strategy_keys: body.strategy_keys,
+      strategy_names: body.strategy_names ?? {},
+      matches_by_strategy: body.matches_by_strategy ?? {},
+      failed_by_strategy: body.failed_by_strategy ?? {},
+      error_message: body.error_message ?? null,
+    })
+    .select('id')
+    .single()
+
+  if (error) {
+    console.error('[screener-runs] POST error:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ ok: true, id: data.id })
+}
+
+export async function DELETE(req: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 필요' }, { status: auth.status || 401 })
+  }
+  const { searchParams } = new URL(req.url)
+  const id = searchParams.get('id')
+  if (!id) return NextResponse.json({ error: 'id 누락' }, { status: 400 })
+
+  const supabase = await createClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase as any)
+    .from('screener_runs')
+    .delete()
+    .eq('id', id)
+    .eq('user_id', auth.user.id)
+
+  if (error) {
+    console.error('[screener-runs] DELETE error:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ ok: true })
+}

--- a/dental-clinic-manager/src/app/api/investment/ticker-analysis/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/ticker-analysis/route.ts
@@ -1,0 +1,242 @@
+/**
+ * 종목 회사 분석 — yahoo (정량) + Claude (서술) 결합.
+ *
+ *   GET /api/investment/ticker-analysis?ticker=AAPL&market=US
+ *
+ * 응답: 회사 소개, 매출/EPS 컨센서스 (올해/내년/내후년), 향후 전망 + 위험 요소.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import Anthropic from '@anthropic-ai/sdk'
+
+export const revalidate = 86400 // 24시간 캐시
+const MODEL_ID = 'claude-haiku-4-5-20251001'
+
+interface AnalysisResponse {
+  ticker: string
+  market: 'KR' | 'US'
+  name: string
+  description: string | null
+  sector: string | null
+  industry: string | null
+  earnings: {
+    label: string  // "올해", "내년", "내후년"
+    revenueAvg: number | null
+    earningsAvg: number | null
+    growth: number | null  // YoY 성장률 (소수)
+  }[]
+  outlook: string  // 향후 전망 (3-5문장)
+  risks: string[]  // 위험 요소 (3-5개)
+  asOf: string
+}
+
+interface ProfileSummary {
+  name: string
+  sector: string | null
+  industry: string | null
+  longBusinessSummary: string | null
+  marketCap: number | null
+  trailingPE: number | null
+  forwardPE: number | null
+  profitMargin: number | null
+  revenue: number | null
+  earningsTrend: Array<{
+    period: string  // 0q/+1q/0y/+1y
+    revenueAvg: number | null
+    earningsAvg: number | null
+    revenueGrowth: number | null
+    earningsGrowth: number | null
+  }>
+  recommendationKey: string | null
+}
+
+async function fetchProfile(symbol: string): Promise<ProfileSummary | null> {
+  const YahooFinance = (await import('yahoo-finance2')).default
+  const yahoo = new YahooFinance()
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sum: any = await yahoo.quoteSummary(symbol, {
+      modules: ['assetProfile', 'price', 'summaryProfile', 'summaryDetail', 'defaultKeyStatistics', 'financialData', 'earningsTrend', 'recommendationTrend'],
+    })
+    const profile = sum?.assetProfile ?? sum?.summaryProfile ?? {}
+    const price = sum?.price ?? {}
+    const detail = sum?.summaryDetail ?? {}
+    const stats = sum?.defaultKeyStatistics ?? {}
+    const fin = sum?.financialData ?? {}
+    const trends = sum?.earningsTrend?.trend ?? []
+    const recs = sum?.recommendationTrend?.trend ?? []
+
+    return {
+      name: price?.shortName ?? price?.longName ?? '',
+      sector: profile?.sector ?? null,
+      industry: profile?.industry ?? null,
+      longBusinessSummary: profile?.longBusinessSummary ?? null,
+      marketCap: typeof price?.marketCap === 'number' ? price.marketCap : (typeof detail?.marketCap === 'number' ? detail.marketCap : null),
+      trailingPE: typeof detail?.trailingPE === 'number' ? detail.trailingPE : null,
+      forwardPE: typeof stats?.forwardPE === 'number' ? stats.forwardPE : null,
+      profitMargin: typeof fin?.profitMargins === 'number' ? fin.profitMargins : null,
+      revenue: typeof fin?.totalRevenue === 'number' ? fin.totalRevenue : null,
+      earningsTrend: trends.map((t: any) => ({
+        period: t?.period ?? '',
+        revenueAvg: typeof t?.revenueEstimate?.avg === 'number' ? t.revenueEstimate.avg : null,
+        earningsAvg: typeof t?.earningsEstimate?.avg === 'number' ? t.earningsEstimate.avg : null,
+        revenueGrowth: typeof t?.revenueEstimate?.growth === 'number' ? t.revenueEstimate.growth : null,
+        earningsGrowth: typeof t?.earningsEstimate?.growth === 'number' ? t.earningsEstimate.growth : null,
+      })),
+      recommendationKey: recs?.[0]?.toString() ?? null,
+    }
+  } catch (err) {
+    console.error('[ticker-analysis] yahoo profile error:', err instanceof Error ? err.message : err)
+    return null
+  }
+}
+
+async function resolveSymbol(ticker: string, market: 'KR' | 'US'): Promise<string | null> {
+  const t = ticker.toUpperCase().trim()
+  if (!t) return null
+  if (market === 'US') return t
+  const YahooFinance = (await import('yahoo-finance2')).default
+  const yahoo = new YahooFinance()
+  for (const suffix of ['.KS', '.KQ']) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (yahoo.quoteSummary as any)(t + suffix, { modules: ['price'] })
+      return t + suffix
+    } catch {
+      // try next
+    }
+  }
+  return null
+}
+
+let anthropicClient: Anthropic | null = null
+function getAnthropic(): Anthropic {
+  if (!anthropicClient) {
+    const apiKey = process.env.ANTHROPIC_API_KEY
+    if (!apiKey) throw new Error('ANTHROPIC_API_KEY 미설정')
+    anthropicClient = new Anthropic({ apiKey })
+  }
+  return anthropicClient
+}
+
+interface LLMResult {
+  description: string
+  outlook: string
+  risks: string[]
+}
+
+async function generateAnalysis(profile: ProfileSummary, ticker: string, market: 'KR' | 'US'): Promise<LLMResult> {
+  const anthropic = getAnthropic()
+  const prompt = `다음은 ${market === 'KR' ? '한국' : '미국'} 상장 종목 ${ticker} (${profile.name})의 정량 데이터입니다. 이를 바탕으로 한국어로 분석해주세요.
+
+## 정량 데이터
+- 섹터/산업: ${profile.sector ?? '미상'} / ${profile.industry ?? '미상'}
+- 시가총액: ${profile.marketCap ? `$${(profile.marketCap / 1e9).toFixed(1)}B` : '미상'}
+- 주가수익비율(PER): trailing ${profile.trailingPE?.toFixed(1) ?? '미상'}, forward ${profile.forwardPE?.toFixed(1) ?? '미상'}
+- 순이익률: ${profile.profitMargin ? (profile.profitMargin * 100).toFixed(1) + '%' : '미상'}
+- 연 매출: ${profile.revenue ? `$${(profile.revenue / 1e9).toFixed(1)}B` : '미상'}
+- 애널리스트 컨센서스 (period: revenueAvg / earningsGrowth):
+${profile.earningsTrend.map(t => `  · ${t.period}: 매출 ${t.revenueAvg ? '$' + (t.revenueAvg / 1e9).toFixed(1) + 'B' : '미상'}, EPS 성장률 ${t.earningsGrowth != null ? (t.earningsGrowth * 100).toFixed(1) + '%' : '미상'}`).join('\n')}
+- 회사 사업 요약(영문): ${profile.longBusinessSummary?.slice(0, 500) ?? '미상'}
+
+## 출력 형식 (JSON only, 코드 블록 없이)
+{
+  "description": "이 회사가 무엇을 하는지 한국어로 2-3문장. 주요 사업 부문과 경쟁력 위주.",
+  "outlook": "향후 1-3년 전망을 4-6문장. 매출/이익 성장률, 산업 트렌드, 경쟁 환경, 컨센서스 평가.",
+  "risks": ["위험 요소 1", "위험 요소 2", "위험 요소 3", "위험 요소 4"]
+}
+
+규칙:
+- description, outlook은 단정 대신 "~로 보입니다", "~할 것으로 예상됩니다" 톤
+- 매수/매도 추천이나 목표가 명시 금지
+- risks는 4-5개, 각 1-2문장
+- 영어 약어는 한국어로 풀어쓰고 괄호 표기 (예: "주가수익비율(PER)")`
+
+  const res = await anthropic.messages.create({
+    model: MODEL_ID,
+    max_tokens: 1500,
+    messages: [{ role: 'user', content: prompt }],
+  })
+
+  const text = res.content
+    .filter((b) => b.type === 'text')
+    .map((b) => (b as { text: string }).text)
+    .join('\n')
+    .trim()
+
+  // JSON 파싱 (모델이 ```json 감쌀 가능성 대비)
+  const jsonStart = text.indexOf('{')
+  const jsonEnd = text.lastIndexOf('}')
+  if (jsonStart < 0 || jsonEnd < 0) throw new Error('LLM 응답에서 JSON을 찾지 못함')
+  const parsed = JSON.parse(text.slice(jsonStart, jsonEnd + 1))
+  return {
+    description: typeof parsed.description === 'string' ? parsed.description : '',
+    outlook: typeof parsed.outlook === 'string' ? parsed.outlook : '',
+    risks: Array.isArray(parsed.risks) ? parsed.risks.filter((r: unknown) => typeof r === 'string') : [],
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const ticker = (searchParams.get('ticker') ?? '').trim()
+  const market = searchParams.get('market') as 'KR' | 'US' | null
+  if (!ticker) return NextResponse.json({ error: '종목 코드가 비어있습니다' }, { status: 400 })
+  if (market !== 'KR' && market !== 'US') {
+    return NextResponse.json({ error: '올바르지 않은 시장 코드' }, { status: 400 })
+  }
+
+  const symbol = await resolveSymbol(ticker, market)
+  if (!symbol) {
+    return NextResponse.json({ error: '종목 정보를 찾을 수 없습니다' }, { status: 404 })
+  }
+
+  const profile = await fetchProfile(symbol)
+  if (!profile) {
+    return NextResponse.json({ error: '종목 프로필을 가져오지 못했습니다' }, { status: 502 })
+  }
+
+  let llm: LLMResult
+  try {
+    llm = await generateAnalysis(profile, ticker, market)
+  } catch (err) {
+    console.error('[ticker-analysis] LLM 실패:', err instanceof Error ? err.message : err)
+    return NextResponse.json({ error: '분석 생성 실패' }, { status: 502 })
+  }
+
+  // earningsTrend의 +1y, +2y, 0y 매핑 (yahoo 기준)
+  const labelMap: Record<string, string> = {
+    '0y': '올해 컨센서스',
+    '+1y': '내년 컨센서스',
+    '+2y': '내후년 컨센서스',
+  }
+  const earnings: AnalysisResponse['earnings'] = []
+  for (const period of ['0y', '+1y', '+2y']) {
+    const t = profile.earningsTrend.find((x) => x.period === period)
+    if (!t) continue
+    earnings.push({
+      label: labelMap[period],
+      revenueAvg: t.revenueAvg,
+      earningsAvg: t.earningsAvg,
+      growth: t.revenueGrowth,
+    })
+  }
+
+  const body: AnalysisResponse = {
+    ticker: ticker.toUpperCase(),
+    market,
+    name: profile.name,
+    description: llm.description,
+    sector: profile.sector,
+    industry: profile.industry,
+    earnings,
+    outlook: llm.outlook,
+    risks: llm.risks,
+    asOf: new Date().toISOString(),
+  }
+
+  return NextResponse.json(body, {
+    headers: {
+      'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=3600',
+    },
+  })
+}

--- a/dental-clinic-manager/src/app/api/investment/ticker-info/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/ticker-info/route.ts
@@ -90,6 +90,41 @@ export async function GET(req: NextRequest) {
     const stats = sum?.defaultKeyStatistics ?? {}
     const fin = sum?.financialData ?? {}
 
+    // KR 종목은 trailingPE/EPS/PBR/operatingIncome이 비어 오는 경우가 많음.
+    // quote() 응답에서 추가 필드 시도 (priceEpsCurrentYear, forwardPE 등 KR에서도 종종 채워짐).
+    const q: any = await yahoo.quote(symbol).catch(() => null)
+    const currentPrice = numOrNull((price as any)?.regularMarketPrice ?? q?.regularMarketPrice)
+
+    // PER fallback: trailing → forward → currentYear EPS 기준
+    const per = numOrNull(
+      (detail as any)?.trailingPE
+        ?? (stats as any)?.trailingPE
+        ?? q?.trailingPE
+        ?? (stats as any)?.forwardPE
+        ?? q?.forwardPE
+        ?? q?.priceEpsCurrentYear,
+    )
+
+    // EPS fallback: trailing → forward → 계산(price/per)
+    let eps = numOrNull(
+      (stats as any)?.trailingEps
+        ?? (fin as any)?.epsTrailingTwelveMonths
+        ?? q?.epsTrailingTwelveMonths
+        ?? q?.epsForward
+        ?? (stats as any)?.forwardEps,
+    )
+    if (eps == null && per != null && currentPrice != null && per > 0) {
+      eps = currentPrice / per
+    }
+
+    // operatingIncome fallback: 직접값 → revenue × operatingMargin 추정
+    const totalRevenue = numOrNull((fin as any)?.totalRevenue)
+    const operatingMargins = numOrNull((fin as any)?.operatingMargins)
+    let operatingIncome = numOrNull((fin as any)?.operatingIncome)
+    if (operatingIncome == null && totalRevenue != null && operatingMargins != null) {
+      operatingIncome = totalRevenue * operatingMargins
+    }
+
     const rank = market === 'US'
       ? getUSMarketCapRank(ticker)
       : getKRMarketCapRank(ticker)
@@ -132,15 +167,15 @@ export async function GET(req: NextRequest) {
       marketCap: numOrNull((price as any)?.marketCap ?? (detail as any)?.marketCap),
       marketCapRank: rank,
       fundamentals: {
-        per: numOrNull((detail as any)?.trailingPE ?? (stats as any)?.trailingPE),
-        pbr: numOrNull((stats as any)?.priceToBook),
+        per,
+        pbr: numOrNull((stats as any)?.priceToBook ?? q?.priceToBook),
         roe: numOrNull((fin as any)?.returnOnEquity),
-        eps: numOrNull((stats as any)?.trailingEps ?? (fin as any)?.epsTrailingTwelveMonths),
-        dividendYield: numOrNull((detail as any)?.dividendYield),
-        revenue: numOrNull((fin as any)?.totalRevenue),
-        operatingIncome: numOrNull((fin as any)?.operatingIncome),
+        eps,
+        dividendYield: numOrNull((detail as any)?.dividendYield ?? q?.trailingAnnualDividendYield),
+        revenue: totalRevenue,
+        operatingIncome,
         netIncome: numOrNull((fin as any)?.netIncomeToCommon ?? (stats as any)?.netIncomeToCommon),
-        operatingMargin: numOrNull((fin as any)?.operatingMargins),
+        operatingMargin: operatingMargins,
         profitMargin: numOrNull((fin as any)?.profitMargins),
         debtToEquity: numOrNull((fin as any)?.debtToEquity),
       },

--- a/dental-clinic-manager/src/components/Investment/CompareContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/CompareContent.tsx
@@ -91,7 +91,6 @@ const METRIC_GLOSSARY: Record<string, { title: string; body: string; formula?: s
 const MAX_COMPARE = 50
 // 다중 종목 비교 상한 (종목 × 전략 = 백테스트 호출 수)
 const MAX_TICKERS = 10
-const MAX_PAIRS = 200
 // 백테스트 동시 호출 수 (서버 부하 분산)
 const COMPARE_CHUNK = 8
 
@@ -283,11 +282,8 @@ function LiveCompareSection() {
   const runCompare = async () => {
     if (selectedIds.size === 0) return setError('비교할 전략을 1개 이상 선택해주세요')
     if (tickers.length === 0) return setError('비교할 종목을 1개 이상 선택해주세요')
-    const totalPairs = selectedIds.size * tickers.length
-    if (totalPairs > MAX_PAIRS) {
-      return setError(`종목 ${tickers.length} × 전략 ${selectedIds.size} = ${totalPairs}회는 너무 많습니다 (최대 ${MAX_PAIRS}회).`)
-    }
 
+    const totalPairs = selectedIds.size * tickers.length
     setRunning(true)
     setError(null)
     setResults([])
@@ -852,45 +848,65 @@ function MatrixView({
         </table>
       </div>
 
-      {/* 활성 셀 상세 */}
+      {/* 활성 셀 상세 — 모달 */}
       {activeResult && !activeResult.error && (
-        <div className="rounded-xl border border-at-accent/40 bg-blue-50/40 p-3">
-          <div className="flex items-center justify-between mb-2 flex-wrap gap-2">
-            <div className="flex items-center gap-2">
-              <span className="text-xs px-2 py-0.5 rounded bg-white border border-at-border font-mono font-semibold">
-                {activeResult.ticker}
-              </span>
-              <span className="text-sm font-semibold text-at-text">{activeResult.strategyName}</span>
+        <div
+          className="fixed inset-0 z-50 flex items-start justify-center p-4 sm:p-6 overflow-y-auto bg-black/50 backdrop-blur-sm"
+          onClick={() => onCellClick(null)}
+        >
+          <div
+            className="relative w-full max-w-5xl bg-at-surface rounded-2xl shadow-2xl border border-at-border my-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between gap-3 px-5 py-3 border-b border-at-border">
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-xs px-2 py-0.5 rounded bg-at-surface-alt border border-at-border font-mono font-semibold">
+                  {activeResult.ticker}
+                </span>
+                <span className="text-sm font-semibold text-at-text truncate">{activeResult.strategyName}</span>
+              </div>
+              <button
+                type="button"
+                onClick={() => onCellClick(null)}
+                className="text-at-text-weak hover:text-at-text"
+                title="닫기"
+              >
+                <X className="w-5 h-5" />
+              </button>
             </div>
-            <button
-              onClick={() => onCellClick(null)}
-              className="text-xs text-at-text-secondary hover:text-at-text inline-flex items-center gap-0.5"
-              type="button"
-            >
-              <X className="w-3 h-3" />닫기
-            </button>
-          </div>
-          <div className="grid grid-cols-3 md:grid-cols-7 gap-2 text-[11px]">
-            <Metric label="수익률" value={`${activeResult.metrics.totalReturn > 0 ? '+' : ''}${activeResult.metrics.totalReturn.toFixed(2)}%`} />
-            <Metric label="B&H" value={`${(activeResult.buyHold?.totalReturn ?? 0) > 0 ? '+' : ''}${(activeResult.buyHold?.totalReturn ?? 0).toFixed(2)}%`} />
-            <Metric label="승률" value={`${activeResult.metrics.winRate.toFixed(1)}%`} />
-            <Metric label="거래" value={`${activeResult.metrics.totalTrades}`} />
-            <Metric label="Sharpe" value={`${activeResult.metrics.sharpeRatio.toFixed(2)}`} />
-            <Metric label="MDD" value={`${activeResult.metrics.maxDrawdown.toFixed(2)}%`} />
-            <Metric label="PF" value={`${activeResult.metrics.profitFactor.toFixed(2)}`} />
-          </div>
-          {activeResult.trades.length > 0 && (
-            <div className="mt-3">
-              <p className="text-[11px] font-semibold text-at-text-secondary mb-1">매매 내역</p>
-              <TradesMiniTable trades={activeResult.trades} />
+            <div className="p-5 space-y-4">
+              <div className="grid grid-cols-3 md:grid-cols-7 gap-2 text-[11px]">
+                <Metric label="수익률" value={`${activeResult.metrics.totalReturn > 0 ? '+' : ''}${activeResult.metrics.totalReturn.toFixed(2)}%`} />
+                <Metric label="B&H" value={`${(activeResult.buyHold?.totalReturn ?? 0) > 0 ? '+' : ''}${(activeResult.buyHold?.totalReturn ?? 0).toFixed(2)}%`} />
+                <Metric label="승률" value={`${activeResult.metrics.winRate.toFixed(1)}%`} />
+                <Metric label="거래" value={`${activeResult.metrics.totalTrades}`} />
+                <Metric label="Sharpe" value={`${activeResult.metrics.sharpeRatio.toFixed(2)}`} />
+                <Metric label="MDD" value={`${activeResult.metrics.maxDrawdown.toFixed(2)}%`} />
+                <Metric label="PF" value={`${activeResult.metrics.profitFactor.toFixed(2)}`} />
+              </div>
+              {activeResult.trades.length > 0 && (
+                <div>
+                  <p className="text-[11px] font-semibold text-at-text-secondary mb-1">매매 내역</p>
+                  <TradesMiniTable trades={activeResult.trades} />
+                </div>
+              )}
             </div>
-          )}
+            <div className="px-5 py-3 border-t border-at-border flex items-center justify-end">
+              <button
+                type="button"
+                onClick={() => onCellClick(null)}
+                className="text-xs px-3 py-1.5 rounded bg-at-accent text-white hover:opacity-90"
+              >
+                닫기
+              </button>
+            </div>
+          </div>
         </div>
       )}
 
       {/* 범례 */}
       <div className="flex items-center justify-between text-[10px] text-at-text-weak">
-        <span>셀 클릭 → 상세 메트릭과 매매내역 펼침</span>
+        <span>셀 클릭 → 상세 메트릭·매매 내역 모달</span>
         <span className="flex items-center gap-2">
           <span className="inline-flex items-center gap-1">
             <span className="w-3 h-3 rounded" style={{ background: 'rgba(59,130,246,0.35)' }} />

--- a/dental-clinic-manager/src/components/Investment/ScreenerContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/ScreenerContent.tsx
@@ -11,9 +11,10 @@
  */
 
 import { useState, useEffect, useCallback, useMemo } from 'react'
-import { Search, Loader2, AlertCircle, Sparkles, User, X, CheckCircle2, ChevronDown, ChevronRight, Info, Zap } from 'lucide-react'
+import { Search, Loader2, AlertCircle, Sparkles, User, X, CheckCircle2, ChevronDown, ChevronRight, Info, Zap, History } from 'lucide-react'
 import TickerInfoModal from './TickerInfoModal'
 import FavoritesButtons from './FavoritesButtons'
+import ScreenerHistoryTab from './ScreenerHistoryTab'
 import { PRESET_STRATEGIES } from '@/components/Investment/StrategyBuilder/presets'
 import PresetDetailView from '@/components/Investment/PresetDetailView'
 import { getUniverse, type UniverseId } from '@/lib/screenerUniverses'
@@ -54,9 +55,12 @@ const UNIVERSE_OPTIONS: { id: UniverseId; label: string; eta: string; desc: stri
   { id: 'ALL', label: '전체 (KR + US)', eta: '~2.5분', desc: '국내 + 미국 약 328개' },
 ]
 
+type ViewMode = 'new' | 'history'
+
 export default function ScreenerContent() {
   const { job, startScan, cancelScan } = useScanner()
 
+  const [viewMode, setViewMode] = useState<ViewMode>('new')
   const [strategies, setStrategies] = useState<InvestmentStrategy[]>([])
   const [loadingStrategies, setLoadingStrategies] = useState(true)
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
@@ -196,6 +200,44 @@ export default function ScreenerContent() {
           여러 전략을 동시에 선택하면 전략별로 분리된 결과를 한 번에 확인할 수 있습니다.
         </p>
       </div>
+
+      {/* 탭 네비게이션 */}
+      <div className="flex items-center gap-1 border-b border-at-border">
+        <button
+          type="button"
+          onClick={() => setViewMode('new')}
+          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
+            viewMode === 'new'
+              ? 'border-purple-500 text-purple-700'
+              : 'border-transparent text-at-text-secondary hover:text-at-text'
+          }`}
+        >
+          <Search className="inline w-4 h-4 mr-1" />
+          새 스캔
+        </button>
+        <button
+          type="button"
+          onClick={() => setViewMode('history')}
+          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
+            viewMode === 'history'
+              ? 'border-purple-500 text-purple-700'
+              : 'border-transparent text-at-text-secondary hover:text-at-text'
+          }`}
+        >
+          <History className="inline w-4 h-4 mr-1" />
+          히스토리
+        </button>
+      </div>
+
+      {viewMode === 'history' && (
+        <ScreenerHistoryTab
+          onSelectTicker={(ticker, market, name) => {
+            setInfoTicker({ ticker, market, name })
+          }}
+        />
+      )}
+
+      {viewMode === 'new' && (<>
 
       {/* 즐겨찾기 종목 바로가기 */}
       <FavoritesButtons
@@ -537,6 +579,8 @@ export default function ScreenerContent() {
           </div>
         </section>
       )}
+
+      </>)}
 
       {/* 상세 모달 */}
       {detailPresetId && (

--- a/dental-clinic-manager/src/components/Investment/ScreenerHistoryTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/ScreenerHistoryTab.tsx
@@ -1,0 +1,243 @@
+'use client'
+
+/**
+ * 스크리너 히스토리 탭 — 사용자가 실행한 screener_runs를 날짜별로 그룹핑해 노출.
+ * 항목 클릭 시 ScreenerResultsView로 결과를 펼쳐 보여줌.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import { Calendar, ChevronDown, ChevronRight, Loader2, Trash2 } from 'lucide-react'
+import ScreenerResultsView, { type ScreenerResultsData } from './ScreenerResultsView'
+import type { Market } from '@/types/investment'
+
+interface RunSummary {
+  id: string
+  started_at: string
+  finished_at: string | null
+  status: 'completed' | 'cancelled' | 'error'
+  as_of_date: string
+  universe: string
+  universe_label: string | null
+  realtime: boolean
+  total_tickers: number
+  total_matches: number
+  strategy_keys: string[]
+  strategy_names: Record<string, string>
+}
+
+interface RunFull extends RunSummary {
+  matches_by_strategy: Record<string, ScreenerResultsData['matchesByStrategy'][string]>
+  failed_by_strategy: Record<string, ScreenerResultsData['failedByStrategy'][string]>
+  error_message: string | null
+}
+
+interface Props {
+  onSelectTicker?: (ticker: string, market: Market, name: string) => void
+}
+
+export default function ScreenerHistoryTab({ onSelectTicker }: Props) {
+  const [runs, setRuns] = useState<RunSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [expandedDate, setExpandedDate] = useState<string | null>(null)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [selectedRun, setSelectedRun] = useState<RunFull | null>(null)
+  const [loadingDetail, setLoadingDetail] = useState(false)
+
+  const refresh = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/investment/screener-runs', { cache: 'no-store' })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j?.error ?? `HTTP ${res.status}`)
+      }
+      const json = await res.json()
+      setRuns(json.items ?? [])
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '히스토리 조회 실패')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { refresh() }, [])
+
+  // 날짜별 그룹핑
+  const groups = useMemo(() => {
+    const map: Record<string, RunSummary[]> = {}
+    for (const r of runs) {
+      const d = new Date(r.started_at)
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+      if (!map[key]) map[key] = []
+      map[key].push(r)
+    }
+    return Object.entries(map).sort((a, b) => (a[0] < b[0] ? 1 : -1))
+  }, [runs])
+
+  // selectedId 변경 시 단건 fetch
+  useEffect(() => {
+    if (!selectedId) {
+      setSelectedRun(null)
+      return
+    }
+    let cancelled = false
+    setLoadingDetail(true)
+    fetch(`/api/investment/screener-runs?id=${encodeURIComponent(selectedId)}`)
+      .then(async (r) => {
+        if (!r.ok) {
+          const j = await r.json().catch(() => ({}))
+          throw new Error(j?.error ?? `HTTP ${r.status}`)
+        }
+        return r.json()
+      })
+      .then((j) => { if (!cancelled) setSelectedRun(j.item ?? null) })
+      .catch((e) => {
+        if (!cancelled) {
+          console.error(e)
+          setSelectedRun(null)
+        }
+      })
+      .finally(() => { if (!cancelled) setLoadingDetail(false) })
+    return () => { cancelled = true }
+  }, [selectedId])
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('이 스크리닝 결과를 삭제하시겠습니까?')) return
+    try {
+      const res = await fetch(`/api/investment/screener-runs?id=${encodeURIComponent(id)}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error('삭제 실패')
+      if (selectedId === id) {
+        setSelectedId(null)
+      }
+      refresh()
+    } catch (e) {
+      alert(e instanceof Error ? e.message : '삭제 실패')
+    }
+  }
+
+  const resultsData: ScreenerResultsData | null = selectedRun ? {
+    asOfDate: selectedRun.as_of_date,
+    universeLabel: selectedRun.universe_label || selectedRun.universe,
+    realtime: selectedRun.realtime,
+    total: selectedRun.total_tickers,
+    processed: selectedRun.total_tickers,
+    strategyKeys: selectedRun.strategy_keys,
+    strategyNames: selectedRun.strategy_names,
+    matchesByStrategy: selectedRun.matches_by_strategy,
+    failedByStrategy: selectedRun.failed_by_strategy,
+  } : null
+
+  return (
+    <div className="space-y-4">
+      {loading && (
+        <div className="flex items-center gap-2 text-at-text-secondary text-sm">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          히스토리 불러오는 중...
+        </div>
+      )}
+      {error && !loading && (
+        <div className="text-rose-600 text-sm bg-rose-50 border border-rose-200 rounded-lg px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && runs.length === 0 && (
+        <div className="text-xs text-at-text-weak text-center py-8 bg-white rounded-2xl border border-at-border">
+          저장된 스크리닝 결과가 없습니다. 새 스캔을 실행하면 자동으로 저장됩니다.
+        </div>
+      )}
+
+      {!loading && !error && runs.length > 0 && (
+        <div className="bg-white rounded-2xl border border-at-border divide-y divide-at-border">
+          {groups.map(([dateKey, items]) => {
+            const isOpen = expandedDate === dateKey
+            const totalMatchSum = items.reduce((s, r) => s + r.total_matches, 0)
+            return (
+              <div key={dateKey}>
+                <button
+                  onClick={() => setExpandedDate(isOpen ? null : dateKey)}
+                  className="w-full flex items-center justify-between px-4 py-3 hover:bg-at-surface-alt"
+                >
+                  <div className="flex items-center gap-2 text-sm">
+                    {isOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                    <Calendar className="w-3.5 h-3.5 text-at-text-weak" />
+                    <span className="font-semibold text-at-text">{dateKey}</span>
+                    <span className="text-xs text-at-text-secondary">{items.length}회 실행</span>
+                  </div>
+                  <span className="text-xs text-at-text-secondary">
+                    누적 매칭 <span className="font-mono font-semibold text-purple-600">{totalMatchSum}</span>건
+                  </span>
+                </button>
+
+                {isOpen && (
+                  <div className="bg-at-surface-alt/30 px-4 py-2 space-y-1">
+                    {items.map((r) => {
+                      const time = new Date(r.started_at).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+                      const isSelected = selectedId === r.id
+                      const strategyDisplay = r.strategy_keys
+                        .map((k) => r.strategy_names[k] || k)
+                        .slice(0, 3)
+                        .join(', ') + (r.strategy_keys.length > 3 ? ` 외 ${r.strategy_keys.length - 3}` : '')
+                      return (
+                        <div
+                          key={r.id}
+                          className={`flex items-center justify-between gap-2 rounded px-3 py-2 text-xs cursor-pointer ${isSelected ? 'bg-blue-100/50 border border-blue-300' : 'hover:bg-white border border-transparent'}`}
+                          onClick={() => setSelectedId(r.id)}
+                        >
+                          <div className="flex items-center gap-2 min-w-0">
+                            <span className="font-mono text-at-text-secondary">{time}</span>
+                            <span className={`text-[10px] px-1.5 py-0.5 rounded font-bold ${
+                              r.status === 'completed' ? 'bg-emerald-100 text-emerald-700'
+                              : r.status === 'cancelled' ? 'bg-amber-100 text-amber-700'
+                              : 'bg-rose-100 text-rose-700'
+                            }`}>
+                              {r.status === 'completed' ? '완료' : r.status === 'cancelled' ? '취소' : '에러'}
+                            </span>
+                            <span className="truncate text-at-text">{strategyDisplay}</span>
+                            <span className="text-at-text-weak">·</span>
+                            <span className="text-at-text-weak">{r.universe_label || r.universe}</span>
+                          </div>
+                          <div className="flex items-center gap-2 shrink-0">
+                            <span className="font-mono font-semibold text-purple-600">{r.total_matches}건</span>
+                            <button
+                              type="button"
+                              onClick={(e) => { e.stopPropagation(); handleDelete(r.id) }}
+                              className="text-at-text-weak hover:text-rose-500 p-0.5"
+                              title="삭제"
+                            >
+                              <Trash2 className="w-3 h-3" />
+                            </button>
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {selectedId && (
+        <div className="space-y-2">
+          {loadingDetail && (
+            <div className="flex items-center gap-2 text-at-text-secondary text-sm">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              결과 불러오는 중...
+            </div>
+          )}
+          {!loadingDetail && resultsData && (
+            <ScreenerResultsView
+              data={resultsData}
+              onSelectTicker={onSelectTicker}
+              headerLabel="📁 저장된 스크리닝 결과"
+            />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/ScreenerResultsView.tsx
+++ b/dental-clinic-manager/src/components/Investment/ScreenerResultsView.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useState } from 'react'
-import { AlertCircle, ChevronDown, ChevronRight, Info, Zap } from 'lucide-react'
+import { AlertCircle, ChevronDown, ChevronRight, Info, Zap, Sparkles, Trophy, Loader2 } from 'lucide-react'
 import { topByMarketCap as topUSByMarketCap } from '@/lib/usTickerCatalog'
 import { getKRMarketCapRank } from '@/lib/krTickerCatalog'
 import type { Market } from '@/types/investment'
@@ -143,6 +143,14 @@ export default function ScreenerResultsView({
 
               {!isCollapsed && (
                 <>
+                  {matches.length >= 3 && (
+                    <RecommendBlock
+                      strategyKey={strategyKey}
+                      strategyName={strategyName}
+                      matches={matches.map(({ _rank, ...rest }) => rest)}
+                      onSelectTicker={onSelectTicker}
+                    />
+                  )}
                   {matches.length === 0 ? (
                     <div className="p-6 text-center">
                       <AlertCircle className="w-6 h-6 mx-auto text-at-text-weak mb-1.5 opacity-60" />
@@ -226,5 +234,130 @@ export default function ScreenerResultsView({
         </div>
       )}
     </section>
+  )
+}
+
+interface RecommendBlockProps {
+  strategyKey: string
+  strategyName: string
+  matches: ScreenerMatch[]
+  onSelectTicker?: (ticker: string, market: Market, name: string) => void
+}
+
+interface RecommendResponse {
+  strategyKey: string
+  strategyName: string
+  criteria: string
+  rankings: Array<{
+    ticker: string
+    market: Market
+    name: string
+    score: number
+    reasoning: string
+  }>
+}
+
+function RecommendBlock({ strategyKey, strategyName, matches, onSelectTicker }: RecommendBlockProps) {
+  const [open, setOpen] = useState(false)
+  const [data, setData] = useState<RecommendResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = async () => {
+    if (data || loading) return
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/investment/screener-recommend', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ strategyKey, strategyName, matches }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j?.error ?? `HTTP ${res.status}`)
+      }
+      const json: RecommendResponse = await res.json()
+      setData(json)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '추천 생성 실패')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="border-t border-at-border bg-gradient-to-br from-amber-50/40 to-purple-50/40 px-4 py-3">
+      <button
+        type="button"
+        onClick={() => { setOpen(!open); if (!open) load() }}
+        className="w-full flex items-center justify-between gap-2 hover:opacity-80"
+      >
+        <div className="flex items-center gap-2">
+          <Trophy className="w-4 h-4 text-amber-600" />
+          <span className="font-semibold text-sm text-at-text">AI 추천 상위 3</span>
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 font-bold">Claude</span>
+        </div>
+        {open ? <ChevronDown className="w-4 h-4 text-at-text-weak" /> : <ChevronRight className="w-4 h-4 text-at-text-weak" />}
+      </button>
+
+      {open && (
+        <div className="mt-3 space-y-2">
+          {loading && (
+            <div className="flex items-center gap-2 text-at-text-secondary text-xs">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              상위 3개 분석 중... (5-8초)
+            </div>
+          )}
+          {error && !loading && (
+            <div className="text-rose-600 text-xs bg-rose-50 border border-rose-200 rounded px-3 py-2">{error}</div>
+          )}
+          {data && !loading && (
+            <>
+              <div className="bg-white border border-at-border rounded px-3 py-2">
+                <p className="text-[11px] font-semibold text-at-text-secondary mb-1 inline-flex items-center gap-1">
+                  <Sparkles className="w-3 h-3 text-purple-600" />
+                  평가 기준
+                </p>
+                <p className="text-xs text-at-text leading-relaxed">{data.criteria}</p>
+              </div>
+              <div className="space-y-2">
+                {data.rankings.map((r, i) => (
+                  <div
+                    key={r.ticker}
+                    className={`bg-white border rounded p-3 ${onSelectTicker ? 'cursor-pointer hover:bg-at-surface-alt' : ''} ${
+                      i === 0 ? 'border-amber-300' : i === 1 ? 'border-zinc-300' : 'border-orange-200'
+                    }`}
+                    onClick={() => onSelectTicker?.(r.ticker, r.market, r.name)}
+                  >
+                    <div className="flex items-center justify-between gap-2 mb-1">
+                      <div className="flex items-center gap-2">
+                        <span className={`text-base font-bold ${i === 0 ? 'text-amber-600' : i === 1 ? 'text-zinc-500' : 'text-orange-500'}`}>
+                          {i === 0 ? '🥇' : i === 1 ? '🥈' : '🥉'}
+                        </span>
+                        <span className="font-mono font-bold text-at-accent">{r.ticker}</span>
+                        <span className="text-xs text-at-text">{r.name}</span>
+                        <span className={`text-[10px] px-1.5 py-0.5 rounded font-bold ${
+                          r.market === 'KR' ? 'bg-blue-100 text-blue-700' : 'bg-purple-100 text-purple-700'
+                        }`}>
+                          {r.market === 'KR' ? '국내' : '미국'}
+                        </span>
+                      </div>
+                      <span className="text-xs font-mono font-semibold text-purple-600">
+                        {r.score.toFixed(1)}/10
+                      </span>
+                    </div>
+                    <p className="text-xs text-at-text-secondary leading-relaxed">{r.reasoning}</p>
+                  </div>
+                ))}
+              </div>
+              <p className="text-[10px] text-at-text-weak">
+                * AI 분석 기반 — 투자 권유 아님. 본인 판단으로 의사결정 하세요.
+              </p>
+            </>
+          )}
+        </div>
+      )}
+    </div>
   )
 }

--- a/dental-clinic-manager/src/components/Investment/ScreenerResultsView.tsx
+++ b/dental-clinic-manager/src/components/Investment/ScreenerResultsView.tsx
@@ -1,0 +1,230 @@
+'use client'
+
+/**
+ * 스크리너 결과 뷰 — 라이브 스캔 결과와 히스토리 단건 조회 뷰에서 공용 사용.
+ *
+ * 시총 순위로 정렬 + 매치 종목 행 클릭 시 onSelectTicker 콜백.
+ */
+
+import { useState } from 'react'
+import { AlertCircle, ChevronDown, ChevronRight, Info, Zap } from 'lucide-react'
+import { topByMarketCap as topUSByMarketCap } from '@/lib/usTickerCatalog'
+import { getKRMarketCapRank } from '@/lib/krTickerCatalog'
+import type { Market } from '@/types/investment'
+
+interface ScreenerMatch {
+  ticker: string
+  market: Market
+  name: string
+  price: number
+  asOfDate: string
+  matchedConditions: string[]
+  indicators: Record<string, unknown>
+}
+
+interface FailedEntry {
+  ticker: string
+  market: Market
+  reason: string
+}
+
+export interface ScreenerResultsData {
+  asOfDate: string
+  universeLabel: string
+  realtime: boolean
+  total: number
+  processed: number
+  strategyKeys: string[]
+  strategyNames: Record<string, string>
+  matchesByStrategy: Record<string, ScreenerMatch[]>
+  failedByStrategy: Record<string, FailedEntry[]>
+}
+
+interface Props {
+  data: ScreenerResultsData
+  onSelectTicker?: (ticker: string, market: Market, name: string) => void
+  /** 헤더 메시지 prefix 변경 (예: '🎯 매수 조건 충족 종목' 기본) */
+  headerLabel?: string
+}
+
+let _usRankIndex: Map<string, number> | null = null
+function getMarketCapRank(ticker: string, market: Market): number | null {
+  if (market === 'KR') return getKRMarketCapRank(ticker)
+  if (!_usRankIndex) {
+    const list = topUSByMarketCap(10000)
+    _usRankIndex = new Map(list.map((e, i) => [e.ticker, i + 1]))
+  }
+  return _usRankIndex.get((ticker ?? '').toUpperCase()) ?? null
+}
+
+export default function ScreenerResultsView({
+  data,
+  onSelectTicker,
+  headerLabel = '🎯 매수 조건 충족 종목',
+}: Props) {
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+
+  const totalMatches = Object.values(data.matchesByStrategy).reduce(
+    (sum, arr) => sum + arr.length,
+    0,
+  )
+
+  const toggle = (key: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  if (data.strategyKeys.length === 0) {
+    return (
+      <div className="text-xs text-at-text-weak text-center py-6">
+        실행된 전략이 없습니다.
+      </div>
+    )
+  }
+
+  return (
+    <section className="bg-white rounded-2xl shadow-sm border border-at-border p-5">
+      <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <h2 className="font-semibold text-at-text">
+          {headerLabel} (전체 {totalMatches}건 / {data.processed}/{data.total} 평가)
+        </h2>
+        <div className="flex items-center gap-2 text-xs text-at-text-secondary">
+          <span>기준일: <span className="font-mono">{data.asOfDate}</span></span>
+          <span>·</span>
+          <span>{data.universeLabel}</span>
+          {data.realtime && (
+            <>
+              <span>·</span>
+              <span className="inline-flex items-center gap-0.5 text-amber-700 font-semibold">
+                <Zap className="w-3 h-3" /> 실시간
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {data.strategyKeys.map((strategyKey) => {
+          const rawMatches = data.matchesByStrategy[strategyKey] || []
+          const matches = rawMatches
+            .map((m) => ({ ...m, _rank: getMarketCapRank(m.ticker, m.market) }))
+            .sort((a, b) => {
+              const ra = a._rank ?? Number.POSITIVE_INFINITY
+              const rb = b._rank ?? Number.POSITIVE_INFINITY
+              return ra - rb
+            })
+          const failed = data.failedByStrategy[strategyKey] || []
+          const strategyName = data.strategyNames[strategyKey] || strategyKey
+          const isCollapsed = collapsed.has(strategyKey)
+
+          return (
+            <div key={strategyKey} className="rounded-xl border border-at-border bg-white">
+              <button
+                onClick={() => toggle(strategyKey)}
+                className="w-full flex items-center justify-between gap-2 px-4 py-2.5 bg-at-surface-alt hover:bg-at-bg rounded-t-xl"
+              >
+                <div className="flex items-center gap-2">
+                  {isCollapsed ? <ChevronRight className="w-4 h-4 text-at-text-weak" /> : <ChevronDown className="w-4 h-4 text-at-text-weak" />}
+                  <span className="font-semibold text-sm text-at-text">{strategyName}</span>
+                  <span className={`text-[10px] px-2 py-0.5 rounded-full font-bold ${
+                    matches.length > 0 ? 'bg-emerald-100 text-emerald-700' : 'bg-at-surface text-at-text-weak'
+                  }`}>
+                    {matches.length}건 충족
+                  </span>
+                </div>
+                {failed.length > 0 && (
+                  <span className="text-[10px] text-at-text-weak">실패 {failed.length}건</span>
+                )}
+              </button>
+
+              {!isCollapsed && (
+                <>
+                  {matches.length === 0 ? (
+                    <div className="p-6 text-center">
+                      <AlertCircle className="w-6 h-6 mx-auto text-at-text-weak mb-1.5 opacity-60" />
+                      <p className="text-xs text-at-text-secondary">충족 종목 없음</p>
+                    </div>
+                  ) : (
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-xs">
+                        <thead className="bg-at-surface-alt/40 border-t border-at-border/60">
+                          <tr>
+                            <th className="px-3 py-2 text-left font-medium text-at-text-secondary w-16">시총 순위</th>
+                            <th className="px-3 py-2 text-left font-medium text-at-text-secondary">시장</th>
+                            <th className="px-3 py-2 text-left font-medium text-at-text-secondary">종목</th>
+                            <th className="px-3 py-2 text-left font-medium text-at-text-secondary">이름</th>
+                            <th className="px-3 py-2 text-right font-medium text-at-text-secondary">기준일 종가</th>
+                            <th className="px-3 py-2 text-left font-medium text-at-text-secondary">충족 조건</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {matches.map((m) => {
+                            const rowKey = `${strategyKey}|${m.market}:${m.ticker}`
+                            return (
+                              <tr
+                                key={rowKey}
+                                className={`border-t border-at-border ${onSelectTicker ? 'hover:bg-at-surface-alt cursor-pointer' : ''}`}
+                                onClick={() => onSelectTicker?.(m.ticker, m.market, m.name)}
+                              >
+                                <td className="px-3 py-2 font-mono text-at-text-secondary">
+                                  {m._rank == null ? '—' : `#${m._rank}`}
+                                </td>
+                                <td className="px-3 py-2">
+                                  <span className={`text-[10px] px-1.5 py-0.5 rounded font-bold ${
+                                    m.market === 'KR' ? 'bg-blue-100 text-blue-700' : 'bg-purple-100 text-purple-700'
+                                  }`}>
+                                    {m.market === 'KR' ? '국내' : '미국'}
+                                  </span>
+                                </td>
+                                <td className="px-3 py-2 font-mono font-semibold text-at-accent">{m.ticker}</td>
+                                <td className="px-3 py-2 text-at-text">{m.name}</td>
+                                <td className="px-3 py-2 text-right font-mono">
+                                  {m.market === 'KR' ? `${Math.round(m.price).toLocaleString()}원` : `$${m.price.toFixed(2)}`}
+                                </td>
+                                <td className="px-3 py-2 text-at-text-secondary text-[11px]">
+                                  {m.matchedConditions.length === 0 ? '—' :
+                                    m.matchedConditions.length === 1 ? m.matchedConditions[0] :
+                                    `${m.matchedConditions[0]} 외 ${m.matchedConditions.length - 1}건`}
+                                </td>
+                              </tr>
+                            )
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+
+                  {failed.length > 0 && (
+                    <div className="px-3 py-2 text-xs text-at-text-weak border-t border-at-border/60">
+                      <details>
+                        <summary className="cursor-pointer hover:text-at-text">
+                          평가 실패 {failed.length}건
+                        </summary>
+                        <ul className="mt-2 space-y-0.5 ml-4">
+                          {failed.slice(0, 10).map((f, i) => (
+                            <li key={i}>[{f.market}] {f.ticker} — {f.reason}</li>
+                          ))}
+                        </ul>
+                      </details>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {onSelectTicker && (
+        <div className="mt-3 flex items-center gap-2 text-[11px] text-at-text-weak">
+          <Info className="w-3 h-3" />
+          <span>각 종목 행 클릭 시 펀더멘털·차트·충족 조건 상세 모달 오픈. 전략 헤더 클릭으로 섹션 접기/펼치기.</span>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/TickerInfoModal.tsx
+++ b/dental-clinic-manager/src/components/Investment/TickerInfoModal.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useEffect, useState } from 'react'
-import { Star, X, BarChart3, ExternalLink, Loader2 } from 'lucide-react'
+import { Star, X, BarChart3, ExternalLink, Loader2, Sparkles, ChevronDown, ChevronRight, AlertTriangle } from 'lucide-react'
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
 import { useFavorites } from '@/hooks/useFavorites'
 import type { Market } from '@/types/investment'
@@ -144,6 +144,7 @@ export default function TickerInfoModal({ ticker, market, tickerName, onClose, o
               <PriceCard data={data} />
               <FundamentalGrid data={data} />
               <ChartBlock data={data} range={range} setRange={setRange} />
+              <AIAnalysisSection ticker={ticker} market={market} />
             </>
           )}
 
@@ -346,4 +347,128 @@ function fmtMarketCap(v: number | null, market: Market): string {
 }
 function fmtBigMoney(v: number | null, market: Market): string {
   return fmtMarketCap(v, market)
+}
+
+interface AnalysisData {
+  ticker: string
+  market: Market
+  name: string
+  description: string | null
+  sector: string | null
+  industry: string | null
+  earnings: { label: string; revenueAvg: number | null; earningsAvg: number | null; growth: number | null }[]
+  outlook: string
+  risks: string[]
+  asOf: string
+}
+
+function AIAnalysisSection({ ticker, market }: { ticker: string; market: Market }) {
+  const [open, setOpen] = useState(false)
+  const [data, setData] = useState<AnalysisData | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = () => {
+    if (data || loading) return
+    setLoading(true)
+    setError(null)
+    fetch(`/api/investment/ticker-analysis?ticker=${encodeURIComponent(ticker)}&market=${market}`)
+      .then(async (r) => {
+        if (!r.ok) {
+          const j = await r.json().catch(() => ({}))
+          throw new Error(j?.error ?? `HTTP ${r.status}`)
+        }
+        return r.json() as Promise<AnalysisData>
+      })
+      .then(setData)
+      .catch((e) => setError(e instanceof Error ? e.message : '분석 실패'))
+      .finally(() => setLoading(false))
+  }
+
+  return (
+    <div className="border border-purple-200 rounded-xl bg-gradient-to-br from-purple-50/40 to-blue-50/40">
+      <button
+        type="button"
+        onClick={() => { setOpen(!open); if (!open) load() }}
+        className="w-full flex items-center justify-between gap-2 px-4 py-2.5 hover:bg-white/40 rounded-t-xl"
+      >
+        <div className="flex items-center gap-2">
+          <Sparkles className="w-4 h-4 text-purple-600" />
+          <span className="font-semibold text-sm text-at-text">AI 회사 분석</span>
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 font-bold">Claude</span>
+        </div>
+        {open ? <ChevronDown className="w-4 h-4 text-at-text-weak" /> : <ChevronRight className="w-4 h-4 text-at-text-weak" />}
+      </button>
+
+      {open && (
+        <div className="px-4 pb-4 space-y-3">
+          {loading && (
+            <div className="flex items-center gap-2 text-at-text-secondary text-xs">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              회사 분석 생성 중... (3-5초 소요)
+            </div>
+          )}
+          {error && !loading && (
+            <div className="text-rose-600 text-xs bg-rose-50 border border-rose-200 rounded px-3 py-2">
+              {error}
+            </div>
+          )}
+          {data && !loading && (
+            <>
+              <div>
+                <p className="text-[11px] font-semibold text-at-text-secondary mb-1">
+                  {data.sector || '미상'} · {data.industry || '미상'}
+                </p>
+                <p className="text-xs text-at-text leading-relaxed">{data.description || '—'}</p>
+              </div>
+
+              {data.earnings.length > 0 && (
+                <div>
+                  <p className="text-[11px] font-semibold text-at-text-secondary mb-1">📊 애널리스트 컨센서스</p>
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+                    {data.earnings.map((e, i) => (
+                      <div key={i} className="bg-white border border-at-border rounded px-2 py-1.5">
+                        <p className="text-[10px] text-at-text-weak">{e.label}</p>
+                        <p className="text-xs font-mono text-at-text">
+                          매출 {fmtBigMoney(e.revenueAvg, market)}
+                        </p>
+                        <p className="text-[10px] font-mono text-at-text-secondary">
+                          {e.growth != null ? `성장률 ${(e.growth * 100).toFixed(1)}%` : '—'}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div>
+                <p className="text-[11px] font-semibold text-at-text-secondary mb-1">🔮 향후 전망</p>
+                <p className="text-xs text-at-text leading-relaxed whitespace-pre-line">{data.outlook}</p>
+              </div>
+
+              {data.risks.length > 0 && (
+                <div>
+                  <p className="text-[11px] font-semibold text-at-text-secondary mb-1 inline-flex items-center gap-1">
+                    <AlertTriangle className="w-3 h-3 text-amber-600" />
+                    위험 요소
+                  </p>
+                  <ul className="space-y-1">
+                    {data.risks.map((r, i) => (
+                      <li key={i} className="text-xs text-at-text bg-white border border-amber-200/60 rounded px-2 py-1.5">
+                        {r}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <p className="text-[10px] text-at-text-weak">
+                * 정량 데이터: yahoo-finance · 서술 분석: Claude · 투자 권유 아님
+              </p>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
 }

--- a/dental-clinic-manager/src/components/Investment/TickerInfoModal.tsx
+++ b/dental-clinic-manager/src/components/Investment/TickerInfoModal.tsx
@@ -217,6 +217,22 @@ function PriceCard({ data }: { data: ApiResponse }) {
   )
 }
 
+// 지표 의미 — 호버 툴팁
+const INDICATOR_HINTS: Record<string, string> = {
+  PER: '주가수익비율 (Price-to-Earnings) — 주가가 EPS의 몇 배인지. 낮을수록 저평가, 업종별 평균과 비교.',
+  PBR: '주가순자산비율 (Price-to-Book) — 주가가 순자산의 몇 배인지. 1 미만이면 청산가치보다 싼 상태.',
+  ROE: '자기자본이익률 (Return on Equity) — 주주 자본 대비 1년간 번 순이익 비율. 15% 이상이면 우수.',
+  영업이익률: '영업이익 ÷ 매출 — 본업 수익성. 산업 평균 대비로 비교.',
+  순이익률: '순이익 ÷ 매출 — 모든 비용·세금 차감 후 최종 마진.',
+  EPS: '주당순이익 (Earnings Per Share) — 1주당 순이익. 추세 상승 = 이익 성장.',
+  배당수익률: '주당 배당금 ÷ 주가 — 배당 투자 수익률. 한국 평균 ~2%.',
+  부채비율: '부채 ÷ 자기자본 (Debt-to-Equity, %로 표기되기도). 200% 이상이면 부채 위험.',
+  매출: '연간 매출액 (Revenue) — 회사 외형 규모.',
+  영업이익: '매출에서 매출원가·판관비를 뺀 본업 이익. 매출 × 영업이익률로 추정될 수 있음.',
+  순이익: '모든 비용·이자·세금 차감 후 남은 최종 이익.',
+  기준일: '데이터 기준 시각 (yahoo 응답 시각).',
+}
+
 function FundamentalGrid({ data }: { data: ApiResponse }) {
   const f = data.fundamentals
   return (
@@ -290,9 +306,16 @@ function Row({ k, v }: { k: string; v: string }) {
   )
 }
 function Cell({ k, v }: { k: string; v: string }) {
+  const hint = INDICATOR_HINTS[k]
   return (
-    <div className="bg-white border border-at-border rounded px-2 py-1.5">
-      <p className="text-[10px] text-at-text-weak">{k}</p>
+    <div
+      className={`bg-white border border-at-border rounded px-2 py-1.5 ${hint ? 'cursor-help' : ''}`}
+      title={hint}
+    >
+      <p className="text-[10px] text-at-text-weak inline-flex items-center gap-1">
+        {k}
+        {hint && <span className="text-at-text-weak/60 text-[9px]">ⓘ</span>}
+      </p>
       <p className="text-sm font-semibold font-mono text-at-text">{v}</p>
     </div>
   )

--- a/dental-clinic-manager/src/contexts/ScannerContext.tsx
+++ b/dental-clinic-manager/src/contexts/ScannerContext.tsx
@@ -14,6 +14,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useRef,
   useState,
 } from 'react'
@@ -149,6 +150,44 @@ export function ScannerProvider({ children }: { children: React.ReactNode }) {
   const [job, setJob] = useState<ScannerJob | null>(null)
   const abortRef = useRef<AbortController | null>(null)
   const cancelledRef = useRef(false)
+  /** 이미 DB에 저장한 job id (중복 저장 방지) */
+  const savedJobIdsRef = useRef<Set<string>>(new Set())
+
+  // job 종료 시 자동으로 screener_runs에 저장
+  useEffect(() => {
+    if (!job) return
+    if (job.status !== 'completed' && job.status !== 'cancelled' && job.status !== 'error') return
+    if (savedJobIdsRef.current.has(job.id)) return
+    savedJobIdsRef.current.add(job.id)
+    const totalMatches = Object.values(job.matchesByStrategy).reduce(
+      (sum, arr) => sum + arr.length,
+      0,
+    )
+    fetch('/api/investment/screener-runs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        started_at: new Date(job.startedAt).toISOString(),
+        finished_at: job.finishedAt ? new Date(job.finishedAt).toISOString() : null,
+        status: job.status,
+        as_of_date: job.asOfDate,
+        universe: job.universe,
+        universe_label: job.universeLabel,
+        realtime: job.realtime,
+        total_tickers: job.total,
+        total_matches: totalMatches,
+        strategy_keys: job.strategyKeys,
+        strategy_names: job.strategyNames,
+        matches_by_strategy: job.matchesByStrategy,
+        failed_by_strategy: job.failedByStrategy,
+        error_message: job.error ?? null,
+      }),
+    }).catch((err) => {
+      console.warn('[ScannerContext] screener_runs 저장 실패:', err)
+      // 실패 시 다시 시도할 수 있도록 set에서 제거
+      savedJobIdsRef.current.delete(job.id)
+    })
+  }, [job])
 
   const startScan = useCallback(async (input: StartScanInput) => {
     // 1. 이전 스캔이 진행 중이면 abort

--- a/dental-clinic-manager/supabase/migrations/20260506_screener_runs.sql
+++ b/dental-clinic-manager/supabase/migrations/20260506_screener_runs.sql
@@ -1,0 +1,45 @@
+-- ============================================
+-- 종목 스크리너 실행 히스토리 (사용자별)
+-- - screener_runs: 사용자가 실행한 스크리닝 결과 영속 저장
+-- Migration: 20260506_screener_runs.sql
+-- Created: 2026-05-06
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS screener_runs (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id             UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  started_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  finished_at         TIMESTAMPTZ,
+  status              VARCHAR(20) NOT NULL DEFAULT 'completed' CHECK (status IN ('completed','cancelled','error')),
+  as_of_date          DATE NOT NULL,
+  universe            VARCHAR(20) NOT NULL,
+  universe_label      TEXT,
+  realtime            BOOLEAN NOT NULL DEFAULT FALSE,
+  total_tickers       INTEGER NOT NULL DEFAULT 0,
+  total_matches       INTEGER NOT NULL DEFAULT 0,
+  strategy_keys       TEXT[] NOT NULL DEFAULT '{}',
+  strategy_names      JSONB NOT NULL DEFAULT '{}'::jsonb,
+  matches_by_strategy JSONB NOT NULL DEFAULT '{}'::jsonb,
+  failed_by_strategy  JSONB NOT NULL DEFAULT '{}'::jsonb,
+  error_message       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_screener_runs_user_started
+  ON screener_runs (user_id, started_at DESC);
+
+ALTER TABLE screener_runs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "screener_runs_select_own" ON screener_runs;
+CREATE POLICY "screener_runs_select_own" ON screener_runs
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "screener_runs_insert_own" ON screener_runs;
+CREATE POLICY "screener_runs_insert_own" ON screener_runs
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "screener_runs_delete_own" ON screener_runs;
+CREATE POLICY "screener_runs_delete_own" ON screener_runs
+  FOR DELETE TO authenticated
+  USING (user_id = auth.uid());


### PR DESCRIPTION
## Summary

- 종목 상세 모달(yahoo 펀더멘털·시총 순위·차트) + 사용자별 즐겨찾기 시스템 (Supabase RLS)
- KR 종목 PER/EPS/영업이익 누락 fallback (forwardPE, EPS=price/PER, 영업이익=매출×영업이익률)
- 스크리너 결과 영구 저장 + 히스토리 탭 (날짜→시간대→결과 drill-down)
- 종목 모달의 AI 회사 분석 (yahoo 정량 + Claude 서술: 사업·컨센서스·전망·위험)
- 전략별 AI 상위 3개 추천 (정량 점수 → Claude 이유 작성)
- 전략 비교: 백테스트 횟수 제한 제거, 매트릭스 셀 클릭 시 모달
- 스크리너 결과 표 시총 순위 컬럼 + 시총 정렬

## Test plan
- [ ] 빌드 통과 (검증됨)
- [ ] /investment 스크리너 실행 후 [히스토리] 탭에서 결과 재조회
- [ ] 결과 행 클릭 → 모달의 [AI 회사 분석] / [AI 추천 상위 3] 펼침 동작
- [ ] 전략 비교 다중 종목 백테스트 — 200회 초과도 실행 가능
- [ ] 매트릭스 셀 클릭 시 모달로 상세 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)