### PR TITLE
feat: 경쟁 글 분석 미리보기에 참고 글 목록 표시

### DIFF
--- a/dental-clinic-manager/src/app/api/marketing/seo/preview/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/seo/preview/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import { extractKeywordsFromPosts } from '@/lib/marketing/seo-text-miner';
-import type { SeoKeywordMiningResult } from '@/types/marketing';
+import type { SeoKeywordMiningResult, SeoReferencedPost } from '@/types/marketing';
 
 // 글 작성 전 SEO 분석 미리보기
 // - POST: 즉시 응답 (캐시 결과 또는 큐 상태). stale 잡(5분+ running)은 자동 fail 처리 후 재큐잉
@@ -56,14 +56,38 @@ function estimateRunningProgress(startedAt: string | null): { progress: number; 
 /** 캐시된 완료 분석을 SeoKeywordMiningResult로 변환 (없으면 on-the-fly 계산) */
 async function buildResultFromAnalysis(admin: ReturnType<typeof getSupabaseAdmin>, analysis: AnalysisRow, keyword: string): Promise<SeoKeywordMiningResult | null> {
   if (!admin) return null;
-  if (analysis.summary?.textMining) return analysis.summary.textMining;
-  const { data: posts } = await admin
+
+  // 참고 글 목록은 캐시에 저장되어 있지 않은 기존 분석도 보강할 수 있도록 별도로 항상 조회한다.
+  const { data: postRows } = await admin
     .from('seo_analyzed_posts')
-    .select('body_text, title, tags, body_length, image_count, heading_count, keyword_count')
+    .select('body_text, title, tags, body_length, image_count, heading_count, keyword_count, rank, post_url, blog_name')
     .eq('analysis_id', analysis.id)
     .order('rank', { ascending: true });
-  if (!posts || posts.length === 0) return null;
-  return extractKeywordsFromPosts(posts, keyword);
+
+  // postUrl 기준 중복 제거 (워커가 같은 글을 두 번 저장하는 경우가 있음 — rank별 1행만 유지)
+  const seenUrls = new Set<string>();
+  const referencedPosts: SeoReferencedPost[] = [];
+  for (const p of postRows ?? []) {
+    const postUrl = typeof p.post_url === 'string' ? p.post_url : '';
+    if (postUrl && seenUrls.has(postUrl)) continue;
+    if (postUrl) seenUrls.add(postUrl);
+    referencedPosts.push({
+      rank: typeof p.rank === 'number' ? p.rank : 0,
+      title: typeof p.title === 'string' ? p.title : '',
+      postUrl,
+      blogName: typeof p.blog_name === 'string' ? p.blog_name : null,
+      bodyLength: typeof p.body_length === 'number' ? p.body_length : 0,
+      imageCount: typeof p.image_count === 'number' ? p.image_count : 0,
+      headingCount: typeof p.heading_count === 'number' ? p.heading_count : 0,
+    });
+  }
+
+  if (analysis.summary?.textMining) {
+    return { ...analysis.summary.textMining, referencedPosts };
+  }
+  if (!postRows || postRows.length === 0) return null;
+  const mined = extractKeywordsFromPosts(postRows, keyword);
+  return { ...mined, referencedPosts };
 }
 
 /** 키워드의 현재 상태 조사 — POST/GET 공용 핵심 로직 */

--- a/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
@@ -482,6 +482,39 @@ export default function NewMarketingPostPage() {
                   </div>
                 )}
 
+                {seoResult.referencedPosts && seoResult.referencedPosts.length > 0 && (
+                  <div>
+                    <p className="text-[11px] font-medium text-at-text-secondary mb-1.5">
+                      분석에 참고한 글 ({seoResult.referencedPosts.length}개)
+                    </p>
+                    <ul className="space-y-1">
+                      {seoResult.referencedPosts.map((p) => (
+                        <li key={`${p.rank}-${p.postUrl}`} className="text-[11px] leading-relaxed">
+                          <span className="inline-block w-6 text-at-text-weak font-medium">{p.rank}위</span>
+                          <span className="text-at-text-weak">
+                            글자수 {p.bodyLength.toLocaleString()}자 · 이미지 {p.imageCount}장 · 소제목 {p.headingCount}개 —{' '}
+                          </span>
+                          {p.postUrl ? (
+                            <a
+                              href={p.postUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-indigo-700 hover:underline break-all"
+                            >
+                              {p.title || p.postUrl}
+                            </a>
+                          ) : (
+                            <span className="text-at-text">{p.title}</span>
+                          )}
+                          {p.blogName && (
+                            <span className="text-at-text-weak"> ({p.blogName})</span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
                 <div className="flex items-center gap-2 flex-wrap">
                   <button
                     type="button"

--- a/dental-clinic-manager/src/types/marketing.ts
+++ b/dental-clinic-manager/src/types/marketing.ts
@@ -400,6 +400,16 @@ export interface SEOValidationResult {
 
 // ─── SEO 텍스트 마이닝 결과 ───
 
+export interface SeoReferencedPost {
+  rank: number;
+  title: string;
+  postUrl: string;
+  blogName: string | null;
+  bodyLength: number;
+  imageCount: number;
+  headingCount: number;
+}
+
 export interface SeoKeywordMiningResult {
   competitorKeywords: { keyword: string; frequency: number; postCount: number; perPostFrequency?: number[] }[];
   recommendedKeywords: string[];
@@ -408,6 +418,8 @@ export interface SeoKeywordMiningResult {
   avgHeadingCount: number;
   avgKeywordCount: number;
   commonTags: string[];
+  /** 분석에 참고한 네이버 상위 노출 글 (rank 오름차순) */
+  referencedPosts?: SeoReferencedPost[];
   titlePatterns: string[];
 }
 


### PR DESCRIPTION
## Summary
- 경쟁 글 분석 미리보기 카드에 "분석에 참고한 글 (N개)" 섹션 추가
- 각 항목: 순위·글자수·이미지수·소제목수 + 제목(외부 링크, 새 탭) + 블로그명
- preview API가 seo_analyzed_posts에서 항상 글 정보를 조회하여 referencedPosts로 반환 → 기존 캐시 호환
- postUrl 기준 dedupe (워커 중복 저장 방어)

## E2E 검증
- 테스트 키워드 "천호역 임플란트" → 5개 글이 정상 dedupe되어 1~5위 노출
- 각 항목 제목 링크 클릭 시 새 탭으로 원본 네이버 블로그 이동
- 빌드 통과

## Test plan
- [ ] /dashboard/marketing/posts/new에서 키워드 입력 후 "분석 실행"
- [ ] 분석 완료 후 미리보기 카드에 "분석에 참고한 글 (5개)" 섹션 확인
- [ ] 각 항목의 제목 링크 클릭 시 새 탭에서 원본 글 열림
- [ ] 글자수 0인 글(스크래핑 실패)도 목록에 표시되되 통계는 0으로 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)