### PR TITLE
feat(hometax): 사업용 신용카드 매입을 매입세액 공제 확인/변경 메뉴(월별)로 전환

### DIFF
--- a/dental-clinic-manager/__tests__/utils/hometax-business-card.test.ts
+++ b/dental-clinic-manager/__tests__/utils/hometax-business-card.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { extractMonthAmount, findMonthRows } from '@/utils/hometaxAmount'
+
+describe('hometaxAmount — 사업용 신용카드 매입세액 공제 확인/변경 (월별)', () => {
+  it('새 워커가 메타데이터 행으로 삽입한 "총 사용금액"을 인식한다', () => {
+    // 새 흐름: 워커가 records[0]에 메타데이터 행을 삽입
+    // (구분: '총 사용금액', 총 사용금액: '1,234,567', 거래년월: '2026-04')
+    const records = [
+      {
+        구분: '총 사용금액',
+        '총 사용금액': '1,234,567',
+        거래년월: '2026-04',
+      },
+    ]
+
+    const amount = extractMonthAmount(records, 2026, 4)
+    expect(amount).toBe(1234567)
+  })
+
+  it('"총 사용금액" 키가 "합계(①+②)" legacy 키보다 우선한다', () => {
+    // 합계(①+②)는 누계 조회의 legacy 필드. 새 흐름은 총 사용금액을 사용
+    const records = [
+      {
+        거래년월: '2026-04',
+        '총 사용금액': '500,000',
+        '합계(①+②)': '999,999',
+      },
+    ]
+
+    const amount = extractMonthAmount(records, 2026, 4)
+    expect(amount).toBe(500000)
+  })
+
+  it('legacy 누계 조회 데이터(합계(①+②))도 호환 처리한다', () => {
+    // 기존 워커가 push한 데이터는 그대로 합산되어야 함
+    const records = [
+      { 거래년월: '2026-04', '합계(①+②)': '300,000' },
+      { 거래년월: '2026-04', '합계(①+②)': '200,000' },
+      { 거래년월: '2026-03', '합계(①+②)': '999,999' }, // 다른 월
+    ]
+
+    const amount = extractMonthAmount(records, 2026, 4)
+    expect(amount).toBe(500000)
+  })
+
+  it('월(月) 텍스트 필드만 있는 메타데이터 행을 해당 월로 인식한다', () => {
+    const records = [
+      { 월: '4월', '총 사용금액': '777,777' },
+      { 월: '3월', '총 사용금액': '888,888' },
+    ]
+
+    const amount = extractMonthAmount(records, 2026, 4)
+    expect(amount).toBe(777777)
+  })
+
+  it('"원" / 콤마 / 공백 문자열을 정규화하여 합산한다', () => {
+    const records = [
+      { 거래년월: '2026-05', '총 사용금액': '1,500,000원' },
+      { 거래년월: '2026-05', '총 사용금액': ' 2,500,000 ' },
+    ]
+
+    const amount = extractMonthAmount(records, 2026, 5)
+    expect(amount).toBe(4000000)
+  })
+
+  it('연월 필드가 일치하지 않으면 0을 반환한다 (잘못된 폴백 방지)', () => {
+    // 5월을 요청했지만 데이터는 4월만 존재 → 0 반환해야 함
+    const records = [{ 거래년월: '2026-04', '총 사용금액': '500,000' }]
+
+    const amount = extractMonthAmount(records, 2026, 5)
+    expect(amount).toBe(0)
+  })
+
+  it('빈 records 배열은 0을 반환한다', () => {
+    expect(extractMonthAmount([], 2026, 4)).toBe(0)
+  })
+
+  it('findMonthRows: "거래년월" 필드 기준 정확한 월 매칭', () => {
+    const records = [
+      { 거래년월: '2026-04', amount: '100' },
+      { 거래년월: '2026-05', amount: '200' },
+      { 거래년월: '2026-04', amount: '300' },
+    ]
+
+    const aprRows = findMonthRows(records, 2026, 4)
+    expect(aprRows).toHaveLength(2)
+    expect(aprRows.every((r) => r.거래년월 === '2026-04')).toBe(true)
+  })
+})

--- a/dental-clinic-manager/marketing-worker/electron/src/hometax-scrapers.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/hometax-scrapers.ts
@@ -25,8 +25,22 @@ export type DataType =
 /** 메뉴 ID 매핑 (홈택스 fn_topMenuOpen 호출용) */
 const MENU_ID_MAP: Record<DataType, string> = {
   cash_receipt_purchase: 'menuAtag_4605010100',
-  business_card_purchase: 'menuAtag_4608020300',
+  business_card_purchase: 'menuAtag_4608020200',
 };
+
+// 사업용신용카드 매입세액 공제 확인/변경 메뉴 후보 (홈택스 환경 변동 대응)
+const BUSINESS_CARD_DEDUCTION_CANDIDATES = [
+  'menuAtag_4608020200',
+  'menuAtag_4608020100',
+  'menuAtag_4608010100',
+  'menuAtag_4608010200',
+];
+
+const BUSINESS_CARD_DEDUCTION_KEYWORDS = [
+  '매입세액 공제 확인/변경',
+  '매입세액공제 확인/변경',
+  '매입세액 공제',
+];
 
 /** YYYYMMDD 형식 월별 기간 */
 function getMonthPeriod(year: number, month: number): { start: string; end: string } {
@@ -316,22 +330,225 @@ async function scrapeCashReceiptPurchase(
   };
 }
 
