### PR TITLE
Merge develop: 자동매매 전략 개수 제한 제거

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/strategies/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/strategies/route.ts
@@ -128,16 +128,6 @@ export async function POST(request: NextRequest) {
       ? (riskSettings as object)
       : NOOP_RISK_SETTINGS
 
-  // 전략 개수 제한 (사용자당 최대 10개)
-  const { count } = await supabase
-    .from('investment_strategies')
-    .select('id', { count: 'exact', head: true })
-    .eq('user_id', userId)
-
-  if ((count ?? 0) >= 10) {
-    return NextResponse.json({ error: '전략은 최대 10개까지 생성 가능합니다' }, { status: 400 })
-  }
-
   // DB 저장
   const { data, error } = await supabase
     .from('investment_strategies')

--- a/dental-clinic-manager/src/app/api/marketing/worker-api/seo/data/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/worker-api/seo/data/route.ts
@@ -1,66 +1,165 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyWorkerApiKey } from '@/lib/marketing/workerApiAuth';
 
+// 워커 → 대시보드 SEO 결과 저장 라우트
+// 워커는 항상 { type, data: {...} } 봉투(envelope) 형태로 전송
+// (seo-bridge.ts의 client.saveData 참조)
+//
+// 각 타입별로 data를 풀어 적절한 테이블에 매핑한다.
+// analyzed_post의 analysis_id는 워커가 보낸 keyword/job_id로 자동 조회.
+
+type SeoDataBody = {
+  type: string;
+  data?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+async function findAnalysisId(
+  admin: NonNullable<Awaited<ReturnType<typeof verifyWorkerApiKey>>>,
+  opts: { jobId?: string; keyword?: string }
+): Promise<string | null> {
+  if (opts.jobId) {
+    const { data } = await admin
+      .from('seo_keyword_analyses')
+      .select('id')
+      .eq('job_id', opts.jobId)
+      .maybeSingle();
+    if (data?.id) return data.id as string;
+  }
+  if (opts.keyword) {
+    const { data } = await admin
+      .from('seo_keyword_analyses')
+      .select('id')
+      .eq('keyword', opts.keyword)
+      .in('status', ['analyzing', 'running'])
+      .order('analyzed_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (data?.id) return data.id as string;
+  }
+  return null;
+}
+
 export async function POST(request: NextRequest) {
   try {
     const admin = await verifyWorkerApiKey(request);
     if (!admin) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-    const body = await request.json();
-    const { type, ...payload } = body as { type: string; [key: string]: unknown };
+    const body = (await request.json()) as SeoDataBody;
+    const { type } = body;
+    const data = (body.data || {}) as Record<string, unknown>;
 
     if (!type) {
       return NextResponse.json({ error: 'type is required' }, { status: 400 });
     }
 
     if (type === 'keyword_analysis') {
-      const { error } = await admin
-        .from('seo_keyword_analyses')
-        .upsert(payload, { onConflict: 'id' });
-      if (error) {
-        return NextResponse.json({ error: error.message }, { status: 500 });
+      // 새 분석 레코드 생성 (또는 같은 job_id면 update)
+      const keyword = data.keyword as string | undefined;
+      const status = (data.status as string | undefined) || 'analyzing';
+      const job_id = data.job_id as string | undefined;
+      const analyzed_by = data.analyzed_by as string | undefined;
+
+      if (!keyword) {
+        return NextResponse.json({ error: 'data.keyword is required' }, { status: 400 });
       }
-      return NextResponse.json({ ok: true });
+
+      if (job_id) {
+        const existingId = await findAnalysisId(admin, { jobId: job_id });
+        if (existingId) {
+          const { error } = await admin
+            .from('seo_keyword_analyses')
+            .update({ keyword, status, analyzed_by, analyzed_at: new Date().toISOString() })
+            .eq('id', existingId);
+          if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+          return NextResponse.json({ ok: true, id: existingId });
+        }
+      }
+
+      const { data: created, error } = await admin
+        .from('seo_keyword_analyses')
+        .insert({
+          keyword,
+          status,
+          job_id,
+          analyzed_by,
+          analyzed_at: new Date().toISOString(),
+        })
+        .select('id')
+        .single();
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+      return NextResponse.json({ ok: true, id: created.id });
     }
 
     if (type === 'analyzed_post') {
+      // analyzed_posts는 analysis_id (FK)가 필수.
+      // 워커는 keyword/job_id를 함께 보내므로 그걸로 가장 최근 analyzing 분석을 찾아 매핑.
+      const keyword = data.keyword as string | undefined;
+      const job_id = data.job_id as string | undefined;
+      let analysisId = (data.analysis_id as string | undefined) || null;
+
+      if (!analysisId) {
+        analysisId = await findAnalysisId(admin, { jobId: job_id, keyword });
+      }
+      if (!analysisId) {
+        return NextResponse.json(
+          { error: 'analysis_id를 찾을 수 없음 (keyword_analysis 레코드가 먼저 필요)' },
+          { status: 400 }
+        );
+      }
+
+      // 비-스키마 필드 제거 (keyword/job_id는 analyzed_posts 테이블에 없음)
+      const { keyword: _kw, job_id: _jid, analysis_id: _aid, ...insertData } = data;
+
       const { error } = await admin
         .from('seo_analyzed_posts')
-        .insert(payload);
-      if (error) {
-        return NextResponse.json({ error: error.message }, { status: 500 });
+        .insert({ ...insertData, analysis_id: analysisId });
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+      return NextResponse.json({ ok: true });
+    }
+
+    if (type === 'update_analysis_status') {
+      const id = data.id as string | undefined;
+      const job_id = data.job_id as string | undefined;
+      const keyword = data.keyword as string | undefined;
+      const status = data.status as string | undefined;
+      const summary = data.summary as Record<string, unknown> | undefined;
+      // post_count는 seo_keyword_analyses 테이블에 없는 컬럼 — 무시 (또는 summary에 병합)
+
+      if (!status) {
+        return NextResponse.json({ error: 'data.status is required' }, { status: 400 });
       }
+
+      const analysisId = id || (await findAnalysisId(admin, { jobId: job_id, keyword }));
+      if (!analysisId) {
+        return NextResponse.json({ error: 'analysis 레코드를 찾을 수 없음' }, { status: 404 });
+      }
+
+      const updatePayload: Record<string, unknown> = { status };
+      if (summary) updatePayload.summary = summary;
+
+      const { error } = await admin
+        .from('seo_keyword_analyses')
+        .update(updatePayload)
+        .eq('id', analysisId);
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
       return NextResponse.json({ ok: true });
     }
 
     if (type === 'compare_result') {
       const { error } = await admin
         .from('seo_compare_results')
-        .upsert(payload, { onConflict: 'id' });
-      if (error) {
-        return NextResponse.json({ error: error.message }, { status: 500 });
-      }
-      return NextResponse.json({ ok: true });
-    }
-
-    if (type === 'update_analysis_status') {
-      const { id, status, ...rest } = payload as { id: string; status: string; [key: string]: unknown };
-      if (!id || !status) {
-        return NextResponse.json({ error: 'id and status are required' }, { status: 400 });
-      }
-      const { error } = await admin
-        .from('seo_keyword_analyses')
-        .update({ status, ...rest })
-        .eq('id', id);
-      if (error) {
-        return NextResponse.json({ error: error.message }, { status: 500 });
-      }
+        .insert(data);
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
       return NextResponse.json({ ok: true });
     }
 
     return NextResponse.json({ error: `Unknown type: ${type}` }, { status: 400 });
   } catch (error) {
     console.error('[worker-api/seo/data POST]', error);
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal error' },
+      { status: 500 }
+    );
   }
 }

--- a/dental-clinic-manager/src/components/Investment/ScreenerContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/ScreenerContent.tsx
@@ -24,7 +24,6 @@ import { useScanner, type StrategyPayload } from '@/contexts/ScannerContext'
 import type { InvestmentStrategy, ConditionGroup, IndicatorConfig } from '@/types/investment'
 
 const DAYTRADING_PRESET_IDS = new Set(['day-vwap-bounce', 'day-orb-breakout', 'day-closing-pressure'])
-const MAX_STRATEGIES = 10
 
 // 시총 순위 조회 — US는 lazy 인덱스 빌드, KR은 모듈 캐시 사용
 let _usRankIndex: Map<string, number> | null = null
@@ -116,10 +115,8 @@ export default function ScreenerContent() {
       const next = new Set(prev)
       if (next.has(key)) {
         next.delete(key)
-      } else if (next.size < MAX_STRATEGIES) {
-        next.add(key)
       } else {
-        alert(`한 번에 최대 ${MAX_STRATEGIES}개 전략까지 동시 스캔 가능합니다.`)
+        next.add(key)
       }
       return next
     })
@@ -251,7 +248,7 @@ export default function ScreenerContent() {
       <section className="bg-white rounded-2xl shadow-sm border border-at-border p-5">
         <div className="flex items-center justify-between flex-wrap gap-2 mb-3">
           <h2 className="font-semibold text-at-text">📋 1. 전략 선택 (다중 가능)</h2>
-          <span className="text-xs text-at-text-secondary">{selectedKeys.size} / {MAX_STRATEGIES}개 선택됨</span>
+          <span className="text-xs text-at-text-secondary">{selectedKeys.size}개 선택됨</span>
         </div>
 
         {!loadingStrategies && userItems.length > 0 && (


### PR DESCRIPTION
## Summary
- 사용자당 전략 저장 10개 제한 해제
- 스크리너 동시 스캔 10개 제한 해제
- (그리고 직전 develop 커밋 65cfc08c 동반 머지)

## Test plan
- [x] develop 빌드 검증 완료
- [ ] main 머지 후 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)