### PR TITLE
Merge develop: 백테스트 통계 통합 + 자동매매 전략 개수 제한 제거

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/strategies/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/strategies/route.ts
@@ -144,6 +144,9 @@ export async function POST(request: NextRequest) {
       automation_level: automationLevel as number,
       strategy_type: strategyType,
       rl_model_id: (body.rl_model_id as string | undefined) ?? null,
+      source_preset_id: typeof body.sourcePresetId === 'string' && body.sourcePresetId.trim()
+        ? body.sourcePresetId.trim()
+        : null,
       is_active: false, // 신규 전략은 비활성
     })
     .select()

--- a/dental-clinic-manager/src/app/api/investment/strategies/stats/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/strategies/stats/route.ts
@@ -2,11 +2,20 @@
  * 전략별 백테스트 통계 집계
  *
  * GET /api/investment/strategies/stats
- * 사용자의 모든 전략에 대해 backtest_runs 집계 — 전략 카드에 통계 표시용.
+ * 사용자의 모든 전략(저장 전략 + 프리셋)에 대해 backtest_runs 집계.
+ *
+ * 집계 키 규칙:
+ *   - 사용자 전략에 source_preset_id가 있으면 → preset:<source_preset_id>로 묶음 (프리셋 통계와 합산)
+ *   - 사용자 전략에 source_preset_id가 없으면 → user:<strategy_id>로 별도 집계
+ *   - 프리셋만 있는 backtest run (strategy_id IS NULL) → preset:<preset_id>로 집계
  *
  * Response: {
  *   data: [{
- *     strategyId, runs, tickerCount,
+ *     key,                  // 'user:<uuid>' or 'preset:<id>'
+ *     strategyId?,          // user 키일 때
+ *     presetId?,            // preset 키일 때
+ *     linkedStrategyIds?,   // preset 키에 합쳐진 사용자 저장 전략 ID 목록
+ *     runs, tickerCount,
  *     avgReturn, bestReturn, worstReturn,
  *     avgWinRate, avgMDD, avgSharpe,
  *     totalTrades, lastRunAt
@@ -21,7 +30,10 @@ import { getSupabaseAdmin } from '@/lib/supabase/admin'
 export const dynamic = 'force-dynamic'
 
 interface StrategyStats {
-  strategyId: string
+  key: string
+  strategyId?: string
+  presetId?: string
+  linkedStrategyIds?: string[]
   runs: number
   tickerCount: number
   avgReturn: number
@@ -45,22 +57,33 @@ export async function GET() {
     return NextResponse.json({ error: 'Server error' }, { status: 500 })
   }
 
-  // 모든 사용자 backtest run의 핵심 지표만 조회 — 클라이언트보다 더 큰 limit 허용
+  // 사용자의 저장 전략 → source_preset_id 매핑
+  const { data: strategies } = await supabase
+    .from('investment_strategies')
+    .select('id, source_preset_id')
+    .eq('user_id', auth.user.id)
+
+  const strategyToPreset = new Map<string, string | null>()
+  for (const s of (strategies ?? []) as Array<{ id: string; source_preset_id: string | null }>) {
+    strategyToPreset.set(s.id, s.source_preset_id ?? null)
+  }
+
+  // 백테스트 결과 조회
   const { data: runs, error } = await supabase
     .from('backtest_runs')
-    .select('strategy_id, ticker, total_return, win_rate, max_drawdown, sharpe_ratio, total_trades, executed_at')
+    .select('strategy_id, preset_id, ticker, total_return, win_rate, max_drawdown, sharpe_ratio, total_trades, executed_at')
     .eq('user_id', auth.user.id)
     .eq('status', 'completed')
-    .limit(2000)
+    .limit(5000)
 
   if (error) {
     console.error('[strategies/stats] 조회 실패:', error)
     return NextResponse.json({ error: '통계 조회 실패' }, { status: 500 })
   }
 
-  // strategy_id별 집계
   type RunRow = {
-    strategy_id: string
+    strategy_id: string | null
+    preset_id: string | null
     ticker: string
     total_return: number | null
     win_rate: number | null
@@ -70,31 +93,53 @@ export async function GET() {
     executed_at: string | null
   }
 
-  const grouped = new Map<string, RunRow[]>()
+  // key별 그룹핑
+  const grouped = new Map<string, { rows: RunRow[]; linkedStrategies: Set<string> }>()
+  const upsert = (key: string, row: RunRow, linkedStrategyId?: string) => {
+    const entry = grouped.get(key) ?? { rows: [], linkedStrategies: new Set<string>() }
+    entry.rows.push(row)
+    if (linkedStrategyId) entry.linkedStrategies.add(linkedStrategyId)
+    grouped.set(key, entry)
+  }
+
   for (const r of (runs ?? []) as RunRow[]) {
-    if (!r.strategy_id) continue
-    const arr = grouped.get(r.strategy_id) ?? []
-    arr.push(r)
-    grouped.set(r.strategy_id, arr)
+    if (r.strategy_id) {
+      // 사용자 전략 run — source_preset_id 있으면 preset 키로 묶음
+      const sourcePreset = strategyToPreset.get(r.strategy_id)
+      if (sourcePreset) {
+        upsert(`preset:${sourcePreset}`, r, r.strategy_id)
+      } else {
+        upsert(`user:${r.strategy_id}`, r)
+      }
+    } else if (r.preset_id) {
+      upsert(`preset:${r.preset_id}`, r)
+    }
+    // 둘 다 없는 row는 무시
   }
 
   const stats: StrategyStats[] = []
-  for (const [sid, group] of grouped) {
-    const returns = group.map((g) => Number(g.total_return ?? 0))
-    const winRates = group.map((g) => Number(g.win_rate ?? 0))
-    const mdds = group.map((g) => Number(g.max_drawdown ?? 0))
-    const sharpes = group.map((g) => Number(g.sharpe_ratio ?? 0))
-    const trades = group.reduce((s, g) => s + Number(g.total_trades ?? 0), 0)
-    const tickers = new Set(group.map((g) => g.ticker))
-    const lastRunAt = group
+  for (const [key, { rows, linkedStrategies }] of grouped) {
+    const returns = rows.map((g) => Number(g.total_return ?? 0))
+    const winRates = rows.map((g) => Number(g.win_rate ?? 0))
+    const mdds = rows.map((g) => Number(g.max_drawdown ?? 0))
+    const sharpes = rows.map((g) => Number(g.sharpe_ratio ?? 0))
+    const trades = rows.reduce((s, g) => s + Number(g.total_trades ?? 0), 0)
+    const tickers = new Set(rows.map((g) => g.ticker))
+    const lastRunAt = rows
       .map((g) => g.executed_at)
       .filter((x): x is string => Boolean(x))
       .sort()
       .pop() ?? null
 
+    const isPreset = key.startsWith('preset:')
+    const idPart = key.slice(key.indexOf(':') + 1)
+
     stats.push({
-      strategyId: sid,
-      runs: group.length,
+      key,
+      strategyId: isPreset ? undefined : idPart,
+      presetId: isPreset ? idPart : undefined,
+      linkedStrategyIds: isPreset && linkedStrategies.size > 0 ? Array.from(linkedStrategies) : undefined,
+      runs: rows.length,
       tickerCount: tickers.size,
       avgReturn: returns.reduce((s, v) => s + v, 0) / Math.max(returns.length, 1),
       bestReturn: returns.length > 0 ? Math.max(...returns) : 0,

--- a/dental-clinic-manager/src/components/Investment/AutoTradeFromBacktest.tsx
+++ b/dental-clinic-manager/src/components/Investment/AutoTradeFromBacktest.tsx
@@ -318,6 +318,7 @@ export default function AutoTradeFromBacktest() {
             riskSettings: preset.riskSettings,
             automationLevel: 2,
             mode: preset.mode ?? 'swing',
+            sourcePresetId: preset.id,
           }),
         })
         const createJson = await createRes.json()

--- a/dental-clinic-manager/src/components/Investment/CompareContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/CompareContent.tsx
@@ -27,6 +27,8 @@ import type {
 /** 비교 가능한 단일 항목 (사용자 저장 전략 또는 프리셋) */
 interface SelectableItem {
   key: string  // 'user:<uuid>' 또는 'preset:<id>'
+  /** 통계 조회용 키 ('user:<uuid>' 또는 'preset:<id>'). source_preset_id가 있는 사용자 전략은 preset:로 묶임. */
+  statsKey: string
   source: 'user' | 'preset'
   name: string
   description?: string
@@ -189,7 +191,7 @@ function LiveCompareSection() {
       const json = await res.json()
       if (res.ok && Array.isArray(json.data)) {
         const map = new Map<string, StrategyBacktestStats>()
-        for (const s of json.data as StrategyBacktestStats[]) map.set(s.strategyId, s)
+        for (const s of json.data as StrategyBacktestStats[]) map.set(s.key, s)
         setStatsByStrategy(map)
       }
     } catch { /* ignore */ }
@@ -206,6 +208,7 @@ function LiveCompareSection() {
       .filter(s => s.target_market === market)
       .map(s => ({
         key: `user:${s.id}`,
+        statsKey: s.source_preset_id ? `preset:${s.source_preset_id}` : `user:${s.id}`,
         source: 'user' as const,
         name: s.name,
         description: s.description || undefined,
@@ -222,6 +225,7 @@ function LiveCompareSection() {
       .filter(p => !DAYTRADING_PRESET_IDS.has(p.id))
       .map((p: PresetStrategy) => ({
         key: `preset:${p.id}`,
+        statsKey: `preset:${p.id}`,
         source: 'preset' as const,
         name: p.name,
         description: p.description,
@@ -655,7 +659,7 @@ function LiveCompareSection() {
                   selectedIds={selectedIds}
                   onToggle={toggleStrategy}
                   onOpenDetail={setDetailPresetId}
-                  stats={item.strategyId ? statsByStrategy.get(item.strategyId) ?? null : null}
+                  stats={statsByStrategy.get(item.statsKey) ?? null}
                 />
               ))}
             </div>
@@ -703,6 +707,7 @@ function LiveCompareSection() {
                 selectedIds={selectedIds}
                 onToggle={toggleStrategy}
                 onOpenDetail={setDetailPresetId}
+                stats={statsByStrategy.get(item.statsKey) ?? null}
               />
             ))}
           </div>
@@ -1158,12 +1163,10 @@ function SelectableCard({ item, selectedIds, onToggle, onOpenDetail, stats }: {
               )}
             </div>
 
-            {/* 백테스트 통계 (사용자 저장 전략만 — 프리셋은 backtest_runs에 저장 안 됨) */}
-            {item.source === 'user' && (
-              <div className="mt-2">
-                <StrategyStatsBlock stats={stats} compact />
-              </div>
-            )}
+            {/* 백테스트 통계 — 사용자 전략 + 프리셋 모두 표시 */}
+            <div className="mt-2">
+              <StrategyStatsBlock stats={stats} compact />
+            </div>
           </div>
           {isSelected && color && (
             <span className={`flex-shrink-0 w-6 h-6 rounded-full ${color.bg} text-white text-xs font-bold flex items-center justify-center`}>

--- a/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
@@ -88,14 +88,14 @@ export default function InvestmentTab() {
       const json = await res.json()
       if (json.data) setStrategies(json.data)
 
-      // 전략별 백테스트 통계 (병렬)
+      // 전략별 백테스트 통계 (병렬) — key는 'user:<id>' 또는 'preset:<id>'
       try {
         const statsRes = await fetch('/api/investment/strategies/stats')
         const statsJson = await statsRes.json()
         if (statsRes.ok && Array.isArray(statsJson.data)) {
           const map = new Map<string, StrategyBacktestStats>()
           for (const s of statsJson.data as StrategyBacktestStats[]) {
-            map.set(s.strategyId, s)
+            map.set(s.key, s)
           }
           setStatsByStrategy(map)
         }
@@ -572,16 +572,19 @@ function StrategySubTab({ strategies, statsByStrategy, onRefresh, onBacktest, ha
         </div>
       ) : (
         <div className="space-y-3">
-          {strategies.map(s => (
-            <StrategyCard
-              key={s.id}
-              strategy={s}
-              hasCredential={hasCredential}
-              onRefresh={onRefresh}
-              onBacktest={onBacktest}
-              stats={statsByStrategy.get(s.id) ?? null}
-            />
-          ))}
+          {strategies.map(s => {
+            const statKey = s.source_preset_id ? `preset:${s.source_preset_id}` : `user:${s.id}`
+            return (
+              <StrategyCard
+                key={s.id}
+                strategy={s}
+                hasCredential={hasCredential}
+                onRefresh={onRefresh}
+                onBacktest={onBacktest}
+                stats={statsByStrategy.get(statKey) ?? null}
+              />
+            )
+          })}
         </div>
       )}
     </div>

--- a/dental-clinic-manager/src/components/Investment/ScreenerContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/ScreenerContent.tsx
@@ -15,6 +15,7 @@ import { Search, Loader2, AlertCircle, Sparkles, User, X, CheckCircle2, ChevronD
 import TickerInfoModal from './TickerInfoModal'
 import FavoritesButtons from './FavoritesButtons'
 import ScreenerHistoryTab from './ScreenerHistoryTab'
+import StrategyStatsBlock, { type StrategyBacktestStats } from './StrategyStatsBlock'
 import { PRESET_STRATEGIES } from '@/components/Investment/StrategyBuilder/presets'
 import PresetDetailView from '@/components/Investment/PresetDetailView'
 import { getUniverse, type UniverseId } from '@/lib/screenerUniverses'
@@ -38,6 +39,8 @@ function getMarketCapRank(ticker: string, market: 'KR' | 'US'): number | null {
 
 interface SelectableItem {
   key: string  // 'user:<id>' or 'preset:<id>'
+  /** 통계 조회 키 — source_preset_id 있는 사용자 전략은 preset:로 묶임 */
+  statsKey: string
   source: 'user' | 'preset'
   name: string
   description?: string
@@ -70,6 +73,7 @@ export default function ScreenerContent() {
   const [detailPresetId, setDetailPresetId] = useState<string | null>(null)
   const [infoTicker, setInfoTicker] = useState<{ ticker: string; market: 'KR' | 'US'; name: string } | null>(null)
   const [collapsedStrategies, setCollapsedStrategies] = useState<Set<string>>(new Set())
+  const [statsByKey, setStatsByKey] = useState<Map<string, StrategyBacktestStats>>(new Map())
 
   const loadStrategies = useCallback(async () => {
     try {
@@ -86,10 +90,23 @@ export default function ScreenerContent() {
     }
   }, [])
 
-  useEffect(() => { loadStrategies() }, [loadStrategies])
+  const loadStrategyStats = useCallback(async () => {
+    try {
+      const res = await fetch('/api/investment/strategies/stats')
+      const json = await res.json()
+      if (res.ok && Array.isArray(json.data)) {
+        const map = new Map<string, StrategyBacktestStats>()
+        for (const s of json.data as StrategyBacktestStats[]) map.set(s.key, s)
+        setStatsByKey(map)
+      }
+    } catch { /* ignore */ }
+  }, [])
+
+  useEffect(() => { loadStrategies(); loadStrategyStats() }, [loadStrategies, loadStrategyStats])
 
   const userItems: SelectableItem[] = strategies.map(s => ({
     key: `user:${s.id}`,
+    statsKey: s.source_preset_id ? `preset:${s.source_preset_id}` : `user:${s.id}`,
     source: 'user',
     name: s.name,
     description: s.description || undefined,
@@ -101,6 +118,7 @@ export default function ScreenerContent() {
     .filter(p => !DAYTRADING_PRESET_IDS.has(p.id))
     .map(p => ({
       key: `preset:${p.id}`,
+      statsKey: `preset:${p.id}`,
       source: 'preset',
       name: p.name,
       description: p.description,
@@ -266,6 +284,7 @@ export default function ScreenerContent() {
                   selected={selectedKeys.has(item.key)}
                   onToggle={() => toggleStrategy(item.key)}
                   onOpenDetail={setDetailPresetId}
+                  stats={statsByKey.get(item.statsKey) ?? null}
                 />
               ))}
             </div>
@@ -289,6 +308,7 @@ export default function ScreenerContent() {
                   selected={selectedKeys.has(item.key)}
                   onToggle={() => toggleStrategy(item.key)}
                   onOpenDetail={setDetailPresetId}
+                  stats={statsByKey.get(item.statsKey) ?? null}
                 />
               ))}
             </div>
@@ -652,11 +672,12 @@ export default function ScreenerContent() {
   )
 }
 
-function StrategyCard({ item, selected, onToggle, onOpenDetail }: {
+function StrategyCard({ item, selected, onToggle, onOpenDetail, stats }: {
   item: SelectableItem
   selected: boolean
   onToggle: () => void
   onOpenDetail: (id: string) => void
+  stats?: StrategyBacktestStats | null
 }) {
   const presetId = item.source === 'preset' ? item.key.replace(/^preset:/, '') : null
   return (
@@ -677,6 +698,9 @@ function StrategyCard({ item, selected, onToggle, onOpenDetail }: {
           {item.source === 'preset' && (
             <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-100 text-purple-700">프리셋</span>
           )}
+        </div>
+        <div className="mt-1.5">
+          <StrategyStatsBlock stats={stats} compact />
         </div>
       </button>
       {selected && (

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/StrategyBuilder.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/StrategyBuilder.tsx
@@ -36,6 +36,7 @@ export default function StrategyBuilder({ onSaved, onCancel }: Props) {
   const [indicators, setIndicators] = useState<IndicatorConfig[]>([])
   const [buyConditions, setBuyConditions] = useState<ConditionGroup>(EMPTY_GROUP)
   const [sellConditions, setSellConditions] = useState<ConditionGroup>(EMPTY_GROUP)
+  const [sourcePresetId, setSourcePresetId] = useState<string | null>(null)
 
   const handleCancel = () => {
     if (onCancel) {
@@ -51,6 +52,7 @@ export default function StrategyBuilder({ onSaved, onCancel }: Props) {
     setIndicators(preset.indicators)
     setBuyConditions(preset.buyConditions)
     setSellConditions(preset.sellConditions)
+    setSourcePresetId(preset.id)
     setStep('indicators')
   }
 
@@ -73,6 +75,7 @@ export default function StrategyBuilder({ onSaved, onCancel }: Props) {
           buyConditions,
           sellConditions,
           automationLevel,
+          sourcePresetId,
         }),
       })
       const json = await res.json()

--- a/dental-clinic-manager/src/components/Investment/StrategyStatsBlock.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyStatsBlock.tsx
@@ -8,7 +8,12 @@
 import { TrendingUp, TrendingDown, BarChart3 } from 'lucide-react'
 
 export interface StrategyBacktestStats {
-  strategyId: string
+  /** 집계 키: 'user:<uuid>' 또는 'preset:<id>' */
+  key: string
+  strategyId?: string
+  presetId?: string
+  /** 프리셋 키에 합쳐진 사용자 저장 전략 ID 목록 */
+  linkedStrategyIds?: string[]
   runs: number
   tickerCount: number
   avgReturn: number
@@ -50,6 +55,12 @@ export default function StrategyStatsBlock({ stats, compact = false }: Props) {
         </span>
         <span className={`px-1.5 py-0.5 rounded font-mono font-semibold ${stats.avgReturn >= 0 ? 'bg-red-50 text-red-700' : 'bg-blue-50 text-blue-700'}`}>
           평균 {fmtPct(stats.avgReturn)}
+        </span>
+        <span className="px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 font-mono">
+          승률 {stats.avgWinRate.toFixed(0)}%
+        </span>
+        <span className="px-1.5 py-0.5 rounded bg-blue-50 text-blue-700 font-mono">
+          MDD {fmtPct(-Math.abs(stats.avgMDD))}
         </span>
         {stats.bestReturn !== stats.avgReturn && (
           <span className="px-1.5 py-0.5 rounded bg-emerald-50 text-emerald-700 font-mono">

--- a/dental-clinic-manager/src/types/investment.ts
+++ b/dental-clinic-manager/src/types/investment.ts
@@ -200,6 +200,8 @@ export interface InvestmentStrategy {
   is_active: boolean
   created_at: string
   updated_at: string
+  /** 프리셋에서 생성된 경우 원본 프리셋 ID (통계 집계 시 같은 그룹으로 합산) */
+  source_preset_id?: string | null
 }
 
 export interface StrategyInput {

--- a/dental-clinic-manager/supabase/migrations/20260507_add_source_preset_id.sql
+++ b/dental-clinic-manager/supabase/migrations/20260507_add_source_preset_id.sql
@@ -1,0 +1,13 @@
+-- ============================================
+-- 사용자 전략에 원본 프리셋 ID 추가
+-- 프리셋에서 만든 사용자 전략의 백테스트 통계를 프리셋 통계와 합산하기 위함
+-- ============================================
+
+ALTER TABLE investment_strategies
+  ADD COLUMN IF NOT EXISTS source_preset_id TEXT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_investment_strategies_source_preset_id
+  ON investment_strategies (source_preset_id) WHERE source_preset_id IS NOT NULL;
+
+COMMENT ON COLUMN investment_strategies.source_preset_id IS
+  '프리셋 기반으로 생성된 사용자 전략의 원본 프리셋 ID. 통계 집계 시 같은 그룹으로 묶기 위함.';


### PR DESCRIPTION
## Summary
- 자동매매 전략 개수 제한 제거 (저장 10개·동시 스캔 10개)
- 전략 백테스트 통계 — 프리셋·사용자 전략 통합 집계 + 모든 picker 노출
- 사용자 전략에 source_preset_id 추가, 프리셋 origin 추적
- 통계 응답 key 기반 (user/preset), 승률·MDD 표시 추가

## Test plan
- [x] develop 빌드 검증 완료
- [ ] main 머지 후 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)