### PR TITLE
feat: 텍스트 카드 라이브 미리보기 + 브랜드 메뉴 통합

### DIFF
--- a/dental-clinic-manager/src/app/api/marketing/brand/assets/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/brand/assets/route.ts
@@ -45,6 +45,9 @@ export async function PUT(request: NextRequest) {
     ? body.medical_law_preset
     : 'yellow_black';
 
+  const rawWidth = Number(body.title_border_width);
+  const titleBorderWidth = Number.isFinite(rawWidth) ? Math.min(60, Math.max(0, Math.round(rawWidth))) : 16;
+
   const payload: Partial<BrandAssets> = {
     name_ko: body.name_ko ?? null,
     name_en: body.name_en ?? null,
@@ -55,6 +58,7 @@ export async function PUT(request: NextRequest) {
     medical_law_preset: preset,
     medical_law_top_text: body.medical_law_top_text || '본 포스팅은 의료법 제56조 및 동법 시행령을 준수하여 {clinic_name}에서 정보제공을 위해 직접 작성하였습니다.',
     medical_law_bottom_text: body.medical_law_bottom_text || '모든 시술 및 수술은 부작용이 발생할 수 있으니 의료진과 충분한 상담 후 치료받으시기 바랍니다.',
+    title_border_width: titleBorderWidth,
   };
 
   const admin = getSupabaseAdmin();

--- a/dental-clinic-manager/src/app/api/marketing/brand/render/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/brand/render/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import { renderBrandImage } from '@/lib/marketing/brand/render-engine';
-import type { BrandAssets, BrandImageType, BrandPhoto } from '@/types/brand';
+import type { BrandAssets, BrandImageType, BrandPhoto, DraftBrandAssets } from '@/types/brand';
 
 export const maxDuration = 60;
 
@@ -10,6 +10,27 @@ interface RenderBody {
   type: BrandImageType;
   copy?: string;
   photoId?: string;
+  /** 저장되지 않은 자산을 라이브 미리보기로 합성할 때 사용. 합성 결과는 캐시하지 않는다. */
+  draftAssets?: DraftBrandAssets;
+}
+
+const DRAFT_KEYS: (keyof DraftBrandAssets)[] = [
+  'name_ko', 'name_en', 'logo_url',
+  'primary_color', 'secondary_color', 'slogan',
+  'medical_law_preset', 'medical_law_top_text', 'medical_law_bottom_text',
+  'title_border_width',
+];
+
+function applyDraft(base: BrandAssets, draft: DraftBrandAssets | undefined): BrandAssets {
+  if (!draft) return base;
+  const merged = { ...base };
+  for (const k of DRAFT_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(draft, k)) {
+      // 안전한 동적 대입
+      (merged as unknown as Record<string, unknown>)[k] = (draft as unknown as Record<string, unknown>)[k];
+    }
+  }
+  return merged;
 }
 
 export async function POST(request: NextRequest) {
@@ -34,12 +55,14 @@ export async function POST(request: NextRequest) {
     const clinicId = profile.clinic_id;
 
     // 자산 조회
-    const { data: assets } = await (admin as any)
+    const { data: rawAssets } = await (admin as any)
       .from('clinic_brand_assets')
       .select('*')
       .eq('clinic_id', clinicId)
       .maybeSingle();
-    if (!assets) return NextResponse.json({ error: '브랜드 자산 미설정' }, { status: 404 });
+    if (!rawAssets) return NextResponse.json({ error: '브랜드 자산 미설정' }, { status: 404 });
+
+    const assets = applyDraft(rawAssets as BrandAssets, body.draftAssets);
 
     // 사진 조회 (필요 시)
     let photo: BrandPhoto | undefined;
@@ -57,9 +80,11 @@ export async function POST(request: NextRequest) {
 
     const url = await renderBrandImage({
       type: body.type,
-      assets: assets as BrandAssets,
+      assets,
       copy: body.copy,
       photo,
+      // draft 모드일 때는 cache hit/miss를 캐시 테이블에 기록하지 않음 (DB 미저장 상태이므로 의미 없음)
+      bypassCache: !!body.draftAssets,
     });
     return NextResponse.json({ url });
   } catch (err) {

--- a/dental-clinic-manager/src/app/dashboard/marketing/brand/BrandSettingsClient.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/brand/BrandSettingsClient.tsx
@@ -1,13 +1,45 @@
 'use client';
+import { useEffect, useState } from 'react';
 import { useBrandAssets } from '@/hooks/useBrandAssets';
-import { BrandSettingsForm } from '@/components/marketing/brand/BrandSettingsForm';
+import {
+  BrandSettingsForm,
+  fromAssets,
+  type BrandFormState,
+} from '@/components/marketing/brand/BrandSettingsForm';
 import { BrandPhotoUploader } from '@/components/marketing/brand/BrandPhotoUploader';
 import { BrandPreview } from '@/components/marketing/brand/BrandPreview';
+import type { DraftBrandAssets } from '@/types/brand';
 
 interface Props { canManage: boolean }
 
+function toDraftAssets(state: BrandFormState): DraftBrandAssets {
+  return {
+    name_ko: state.name_ko || null,
+    name_en: state.name_en || null,
+    logo_url: state.logo_url || null,
+    primary_color: state.primary_color,
+    secondary_color: state.secondary_color,
+    slogan: state.slogan || null,
+    medical_law_preset: state.medical_law_preset,
+    medical_law_top_text: state.medical_law_top_text,
+    medical_law_bottom_text: state.medical_law_bottom_text,
+    title_border_width: state.title_border_width,
+  };
+}
+
 export function BrandSettingsClient({ canManage }: Props) {
   const { assets, photos, loading, saveAssets, uploadPhoto, deletePhoto, updatePhoto } = useBrandAssets();
+  const [formState, setFormState] = useState<BrandFormState>(() => fromAssets(null));
+  const [saving, setSaving] = useState(false);
+
+  // 자산 로드/갱신 시 폼 초기화 (사용자가 수정 중이면 덮어쓰지 않음)
+  const [initialized, setInitialized] = useState(false);
+  useEffect(() => {
+    if (!loading && !initialized) {
+      setFormState(fromAssets(assets));
+      setInitialized(true);
+    }
+  }, [loading, initialized, assets]);
 
   const handleLogoUpload = async (file: File): Promise<string> => {
     const fd = new FormData();
@@ -18,7 +50,32 @@ export function BrandSettingsClient({ canManage }: Props) {
     return json.url;
   };
 
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const saved = await saveAssets({
+        name_ko: formState.name_ko || null,
+        name_en: formState.name_en || null,
+        logo_url: formState.logo_url || null,
+        primary_color: formState.primary_color,
+        secondary_color: formState.secondary_color,
+        slogan: formState.slogan || null,
+        medical_law_preset: formState.medical_law_preset,
+        medical_law_top_text: formState.medical_law_top_text,
+        medical_law_bottom_text: formState.medical_law_bottom_text,
+        title_border_width: formState.title_border_width,
+      });
+      // 저장 완료 후 폼을 서버 결과로 동기화
+      setFormState(fromAssets(saved));
+    } finally {
+      setSaving(false);
+    }
+  };
+
   if (loading) return <div className="p-8 text-sm text-at-text-weak">불러오는 중…</div>;
+
+  // 라이브 미리보기용 draft. 저장된 자산이 없으면 BrandPreview는 안내만 표시하므로 무관.
+  const draftAssets = canManage ? toDraftAssets(formState) : undefined;
 
   return (
     <div className="p-6 space-y-6">
@@ -32,7 +89,13 @@ export function BrandSettingsClient({ canManage }: Props) {
           <section className="bg-white rounded-xl border border-at-border p-5">
             <h2 className="text-sm font-semibold text-at-text mb-4">자산 입력</h2>
             {canManage ? (
-              <BrandSettingsForm assets={assets} onSave={saveAssets} onLogoUpload={handleLogoUpload} />
+              <BrandSettingsForm
+                state={formState}
+                onChange={setFormState}
+                onSave={handleSave}
+                onLogoUpload={handleLogoUpload}
+                saving={saving}
+              />
             ) : (
               <p className="text-sm text-at-text-weak">조회만 가능합니다 (자산 관리 권한 없음).</p>
             )}
@@ -55,8 +118,8 @@ export function BrandSettingsClient({ canManage }: Props) {
 
         <aside className="lg:col-span-1">
           <section className="bg-white rounded-xl border border-at-border p-5 sticky top-4">
-            <h2 className="text-sm font-semibold text-at-text mb-4">미리보기</h2>
-            <BrandPreview assets={assets} photos={photos} />
+            <h2 className="text-sm font-semibold text-at-text mb-4">미리보기 (수정 시 즉시 반영)</h2>
+            <BrandPreview assets={assets} photos={photos} draftAssets={draftAssets} />
           </section>
         </aside>
       </div>

--- a/dental-clinic-manager/src/app/dashboard/marketing/brand/BrandSettingsClient.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/brand/BrandSettingsClient.tsx
@@ -10,7 +10,11 @@ import { BrandPhotoUploader } from '@/components/marketing/brand/BrandPhotoUploa
 import { BrandPreview } from '@/components/marketing/brand/BrandPreview';
 import type { DraftBrandAssets } from '@/types/brand';
 
-interface Props { canManage: boolean }
+interface Props {
+  canManage: boolean;
+  /** true면 페이지 헤더와 외곽 padding을 생략 (서브탭/모달 안에서 사용) */
+  embedded?: boolean;
+}
 
 function toDraftAssets(state: BrandFormState): DraftBrandAssets {
   return {
@@ -27,7 +31,7 @@ function toDraftAssets(state: BrandFormState): DraftBrandAssets {
   };
 }
 
-export function BrandSettingsClient({ canManage }: Props) {
+export function BrandSettingsClient({ canManage, embedded = false }: Props) {
   const { assets, photos, loading, saveAssets, uploadPhoto, deletePhoto, updatePhoto } = useBrandAssets();
   const [formState, setFormState] = useState<BrandFormState>(() => fromAssets(null));
   const [saving, setSaving] = useState(false);
@@ -78,11 +82,16 @@ export function BrandSettingsClient({ canManage }: Props) {
   const draftAssets = canManage ? toDraftAssets(formState) : undefined;
 
   return (
-    <div className="p-6 space-y-6">
-      <header>
-        <h1 className="text-2xl font-bold text-at-text">브랜드 이미지 설정</h1>
-        <p className="text-sm text-at-text-secondary mt-1">블로그 글에 자동으로 삽입될 의료법 안내·텍스트 카드·사진 오버레이의 디자인 자산을 설정합니다.</p>
-      </header>
+    <div className={embedded ? 'space-y-6' : 'p-6 space-y-6'}>
+      {!embedded && (
+        <header>
+          <h1 className="text-2xl font-bold text-at-text">브랜드 이미지 설정</h1>
+          <p className="text-sm text-at-text-secondary mt-1">블로그 글에 자동으로 삽입될 의료법 안내·텍스트 카드·사진 오버레이의 디자인 자산을 설정합니다.</p>
+        </header>
+      )}
+      {embedded && (
+        <p className="text-sm text-at-text-secondary">블로그 글에 자동으로 삽입될 의료법 안내·텍스트 카드·사진 오버레이의 디자인 자산을 설정합니다.</p>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2 space-y-6">

--- a/dental-clinic-manager/src/app/dashboard/marketing/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/page.tsx
@@ -26,6 +26,8 @@ import PremiumGate from '@/components/Premium/PremiumGate'
 import NewPostForm from '@/components/marketing/NewPostForm'
 import ScheduleModal from '@/components/marketing/ScheduleModal'
 import WorkerStatusBanner from '@/components/marketing/WorkerStatusBanner'
+import { BrandSettingsClient } from '@/app/dashboard/marketing/brand/BrandSettingsClient'
+import { usePermissions } from '@/hooks/usePermissions'
 import dynamic from 'next/dynamic'
 
 const ContentEditor = dynamic(() => import('@/components/marketing/ContentEditor'), { ssr: false })
@@ -841,7 +843,53 @@ interface PlatformSetting {
 }
 
 // ─── 설정 ───
+// ─── 설정 (서브탭: 플랫폼 연동 / 브랜드 이미지) ───
+type SettingsSubTab = 'platforms' | 'brand'
+
 function SettingsContent() {
+  const [subTab, setSubTab] = useState<SettingsSubTab>('platforms')
+  const { hasPermission } = usePermissions()
+  const canViewBrand = hasPermission('marketing_brand_view')
+  const canManageBrand = hasPermission('marketing_brand_manage')
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2 border-b border-at-border pb-3">
+        <button
+          type="button"
+          onClick={() => setSubTab('platforms')}
+          className={`py-1.5 px-3 inline-flex items-center rounded-lg text-sm font-medium transition-all ${
+            subTab === 'platforms'
+              ? 'bg-at-accent-light text-at-accent'
+              : 'text-at-text-weak hover:text-at-text-secondary hover:bg-at-surface-alt'
+          }`}
+        >
+          플랫폼 연동
+        </button>
+        {canViewBrand && (
+          <button
+            type="button"
+            onClick={() => setSubTab('brand')}
+            className={`py-1.5 px-3 inline-flex items-center rounded-lg text-sm font-medium transition-all ${
+              subTab === 'brand'
+                ? 'bg-at-accent-light text-at-accent'
+                : 'text-at-text-weak hover:text-at-text-secondary hover:bg-at-surface-alt'
+            }`}
+          >
+            브랜드 이미지
+          </button>
+        )}
+      </div>
+
+      {subTab === 'platforms' && <PlatformSettings />}
+      {subTab === 'brand' && canViewBrand && (
+        <BrandSettingsClient canManage={canManageBrand} embedded />
+      )}
+    </div>
+  )
+}
+
+function PlatformSettings() {
   const [settings, setSettings] = useState<PlatformSetting[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [editingPlatform, setEditingPlatform] = useState<PlatformId | null>(null)

--- a/dental-clinic-manager/src/components/marketing/brand/BrandPreview.tsx
+++ b/dental-clinic-manager/src/components/marketing/brand/BrandPreview.tsx
@@ -1,10 +1,14 @@
 'use client';
 import { useEffect, useState } from 'react';
-import type { BrandAssets, BrandPhoto } from '@/types/brand';
+import type { BrandAssets, BrandPhoto, DraftBrandAssets } from '@/types/brand';
 
 interface Props {
+  /** 저장된 자산 (없으면 안내 메시지 표시) */
   assets: BrandAssets | null;
   photos: BrandPhoto[];
+  /** 라이브 미리보기용 임시 자산 — 폼 입력값을 즉시 반영 */
+  draftAssets?: DraftBrandAssets;
+  /** 텍스트 카드 미리보기 카피. 미지정 시 `{name_ko} / 임플란트` 자동 생성 */
   sampleCopy?: string;
 }
 
@@ -14,34 +18,50 @@ const TYPES = [
   { type: 'photo' as const, label: '병원 사진' },
 ];
 
-export function BrandPreview({ assets, photos, sampleCopy = '강남숙면치과 / 임플란트' }: Props) {
+function deriveSampleCopy(assets: BrandAssets | null, draft: DraftBrandAssets | undefined, override: string | undefined): string {
+  if (override) return override;
+  const nameKo = (draft?.name_ko ?? assets?.name_ko ?? '').trim();
+  const base = nameKo || '클리닉명';
+  return `${base} / 임플란트`;
+}
+
+export function BrandPreview({ assets, photos, draftAssets, sampleCopy: sampleCopyProp }: Props) {
   const [urls, setUrls] = useState<Record<string, string | undefined>>({});
   const [loading, setLoading] = useState(false);
 
+  // draftAssets는 객체 참조가 매번 달라지므로 의미 있는 부분만 직렬화하여 의존성으로 사용
+  const draftKey = draftAssets ? JSON.stringify(draftAssets) : '';
+  const photosKey = photos.map((p) => p.id).join(',');
+
   useEffect(() => {
     if (!assets) return;
+    const sampleCopy = deriveSampleCopy(assets, draftAssets, sampleCopyProp);
+
     let cancelled = false;
     const t = setTimeout(async () => {
       setLoading(true);
       try {
         const requests: Promise<{ key: string; url?: string }>[] = [];
+
+        const baseBody = draftAssets ? { draftAssets } : {};
+
         requests.push(
           fetch('/api/marketing/brand/render', {
             method: 'POST', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ type: 'medical_law' }),
+            body: JSON.stringify({ type: 'medical_law', ...baseBody }),
           }).then(r => r.json()).then(j => ({ key: 'medical_law', url: j.url })),
         );
         requests.push(
           fetch('/api/marketing/brand/render', {
             method: 'POST', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ type: 'title', copy: sampleCopy }),
+            body: JSON.stringify({ type: 'title', copy: sampleCopy, ...baseBody }),
           }).then(r => r.json()).then(j => ({ key: 'title', url: j.url })),
         );
         if (photos.length > 0) {
           requests.push(
             fetch('/api/marketing/brand/render', {
               method: 'POST', headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ type: 'photo', photoId: photos[0].id }),
+              body: JSON.stringify({ type: 'photo', photoId: photos[0].id, ...baseBody }),
             }).then(r => r.json()).then(j => ({ key: 'photo', url: j.url })),
           );
         }
@@ -55,7 +75,8 @@ export function BrandPreview({ assets, photos, sampleCopy = '강남숙면치과 
       }
     }, 500);
     return () => { cancelled = true; clearTimeout(t); };
-  }, [assets, photos, sampleCopy]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [assets?.clinic_id, photosKey, draftKey, sampleCopyProp]);
 
   if (!assets) return <p className="text-sm text-at-text-weak">먼저 자산을 저장해주세요.</p>;
 

--- a/dental-clinic-manager/src/components/marketing/brand/BrandSettingsForm.tsx
+++ b/dental-clinic-manager/src/components/marketing/brand/BrandSettingsForm.tsx
@@ -1,65 +1,78 @@
 'use client';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import type { BrandAssets, MedicalLawPresetKey } from '@/types/brand';
 import { MedicalLawPresetPicker } from './MedicalLawPresetPicker';
 
-interface Props {
-  assets: BrandAssets | null;
-  onSave: (input: Partial<BrandAssets>) => Promise<BrandAssets>;
-  onLogoUpload: (file: File) => Promise<string>;
+export interface BrandFormState {
+  name_ko: string;
+  name_en: string;
+  logo_url: string;
+  primary_color: string;
+  secondary_color: string;
+  slogan: string;
+  medical_law_preset: MedicalLawPresetKey;
+  medical_law_top_text: string;
+  medical_law_bottom_text: string;
+  title_border_width: number;
 }
 
-export function BrandSettingsForm({ assets, onSave, onLogoUpload }: Props) {
-  const [nameKo, setNameKo] = useState(assets?.name_ko ?? '');
-  const [nameEn, setNameEn] = useState(assets?.name_en ?? '');
-  const [logoUrl, setLogoUrl] = useState(assets?.logo_url ?? '');
-  const [primary, setPrimary] = useState(assets?.primary_color ?? '#1B5E20');
-  const [secondary, setSecondary] = useState(assets?.secondary_color ?? '#FFC107');
-  const [slogan, setSlogan] = useState(assets?.slogan ?? '');
-  const [preset, setPreset] = useState<MedicalLawPresetKey>(assets?.medical_law_preset ?? 'yellow_black');
-  const [topText, setTopText] = useState(assets?.medical_law_top_text ?? '본 포스팅은 의료법 제56조 및 동법 시행령을 준수하여 {clinic_name}에서 정보제공을 위해 직접 작성하였습니다.');
-  const [bottomText, setBottomText] = useState(assets?.medical_law_bottom_text ?? '모든 시술 및 수술은 부작용이 발생할 수 있으니 의료진과 충분한 상담 후 치료받으시기 바랍니다.');
-  const [saving, setSaving] = useState(false);
+export const DEFAULT_FORM_STATE: BrandFormState = {
+  name_ko: '',
+  name_en: '',
+  logo_url: '',
+  primary_color: '#1B5E20',
+  secondary_color: '#FFC107',
+  slogan: '',
+  medical_law_preset: 'yellow_black',
+  medical_law_top_text: '본 포스팅은 의료법 제56조 및 동법 시행령을 준수하여 {clinic_name}에서 정보제공을 위해 직접 작성하였습니다.',
+  medical_law_bottom_text: '모든 시술 및 수술은 부작용이 발생할 수 있으니 의료진과 충분한 상담 후 치료받으시기 바랍니다.',
+  title_border_width: 16,
+};
+
+export function fromAssets(a: BrandAssets | null): BrandFormState {
+  if (!a) return DEFAULT_FORM_STATE;
+  return {
+    name_ko: a.name_ko ?? '',
+    name_en: a.name_en ?? '',
+    logo_url: a.logo_url ?? '',
+    primary_color: a.primary_color || '#1B5E20',
+    secondary_color: a.secondary_color || '#FFC107',
+    slogan: a.slogan ?? '',
+    medical_law_preset: a.medical_law_preset,
+    medical_law_top_text: a.medical_law_top_text || DEFAULT_FORM_STATE.medical_law_top_text,
+    medical_law_bottom_text: a.medical_law_bottom_text || DEFAULT_FORM_STATE.medical_law_bottom_text,
+    title_border_width: typeof a.title_border_width === 'number' ? a.title_border_width : 16,
+  };
+}
+
+interface Props {
+  state: BrandFormState;
+  onChange: (next: BrandFormState) => void;
+  onSave: () => Promise<void>;
+  onLogoUpload: (file: File) => Promise<string>;
+  saving?: boolean;
+}
+
+export function BrandSettingsForm({ state, onChange, onSave, onLogoUpload, saving }: Props) {
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!assets) return;
-    setNameKo(assets.name_ko ?? '');
-    setNameEn(assets.name_en ?? '');
-    setLogoUrl(assets.logo_url ?? '');
-    setPrimary(assets.primary_color);
-    setSecondary(assets.secondary_color);
-    setSlogan(assets.slogan ?? '');
-    setPreset(assets.medical_law_preset);
-    setTopText(assets.medical_law_top_text);
-    setBottomText(assets.medical_law_bottom_text);
-  }, [assets]);
+  const update = <K extends keyof BrandFormState>(key: K, value: BrandFormState[K]) => {
+    onChange({ ...state, [key]: value });
+  };
 
   const handleSave = async () => {
-    setSaving(true); setError(null);
+    setError(null);
     try {
-      await onSave({
-        name_ko: nameKo || null,
-        name_en: nameEn || null,
-        logo_url: logoUrl || null,
-        primary_color: primary,
-        secondary_color: secondary,
-        slogan: slogan || null,
-        medical_law_preset: preset,
-        medical_law_top_text: topText,
-        medical_law_bottom_text: bottomText,
-      });
+      await onSave();
     } catch (e) {
       setError(e instanceof Error ? e.message : '저장 실패');
-    } finally {
-      setSaving(false);
     }
   };
 
   const handleLogo = async (file: File) => {
     try {
       const url = await onLogoUpload(file);
-      setLogoUrl(url);
+      update('logo_url', url);
     } catch (e) {
       setError(e instanceof Error ? e.message : '로고 업로드 실패');
     }
@@ -69,18 +82,18 @@ export function BrandSettingsForm({ assets, onSave, onLogoUpload }: Props) {
     <div className="space-y-5">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <Field label="클리닉명 (한글)">
-          <input value={nameKo} onChange={(e) => setNameKo(e.target.value)} className={inputCls} placeholder="강남숙면치과" />
+          <input value={state.name_ko} onChange={(e) => update('name_ko', e.target.value)} className={inputCls} placeholder="강남숙면치과" />
         </Field>
         <Field label="클리닉명 (영문)">
-          <input value={nameEn} onChange={(e) => setNameEn(e.target.value)} className={inputCls} placeholder="GANGNAM SM DENTAL CLINIC" />
+          <input value={state.name_en} onChange={(e) => update('name_en', e.target.value)} className={inputCls} placeholder="GANGNAM SM DENTAL CLINIC" />
         </Field>
       </div>
 
       <Field label="로고 이미지">
         <div className="flex items-center gap-3">
-          {logoUrl && (
+          {state.logo_url && (
             // eslint-disable-next-line @next/next/no-img-element
-            <img src={logoUrl} alt="" className="h-16 w-16 object-contain bg-white border border-at-border rounded" />
+            <img src={state.logo_url} alt="" className="h-16 w-16 object-contain bg-white border border-at-border rounded" />
           )}
           <label className="cursor-pointer inline-flex items-center gap-2 px-3 py-1.5 border border-at-border rounded-lg hover:bg-at-surface-alt text-sm">
             업로드
@@ -91,35 +104,51 @@ export function BrandSettingsForm({ assets, onSave, onLogoUpload }: Props) {
       </Field>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <Field label="주 브랜드 컬러">
+        <Field label="주 브랜드 컬러 (텍스트 카드 테두리)">
           <div className="flex items-center gap-2">
-            <input type="color" value={primary} onChange={(e) => setPrimary(e.target.value)} className="h-9 w-12 cursor-pointer" />
-            <input value={primary} onChange={(e) => setPrimary(e.target.value)} className={inputCls} />
+            <input type="color" value={state.primary_color} onChange={(e) => update('primary_color', e.target.value)} className="h-9 w-12 cursor-pointer" />
+            <input value={state.primary_color} onChange={(e) => update('primary_color', e.target.value)} className={inputCls} />
           </div>
         </Field>
         <Field label="보조 브랜드 컬러">
           <div className="flex items-center gap-2">
-            <input type="color" value={secondary} onChange={(e) => setSecondary(e.target.value)} className="h-9 w-12 cursor-pointer" />
-            <input value={secondary} onChange={(e) => setSecondary(e.target.value)} className={inputCls} />
+            <input type="color" value={state.secondary_color} onChange={(e) => update('secondary_color', e.target.value)} className="h-9 w-12 cursor-pointer" />
+            <input value={state.secondary_color} onChange={(e) => update('secondary_color', e.target.value)} className={inputCls} />
           </div>
         </Field>
       </div>
 
+      <Field label={`테스트 카드 테두리 두께 (${state.title_border_width}px)`}>
+        <div className="flex items-center gap-3">
+          <input
+            type="range"
+            min={0}
+            max={60}
+            step={2}
+            value={state.title_border_width}
+            onChange={(e) => update('title_border_width', Number(e.target.value))}
+            className="flex-1 h-2 accent-at-accent cursor-pointer"
+          />
+          <span className="w-12 text-right text-sm text-at-text-secondary">{state.title_border_width}px</span>
+        </div>
+        <p className="text-[11px] text-at-text-weak mt-1">0px(테두리 없음) ~ 60px. 주 브랜드 컬러로 적용됩니다.</p>
+      </Field>
+
       <Field label="슬로건 (텍스트 이미지 상단)">
-        <input value={slogan} onChange={(e) => setSlogan(e.target.value)} className={inputCls} placeholder="보건복지부 인증 치주과 전문의 의료진의 책임진료!" />
+        <input value={state.slogan} onChange={(e) => update('slogan', e.target.value)} className={inputCls} placeholder="보건복지부 인증 치주과 전문의 의료진의 책임진료!" />
       </Field>
 
       <Field label="의료법 안내 컬러 프리셋">
-        <MedicalLawPresetPicker value={preset} onChange={setPreset} />
+        <MedicalLawPresetPicker value={state.medical_law_preset} onChange={(p) => update('medical_law_preset', p)} />
       </Field>
 
       <Field label="의료법 안내 — 상단 문장">
-        <textarea value={topText} onChange={(e) => setTopText(e.target.value)} className={`${inputCls} min-h-[60px]`} />
+        <textarea value={state.medical_law_top_text} onChange={(e) => update('medical_law_top_text', e.target.value)} className={`${inputCls} min-h-[60px]`} />
         <p className="text-[11px] text-at-text-weak mt-1">{'`{clinic_name}`은 클리닉명으로 자동 치환됩니다.'}</p>
       </Field>
 
       <Field label="의료법 안내 — 하단 문장">
-        <textarea value={bottomText} onChange={(e) => setBottomText(e.target.value)} className={`${inputCls} min-h-[60px]`} />
+        <textarea value={state.medical_law_bottom_text} onChange={(e) => update('medical_law_bottom_text', e.target.value)} className={`${inputCls} min-h-[60px]`} />
       </Field>
 
       {error && <p className="text-sm text-at-error">{error}</p>}

--- a/dental-clinic-manager/src/config/menuConfig.ts
+++ b/dental-clinic-manager/src/config/menuConfig.ts
@@ -371,17 +371,7 @@ export const MENU_CONFIG: MenuConfigItem[] = [
     visible: true,
     premiumFeature: true,  // 프리미엄 기능
   },
-  {
-    id: 'marketing-brand',
-    label: '브랜드 이미지',
-    icon: 'Palette',
-    route: '/dashboard/marketing/brand',
-    permissions: ['marketing_brand_view'],
-    categoryId: 'operations',
-    order: 16.1,
-    visible: true,
-    premiumFeature: true,  // 프리미엄 기능 (마케팅 자동화 plan 포함)
-  },
+  // 브랜드 이미지는 마케팅 자동화 페이지 내 "설정" 탭의 서브메뉴로 통합됨
 
   // === 투자 카테고리 ===
   {

--- a/dental-clinic-manager/src/lib/marketing/brand/cache-key.ts
+++ b/dental-clinic-manager/src/lib/marketing/brand/cache-key.ts
@@ -30,6 +30,7 @@ export function computeCacheKey(
         assets.logo_url ?? '',
         assets.primary_color,
         assets.slogan ?? '',
+        String(assets.title_border_width ?? 16),
         inputs.copy ?? '',
       );
       break;

--- a/dental-clinic-manager/src/lib/marketing/brand/render-engine.ts
+++ b/dental-clinic-manager/src/lib/marketing/brand/render-engine.ts
@@ -52,23 +52,27 @@ interface RenderArgs {
   assets: BrandAssets;
   copy?: string;
   photo?: BrandPhoto;
+  /** true면 캐시 조회/저장을 건너뛰고 무조건 새로 합성 (라이브 미리보기 전용) */
+  bypassCache?: boolean;
 }
 
-export async function renderBrandImage({ type, assets, copy, photo }: RenderArgs): Promise<string> {
+export async function renderBrandImage({ type, assets, copy, photo, bypassCache }: RenderArgs): Promise<string> {
   const admin = getSupabaseAdmin();
   if (!admin) throw new Error('Supabase admin client unavailable');
 
   const cacheKey = computeCacheKey(type, assets, { copy, photoId: photo?.id });
 
   // 1. 캐시 조회 (테이블이 generated types에 아직 없어 any 캐스트)
-  const { data: cached } = await (admin as any)
-    .from('clinic_brand_image_renders')
-    .select('image_url')
-    .eq('clinic_id', assets.clinic_id)
-    .eq('image_type', type)
-    .eq('cache_key', cacheKey)
-    .maybeSingle();
-  if (cached?.image_url) return cached.image_url as string;
+  if (!bypassCache) {
+    const { data: cached } = await (admin as any)
+      .from('clinic_brand_image_renders')
+      .select('image_url')
+      .eq('clinic_id', assets.clinic_id)
+      .eq('image_type', type)
+      .eq('cache_key', cacheKey)
+      .maybeSingle();
+    if (cached?.image_url) return cached.image_url as string;
+  }
 
   // 2. 합성
   const fonts = (cachedFonts ??= await loadFonts());
@@ -95,23 +99,27 @@ export async function renderBrandImage({ type, assets, copy, photo }: RenderArgs
     throw new Error(`Unsupported brand image type: ${type}`);
   }
 
-  // 3. Storage 업로드
-  const objectPath = `clinics/${assets.clinic_id}/renders/${type}/${cacheKey}.png`;
+  // 3. Storage 업로드 — draft 모드는 별도 폴더에 저장 (캐시 INSERT 없음, upsert로 덮어씀)
+  const objectFolder = bypassCache ? 'drafts' : 'renders';
+  const objectPath = `clinics/${assets.clinic_id}/${objectFolder}/${type}/${cacheKey}.png`;
   const { error: uploadErr } = await admin.storage
     .from(BUCKET)
     .upload(objectPath, pngBuffer, { contentType: 'image/png', upsert: true });
   if (uploadErr) throw uploadErr;
 
   const { data: pub } = admin.storage.from(BUCKET).getPublicUrl(objectPath);
-  const publicUrl = pub.publicUrl;
+  // draft URL은 브라우저 캐시 무력화 (같은 path로 덮어쓰는 경우 갱신을 보장)
+  const publicUrl = bypassCache ? `${pub.publicUrl}?t=${Date.now()}` : pub.publicUrl;
 
-  // 4. 캐시 INSERT (동시성: ON CONFLICT 무시)
-  await (admin as any)
-    .from('clinic_brand_image_renders')
-    .upsert(
-      { clinic_id: assets.clinic_id, image_type: type, cache_key: cacheKey, image_url: publicUrl },
-      { onConflict: 'clinic_id,image_type,cache_key' },
-    );
+  // 4. 캐시 INSERT (저장 자산일 때만)
+  if (!bypassCache) {
+    await (admin as any)
+      .from('clinic_brand_image_renders')
+      .upsert(
+        { clinic_id: assets.clinic_id, image_type: type, cache_key: cacheKey, image_url: publicUrl },
+        { onConflict: 'clinic_id,image_type,cache_key' },
+      );
+  }
 
   return publicUrl;
 }

--- a/dental-clinic-manager/src/lib/marketing/brand/templates/TitleCard.tsx
+++ b/dental-clinic-manager/src/lib/marketing/brand/templates/TitleCard.tsx
@@ -11,26 +11,29 @@ export function TitleCard({ assets, copy, logoDataUrl }: Props) {
   const slogan = assets.slogan ?? '';
   const nameKo = assets.name_ko ?? '';
   const nameEn = assets.name_en ?? '';
+  const borderWidth = Math.min(60, Math.max(0, Math.round(assets.title_border_width ?? 16)));
 
   // 30자 + 개행 1회 제한 (스펙 5.5)
   const truncated = copy.length > 31 ? copy.slice(0, 30) + '…' : copy;
 
   return (
     <div style={{
-      width: 1080, height: 1080, display: 'flex', padding: 40,
-      background: '#FFFFFF', fontFamily: 'Pretendard',
+      width: 1080, height: 1080, display: 'flex',
+      background: primary, fontFamily: 'Pretendard',
+      padding: borderWidth,
     }}>
       <div style={{
         flex: 1, display: 'flex', flexDirection: 'column',
-        background: primary, borderRadius: 24, padding: 60,
+        background: '#FFFFFF', borderRadius: Math.max(0, 24 - Math.round(borderWidth / 2)),
+        padding: 60,
         alignItems: 'center', justifyContent: 'space-between',
       }}>
         {/* 슬로건 */}
         {slogan && (
           <div style={{
-            background: 'rgba(0,0,0,0.6)', color: '#FFFFFF',
-            padding: '12px 28px', borderRadius: 999,
-            fontSize: 28, fontWeight: 700,
+            background: '#1B1B1B', color: '#FFFFFF',
+            padding: '14px 32px', borderRadius: 999,
+            fontSize: 30, fontWeight: 700, textAlign: 'center',
           }}>
             {slogan}
           </div>
@@ -42,13 +45,13 @@ export function TitleCard({ assets, copy, logoDataUrl }: Props) {
           fontSize: 110, fontWeight: 900, color: '#FBC531',
           textShadow: '4px 4px 0 #1B1B1B',
         }}>
-          {truncated}
+          {truncated || nameKo || ' '}
         </div>
-        {/* 영문명 */}
+        {/* 영문명 (큰 글씨와 로고 사이) */}
         {nameEn && (
           <div style={{
-            fontSize: 26, letterSpacing: 4, color: 'rgba(255,255,255,0.7)',
-            fontFamily: 'Inter',
+            fontSize: 28, letterSpacing: 4, color: '#9AA0A6',
+            fontFamily: 'Inter', marginBottom: 12,
           }}>
             {nameEn}
           </div>
@@ -58,6 +61,7 @@ export function TitleCard({ assets, copy, logoDataUrl }: Props) {
           <div style={{
             display: 'flex', alignItems: 'center', gap: 16,
             background: '#FFFFFF', borderRadius: 16, padding: '14px 28px',
+            border: '2px solid #E5E5E5',
           }}>
             {logoDataUrl && (
               // eslint-disable-next-line jsx-a11y/alt-text

--- a/dental-clinic-manager/src/types/brand.ts
+++ b/dental-clinic-manager/src/types/brand.ts
@@ -19,6 +19,8 @@ export interface BrandAssets {
   medical_law_preset: MedicalLawPresetKey;
   medical_law_top_text: string;
   medical_law_bottom_text: string;
+  /** 텍스트 카드 외곽 테두리 두께(px). 0~60. */
+  title_border_width: number;
   created_at: string;
   updated_at: string;
 }
@@ -42,19 +44,36 @@ export interface MedicalLawPreset {
   textOnBackground: string;
 }
 
+// 라이브 미리보기용 — 저장되지 않은 자산 변경을 임시로 합성에 적용 (캐시 안 함).
+export type DraftBrandAssets = Partial<Pick<BrandAssets,
+  | 'name_ko'
+  | 'name_en'
+  | 'logo_url'
+  | 'primary_color'
+  | 'secondary_color'
+  | 'slogan'
+  | 'medical_law_preset'
+  | 'medical_law_top_text'
+  | 'medical_law_bottom_text'
+  | 'title_border_width'
+>>;
+
 // Render API payload
 export interface RenderMedicalLawPayload {
   type: 'medical_law';
+  draftAssets?: DraftBrandAssets;
 }
 
 export interface RenderTitleCardPayload {
   type: 'title';
   copy: string;
+  draftAssets?: DraftBrandAssets;
 }
 
 export interface RenderPhotoPayload {
   type: 'photo';
   photoId: string;
+  draftAssets?: DraftBrandAssets;
 }
 
 export type RenderPayload =

--- a/dental-clinic-manager/supabase/migrations/20260507_brand_title_border_width.sql
+++ b/dental-clinic-manager/supabase/migrations/20260507_brand_title_border_width.sql
@@ -1,0 +1,9 @@
+-- 브랜드 텍스트 카드 테두리 두께 사용자 조정 지원
+-- 2026-05-07
+
+ALTER TABLE clinic_brand_assets
+  ADD COLUMN IF NOT EXISTS title_border_width INTEGER NOT NULL DEFAULT 16;
+
+ALTER TABLE clinic_brand_assets
+  ADD CONSTRAINT clinic_brand_assets_title_border_width_range
+  CHECK (title_border_width BETWEEN 0 AND 60);


### PR DESCRIPTION
## Summary
두 가지 사용자 요청을 묶어 한 PR로 처리:

### 1. 텍스트 카드 4가지 개선 (커밋 6c9f7eb0)
- 텍스트 카드 미리보기의 클리닉명을 입력값에 따라 즉시 반영 (BrandPreview의 sampleCopy를 draft assets에서 derive)
- 브랜드 컬러를 텍스트 카드 외곽 테두리에 적용 (TitleCard JSX 재설계: outer는 primary_color 배경 + padding=borderWidth로 frame 구성, inner는 흰 배경)
- 테두리 두께 사용자 조정 슬라이더 (0~60px, 기본 16px) — clinic_brand_assets.title_border_width 컬럼 추가
- 모든 수정사항이 즉시 미리보기에 반영 — render API에 draftAssets 옵션, drafts/ 폴더에 저장 (캐시 우회)
- BrandSettingsForm을 controlled component로 전환, BrandSettingsClient에서 form state lift up

### 2. 브랜드 이미지 메뉴 통합 (커밋 ceb571a4)
- 사이드바의 별개 "브랜드 이미지" 메뉴 항목 제거
- 마케팅 자동화 페이지의 "설정" 탭에 서브탭(플랫폼 연동 / 브랜드 이미지) 추가
- BrandSettingsClient에 embedded prop 추가
- 기존 /dashboard/marketing/brand 라우트는 유지 (북마크 호환)

## E2E 검증
- 슬라이더 조정/입력 변경 시 미리보기 즉시 갱신 확인
- 텍스트 카드 디자인이 사용자 첨부 이미지와 동일한 패턴 (브랜드 컬러 테두리 + 흰 배경 + 노랑 큰 글씨)
- 사이드바 → 마케팅 자동화 → 설정 → 브랜드 이미지 서브탭 정상 노출

## DB 마이그레이션
- supabase/migrations/20260507_brand_title_border_width.sql (이미 적용됨)

## Test plan
- [ ] 마케팅 자동화 → 설정 → 브랜드 이미지 서브탭 진입
- [ ] 클리닉명 입력 변경 시 텍스트 카드 미리보기 즉시 반영
- [ ] 주 브랜드 컬러 변경 시 테두리 색상 즉시 반영
- [ ] 테두리 두께 슬라이더 조정 시 미리보기 즉시 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)