-/** 사업용 신용카드 매입 누계 — 년도 조회 */
+/** 사업용신용카드 매입세액 공제 확인/변경 메뉴로 이동 (후보 ID + 키워드 매칭) */
+async function navigateToBusinessCardDeduction(page: Page): Promise<void> {
+  for (const id of BUSINESS_CARD_DEDUCTION_CANDIDATES) {
+    const result = await page.evaluate((menuId: string) => {
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      const win = globalThis as any;
+      try {
+        if (win.$c?.pp?.fn_topMenuOpen) {
+          win.$c.pp.fn_topMenuOpen(win.$p, menuId);
+          return 'success';
+        }
+        const el = win.document.getElementById(menuId);
+        if (el) { el.click(); return 'clicked'; }
+        return 'not_found';
+      } catch (e) {
+        return `error: ${(e as any).message}`;
+      }
+    }, id).catch(() => 'evaluate_error');
+
+    log('info', `[Hometax] 매입세액 공제 메뉴 ID 시도: ${id} → ${result}`);
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+    await page.waitForTimeout(2500);
+
+    if (page.url().includes('tmIdx=')) return;
+  }
+
+  // 키워드 매칭 폴백
+  await page.evaluate((keywords: string[]) => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const doc = (globalThis as any).document;
+    const win = globalThis as any;
+    const items = Array.from(
+      doc.querySelectorAll('a[id*="menuAtag"], a[id*="combineMenuAtag"]') as any[],
+    );
+    for (const el of items) {
+      const text = (el.textContent?.trim() || '').replace(/\s+/g, ' ');
+      for (const kw of keywords) {
+        if (text.includes(kw)) {
+          try {
+            if (win.$c?.pp?.fn_topMenuOpen) {
+              win.$c.pp.fn_topMenuOpen(win.$p, el.id);
+            } else {
+              el.click();
+            }
+            return;
+          } catch {
+            // ignore
+          }
+        }
+      }
+    }
+  }, BUSINESS_CARD_DEDUCTION_KEYWORDS).catch(() => {});
+
+  await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+
+  if (!page.url().includes('tmIdx=')) {
+    throw new Error('사업용신용카드 매입세액 공제 확인/변경 메뉴 이동 실패');
+  }
+}
+
+/** "월별" 조회기간 라디오/탭 클릭 */
+async function selectMonthlyPeriod(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const doc = (globalThis as any).document;
+    const win = globalThis as any;
+
+    const radios = doc.querySelectorAll('input[type="radio"]');
+    for (const r of Array.from(radios) as any[]) {
+      const labelEl = doc.querySelector(`label[for="${r.id}"]`);
+      const labelText = labelEl?.textContent?.trim() || '';
+      const valueText = (r.value || '').toString();
+      if (labelText.includes('월별') || valueText === 'M' || valueText.includes('월')) {
+        r.checked = true;
+        r.click();
+        r.dispatchEvent(new win.Event('change', { bubbles: true }));
+        return;
+      }
+    }
+
+    const candidates = doc.querySelectorAll('a, button, span, div, label, li');
+    for (const el of Array.from(candidates) as any[]) {
+      const text = el.textContent?.trim() || '';
+      if (text === '월별' && (el.offsetParent !== null || el.offsetWidth > 0)) {
+        el.click();
+        return;
+      }
+    }
+  }).catch(() => {});
+
+  await page.waitForTimeout(1500);
+}
+
+/** 연/월 select 또는 input 설정 */
+async function setYearMonth(page: Page, year: number, month: number): Promise<void> {
+  const ym = `${year}${String(month).padStart(2, '0')}`;
+  await page.evaluate(
+    (params: { y: number; m: number; ym: string }) => {
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      const doc = (globalThis as any).document;
+      const win = globalThis as any;
+      const yStr = String(params.y);
+      const mStr = String(params.m).padStart(2, '0');
+
+      const setSelectValue = (el: any, candidates: string[]): boolean => {
+        const opts = el.querySelectorAll('option');
+        for (const opt of Array.from(opts) as any[]) {
+          const v = (opt.value || '').toString();
+          const t = (opt.textContent || '').toString().trim();
+          if (candidates.includes(v) || candidates.includes(t)) {
+            el.value = opt.value;
+            el.dispatchEvent(new win.Event('change', { bubbles: true }));
+            return true;
+          }
+        }
+        return false;
+      };
+
+      const allSelects = Array.from(doc.querySelectorAll('select') as any[]).filter(
+        (el: any) => el.offsetParent !== null || el.offsetWidth > 0,
+      );
+
+      // 1) yyyymm 단일 select 시도
+      for (const sel of allSelects) {
+        if (
+          setSelectValue(sel, [params.ym, `${yStr}${mStr}`, `${yStr}-${mStr}`, `${yStr}년 ${params.m}월`])
+        ) return;
+      }
+
+      // 2) 연도 + 월 분리 select
+      let yearSet = false;
+      let monthSet = false;
+      for (const sel of allSelects) {
+        const idLower = (sel.id || '').toLowerCase();
+        const nameLower = (sel.name || '').toLowerCase();
+        const isYear =
+          idLower.includes('year') || idLower.includes('yyyy') || nameLower.includes('year');
+        const isMonth =
+          idLower.includes('month') || idLower.includes('mm') || nameLower.includes('month');
+        if (isYear && !yearSet && setSelectValue(sel, [yStr, `${yStr}년`])) yearSet = true;
+        if (
+          isMonth &&
+          !monthSet &&
+          setSelectValue(sel, [mStr, String(params.m), `${params.m}월`, `${mStr}월`])
+        )
+          monthSet = true;
+      }
+
+      // 휴리스틱 폴백
+      if (!yearSet || !monthSet) {
+        for (const sel of allSelects) {
+          const opts = Array.from(sel.querySelectorAll('option') as any[]);
+          const hasYearOption = opts.some((o: any) =>
+            /^20\d{2}(년)?$/.test((o.textContent || '').trim()),
+          );
+          const hasMonthOption = opts.some((o: any) =>
+            /^(0?[1-9]|1[0-2])(월)?$/.test((o.textContent || '').trim()),
+          );
+          if (!yearSet && hasYearOption && setSelectValue(sel, [yStr, `${yStr}년`])) yearSet = true;
+          else if (
+            !monthSet &&
+            hasMonthOption &&
+            setSelectValue(sel, [mStr, String(params.m), `${params.m}월`, `${mStr}월`])
+          )
+            monthSet = true;
+        }
+      }
+    },
+    { y: year, m: month, ym },
+  ).catch(() => {});
+
+  await page.waitForTimeout(1000);
+}
+
+/** 사업용신용카드 매입세액 공제 확인/변경 — 월별 조회 → 총 사용금액 */
 async function scrapeBusinessCardPurchase(
   page: Page,
   year: number,
   month: number
 ): Promise<ScrapeResult> {
-  log('info', `[Hometax] 사업용 신용카드 매입 스크래핑 시작 (${year}-${month})`);
+  log('info', `[Hometax] 사업용 신용카드 매입세액 공제 확인/변경 — 월별 (${year}-${month})`);
 
-  await navigateToMenu(page, MENU_ID_MAP.business_card_purchase);
+  await navigateToBusinessCardDeduction(page);
   await page.waitForTimeout(3000);
 
-  await setYear(page, year);
+  await selectMonthlyPeriod(page);
+  await setYearMonth(page, year, month);
   await clickSearch(page);
 
   const records = await parseDataTable(page);
-  log('info', `[Hometax] 사업용 신용카드 매입 ${records.length}건 수집`);
+
+  // 총 사용금액 추출
+  const totalUsageAmount = await page.evaluate(() => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const doc = (globalThis as any).document;
+    const parseAmt = (s: string): number => {
+      const cleaned = String(s).replace(/[,원\s]/g, '');
+      const n = parseInt(cleaned, 10);
+      return Number.isFinite(n) ? n : 0;
+    };
+    const bodyText = doc.body?.innerText || '';
+    const m = bodyText.match(/총\s*사용\s*금액[^\d]*([\d,]+)/);
+    if (m) return parseAmt(m[1]);
+    return null as number | null;
+  }).catch(() => null);
+
+  if (totalUsageAmount !== null && totalUsageAmount > 0) {
+    records.unshift({
+      '구분': '총 사용금액',
+      '총 사용금액': totalUsageAmount.toLocaleString(),
+      '거래년월': `${year}-${String(month).padStart(2, '0')}`,
+    });
+  }
+
+  log(
+    'info',
+    `[Hometax] 사업용 신용카드 매입세액 공제 ${records.length}건 (총 사용금액=${totalUsageAmount ?? 'N/A'})`,
+  );
 
   return {
     dataType: 'business_card_purchase',

--- a/dental-clinic-manager/scraping-worker/src/hometax/scrapers/businessCardScraper.ts
+++ b/dental-clinic-manager/scraping-worker/src/hometax/scrapers/businessCardScraper.ts
@@ -6,7 +6,33 @@ const log = createChildLogger('businessCardScraper');
 
 const HOMETAX_MAIN = 'https://www.hometax.go.kr/websquare/websquare.wq?w2xPath=/ui/pp/index_pp.xml';
 
-// 메뉴 ID: 매입내역 누계 조회 (사업용 신용카드 사용내역 하위) — menuAtag_4608020300
+/**
+ * 사업용신용카드 매입세액 공제 확인/변경 메뉴 — 월별 조회 후 총 사용금액 추출
+ *
+ * 흐름:
+ * 1. 홈택스 로그인 (선행)
+ * 2. 계산서·영수증·카드 → 신용카드 매입 → 사업용 신용카드 사용 내역
+ *    → 사업용신용카드 매입세액 공제 확인/변경
+ *    (fn_topMenuOpen 후보 ID + 키워드 매칭 폴백)
+ * 3. 조회기간을 "월별"로 선택
+ * 4. 해당 연/월 선택
+ * 5. 조회 버튼 클릭
+ * 6. 총 사용금액 + 전체 행을 추출
+ */
+
+// 사업용신용카드 매입세액 공제 확인/변경 메뉴 후보 ID (홈택스 환경 변동 대응)
+const DEDUCTION_MENU_CANDIDATES = [
+  'menuAtag_4608020200',
+  'menuAtag_4608020100',
+  'menuAtag_4608010100',
+  'menuAtag_4608010200',
+];
+
+const DEDUCTION_MENU_KEYWORDS = [
+  '매입세액 공제 확인/변경',
+  '매입세액공제 확인/변경',
+  '매입세액 공제',
+];
 
 async function screenshot(page: Page, label: string): Promise<string> {
   const path = `/tmp/hometax-bizcard-${label}-${Date.now()}.png`;
@@ -15,17 +41,403 @@ async function screenshot(page: Page, label: string): Promise<string> {
   return path;
 }
 
-/**
- * 신용카드 매입 스크래핑 흐름:
- * 1. 로그인 (완료)
- * 2. 계산서·영수증·카드 메뉴
- *   2.1 신용카드 매입
- *   2.2 사업용 신용카드 사용내역
- *   2.3 매입내역 누계 조회
- *     → $c.pp.fn_topMenuOpen($p, 'menuAtag_4608020300')
- *   2.4 조회년도 확인 후 조회 클릭
- *   2.5 필요 정보 스크래핑
- */
+/** 사업용신용카드 매입세액 공제 확인/변경 메뉴로 이동 */
+async function navigateToDeductionMenu(page: Page): Promise<void> {
+  log.info('매입세액 공제 확인/변경 메뉴 이동 시도');
+
+  // 1) 후보 ID로 fn_topMenuOpen 시도
+  for (const id of DEDUCTION_MENU_CANDIDATES) {
+    const result = await page.evaluate((menuId: string) => {
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      const win = globalThis as any;
+      try {
+        if (win.$c?.pp?.fn_topMenuOpen) {
+          win.$c.pp.fn_topMenuOpen(win.$p, menuId);
+          return 'success';
+        }
+        const el = win.document.getElementById(menuId);
+        if (el) { el.click(); return 'clicked'; }
+        return 'not_found';
+      } catch (e) {
+        return `error: ${(e as any).message}`;
+      }
+    }, id).catch(() => 'evaluate_error');
+
+    log.info({ id, result }, '메뉴 ID 시도');
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+    await page.waitForTimeout(2500);
+
+    if (page.url().includes('tmIdx=')) {
+      log.info({ id }, '메뉴 ID로 이동 성공');
+      return;
+    }
+  }
+
+  // 2) 키워드 기반 메뉴 매칭 폴백
+  log.info('후보 ID 실패 — 키워드 매칭 폴백');
+  const keywordMatch = await page.evaluate((keywords: string[]) => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const doc = (globalThis as any).document;
+    const win = globalThis as any;
+    const items = Array.from(
+      doc.querySelectorAll('a[id*="menuAtag"], a[id*="combineMenuAtag"]') as any[],
+    );
+    for (const el of items) {
+      const text = (el.textContent?.trim() || '').replace(/\s+/g, ' ');
+      for (const kw of keywords) {
+        if (text.includes(kw)) {
+          try {
+            if (win.$c?.pp?.fn_topMenuOpen) {
+              win.$c.pp.fn_topMenuOpen(win.$p, el.id);
+            } else {
+              el.click();
+            }
+            return { id: el.id, text };
+          } catch (e) {
+            return { error: String((e as any).message), id: el.id, text };
+          }
+        }
+      }
+    }
+    return null;
+  }, DEDUCTION_MENU_KEYWORDS).catch(() => null);
+
+  log.info({ keywordMatch }, '키워드 매칭 결과');
+  await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+
+  if (!page.url().includes('tmIdx=')) {
+    await screenshot(page, 'nav-failed');
+    throw new Error('사업용신용카드 매입세액 공제 확인/변경 메뉴로 이동 실패');
+  }
+
+  await screenshot(page, 'menu-opened');
+}
+
+/** "월별" 조회 기간 라디오/탭 클릭 */
+async function selectMonthlyPeriod(page: Page): Promise<void> {
+  log.info('조회기간 "월별" 선택');
+
+  const result = await page.evaluate(() => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const doc = (globalThis as any).document;
+    const win = globalThis as any;
+
+    // 1) 라디오 버튼: label 텍스트가 "월별" 또는 value === 'M'
+    const radios = doc.querySelectorAll('input[type="radio"]');
+    for (const r of Array.from(radios) as any[]) {
+      const labelEl = doc.querySelector(`label[for="${r.id}"]`);
+      const labelText = labelEl?.textContent?.trim() || '';
+      const valueText = (r.value || '').toString();
+      if (
+        labelText === '월별' ||
+        labelText.includes('월별') ||
+        valueText === 'M' ||
+        valueText.includes('월')
+      ) {
+        r.checked = true;
+        r.click();
+        r.dispatchEvent(new win.Event('change', { bubbles: true }));
+        return `radio: ${r.id} (label="${labelText}", value="${valueText}")`;
+      }
+    }
+
+    // 2) 탭/버튼: 텍스트가 "월별"
+    const candidates = doc.querySelectorAll('a, button, span, div, label, li');
+    for (const el of Array.from(candidates) as any[]) {
+      const text = el.textContent?.trim() || '';
+      if (text === '월별' && (el.offsetParent !== null || el.offsetWidth > 0)) {
+        el.click();
+        return `tab: ${el.tagName}#${el.id}`;
+      }
+    }
+
+    return 'not_found';
+  }).catch(() => 'error');
+
+  log.info({ result }, '월별 선택 결과');
+  await page.waitForTimeout(1500);
+}
+
+/** 연/월 select 또는 input에 값 설정 */
+async function selectYearMonth(page: Page, year: number, month: number): Promise<void> {
+  const ym = `${year}${String(month).padStart(2, '0')}`;
+  log.info({ year, month, ym }, '연월 설정');
+
+  const results = await page.evaluate(
+    (params: { y: number; m: number; ym: string }) => {
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      const doc = (globalThis as any).document;
+      const win = globalThis as any;
+      const yStr = String(params.y);
+      const mStr = String(params.m).padStart(2, '0');
+      const logs: string[] = [];
+
+      const setSelectValue = (el: any, candidates: string[]): boolean => {
+        const opts = el.querySelectorAll('option');
+        for (const opt of Array.from(opts) as any[]) {
+          const v = (opt.value || '').toString();
+          const t = (opt.textContent || '').toString().trim();
+          if (candidates.includes(v) || candidates.includes(t)) {
+            el.value = opt.value;
+            el.dispatchEvent(new win.Event('change', { bubbles: true }));
+            return true;
+          }
+        }
+        return false;
+      };
+
+      const setInputValue = (el: any, value: string) => {
+        const setter = win.Object.getOwnPropertyDescriptor(
+          win.HTMLInputElement.prototype,
+          'value',
+        )?.set;
+        if (setter) setter.call(el, value);
+        else el.value = value;
+        el.dispatchEvent(new win.Event('input', { bubbles: true }));
+        el.dispatchEvent(new win.Event('change', { bubbles: true }));
+      };
+
+      // 1) yyyymm 단일 select 시도 (예: 202504)
+      const allSelects = Array.from(doc.querySelectorAll('select') as any[]).filter(
+        (el: any) => el.offsetParent !== null || el.offsetWidth > 0,
+      );
+      for (const sel of allSelects) {
+        if (
+          setSelectValue(sel, [params.ym, `${yStr}${mStr}`, `${yStr}-${mStr}`, `${yStr}년 ${params.m}월`])
+        ) {
+          logs.push(`yyyymm select: ${sel.id || sel.name} → ${params.ym}`);
+          return logs;
+        }
+      }
+
+      // 2) 연도 select / 월 select 분리 처리
+      let yearSet = false;
+      let monthSet = false;
+      for (const sel of allSelects) {
+        const idLower = (sel.id || '').toLowerCase();
+        const nameLower = (sel.name || '').toLowerCase();
+        const isYear =
+          idLower.includes('year') ||
+          idLower.includes('yyyy') ||
+          nameLower.includes('year');
+        const isMonth =
+          idLower.includes('month') ||
+          idLower.includes('mm') ||
+          nameLower.includes('month');
+
+        if (isYear && !yearSet) {
+          if (setSelectValue(sel, [yStr, `${yStr}년`])) {
+            logs.push(`year select: ${sel.id} → ${yStr}`);
+            yearSet = true;
+          }
+        }
+        if (isMonth && !monthSet) {
+          if (
+            setSelectValue(sel, [
+              mStr,
+              String(params.m),
+              `${params.m}월`,
+              `${mStr}월`,
+            ])
+          ) {
+            logs.push(`month select: ${sel.id} → ${mStr}`);
+            monthSet = true;
+          }
+        }
+      }
+
+      // 휴리스틱 fallback: yearSet/monthSet 안 됐으면 옵션 텍스트로 추론
+      if (!yearSet || !monthSet) {
+        for (const sel of allSelects) {
+          const opts = Array.from(sel.querySelectorAll('option') as any[]);
+          const hasYearOption = opts.some((o: any) => /^20\d{2}(년)?$/.test((o.textContent || '').trim()));
+          const hasMonthOption = opts.some((o: any) =>
+            /^(0?[1-9]|1[0-2])(월)?$/.test((o.textContent || '').trim()),
+          );
+          if (!yearSet && hasYearOption) {
+            if (setSelectValue(sel, [yStr, `${yStr}년`])) {
+              logs.push(`year (heuristic): ${sel.id} → ${yStr}`);
+              yearSet = true;
+            }
+          } else if (!monthSet && hasMonthOption) {
+            if (
+              setSelectValue(sel, [
+                mStr,
+                String(params.m),
+                `${params.m}월`,
+                `${mStr}월`,
+              ])
+            ) {
+              logs.push(`month (heuristic): ${sel.id} → ${mStr}`);
+              monthSet = true;
+            }
+          }
+        }
+      }
+
+      // 3) input fallback (yyyymm 또는 yyyymmdd)
+      if (!yearSet || !monthSet) {
+        const inputs = Array.from(
+          doc.querySelectorAll('input[type="text"], input:not([type])') as any[],
+        ).filter((el: any) => el.offsetParent !== null || el.offsetWidth > 0);
+        for (const el of inputs) {
+          const idLower = (el.id || '').toLowerCase();
+          if (idLower.includes('year') || idLower.includes('yyyy')) {
+            setInputValue(el, yStr);
+            logs.push(`year input: ${el.id} → ${yStr}`);
+          }
+          if (idLower.includes('month') || idLower.includes('mm')) {
+            setInputValue(el, mStr);
+            logs.push(`month input: ${el.id} → ${mStr}`);
+          }
+        }
+      }
+
+      return logs.length > 0 ? logs : ['no_field_set'];
+    },
+    { y: year, m: month, ym },
+  ).catch(() => ['error']);
+
+  log.info({ results }, '연월 설정 결과');
+  await page.waitForTimeout(1000);
+}
+
+/** 조회 버튼 클릭 + 결과 대기 */
+async function clickSearch(page: Page): Promise<void> {
+  const clicked = await page.evaluate(() => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const doc = (globalThis as any).document;
+    const candidates = doc.querySelectorAll(
+      'a, button, input[type="button"], input[type="submit"], .w2trigger, .w2anchor2',
+    );
+    for (const el of Array.from(candidates) as any[]) {
+      const text = (el.textContent?.trim() || el.value || '').toString();
+      if (
+        (text === '조회' || text === '조회하기') &&
+        (el.offsetParent !== null || el.offsetWidth > 0)
+      ) {
+        el.click();
+        return `clicked: ${el.tagName}#${el.id} text="${text}"`;
+      }
+    }
+    return 'not_found';
+  }).catch(() => 'error');
+
+  log.info({ clicked }, '조회 버튼 클릭 결과');
+  if (clicked === 'not_found' || clicked === 'error') {
+    await screenshot(page, 'search-failed');
+    throw new Error('조회 버튼을 찾을 수 없습니다');
+  }
+
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  await page.waitForTimeout(5000);
+  await page
+    .locator('.loading, .spinner, .w2loading')
+    .first()
+    .waitFor({ state: 'hidden', timeout: 15000 })
+    .catch(() => {});
+}
+
+/** 결과 페이지에서 데이터 + 총 사용금액 추출 */
+async function extractResults(page: Page): Promise<{
+  records: Record<string, unknown>[];
+  totalUsageAmount: number | null;
+}> {
+  return await page.evaluate(() => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const doc = (globalThis as any).document;
+    const records: Record<string, any>[] = [];
+
+    const parseAmt = (s: string): number => {
+      const cleaned = String(s).replace(/[,원\s]/g, '');
+      const n = parseInt(cleaned, 10);
+      return Number.isFinite(n) ? n : 0;
+    };
+
+    // visible 데이터 테이블 추출
+    const tables = doc.querySelectorAll('table');
+    for (const table of Array.from(tables) as any[]) {
+      if (table.offsetParent === null && table.offsetWidth === 0) continue;
+
+      const headers: string[] = [];
+      const headerCells = table.querySelectorAll('thead th, thead td');
+      for (const cell of Array.from(headerCells) as any[]) {
+        headers.push(cell.textContent?.trim() || '');
+      }
+
+      const rows = table.querySelectorAll('tbody tr');
+      if (rows.length === 0) continue;
+
+      const tableRecords: Record<string, any>[] = [];
+      for (const row of Array.from(rows) as any[]) {
+        const cells = row.querySelectorAll('td');
+        if (cells.length < 2) continue;
+        const record: Record<string, any> = {};
+        let hasNumeric = false;
+        for (let i = 0; i < cells.length; i++) {
+          const text = (cells[i] as any).textContent?.trim() || '';
+          record[headers[i] || `col_${i}`] = text;
+          if (text.match(/[\d,]+/) && text !== '0') hasNumeric = true;
+        }
+        if (hasNumeric) tableRecords.push(record);
+      }
+
+      if (tableRecords.length > 0) {
+        records.push(...tableRecords);
+        break;
+      }
+    }
+
+    // WebSquare grid 폴백
+    if (records.length === 0) {
+      const gHeaders: string[] = [];
+      const ghc = doc.querySelectorAll('.w2grid_header .w2grid_cell');
+      for (const c of Array.from(ghc) as any[]) gHeaders.push(c.textContent?.trim() || '');
+      const gRows = doc.querySelectorAll('.w2grid_data tr, .w2grid .w2grid_row');
+      for (const row of Array.from(gRows) as any[]) {
+        const cells = row.querySelectorAll('.w2grid_cell, td');
+        if (cells.length < 2) continue;
+        const record: Record<string, any> = {};
+        let hasData = false;
+        for (let i = 0; i < cells.length; i++) {
+          const text = (cells[i] as any).textContent?.trim() || '';
+          record[gHeaders[i] || `col_${i}`] = text;
+          if (text.match(/[\d,]+/) && text !== '0') hasData = true;
+        }
+        if (hasData) records.push(record);
+      }
+    }
+
+    // "총 사용금액" 추출 — 합계 행 또는 별도 표시
+    let totalUsageAmount: number | null = null;
+    const TOTAL_KEYS = ['총 사용금액', '총사용금액', '총사용 금액', '합계', '계'];
+
+    for (const record of records) {
+      for (const key of Object.keys(record)) {
+        if (TOTAL_KEYS.some((tk) => key.replace(/\s/g, '').includes(tk.replace(/\s/g, '')))) {
+          const amt = parseAmt(record[key]);
+          if (amt > 0) {
+            totalUsageAmount = (totalUsageAmount ?? 0) + amt;
+          }
+        }
+      }
+    }
+
+    // 페이지 내 "총 사용금액 NNN원" 텍스트 폴백
+    if (totalUsageAmount === null || totalUsageAmount === 0) {
+      const bodyText = doc.body?.innerText || '';
+      const m = bodyText.match(/총\s*사용\s*금액[^\d]*([\d,]+)/);
+      if (m) {
+        const amt = parseAmt(m[1]);
+        if (amt > 0) totalUsageAmount = amt;
+      }
+    }
+
+    return { records, totalUsageAmount };
+  }).catch(() => ({ records: [] as Record<string, any>[], totalUsageAmount: null }));
+}
+
 export async function scrapeBusinessCardPurchase(
   context: BrowserContext,
   year: number,
@@ -33,241 +445,72 @@ export async function scrapeBusinessCardPurchase(
   _clinicId?: string,
   sharedPage?: Page,
 ): Promise<ScrapeResult> {
-  log.info({ year, month }, '사업용 신용카드 매입내역 누계 스크래핑 시작');
+  log.info({ year, month }, '사업용 신용카드 매입세액 공제 확인/변경 — 월별 스크래핑 시작');
 
   const doScrape = async (page: Page) => {
     if (!sharedPage) {
-      // ── Step 1: 메인 페이지 + 로그인 확인 (단독 실행 시) ──
       await page.goto(HOMETAX_MAIN, { waitUntil: 'load', timeout: 30000 });
       await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
       await page.waitForTimeout(2000);
-
-      const isLoggedIn = await page.locator('a:has-text("로그아웃")')
+      const isLoggedIn = await page
+        .locator('a:has-text("로그아웃")')
         .or(page.locator('button:has-text("로그아웃")'))
         .or(page.locator('text=로그아웃'))
         .first()
         .waitFor({ state: 'visible', timeout: 10000 })
         .then(() => true)
         .catch(() => false);
-
       if (!isLoggedIn) throw new Error('홈택스 세션이 만료되었습니다.');
     } else {
-      log.info('공유 페이지 사용 — 메인 페이지 로딩 및 로그인 확인 생략');
+      log.info('공유 페이지 사용 — 메인 페이지/로그인 확인 생략');
     }
 
-    // ── Step 2.1~2.3: 매입내역 누계 조회 메뉴 이동 ──
-    log.info('Step 2.1~2.3: 매입내역 누계 조회 메뉴 이동');
-
-    const navResult = await page.evaluate(() => {
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      const win = globalThis as any;
-      try {
-        if (win.$c?.pp?.fn_topMenuOpen) {
-          win.$c.pp.fn_topMenuOpen(win.$p, 'menuAtag_4608020300');
-          return 'success';
-        }
-        const el = win.document.getElementById('menuAtag_4608020300');
-        if (el) { el.click(); return 'clicked'; }
-        return 'not_found';
-      } catch (e) {
-        return `error: ${(e as any).message}`;
-      }
-    }).catch(() => 'evaluate_error');
-
-    log.info({ navResult }, '메뉴 네비게이션 결과');
-    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
-    await page.waitForTimeout(5000);
-
-    if (!page.url().includes('tmIdx=')) {
-      await screenshot(page, 'nav-failed');
-      throw new Error('매입내역 누계 조회 메뉴 이동 실패');
-    }
-    await screenshot(page, '2.3-menu-opened');
-
-    // ── Step 2.4: 조회년도 확인 후 조회 클릭 ──
-    log.info({ year }, 'Step 2.4: 조회년도 설정 + 조회');
+    await navigateToDeductionMenu(page);
     await page.waitForTimeout(3000);
 
-    // Form 요소 분석 (디버그)
-    const formElements = await page.evaluate(() => {
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      const doc = (globalThis as any).document;
-      return Array.from(doc.querySelectorAll('input, select') as any[])
-        .filter((el: any) => el.offsetParent !== null || el.offsetWidth > 0)
-        .map((el: any) => ({
-          tag: el.tagName, id: el.id?.substring(0, 60) || '', type: el.type || '',
-          value: (el.value || '').substring(0, 30), class: el.className?.substring(0, 40) || '',
-        }))
-        .slice(0, 20);
-    }).catch(() => []);
-    log.info({ formElements }, 'Form 요소 분석');
+    await selectMonthlyPeriod(page);
+    await screenshot(page, 'period-monthly');
 
-    // 년도 설정 — 옵션 값이 "2025년" 형식일 수 있음
-    const yearSet = await page.evaluate((y: number) => {
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      const doc = (globalThis as any).document;
-      const win = globalThis as any;
-      const yStr = String(y);
-      const results: string[] = [];
+    await selectYearMonth(page, year, month);
+    await screenshot(page, 'year-month-set');
 
-      // select 요소에서 년도 변경
-      const selects = doc.querySelectorAll('select');
-      for (const el of Array.from(selects) as any[]) {
-        if (el.offsetParent === null && el.offsetWidth === 0) continue;
-        const opts = el.querySelectorAll('option');
-        for (const opt of Array.from(opts) as any[]) {
-          const optVal = opt.value || '';
-          const optText = opt.textContent?.trim() || '';
-          // "2025", "2025년" 모두 매칭
-          if (optVal === yStr || optText === yStr || optVal === `${yStr}년` || optText === `${yStr}년` || optVal.startsWith(yStr)) {
-            el.value = opt.value;
-            el.dispatchEvent(new win.Event('change', { bubbles: true }));
-            results.push(`select: ${el.id} → ${opt.value}`);
-            break;
-          }
-        }
-      }
+    await clickSearch(page);
+    await screenshot(page, 'search-done');
 
-      // input 필드에서 년도 변경
-      const inputs = doc.querySelectorAll('input[type="text"], input:not([type])');
-      for (const el of Array.from(inputs) as any[]) {
-        if (el.offsetParent === null && el.offsetWidth === 0) continue;
-        if (el.value?.match(/^\d{4}/) || el.id?.toLowerCase().includes('year') || el.id?.toLowerCase().includes('yyyy')) {
-          const setter = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'value')?.set;
-          if (setter) setter.call(el, yStr);
-          else el.value = yStr;
-          el.dispatchEvent(new win.Event('input', { bubbles: true }));
-          el.dispatchEvent(new win.Event('change', { bubbles: true }));
-          results.push(`input: ${el.id} → ${yStr}`);
-        }
-      }
+    const { records, totalUsageAmount } = await extractResults(page);
+    log.info(
+      { recordCount: records.length, totalUsageAmount, sample: records.slice(0, 2) },
+      '결과 추출 완료',
+    );
 
-      return results.length > 0 ? results : ['no_year_field_found'];
-    }, year).catch(() => ['error']);
-    log.info({ yearSet }, '년도 설정 결과');
-
-    await page.waitForTimeout(1000);
-    await screenshot(page, '2.4-year-set');
-
-    // 조회 버튼 클릭
-    log.info('조회 버튼 클릭');
-    const searchClicked = await page.evaluate(() => {
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      const doc = (globalThis as any).document;
-      const candidates = doc.querySelectorAll('a, button, input[type="button"], input[type="submit"], .w2trigger, .w2anchor2');
-      for (const el of Array.from(candidates) as any[]) {
-        const text = (el.textContent?.trim() || el.value || '');
-        if ((text === '조회' || text === '조회하기') && (el.offsetParent !== null || el.offsetWidth > 0)) {
-          el.click();
-          return `clicked: ${el.tagName}#${el.id} text="${text}"`;
-        }
-      }
-      return 'not_found';
-    }).catch(() => 'error');
-
-    log.info({ searchClicked }, '조회 버튼 클릭 결과');
-    if (searchClicked === 'not_found' || searchClicked === 'error') {
-      await screenshot(page, '2.4-search-failed');
-      throw new Error('조회 버튼을 찾을 수 없습니다');
-    }
-
-    // 로딩 대기
-    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
-    await page.waitForTimeout(5000);
-    await page.locator('.loading, .spinner, .w2loading').first()
-      .waitFor({ state: 'hidden', timeout: 15000 }).catch(() => {});
-
-    await screenshot(page, '2.4-search-done');
-
-    // ── Step 2.5: 데이터 스크래핑 ──
-    log.info('Step 2.5: 데이터 스크래핑');
-
-    const data = await page.evaluate(() => {
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      const doc = (globalThis as any).document;
-      const results: Record<string, any>[] = [];
-
-      // visible 테이블 중 데이터 테이블 찾기 (td가 3개 이상인 테이블)
-      const tables = doc.querySelectorAll('table');
-      for (const table of Array.from(tables) as any[]) {
-        if (table.offsetParent === null && table.offsetWidth === 0) continue;
-
-        // 헤더 추출
-        const headers: string[] = [];
-        const headerCells = table.querySelectorAll('thead th, thead td');
-        for (const cell of Array.from(headerCells) as any[]) {
-          headers.push(cell.textContent?.trim() || '');
-        }
-
-        // 데이터 행 추출
-        const rows = table.querySelectorAll('tbody tr');
-        if (rows.length === 0) continue;
-
-        const tableRecords: Record<string, any>[] = [];
-        for (const row of Array.from(rows) as any[]) {
-          const cells = row.querySelectorAll('td');
-          if (cells.length < 3) continue; // 데이터 테이블은 최소 3컬럼
-
-          const record: Record<string, any> = {};
-          let hasNumericData = false;
-          for (let i = 0; i < cells.length; i++) {
-            const text = (cells[i] as any).textContent?.trim() || '';
-            record[headers[i] || `col_${i}`] = text;
-            // 숫자 데이터(금액, 건수)가 있는지 확인
-            if (text.match(/[\d,]+/) && text !== '0') hasNumericData = true;
-          }
-          if (hasNumericData) tableRecords.push(record);
-        }
-
-        // 숫자 데이터가 있는 테이블을 데이터 테이블로 판단
-        if (tableRecords.length > 0) {
-          results.push(...tableRecords);
-          break;
-        }
-      }
-
-      // WebSquare 그리드 폴백
-      if (results.length === 0) {
-        const gHeaders: string[] = [];
-        const gHeaderCells = doc.querySelectorAll('.w2grid_header .w2grid_cell');
-        for (const c of Array.from(gHeaderCells) as any[]) gHeaders.push(c.textContent?.trim() || '');
-
-        const gRows = doc.querySelectorAll('.w2grid_data tr, .w2grid .w2grid_row');
-        for (const row of Array.from(gRows) as any[]) {
-          const cells = row.querySelectorAll('.w2grid_cell, td');
-          if (cells.length < 3) continue;
-          const record: Record<string, any> = {};
-          let hasData = false;
-          for (let i = 0; i < cells.length; i++) {
-            const text = (cells[i] as any).textContent?.trim() || '';
-            record[gHeaders[i] || `col_${i}`] = text;
-            if (text.match(/[\d,]+/) && text !== '0') hasData = true;
-          }
-          if (hasData) results.push(record);
-        }
-      }
-
-      return results;
-    }).catch(() => []);
-
-    log.info({ recordCount: data.length, sample: data.slice(0, 2) }, '데이터 추출 완료');
-
-    if (data.length === 0) {
-      const bodyText = await page.evaluate(() =>
-        ((globalThis as any).document.body?.innerText || '').substring(0, 1500)
-      ).catch(() => '');
+    if (records.length === 0) {
+      const bodyText = await page
+        .evaluate(() => ((globalThis as any).document.body?.innerText || '').substring(0, 1500))
+        .catch(() => '');
       log.warn({ bodyText }, '데이터 없음 — 페이지 텍스트 덤프');
-      await screenshot(page, '2.5-no-data');
+      await screenshot(page, 'no-data');
     }
 
-    return data;
+    // 총 사용금액을 별도 metadata 행으로 추가 (consumer가 합산 시 인식)
+    if (totalUsageAmount !== null) {
+      records.unshift({
+        '구분': '총 사용금액',
+        '총 사용금액': totalUsageAmount.toLocaleString(),
+        '거래년월': `${year}-${String(month).padStart(2, '0')}`,
+      });
+    }
+
+    return records;
   };
 
   const records = sharedPage
     ? await doScrape(sharedPage)
     : await withPage(context, doScrape);
 
-  log.info({ year, month, count: records.length }, '사업용 신용카드 매입내역 누계 스크래핑 완료');
+  log.info(
+    { year, month, count: records.length },
+    '사업용 신용카드 매입세액 공제 확인/변경 스크래핑 완료',
+  );
 
   return {
     dataType: 'business_card_purchase',

--- a/dental-clinic-manager/src/utils/hometaxAmount.ts
+++ b/dental-clinic-manager/src/utils/hometaxAmount.ts
@@ -68,15 +68,17 @@ export function extractMonthAmount(
 ): number {
   if (!Array.isArray(records) || records.length === 0) return 0;
 
-  const hasYearMonthField = records.some(record =>
-    YEAR_MONTH_FIELDS.some(key => {
+  // 연월 필드(거래년월 등) 또는 월 텍스트 필드(월/기간 등) 중 하나라도 있으면
+  // per-month 데이터로 간주하여 해당 월만 필터링.
+  const hasPeriodField = records.some(record =>
+    [...YEAR_MONTH_FIELDS, ...MONTH_ONLY_FIELDS].some(key => {
       const val = record[key];
       return val !== undefined && val !== null && val !== '';
     })
   );
 
   let rowsToSum: Record<string, unknown>[];
-  if (hasYearMonthField) {
+  if (hasPeriodField) {
     const monthRows = findMonthRows(records, year, targetMonth);
     if (monthRows.length === 0) return 0;
     rowsToSum = monthRows;

--- a/dental-clinic-manager/src/utils/hometaxAmount.ts
+++ b/dental-clinic-manager/src/utils/hometaxAmount.ts
@@ -8,9 +8,11 @@ const MONTH_ONLY_FIELDS = ['월', '기간', '거래월', '월별', '조회월'];
 
 const AMOUNT_KEYS = [
   // 실제 DB에서 확인된 금액 필드 (우선순위 순)
+  '총 사용금액',   // business_card_purchase (매입세액 공제 확인/변경 — 월별)
+  '총사용금액',
   '총금액',        // cash_receipt_sales
   '매출액계',      // credit_card_sales
-  '합계(①+②)',  // business_card_purchase
+  '합계(①+②)',  // business_card_purchase (legacy 누계 조회)
   // 범용 폴백
   '합계(③+④)', '합계', '매입금액',
   '거래금액', '매출금액',


### PR DESCRIPTION
## Summary

홈택스 워커의 사업용 신용카드 매입 스크래핑을 `매입내역 누계 조회`(연도 누적) → **`사업용신용카드 매입세액 공제 확인/변경`(월별 조회)** 로 전환.

### 신규 흐름
1. 홈택스 로그인 (선행)
2. 계산서·영수증·카드 → 신용카드 매입 → 사업용 신용카드 사용 내역 → 사업용신용카드 매입세액 공제 확인/변경
3. 조회기간 "월별" 선택
4. 해당 연/월 선택
5. 조회 → 총 사용금액 추출 (records[0]에 metadata로 삽입)

### 변경 파일
- `scraping-worker/src/hometax/scrapers/businessCardScraper.ts` — 서버 워커
- `marketing-worker/electron/src/hometax-scrapers.ts` — 사용자 PC Electron 워커
- `src/utils/hometaxAmount.ts` — `'총 사용금액'`을 AMOUNT_KEYS 최상단에 추가, `MONTH_ONLY_FIELDS`도 per-month 분기에 포함되도록 버그 수정
- `__tests__/utils/hometax-business-card.test.ts` — 8개 단위 테스트 신규

### 견고성
- 메뉴 ID 후보 4개 + 키워드 매칭 폴백 (홈택스 환경 변동 대응)
- 월별 라디오/탭 / yyyymm 단일 select / 연·월 분리 select / input fallback 모두 처리
- 총 사용금액은 합계 행 + body 텍스트 정규식 폴백
- legacy `합계(①+②)` 키 호환 유지

## Test plan

- [x] `npm run build` (Next.js + scraping-worker tsc + Electron tsc) 통과
- [x] `npm run test:unit -- __tests__/utils/hometax-business-card.test.ts` 8/8 통과
- [ ] main 머지 후 사용자 PC 워커가 갱신된 코드로 재시작될 때 실제 홈택스 동기화 결과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)