### PR TITLE
fix(smart-money): 분석 시작 시 오늘 날짜 기본 선택 수정

### DIFF
--- a/dental-clinic-manager/docs/superpowers/plans/2026-05-07-investment-personal-subscription-transition.md
+++ b/dental-clinic-manager/docs/superpowers/plans/2026-05-07-investment-personal-subscription-transition.md
@@ -1,0 +1,1908 @@
+# 자동매매 개인 구독 전환 + master 가격 관리 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 자동매매 모듈의 구독 모델을 clinic 단위에서 개인(user) 단위로 전환하고, master 페이지에서 구독료를 변경할 수 있게 하며, 기존 clinic 자동매매 구독자를 자동 이관한다.
+
+**Architecture:** 개인 구독 전용 테이블 3종(`user_subscription_plans`, `user_subscriptions`, `user_subscription_payments`) 신설. 기존 PortOne 빌링키 인프라(`src/lib/portone.ts`)는 그대로 재사용. 자동매매 게이팅을 단일 헬퍼(`src/lib/userSubscription.ts`)로 통합하고, 기존 권한 시스템(`investment_view`)에서 분리. 월말 청구 cron을 user 단위로 재작성하여 월 정액 + 수익 5% 하이브리드 청구.
+
+**Tech Stack:** Next.js 15 App Router, TypeScript, Supabase Postgres, PortOne v2, shadcn/ui, Vercel Cron.
+
+**Spec:** [docs/superpowers/specs/2026-05-07-investment-personal-subscription-and-psychology-design.md](../specs/2026-05-07-investment-personal-subscription-and-psychology-design.md)
+
+---
+
+## File Map
+
+### 신설
+- `supabase/migrations/20260507_user_subscriptions.sql` — 3개 테이블 + RLS + 시드
+- `src/types/userSubscription.ts` — 타입 정의
+- `src/lib/userSubscriptionService.ts` — DB CRUD + 결제 흐름
+- `src/lib/userSubscription.ts` — 게이팅 헬퍼 `checkInvestmentSubscription`/`requireInvestmentSubscription`
+- `src/app/api/investment/subscription/status/route.ts`
+- `src/app/api/investment/subscription/register/route.ts`
+- `src/app/api/investment/subscription/cancel/route.ts`
+- `src/app/api/investment/subscription/webhook/route.ts`
+- `src/app/api/master/user-subscription-plans/route.ts` (GET 목록)
+- `src/app/api/master/user-subscription-plans/[id]/route.ts` (PUT)
+- `src/app/master/subscription/investment/page.tsx` — 가격 관리 UI
+- `src/app/investment/subscribe/page.tsx` — 구독 안내/결제 페이지
+- `scripts/migrate-investment-subscriptions-to-user.ts` — 1회성 이관 스크립트
+
+### 수정
+- `src/config/menuConfig.ts` — 자동매매 메뉴의 `permissions: ['investment_view']` 제거
+- `src/app/api/investment/profit-snapshot/route.ts` — clinic_id → user_id 기반 청구 로직으로 재작성
+- `src/lib/investmentProfit.ts` — `calculateMonthlyProfitForUser(userId, year, month)` 함수 추가
+- `src/app/investment/layout.tsx` — 진입 시 게이팅 체크 (미구독자 → /investment/subscribe)
+
+### 삭제 (마이그레이션 후)
+- 없음 (기존 clinic 구독 시스템은 다른 feature plan에서 계속 사용하므로 유지)
+
+---
+
+## Task 1: 데이터베이스 마이그레이션
+
+**Files:**
+- Create: `supabase/migrations/20260507_user_subscriptions.sql`
+
+- [ ] **Step 1: 마이그레이션 SQL 파일 작성**
+
+```sql
+-- ============================================
+-- 개인 구독 시스템 (user_subscriptions)
+-- 자동매매 모듈을 clinic → 개인 구독으로 전환하기 위한 신규 테이블
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS user_subscription_plans (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  feature_id TEXT UNIQUE NOT NULL,
+  display_name TEXT NOT NULL,
+  monthly_base_price INT NOT NULL DEFAULT 0,
+  revenue_share_pct NUMERIC(5,2) NOT NULL DEFAULT 0,
+  description TEXT,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS user_subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  plan_id UUID NOT NULL REFERENCES user_subscription_plans(id),
+  status TEXT NOT NULL CHECK (status IN ('active','past_due','cancelled','suspended','expired')),
+  billing_key TEXT,
+  card_name TEXT,
+  card_number_last4 TEXT,
+  current_period_start TIMESTAMPTZ,
+  current_period_end TIMESTAMPTZ,
+  next_billing_date TIMESTAMPTZ,
+  cancel_at_period_end BOOLEAN NOT NULL DEFAULT false,
+  cancelled_at TIMESTAMPTZ,
+  retry_count INT NOT NULL DEFAULT 0,
+  next_retry_at TIMESTAMPTZ,
+  migrated_from_clinic_id UUID NULL,
+  migrated_at TIMESTAMPTZ NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_id, plan_id)
+);
+
+CREATE TABLE IF NOT EXISTS user_subscription_payments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  subscription_id UUID REFERENCES user_subscriptions(id) ON DELETE SET NULL,
+  portone_payment_id TEXT NOT NULL,
+  portone_tx_id TEXT,
+  amount INT NOT NULL,
+  base_amount INT NOT NULL DEFAULT 0,
+  revenue_share_amount INT NOT NULL DEFAULT 0,
+  realized_profit_basis INT NOT NULL DEFAULT 0,
+  status TEXT NOT NULL CHECK (status IN ('pending','paid','failed','cancelled','refunded')),
+  paid_at TIMESTAMPTZ,
+  failed_at TIMESTAMPTZ,
+  fail_reason TEXT,
+  billing_period_start DATE,
+  billing_period_end DATE,
+  order_name TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_subs_user_status
+  ON user_subscriptions (user_id, status);
+CREATE INDEX IF NOT EXISTS idx_user_sub_payments_user_time
+  ON user_subscription_payments (user_id, created_at DESC);
+
+-- RLS
+ALTER TABLE user_subscription_plans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_subscription_payments ENABLE ROW LEVEL SECURITY;
+
+-- 플랜은 모두 SELECT 가능, 변경은 master_admin만 (service_role 우회 필요)
+CREATE POLICY "user_subscription_plans_select_all"
+  ON user_subscription_plans FOR SELECT
+  USING (true);
+
+-- 본인 구독만 SELECT
+CREATE POLICY "user_subscriptions_select_own"
+  ON user_subscriptions FOR SELECT
+  USING (user_id = auth.uid());
+
+-- 본인 결제 내역만 SELECT
+CREATE POLICY "user_sub_payments_select_own"
+  ON user_subscription_payments FOR SELECT
+  USING (user_id = auth.uid());
+
+-- INSERT/UPDATE/DELETE는 모두 service_role(API 라우트)에서만 수행 → 별도 정책 추가 안 함
+
+-- 시드: 자동매매 플랜 (운영자가 master UI에서 가격 변경)
+INSERT INTO user_subscription_plans (feature_id, display_name, monthly_base_price, revenue_share_pct, description, is_active)
+VALUES (
+  'investment',
+  '주식 자동매매',
+  9900,
+  5.00,
+  '월 정액 + 실현 수익의 5%. 군중심리 분석 기능 포함.',
+  true
+)
+ON CONFLICT (feature_id) DO NOTHING;
+```
+
+- [ ] **Step 2: Supabase MCP로 마이그레이션 적용**
+
+`mcp__supabase__apply_migration`으로 위 SQL 적용. project_id=`beahjntkmkfhpcbhfnrr`, name=`20260507_user_subscriptions`.
+
+- [ ] **Step 3: 테이블 생성 검증**
+
+```sql
+SELECT table_name FROM information_schema.tables
+WHERE table_schema='public'
+  AND table_name IN ('user_subscription_plans','user_subscriptions','user_subscription_payments');
+```
+
+Expected: 3 rows. `mcp__supabase__execute_sql` 사용.
+
+- [ ] **Step 4: 시드 데이터 확인**
+
+```sql
+SELECT feature_id, display_name, monthly_base_price, revenue_share_pct, is_active
+FROM user_subscription_plans WHERE feature_id='investment';
+```
+
+Expected: 1 row with monthly_base_price=9900, revenue_share_pct=5.00.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260507_user_subscriptions.sql
+git commit -m "feat(subscription): 개인 구독 테이블 신설 (user_subscriptions)"
+```
+
+---
+
+## Task 2: 타입 정의
+
+**Files:**
+- Create: `src/types/userSubscription.ts`
+
+- [ ] **Step 1: 타입 파일 작성**
+
+```typescript
+// 개인 구독 시스템 타입
+// 기존 src/types/subscription.ts(clinic 단위)와 분리하여 user 단위 타입 정의
+
+export type UserSubscriptionStatus =
+  | 'active'
+  | 'past_due'
+  | 'cancelled'
+  | 'suspended'
+  | 'expired'
+
+export type UserSubscriptionPaymentStatus =
+  | 'pending'
+  | 'paid'
+  | 'failed'
+  | 'cancelled'
+  | 'refunded'
+
+export interface UserSubscriptionPlan {
+  id: string
+  feature_id: string
+  display_name: string
+  monthly_base_price: number
+  revenue_share_pct: number
+  description: string | null
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface UserSubscription {
+  id: string
+  user_id: string
+  plan_id: string
+  status: UserSubscriptionStatus
+  billing_key: string | null
+  card_name: string | null
+  card_number_last4: string | null
+  current_period_start: string | null
+  current_period_end: string | null
+  next_billing_date: string | null
+  cancel_at_period_end: boolean
+  cancelled_at: string | null
+  retry_count: number
+  next_retry_at: string | null
+  migrated_from_clinic_id: string | null
+  migrated_at: string | null
+  created_at: string
+  updated_at: string
+  plan?: UserSubscriptionPlan | null
+}
+
+export interface UserSubscriptionPayment {
+  id: string
+  user_id: string
+  subscription_id: string | null
+  portone_payment_id: string
+  portone_tx_id: string | null
+  amount: number
+  base_amount: number
+  revenue_share_amount: number
+  realized_profit_basis: number
+  status: UserSubscriptionPaymentStatus
+  paid_at: string | null
+  failed_at: string | null
+  fail_reason: string | null
+  billing_period_start: string | null
+  billing_period_end: string | null
+  order_name: string | null
+  created_at: string
+}
+
+// API 응답
+export interface UserSubscriptionStatusResponse {
+  subscription: UserSubscription | null
+  plan: UserSubscriptionPlan | null
+  payments: UserSubscriptionPayment[]
+  daysUntilExpiry: number | null
+  nextChargeEstimate: {
+    base: number
+    revenueShareEstimate: number
+    total: number
+    realizedProfitMonthToDate: number
+  } | null
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공 (이 파일은 아직 import되지 않음)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/userSubscription.ts
+git commit -m "feat(subscription): 개인 구독 타입 정의"
+```
+
+---
+
+## Task 3: 게이팅 헬퍼
+
+**Files:**
+- Create: `src/lib/userSubscription.ts`
+
+- [ ] **Step 1: 헬퍼 작성**
+
+```typescript
+// src/lib/userSubscription.ts
+// 자동매매(및 그 서브 기능) 진입 게이팅 단일 헬퍼.
+// 모든 자동매매 페이지/API는 이 헬퍼 한 줄로 게이팅한다.
+
+import { NextResponse } from 'next/server'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import type { UserSubscription, UserSubscriptionPlan } from '@/types/userSubscription'
+
+export type GateResult =
+  | { ok: true; subscription: UserSubscription & { plan: UserSubscriptionPlan } }
+  | { ok: false; reason: 'NO_SUBSCRIPTION' | 'PAST_DUE' | 'EXPIRED' | 'CANCELLED' | 'SUSPENDED' }
+
+const FEATURE_INVESTMENT = 'investment'
+
+/**
+ * 개인 자동매매 구독 상태 조회. 분기는 호출 측이 처리.
+ * 사용자는 한 feature에 대해 1개 활성 구독만 가질 수 있다 (UNIQUE(user_id, plan_id)).
+ */
+export async function checkInvestmentSubscription(userId: string): Promise<GateResult> {
+  const admin = getSupabaseAdmin()
+  if (!admin) return { ok: false, reason: 'NO_SUBSCRIPTION' }
+
+  const { data } = await admin
+    .from('user_subscriptions')
+    .select(`*, plan:user_subscription_plans!inner(*)`)
+    .eq('user_id', userId)
+    .eq('plan.feature_id', FEATURE_INVESTMENT)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (!data) return { ok: false, reason: 'NO_SUBSCRIPTION' }
+
+  const sub = data as unknown as UserSubscription & { plan: UserSubscriptionPlan }
+  const status = sub.status
+
+  if (status === 'active') return { ok: true, subscription: sub }
+  if (status === 'past_due') return { ok: false, reason: 'PAST_DUE' }
+  if (status === 'expired') return { ok: false, reason: 'EXPIRED' }
+  if (status === 'cancelled') return { ok: false, reason: 'CANCELLED' }
+  if (status === 'suspended') return { ok: false, reason: 'SUSPENDED' }
+  return { ok: false, reason: 'NO_SUBSCRIPTION' }
+}
+
+/**
+ * API 라우트 전용. 통과 시 구독 객체 반환, 실패 시 NextResponse를 throw.
+ * 사용 예:
+ *   const sub = await requireInvestmentSubscription(userId)
+ */
+export async function requireInvestmentSubscription(
+  userId: string
+): Promise<UserSubscription & { plan: UserSubscriptionPlan }> {
+  const result = await checkInvestmentSubscription(userId)
+  if (result.ok) return result.subscription
+
+  const status =
+    result.reason === 'PAST_DUE' || result.reason === 'SUSPENDED' ? 402 : 401
+  const message = {
+    NO_SUBSCRIPTION: '주식 자동매매 구독이 필요합니다.',
+    PAST_DUE: '결제 연체 상태입니다. 결제 수단을 확인해주세요.',
+    EXPIRED: '구독이 만료되었습니다.',
+    CANCELLED: '구독이 취소되었습니다.',
+    SUSPENDED: '결제 실패로 구독이 일시 정지되었습니다.',
+  }[result.reason]
+
+  throw NextResponse.json(
+    { error: message, code: result.reason },
+    { status }
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/userSubscription.ts
+git commit -m "feat(subscription): 자동매매 게이팅 헬퍼 추가"
+```
+
+---
+
+## Task 4: 개인 구독 서비스 모듈
+
+**Files:**
+- Create: `src/lib/userSubscriptionService.ts`
+
+- [ ] **Step 1: 서비스 모듈 작성**
+
+```typescript
+// src/lib/userSubscriptionService.ts
+// 개인 구독 DB CRUD + 결제 흐름 (PortOne 재사용)
+
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import {
+  chargeBillingKey,
+  scheduleNextPayment,
+  cancelScheduleByBillingKey,
+  getNextBillingDate,
+} from '@/lib/portone'
+import type {
+  UserSubscription,
+  UserSubscriptionPlan,
+  UserSubscriptionPayment,
+} from '@/types/userSubscription'
+
+const FEATURE_INVESTMENT = 'investment'
+
+export async function getInvestmentPlan(): Promise<UserSubscriptionPlan | null> {
+  const admin = getSupabaseAdmin()
+  if (!admin) return null
+  const { data } = await admin
+    .from('user_subscription_plans')
+    .select('*')
+    .eq('feature_id', FEATURE_INVESTMENT)
+    .single()
+  return (data as UserSubscriptionPlan | null) ?? null
+}
+
+export async function getUserSubscription(userId: string): Promise<UserSubscription | null> {
+  const admin = getSupabaseAdmin()
+  if (!admin) return null
+  const { data } = await admin
+    .from('user_subscriptions')
+    .select(`*, plan:user_subscription_plans(*)`)
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  return (data as UserSubscription | null) ?? null
+}
+
+export async function getUserPayments(userId: string, limit = 12): Promise<UserSubscriptionPayment[]> {
+  const admin = getSupabaseAdmin()
+  if (!admin) return []
+  const { data } = await admin
+    .from('user_subscription_payments')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(limit)
+  return (data as UserSubscriptionPayment[] | null) ?? []
+}
+
+/**
+ * 구독 등록: 빌링키로 첫 결제 + 다음 달 예약 + 구독 레코드 생성.
+ */
+export async function registerUserSubscription(params: {
+  userId: string
+  planId: string
+  billingKey: string
+  cardName: string
+  cardNumberLast4: string
+  customerName: string
+  customerEmail: string
+}): Promise<{ success: boolean; error?: string }> {
+  const admin = getSupabaseAdmin()
+  if (!admin) return { success: false, error: 'Server configuration error' }
+
+  const { data: planData } = await admin
+    .from('user_subscription_plans')
+    .select('*')
+    .eq('id', params.planId)
+    .single()
+  const plan = planData as UserSubscriptionPlan | null
+  if (!plan) return { success: false, error: '플랜을 찾을 수 없습니다' }
+
+  const now = new Date()
+  const nextBilling = getNextBillingDate(now)
+  const orderName = `${plan.display_name} 월 정액`
+
+  try {
+    const paymentResult = await chargeBillingKey({
+      clinicId: params.userId, // PortOne paymentId의 prefix로만 사용 (실제 user 식별은 우리 DB)
+      billingKey: params.billingKey,
+      amount: plan.monthly_base_price,
+      orderName,
+      customerName: params.customerName,
+      customerEmail: params.customerEmail,
+      noticeUrl: `${process.env.NEXT_PUBLIC_BASE_URL}/api/investment/subscription/webhook`,
+    })
+
+    if (paymentResult.status !== 'PAID') {
+      return { success: false, error: '결제에 실패했습니다. 카드 정보를 확인해주세요.' }
+    }
+
+    const subscriptionData = {
+      user_id: params.userId,
+      plan_id: params.planId,
+      status: 'active' as const,
+      billing_key: params.billingKey,
+      card_name: params.cardName,
+      card_number_last4: params.cardNumberLast4,
+      current_period_start: now.toISOString(),
+      current_period_end: nextBilling.toISOString(),
+      next_billing_date: nextBilling.toISOString(),
+      cancel_at_period_end: false,
+      retry_count: 0,
+      next_retry_at: null as string | null,
+      updated_at: now.toISOString(),
+    }
+
+    const { data: existing } = await admin
+      .from('user_subscriptions')
+      .select('id')
+      .eq('user_id', params.userId)
+      .eq('plan_id', params.planId)
+      .maybeSingle()
+
+    let subscriptionId: string | null = null
+    if (existing) {
+      const { data: updated } = await admin
+        .from('user_subscriptions')
+        .update(subscriptionData)
+        .eq('id', (existing as { id: string }).id)
+        .select('id')
+        .single()
+      subscriptionId = (updated as { id: string }).id
+    } else {
+      const { data: inserted } = await admin
+        .from('user_subscriptions')
+        .insert(subscriptionData)
+        .select('id')
+        .single()
+      subscriptionId = (inserted as { id: string }).id
+    }
+
+    await admin.from('user_subscription_payments').insert({
+      user_id: params.userId,
+      subscription_id: subscriptionId,
+      portone_payment_id: paymentResult.paymentId,
+      portone_tx_id: paymentResult.txId,
+      amount: plan.monthly_base_price,
+      base_amount: plan.monthly_base_price,
+      revenue_share_amount: 0,
+      realized_profit_basis: 0,
+      status: 'paid' as const,
+      order_name: orderName,
+      paid_at: paymentResult.paidAt || now.toISOString(),
+      billing_period_start: now.toISOString().slice(0, 10),
+      billing_period_end: nextBilling.toISOString().slice(0, 10),
+    })
+
+    await scheduleNextPayment({
+      clinicId: params.userId,
+      billingKey: params.billingKey,
+      planPrice: plan.monthly_base_price,
+      planName: orderName,
+      customerEmail: params.customerEmail,
+      scheduledAt: nextBilling,
+      noticeUrl: `${process.env.NEXT_PUBLIC_BASE_URL}/api/investment/subscription/webhook`,
+    })
+
+    return { success: true }
+  } catch (err) {
+    console.error('[userSubscription.register] 실패:', err)
+    return { success: false, error: err instanceof Error ? err.message : '구독 등록 실패' }
+  }
+}
+
+/**
+ * 구독 취소. 기본은 기간 만료 후 취소(즉시는 PortOne 예약 + 빌링키 삭제).
+ */
+export async function cancelUserSubscription(params: {
+  userId: string
+  immediate?: boolean
+}): Promise<{ success: boolean; error?: string }> {
+  const admin = getSupabaseAdmin()
+  if (!admin) return { success: false, error: 'Server configuration error' }
+
+  const sub = await getUserSubscription(params.userId)
+  if (!sub) return { success: false, error: '구독을 찾을 수 없습니다' }
+
+  try {
+    if (sub.billing_key) {
+      await cancelScheduleByBillingKey(sub.billing_key)
+    }
+
+    const now = new Date().toISOString()
+    if (params.immediate) {
+      await admin.from('user_subscriptions')
+        .update({ status: 'cancelled', cancelled_at: now, updated_at: now })
+        .eq('id', sub.id)
+    } else {
+      await admin.from('user_subscriptions')
+        .update({ cancel_at_period_end: true, cancelled_at: now, updated_at: now })
+        .eq('id', sub.id)
+    }
+    return { success: true }
+  } catch (err) {
+    console.error('[userSubscription.cancel] 실패:', err)
+    return { success: false, error: err instanceof Error ? err.message : '구독 취소 실패' }
+  }
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/userSubscriptionService.ts
+git commit -m "feat(subscription): 개인 구독 서비스 모듈 (등록/조회/취소)"
+```
+
+---
+
+## Task 5: 구독 상태 조회 API
+
+**Files:**
+- Create: `src/app/api/investment/subscription/status/route.ts`
+
+- [ ] **Step 1: 라우트 작성**
+
+```typescript
+import { NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import {
+  getUserSubscription,
+  getUserPayments,
+  getInvestmentPlan,
+} from '@/lib/userSubscriptionService'
+import { calculateMonthlyProfitForUser } from '@/lib/investmentProfit'
+import type { UserSubscriptionStatusResponse } from '@/types/userSubscription'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const [sub, plan, payments] = await Promise.all([
+    getUserSubscription(auth.user.id),
+    getInvestmentPlan(),
+    getUserPayments(auth.user.id, 12),
+  ])
+
+  let nextChargeEstimate: UserSubscriptionStatusResponse['nextChargeEstimate'] = null
+  if (sub && plan && sub.status === 'active') {
+    const now = new Date()
+    const kst = new Date(now.getTime() + 9 * 3600_000)
+    const { realized } = await calculateMonthlyProfitForUser(
+      auth.user.id, kst.getUTCFullYear(), kst.getUTCMonth() + 1
+    )
+    const revenueShare = Math.max(0, Math.floor(realized * (plan.revenue_share_pct / 100)))
+    nextChargeEstimate = {
+      base: plan.monthly_base_price,
+      revenueShareEstimate: revenueShare,
+      total: plan.monthly_base_price + revenueShare,
+      realizedProfitMonthToDate: realized,
+    }
+  }
+
+  let daysUntilExpiry: number | null = null
+  if (sub?.current_period_end) {
+    const end = new Date(sub.current_period_end)
+    daysUntilExpiry = Math.ceil((end.getTime() - Date.now()) / (1000 * 60 * 60 * 24))
+  }
+
+  const response: UserSubscriptionStatusResponse = {
+    subscription: sub,
+    plan,
+    payments,
+    daysUntilExpiry,
+    nextChargeEstimate,
+  }
+  return NextResponse.json(response)
+}
+```
+
+- [ ] **Step 2: 빌드 + 미인증 호출 검증**
+
+Run: `npm run build`
+Expected: 성공
+
+이 라우트는 `calculateMonthlyProfitForUser`에 의존. Task 7에서 추가 예정. 빌드는 임시로 통과되어야 함 — 만약 컴파일 에러면 import를 임시로 주석 처리하지 말고 Task 7을 먼저 진행 후 돌아옴.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/investment/subscription/status/route.ts
+git commit -m "feat(subscription): 구독 상태 조회 API"
+```
+
+---
+
+## Task 6: 구독 등록/취소 API
+
+**Files:**
+- Create: `src/app/api/investment/subscription/register/route.ts`
+- Create: `src/app/api/investment/subscription/cancel/route.ts`
+
+- [ ] **Step 1: register 라우트 작성**
+
+```typescript
+// src/app/api/investment/subscription/register/route.ts
+import { NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { registerUserSubscription } from '@/lib/userSubscriptionService'
+
+export async function POST(request: Request) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const admin = getSupabaseAdmin()
+  if (!admin) return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+
+  const { data: userData } = await admin
+    .from('users')
+    .select('name, email')
+    .eq('id', auth.user.id)
+    .single()
+
+  const body = await request.json()
+  const { billingKey, planId, cardName, cardNumberLast4 } = body
+  if (!billingKey || !planId) {
+    return NextResponse.json({ error: '필수 정보가 누락되었습니다' }, { status: 400 })
+  }
+
+  const result = await registerUserSubscription({
+    userId: auth.user.id,
+    planId,
+    billingKey,
+    cardName: cardName ?? '',
+    cardNumberLast4: cardNumberLast4 ?? '',
+    customerName: (userData as { name?: string } | null)?.name ?? '',
+    customerEmail: (userData as { email?: string } | null)?.email ?? '',
+  })
+
+  if (!result.success) return NextResponse.json({ error: result.error }, { status: 400 })
+  return NextResponse.json({ success: true })
+}
+```
+
+- [ ] **Step 2: cancel 라우트 작성**
+
+```typescript
+// src/app/api/investment/subscription/cancel/route.ts
+import { NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { cancelUserSubscription } from '@/lib/userSubscriptionService'
+
+export async function POST(request: Request) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = await request.json().catch(() => ({}))
+  const immediate = body.immediate === true
+
+  const result = await cancelUserSubscription({ userId: auth.user.id, immediate })
+  if (!result.success) return NextResponse.json({ error: result.error }, { status: 400 })
+  return NextResponse.json({ success: true })
+}
+```
+
+- [ ] **Step 3: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/investment/subscription/register/route.ts src/app/api/investment/subscription/cancel/route.ts
+git commit -m "feat(subscription): 구독 등록/취소 API"
+```
+
+---
+
+## Task 7: investmentProfit에 user 단위 함수 추가
+
+**Files:**
+- Modify: `src/lib/investmentProfit.ts`
+
+- [ ] **Step 1: 현재 파일 확인**
+
+Run: `cat src/lib/investmentProfit.ts`
+Expected: clinic_id 기반 `calculateMonthlyProfit` 함수만 존재.
+
+- [ ] **Step 2: user 단위 함수 추가**
+
+기존 함수는 유지하고 user 변형 추가:
+
+```typescript
+/**
+ * 월별 user 단위 실현/평가 수익을 반환한다.
+ * 자동매매 사용자별 결제 청구의 기초 수치.
+ *
+ * NOTE: 현재 투자 거래 테이블이 부재하므로 0 반환.
+ * 투자 엔진(orders/positions)이 추가되면 user_id 기반 집계 쿼리로 대체.
+ */
+export async function calculateMonthlyProfitForUser(
+  _userId: string, _year: number, _month: number
+): Promise<{ realized: number; unrealized: number }> {
+  return { realized: 0, unrealized: 0 }
+}
+```
+
+기존 export 끝에 위 함수를 append.
+
+- [ ] **Step 3: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공. Task 5의 import가 이제 해결됨.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/investmentProfit.ts
+git commit -m "feat(profit): user 단위 월별 수익 계산 함수 추가"
+```
+
+---
+
+## Task 8: 결제 webhook
+
+**Files:**
+- Create: `src/app/api/investment/subscription/webhook/route.ts`
+
+- [ ] **Step 1: webhook 라우트 작성**
+
+PortOne v2 webhook 형식: `{ type, timestamp, data: { paymentId, ... } }`. 결제 성공 시 user_subscription_payments 갱신, 실패 시 retry/suspended 처리.
+
+```typescript
+// src/app/api/investment/subscription/webhook/route.ts
+// PortOne v2 결제 webhook. 빌링키 자동결제(예약) 결과 처리.
+//
+// 보안: PortOne webhook 검증은 portone-webhook-secret 헤더 + payload 서명. 1차에는 paymentId 존재 검증만.
+// 추후 정식 서명 검증 추가 (별도 task).
+
+import { NextResponse } from 'next/server'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { getPayment, getNextBillingDate } from '@/lib/portone'
+
+const MAX_RETRY = 3
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null) as
+    | { type?: string; data?: { paymentId?: string } }
+    | null
+  if (!body?.data?.paymentId) {
+    return NextResponse.json({ ok: true, ignored: 'no paymentId' })
+  }
+
+  const portonePaymentId = body.data.paymentId
+  const admin = getSupabaseAdmin()
+  if (!admin) return NextResponse.json({ ok: false }, { status: 500 })
+
+  const portonePayment = await getPayment(portonePaymentId).catch(() => null)
+  if (!portonePayment) return NextResponse.json({ ok: true, ignored: 'no portone payment' })
+
+  // user_subscriptions 중 paymentId 접두사가 일치하는 사용자 추적
+  // PortOne paymentId 포맷: payment-scheduled-<userId>-<timestamp> (registerUserSubscription에서 그대로 사용)
+  const m = portonePaymentId.match(/^payment-(?:scheduled-)?([0-9a-f-]{36})-\d+$/i)
+  const userId = m?.[1] ?? null
+  if (!userId) return NextResponse.json({ ok: true, ignored: 'cannot extract userId' })
+
+  const { data: subData } = await admin
+    .from('user_subscriptions')
+    .select('id, plan_id, billing_key, retry_count, current_period_end')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  const sub = subData as
+    | { id: string; plan_id: string; billing_key: string | null; retry_count: number; current_period_end: string | null }
+    | null
+  if (!sub) return NextResponse.json({ ok: true, ignored: 'no user subscription' })
+
+  const now = new Date()
+
+  if (portonePayment.status === 'PAID') {
+    // 결제 성공 → 다음 주기로 갱신
+    const nextEnd = getNextBillingDate(now)
+    await admin.from('user_subscriptions').update({
+      status: 'active',
+      current_period_start: now.toISOString(),
+      current_period_end: nextEnd.toISOString(),
+      next_billing_date: nextEnd.toISOString(),
+      retry_count: 0,
+      next_retry_at: null,
+      updated_at: now.toISOString(),
+    }).eq('id', sub.id)
+
+    await admin.from('user_subscription_payments').insert({
+      user_id: userId,
+      subscription_id: sub.id,
+      portone_payment_id: portonePaymentId,
+      portone_tx_id: portonePayment.transactionId ?? null,
+      amount: portonePayment.amount.total,
+      base_amount: portonePayment.amount.total,
+      revenue_share_amount: 0,
+      realized_profit_basis: 0,
+      status: 'paid',
+      paid_at: portonePayment.paidAt ?? now.toISOString(),
+      order_name: '주식 자동매매 정기결제',
+      billing_period_start: now.toISOString().slice(0, 10),
+      billing_period_end: nextEnd.toISOString().slice(0, 10),
+    })
+    return NextResponse.json({ ok: true })
+  }
+
+  if (portonePayment.status === 'FAILED') {
+    const retryCount = (sub.retry_count ?? 0) + 1
+    const newStatus = retryCount >= MAX_RETRY ? 'suspended' : 'past_due'
+    const nextRetry = retryCount < MAX_RETRY ? new Date(now.getTime() + 12 * 3600_000) : null
+
+    await admin.from('user_subscriptions').update({
+      status: newStatus,
+      retry_count: retryCount,
+      next_retry_at: nextRetry?.toISOString() ?? null,
+      updated_at: now.toISOString(),
+    }).eq('id', sub.id)
+
+    await admin.from('user_subscription_payments').insert({
+      user_id: userId,
+      subscription_id: sub.id,
+      portone_payment_id: portonePaymentId,
+      portone_tx_id: portonePayment.transactionId ?? null,
+      amount: portonePayment.amount.total,
+      base_amount: portonePayment.amount.total,
+      revenue_share_amount: 0,
+      realized_profit_basis: 0,
+      status: 'failed',
+      failed_at: portonePayment.failedAt ?? now.toISOString(),
+      fail_reason: portonePayment.failReason ?? '결제 실패',
+      order_name: '주식 자동매매 정기결제',
+    })
+  }
+
+  return NextResponse.json({ ok: true })
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/investment/subscription/webhook/route.ts
+git commit -m "feat(subscription): PortOne 결제 webhook 핸들러"
+```
+
+---
+
+## Task 9: master 가격 관리 API
+
+**Files:**
+- Create: `src/app/api/master/user-subscription-plans/route.ts`
+- Create: `src/app/api/master/user-subscription-plans/[id]/route.ts`
+
+- [ ] **Step 1: 목록 조회 라우트**
+
+```typescript
+// src/app/api/master/user-subscription-plans/route.ts
+import { NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+export async function GET() {
+  const auth = await requireAuth(['master_admin'])
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const admin = getSupabaseAdmin()
+  if (!admin) return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+
+  const { data } = await admin
+    .from('user_subscription_plans')
+    .select('*')
+    .order('feature_id')
+  return NextResponse.json(data ?? [])
+}
+```
+
+- [ ] **Step 2: 가격 변경 라우트**
+
+```typescript
+// src/app/api/master/user-subscription-plans/[id]/route.ts
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+export async function PUT(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const auth = await requireAuth(['master_admin'])
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const { id } = await ctx.params
+
+  const body = await req.json().catch(() => null) as {
+    monthly_base_price?: number
+    revenue_share_pct?: number
+    is_active?: boolean
+    description?: string
+  } | null
+  if (!body) return NextResponse.json({ error: 'invalid body' }, { status: 400 })
+
+  const update: Record<string, unknown> = { updated_at: new Date().toISOString() }
+  if (typeof body.monthly_base_price === 'number' && body.monthly_base_price >= 0) {
+    update.monthly_base_price = Math.floor(body.monthly_base_price)
+  }
+  if (typeof body.revenue_share_pct === 'number' && body.revenue_share_pct >= 0 && body.revenue_share_pct <= 50) {
+    update.revenue_share_pct = body.revenue_share_pct
+  }
+  if (typeof body.is_active === 'boolean') update.is_active = body.is_active
+  if (typeof body.description === 'string') update.description = body.description
+
+  const admin = getSupabaseAdmin()
+  if (!admin) return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+
+  const { data, error } = await admin
+    .from('user_subscription_plans')
+    .update(update)
+    .eq('id', id)
+    .select('*')
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+  return NextResponse.json(data)
+}
+```
+
+- [ ] **Step 3: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/master/user-subscription-plans
+git commit -m "feat(master): 개인 구독 플랜 가격 관리 API"
+```
+
+---
+
+## Task 10: master 가격 관리 UI
+
+**Files:**
+- Create: `src/app/master/subscription/investment/page.tsx`
+
+- [ ] **Step 1: UI 작성**
+
+```tsx
+// src/app/master/subscription/investment/page.tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { useRouter } from 'next/navigation'
+import { Loader2, Save } from 'lucide-react'
+
+interface Plan {
+  id: string
+  feature_id: string
+  display_name: string
+  monthly_base_price: number
+  revenue_share_pct: number
+  description: string | null
+  is_active: boolean
+}
+
+export default function InvestmentPlanAdminPage() {
+  const { user, loading: authLoading } = useAuth()
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [plan, setPlan] = useState<Plan | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [savedAt, setSavedAt] = useState<Date | null>(null)
+
+  useEffect(() => {
+    if (!authLoading && (!user || user.role !== 'master_admin')) {
+      router.replace('/dashboard')
+    }
+  }, [user, authLoading, router])
+
+  useEffect(() => {
+    if (!user || user.role !== 'master_admin') return
+    fetch('/api/master/user-subscription-plans')
+      .then(r => r.json())
+      .then((rows: Plan[]) => {
+        const inv = rows.find(p => p.feature_id === 'investment') ?? null
+        setPlan(inv)
+        setLoading(false)
+      })
+      .catch(e => { setError(String(e)); setLoading(false) })
+  }, [user])
+
+  const onSave = async () => {
+    if (!plan) return
+    setSaving(true); setError(null)
+    try {
+      const res = await fetch(`/api/master/user-subscription-plans/${plan.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          monthly_base_price: plan.monthly_base_price,
+          revenue_share_pct: plan.revenue_share_pct,
+          is_active: plan.is_active,
+          description: plan.description ?? '',
+        }),
+      })
+      if (!res.ok) { setError((await res.json()).error ?? '저장 실패') }
+      else setSavedAt(new Date())
+    } finally { setSaving(false) }
+  }
+
+  if (authLoading || loading) {
+    return <div className="p-8"><Loader2 className="w-6 h-6 animate-spin" /></div>
+  }
+  if (!plan) return <div className="p-8 text-red-600">플랜을 찾을 수 없습니다.</div>
+
+  return (
+    <div className="max-w-2xl mx-auto p-8 space-y-6">
+      <h1 className="text-2xl font-bold">자동매매 구독료 관리</h1>
+      <p className="text-sm text-gray-500">
+        변경된 가격은 다음 청구 주기부터 적용됩니다. 진행 중인 결제에는 영향 없음.
+      </p>
+
+      <div className="space-y-4 bg-white rounded-xl border p-6">
+        <div>
+          <label className="block text-sm font-semibold mb-1">월 정액 (원)</label>
+          <input
+            type="number"
+            min={0}
+            value={plan.monthly_base_price}
+            onChange={e => setPlan({ ...plan, monthly_base_price: Number(e.target.value) })}
+            className="w-full border rounded-lg px-3 py-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-semibold mb-1">수익 공유 % (0~50)</label>
+          <input
+            type="number" step="0.01" min={0} max={50}
+            value={plan.revenue_share_pct}
+            onChange={e => setPlan({ ...plan, revenue_share_pct: Number(e.target.value) })}
+            className="w-full border rounded-lg px-3 py-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-semibold mb-1">설명</label>
+          <textarea
+            value={plan.description ?? ''}
+            onChange={e => setPlan({ ...plan, description: e.target.value })}
+            className="w-full border rounded-lg px-3 py-2"
+            rows={3}
+          />
+        </div>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={plan.is_active}
+            onChange={e => setPlan({ ...plan, is_active: e.target.checked })}
+          />
+          플랜 활성화
+        </label>
+
+        {error && <div className="text-red-600 text-sm">{error}</div>}
+        {savedAt && <div className="text-green-600 text-sm">저장됨: {savedAt.toLocaleTimeString()}</div>}
+
+        <button
+          onClick={onSave}
+          disabled={saving}
+          className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white px-4 py-2 rounded-lg"
+        >
+          {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+          저장
+        </button>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공
+
+- [ ] **Step 3: 브라우저 검증 (Chrome DevTools MCP)**
+
+1. `mcp__chrome-devtools__navigate_page` → `http://localhost:3000` (dev 서버 사전 실행)
+2. `sani81@gmail.com / ghkdgmltn81!`로 로그인 (master_admin 계정)
+3. `/master/subscription/investment` 접근
+4. 가격 변경 → 저장 → "저장됨" 메시지 확인
+5. `mcp__supabase__execute_sql`로 `SELECT monthly_base_price FROM user_subscription_plans WHERE feature_id='investment'` → 변경값 반영 확인
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/master/subscription/investment/page.tsx
+git commit -m "feat(master): 자동매매 구독료 변경 UI"
+```
+
+---
+
+## Task 11: 자동매매 구독 안내/결제 페이지
+
+**Files:**
+- Create: `src/app/investment/subscribe/page.tsx`
+
+- [ ] **Step 1: 페이지 작성**
+
+```tsx
+// src/app/investment/subscribe/page.tsx
+// 미구독자 안내 + PortOne SDK로 빌링키 발급 + register API 호출
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { useRouter } from 'next/navigation'
+import { Loader2, CheckCircle } from 'lucide-react'
+import Script from 'next/script'
+
+interface Plan {
+  id: string
+  display_name: string
+  monthly_base_price: number
+  revenue_share_pct: number
+  description: string | null
+  is_active: boolean
+}
+
+declare global {
+  interface Window {
+    PortOne?: {
+      requestIssueBillingKey: (params: Record<string, unknown>) => Promise<{
+        billingKey?: string
+        cardNumber?: string
+        cardName?: string
+        code?: string
+        message?: string
+      }>
+    }
+  }
+}
+
+export default function InvestmentSubscribePage() {
+  const { user, loading: authLoading } = useAuth()
+  const router = useRouter()
+  const [plan, setPlan] = useState<Plan | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [done, setDone] = useState(false)
+
+  useEffect(() => {
+    if (!authLoading && !user) router.replace('/')
+  }, [user, authLoading, router])
+
+  useEffect(() => {
+    fetch('/api/investment/subscription/status').then(r => r.json()).then(d => {
+      if (d.subscription?.status === 'active') router.replace('/investment')
+      setPlan(d.plan)
+    })
+  }, [router])
+
+  const onSubscribe = async () => {
+    if (!plan || !window.PortOne) return
+    setSubmitting(true); setError(null)
+    try {
+      const res = await window.PortOne.requestIssueBillingKey({
+        storeId: process.env.NEXT_PUBLIC_PORTONE_STORE_ID,
+        channelKey: process.env.NEXT_PUBLIC_PORTONE_CHANNEL_KEY,
+        billingKeyMethod: 'CARD',
+        issueId: `issue-${user?.id}-${Date.now()}`,
+        issueName: '자동매매 구독',
+      })
+      if (!res?.billingKey) { setError(res?.message ?? '결제 수단 등록 실패'); return }
+
+      const last4 = (res.cardNumber ?? '').slice(-4)
+      const reg = await fetch('/api/investment/subscription/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          billingKey: res.billingKey,
+          planId: plan.id,
+          cardName: res.cardName ?? '',
+          cardNumberLast4: last4,
+        }),
+      })
+      const regJson = await reg.json()
+      if (!reg.ok) { setError(regJson.error ?? '구독 등록 실패'); return }
+      setDone(true)
+      setTimeout(() => router.replace('/investment'), 1500)
+    } finally { setSubmitting(false) }
+  }
+
+  if (authLoading || !plan) return <div className="p-8"><Loader2 className="w-6 h-6 animate-spin" /></div>
+
+  return (
+    <>
+      <Script src="https://cdn.portone.io/v2/browser-sdk.js" strategy="afterInteractive" />
+      <div className="max-w-xl mx-auto p-8 space-y-6">
+        <h1 className="text-2xl font-bold">{plan.display_name} 구독</h1>
+        {plan.description && <p className="text-gray-600 text-sm">{plan.description}</p>}
+
+        <div className="bg-white rounded-xl border p-6 space-y-3">
+          <div className="flex items-baseline gap-2">
+            <span className="text-3xl font-bold">{plan.monthly_base_price.toLocaleString()}원</span>
+            <span className="text-gray-500">/ 월</span>
+          </div>
+          <div className="text-sm text-gray-600">
+            추가로 매월 실현 수익의 <b>{plan.revenue_share_pct}%</b>가 청구됩니다 (수익이 양수일 때만).
+          </div>
+          <ul className="text-sm space-y-1 text-gray-700 pt-2">
+            <li className="flex gap-2"><CheckCircle className="w-4 h-4 text-green-600" /> AI 자동매매 전략</li>
+            <li className="flex gap-2"><CheckCircle className="w-4 h-4 text-green-600" /> 전략 백테스트</li>
+            <li className="flex gap-2"><CheckCircle className="w-4 h-4 text-green-600" /> 실시간 포트폴리오</li>
+            <li className="flex gap-2"><CheckCircle className="w-4 h-4 text-green-600" /> 군중심리 분석 (포함)</li>
+          </ul>
+        </div>
+
+        {error && <div className="text-red-600 text-sm">{error}</div>}
+        {done && <div className="text-green-600 text-sm">구독이 시작되었습니다. 잠시 후 이동합니다.</div>}
+
+        <button
+          onClick={onSubscribe}
+          disabled={submitting || done}
+          className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white py-3 rounded-xl font-semibold"
+        >
+          {submitting ? '처리 중...' : '구독 시작'}
+        </button>
+      </div>
+    </>
+  )
+}
+```
+
+- [ ] **Step 2: 환경변수 확인**
+
+다음 변수가 `.env.local`에 있어야 함 (없으면 추가):
+- `NEXT_PUBLIC_PORTONE_STORE_ID`
+- `NEXT_PUBLIC_PORTONE_CHANNEL_KEY`
+- `PORTONE_API_SECRET` (server)
+- `PORTONE_STORE_ID` (server)
+
+이미 기존 clinic 구독에서 사용 중인 변수면 그대로 재사용.
+
+- [ ] **Step 3: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/investment/subscribe/page.tsx
+git commit -m "feat(subscription): 자동매매 구독 안내/결제 페이지"
+```
+
+---
+
+## Task 12: investment 레이아웃 게이팅
+
+**Files:**
+- Modify: `src/app/investment/layout.tsx`
+
+- [ ] **Step 1: 현재 파일 확인**
+
+Run: `head -60 src/app/investment/layout.tsx`
+Expected: client component, useAuth로 미인증 시 `/`로 리다이렉트.
+
+- [ ] **Step 2: 게이팅 로직 추가**
+
+`useEffect` 인증 체크 다음에 구독 상태 체크 추가. `/investment/subscribe` 와 `/investment/connect`는 게이팅 면제 (구독 결제 흐름 자체).
+
+```typescript
+// 기존 useAuth + redirect useEffect 다음에 추가
+const [gateChecked, setGateChecked] = useState(false)
+
+useEffect(() => {
+  if (!user) return
+  // 면제 경로
+  if (pathname === '/investment/subscribe' || pathname === '/investment/connect') {
+    setGateChecked(true)
+    return
+  }
+  fetch('/api/investment/subscription/status')
+    .then(r => r.json())
+    .then(d => {
+      if (!d.subscription || d.subscription.status !== 'active') {
+        router.replace('/investment/subscribe')
+      } else setGateChecked(true)
+    })
+    .catch(() => setGateChecked(true))
+}, [user, pathname, router])
+
+if (!gateChecked && pathname !== '/investment/subscribe' && pathname !== '/investment/connect') {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-at-surface">
+      <Loader2 className="w-8 h-8 animate-spin text-at-accent" />
+    </div>
+  )
+}
+```
+
+기존 `if (loading) { ... }` 분기 바로 아래에 위 코드를 통합. `useState`/`useEffect`는 이미 import됨.
+
+- [ ] **Step 3: 빌드 + Chrome DevTools 검증**
+
+Run: `npm run build`
+
+브라우저 검증:
+1. `whitedc0902@gmail.com / ghkdgmltn81!`로 로그인 (개인 구독 없는 일반 계정)
+2. `/investment` 접근 → 자동으로 `/investment/subscribe`로 리다이렉트되는지 확인
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/investment/layout.tsx
+git commit -m "feat(investment): 구독 게이팅 레이아웃 통합"
+```
+
+---
+
+## Task 13: 사이드바 권한 분리
+
+**Files:**
+- Modify: `src/config/menuConfig.ts`
+
+- [ ] **Step 1: 자동매매 메뉴 항목 권한 제거**
+
+`grep -n "investment" src/config/menuConfig.ts`로 위치 확인. 자동매매 메뉴 항목(`id: 'investment'`)의 `permissions: ['investment_view']` 라인을 빈 배열로 교체.
+
+```typescript
+// 변경 전
+{
+  id: 'investment',
+  label: '주식 자동 매매',
+  icon: 'TrendingUp',
+  route: '/dashboard?tab=investment',
+  permissions: ['investment_view'],
+  categoryId: 'investment',
+  order: 16.5,
+},
+
+// 변경 후
+{
+  id: 'investment',
+  label: '주식 자동 매매',
+  icon: 'TrendingUp',
+  route: '/dashboard?tab=investment',
+  permissions: [],   // 모든 사용자에게 노출. 진입 시 개인 구독 게이팅으로 전환.
+  categoryId: 'investment',
+  order: 16.5,
+},
+```
+
+- [ ] **Step 2: 빌드 + permissions 체크 확인**
+
+Run: `npm run check:permissions && npm run build`
+Expected: 둘 다 통과.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/config/menuConfig.ts
+git commit -m "feat(menu): 자동매매 메뉴 권한 제거 (개인 구독 게이팅으로 전환)"
+```
+
+---
+
+## Task 14: profit-snapshot cron을 user 단위 청구로 재작성
+
+**Files:**
+- Modify: `src/app/api/investment/profit-snapshot/route.ts`
+
+- [ ] **Step 1: 라우트 재작성**
+
+월말에 active user 구독자 전체에 대해 base + 5% 수익 청구 + payment 기록.
+
+```typescript
+// src/app/api/investment/profit-snapshot/route.ts
+import { NextResponse } from 'next/server'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { calculateMonthlyProfitForUser } from '@/lib/investmentProfit'
+import { chargeBillingKey, getNextBillingDate } from '@/lib/portone'
+
+function isLastDayOfMonthKST(d: Date): boolean {
+  const kst = new Date(d.getTime() + 9 * 3600_000)
+  const next = new Date(Date.UTC(kst.getUTCFullYear(), kst.getUTCMonth(), kst.getUTCDate() + 1))
+  return next.getUTCDate() === 1
+}
+
+export async function POST(req: Request) {
+  const auth = req.headers.get('authorization')
+  if (auth !== `Bearer ${process.env.CRON_SECRET ?? ''}`) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+  const now = new Date()
+  if (!isLastDayOfMonthKST(now)) return NextResponse.json({ skipped: true })
+
+  const admin = getSupabaseAdmin()
+  if (!admin) return NextResponse.json({ error: 'ADMIN_UNAVAILABLE' }, { status: 500 })
+
+  const { data: subs } = await admin
+    .from('user_subscriptions')
+    .select(`
+      id, user_id, billing_key, plan:user_subscription_plans!inner(id, feature_id, monthly_base_price, revenue_share_pct, display_name, is_active)
+    `)
+    .eq('status', 'active')
+    .eq('plan.feature_id', 'investment')
+    .eq('plan.is_active', true)
+    .not('billing_key', 'is', null)
+
+  if (!subs?.length) return NextResponse.json({ snapshotted: 0 })
+
+  const kst = new Date(now.getTime() + 9 * 3600_000)
+  const year = kst.getUTCFullYear()
+  const month = kst.getUTCMonth() + 1
+  let charged = 0; let failed = 0
+
+  for (const row of subs as unknown as Array<{
+    id: string; user_id: string; billing_key: string;
+    plan: { id: string; monthly_base_price: number; revenue_share_pct: number; display_name: string }
+  }>) {
+    const { realized } = await calculateMonthlyProfitForUser(row.user_id, year, month)
+    const base = row.plan.monthly_base_price
+    const share = Math.max(0, Math.floor(realized * (row.plan.revenue_share_pct / 100)))
+    const total = base + share
+    if (total <= 0) continue
+
+    const { data: u } = await admin.from('users').select('name, email').eq('id', row.user_id).single()
+    const name = (u as { name?: string } | null)?.name ?? ''
+    const email = (u as { email?: string } | null)?.email ?? ''
+
+    try {
+      const result = await chargeBillingKey({
+        clinicId: row.user_id, // paymentId prefix용
+        billingKey: row.billing_key,
+        amount: total,
+        orderName: `${row.plan.display_name} ${year}-${String(month).padStart(2,'0')}`,
+        customerName: name,
+        customerEmail: email,
+        noticeUrl: `${process.env.NEXT_PUBLIC_BASE_URL}/api/investment/subscription/webhook`,
+      })
+
+      const paid = result.status === 'PAID'
+      const periodStart = new Date(Date.UTC(year, month - 1, 1)).toISOString().slice(0, 10)
+      const periodEnd = new Date(Date.UTC(year, month, 0)).toISOString().slice(0, 10)
+
+      await admin.from('user_subscription_payments').insert({
+        user_id: row.user_id,
+        subscription_id: row.id,
+        portone_payment_id: result.paymentId,
+        portone_tx_id: result.txId ?? null,
+        amount: total,
+        base_amount: base,
+        revenue_share_amount: share,
+        realized_profit_basis: Math.max(0, Math.floor(realized)),
+        status: paid ? 'paid' : 'failed',
+        paid_at: paid ? (result.paidAt ?? now.toISOString()) : null,
+        failed_at: paid ? null : now.toISOString(),
+        fail_reason: paid ? null : (result.failReason ?? '결제 실패'),
+        order_name: `${row.plan.display_name} ${year}-${String(month).padStart(2,'0')}`,
+        billing_period_start: periodStart,
+        billing_period_end: periodEnd,
+      })
+
+      if (paid) {
+        const nextEnd = getNextBillingDate(now)
+        await admin.from('user_subscriptions').update({
+          current_period_start: now.toISOString(),
+          current_period_end: nextEnd.toISOString(),
+          next_billing_date: nextEnd.toISOString(),
+          retry_count: 0, next_retry_at: null,
+          updated_at: now.toISOString(),
+        }).eq('id', row.id)
+        charged++
+      } else {
+        await admin.from('user_subscriptions').update({
+          status: 'past_due', retry_count: 1,
+          next_retry_at: new Date(now.getTime() + 12 * 3600_000).toISOString(),
+          updated_at: now.toISOString(),
+        }).eq('id', row.id)
+        failed++
+      }
+    } catch (e) {
+      console.error('[profit-snapshot] charge failed:', row.user_id, e)
+      failed++
+    }
+  }
+
+  return NextResponse.json({ charged, failed, total: subs.length })
+}
+```
+
+기존 GET export가 있다면 유지 가능 — 위는 POST. vercel.json에서 `path: /api/investment/profit-snapshot, schedule: '0 14 28-31 * *'` 같은 KST 23시 매월 말일 트리거 사용 (실제 일자 분기는 코드 내부의 `isLastDayOfMonthKST`).
+
+- [ ] **Step 2: 빌드 + dry-run 검증**
+
+Run: `npm run build`
+Expected: 성공.
+
+dev 환경에서 강제 실행 테스트:
+- 임시로 `isLastDayOfMonthKST(now)` 부분을 `true`로 바꾸지 말고, 다음 SQL로 모의 활성 구독 1건 생성 후 호출:
+
+```sql
+-- (테스트 환경에서만) 모의 활성 구독 + 빌링키
+INSERT INTO user_subscriptions (user_id, plan_id, status, billing_key, current_period_start, current_period_end, next_billing_date)
+SELECT
+  '<test_user_uuid>',
+  (SELECT id FROM user_subscription_plans WHERE feature_id='investment'),
+  'active', 'TEST_BILLING_KEY',
+  NOW(), NOW() + interval '30 days', NOW() + interval '30 days'
+;
+```
+
+월말 테스트는 production 검증 단계에서 실제 cron 실행으로.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/investment/profit-snapshot/route.ts
+git commit -m "feat(billing): user 단위 월말 청구 cron (정액+수익공유 5%)"
+```
+
+---
+
+## Task 15: 기존 clinic 구독자 자동 이관 스크립트
+
+**Files:**
+- Create: `scripts/migrate-investment-subscriptions-to-user.ts`
+
+- [ ] **Step 1: 이관 스크립트 작성**
+
+```typescript
+// scripts/migrate-investment-subscriptions-to-user.ts
+//
+// 1회성 마이그레이션: clinic 단위 자동매매 구독을 개인 단위로 이관.
+//
+// 사용법:
+//   npx tsx scripts/migrate-investment-subscriptions-to-user.ts --dry-run
+//   npx tsx scripts/migrate-investment-subscriptions-to-user.ts --apply
+//
+// 환경변수:
+//   NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY 필수.
+
+import { createClient } from '@supabase/supabase-js'
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error('SUPABASE 환경변수 누락'); process.exit(1)
+}
+const apply = process.argv.includes('--apply')
+
+async function main() {
+  const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
+    auth: { autoRefreshToken: false, persistSession: false }
+  })
+
+  // 1. 자동매매 clinic 구독 조회
+  const { data: clinicSubs } = await supabase
+    .from('subscriptions')
+    .select(`
+      id, clinic_id, billing_key, card_name, card_number_last4,
+      current_period_start, current_period_end, next_billing_date, retry_count,
+      plan:subscription_plans!inner(id, feature_id, display_name)
+    `)
+    .in('status', ['active','past_due','trialing'])
+    .eq('plan.feature_id', 'investment')
+
+  console.log(`[migrate] 대상 clinic 구독: ${clinicSubs?.length ?? 0}건`)
+  if (!clinicSubs?.length) return
+
+  // 2. 신규 user_subscription_plans.investment id
+  const { data: planRow } = await supabase
+    .from('user_subscription_plans')
+    .select('id')
+    .eq('feature_id', 'investment')
+    .single()
+  const userPlanId = (planRow as { id: string } | null)?.id
+  if (!userPlanId) { console.error('user_subscription_plans.investment 시드 누락'); process.exit(1) }
+
+  let migrated = 0; let skipped = 0; let multiUserClinics = 0
+
+  for (const cs of clinicSubs as Array<{
+    id: string; clinic_id: string; billing_key: string | null;
+    card_name: string | null; card_number_last4: string | null;
+    current_period_start: string | null; current_period_end: string | null;
+    next_billing_date: string | null; retry_count: number;
+  }>) {
+    // 3. 활동 사용자 후보 추출
+    const { data: stratUsers } = await supabase
+      .from('investment_strategies').select('user_id')
+      .eq('clinic_id', cs.clinic_id)
+    const stratIds = new Set((stratUsers ?? []).map(r => (r as { user_id: string }).user_id))
+
+    const { data: clinicUsers } = await supabase
+      .from('users')
+      .select('id, role, created_at')
+      .eq('clinic_id', cs.clinic_id)
+    const allUsers = (clinicUsers ?? []) as Array<{ id: string; role: string; created_at: string }>
+
+    const { data: credUsers } = await supabase
+      .from('user_broker_credentials').select('user_id')
+      .in('user_id', allUsers.map(u => u.id))
+    const credIds = new Set((credUsers ?? []).map(r => (r as { user_id: string }).user_id))
+
+    let candidates = allUsers.filter(u => stratIds.has(u.id) || credIds.has(u.id))
+    if (candidates.length === 0) {
+      const owner = allUsers.find(u => u.role === 'owner')
+      if (owner) candidates = [owner]
+    }
+    if (candidates.length > 1) multiUserClinics++
+
+    // 4. created_at 오래된 순 정렬
+    candidates.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+
+    if (candidates.length === 0) {
+      console.log(`[skip] clinic=${cs.clinic_id}: 후보 사용자 없음`)
+      skipped++
+      continue
+    }
+
+    for (let i = 0; i < candidates.length; i++) {
+      const u = candidates[i]
+      const isFirst = i === 0
+      const billingKey = isFirst ? cs.billing_key : null
+
+      console.log(`${apply ? '[apply]' : '[dry-run]'} migrate clinic=${cs.clinic_id} → user=${u.id} (first=${isFirst}, billingKey=${billingKey ? 'yes' : 'no'})`)
+
+      if (!apply) continue
+
+      const { error } = await supabase.from('user_subscriptions').insert({
+        user_id: u.id,
+        plan_id: userPlanId,
+        status: 'active',
+        billing_key: billingKey,
+        card_name: isFirst ? cs.card_name : null,
+        card_number_last4: isFirst ? cs.card_number_last4 : null,
+        current_period_start: cs.current_period_start,
+        current_period_end: cs.current_period_end,
+        next_billing_date: cs.next_billing_date,
+        retry_count: cs.retry_count ?? 0,
+        migrated_from_clinic_id: cs.clinic_id,
+        migrated_at: new Date().toISOString(),
+      })
+      if (error) {
+        if (error.message.includes('duplicate key')) {
+          console.log(`  → 이미 존재 (skip)`)
+        } else {
+          console.error(`  → 실패: ${error.message}`)
+        }
+      }
+    }
+
+    if (apply) {
+      // 5. 기존 clinic 구독 cancel 처리
+      await supabase.from('subscriptions')
+        .update({
+          status: 'cancelled',
+          cancelled_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', cs.id)
+      migrated++
+    }
+  }
+
+  console.log(`\n[summary] migrated=${migrated} skipped=${skipped} multi-user clinics=${multiUserClinics}`)
+}
+
+main().catch(e => { console.error(e); process.exit(1) })
+```
+
+- [ ] **Step 2: dry-run 실행 + 보고서 검토**
+
+Run:
+```bash
+npx tsx scripts/migrate-investment-subscriptions-to-user.ts --dry-run
+```
+
+Expected: 대상 clinic 구독 N건과 각 매핑이 출력. 첫 후보(billingKey=yes), 추가 후보(billingKey=no) 분기 확인. 실제 INSERT는 일어나지 않음.
+
+검토 후 사용자에게 결과 공유. 사용자 승인 시 다음 단계.
+
+- [ ] **Step 3: --apply 실행 (사용자 승인 후)**
+
+Run:
+```bash
+npx tsx scripts/migrate-investment-subscriptions-to-user.ts --apply
+```
+
+Expected: `[summary] migrated=N skipped=M multi-user clinics=K` 출력.
+
+검증:
+```sql
+SELECT COUNT(*) FROM user_subscriptions WHERE migrated_from_clinic_id IS NOT NULL;
+SELECT COUNT(*) FROM subscriptions s
+  JOIN subscription_plans p ON p.id = s.plan_id
+  WHERE p.feature_id = 'investment' AND s.status = 'cancelled';
+```
+
+두 카운트가 일치해야 함.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/migrate-investment-subscriptions-to-user.ts
+git commit -m "feat(migration): clinic 자동매매 구독 → 개인 구독 이관 스크립트"
+```
+
+---
+
+## Task 16: 통합 검증 + develop 푸시
+
+- [ ] **Step 1: 빌드 + 린트 + 권한 체크**
+
+```bash
+npm run check:permissions && npm run lint && npm run build
+```
+Expected: 모두 통과.
+
+- [ ] **Step 2: 일반 사용자 흐름 검증 (Chrome DevTools MCP)**
+
+테스트 계정: `whitedc0902@gmail.com / ghkdgmltn81!`
+
+1. 미구독 상태에서 `/investment` 접근 → `/investment/subscribe` 자동 리다이렉트
+2. 구독 페이지에서 가격(월 9,900 + 수익 5%) 표시 확인
+3. (실제 결제는 PortOne 테스트 카드. 환경 가능 시) 구독 → `/investment` 정상 진입
+4. `/api/investment/subscription/status` 호출 결과에 `subscription.status='active'` 확인
+
+- [ ] **Step 3: master 흐름 검증**
+
+테스트 계정: `sani81@gmail.com / ghkdgmltn81!`
+
+1. `/master/subscription/investment` 접근
+2. 월 정액 12,000으로 변경 → 저장 → SQL로 반영 확인
+3. 다시 9,900으로 복구
+
+- [ ] **Step 4: develop 푸시**
+
+```bash
+git push origin develop
+```
+
+푸시 실패 시: `git pull --rebase origin develop && git push origin develop` 재시도.
+
+- [ ] **Step 5: PR 생성 → main 머지**
+
+```bash
+gh pr create --title "feat: 자동매매 개인 구독 전환 + master 가격 관리" \
+  --base main --head develop \
+  --body "$(cat <<'EOF'
+## Summary
+- 자동매매 구독을 clinic → 개인(user) 단위로 전환
+- 월 정액 + 수익 5% 하이브리드, master 페이지에서 가격 변경 가능
+- 기존 clinic 자동매매 구독자 자동 이관 (1회성 스크립트)
+- 자동매매 메뉴 권한(`investment_view`) 분리, 단일 게이팅 헬퍼로 통합
+
+## Test plan
+- [ ] 미구독자 `/investment` 접근 → `/investment/subscribe` 리다이렉트
+- [ ] 구독 등록 → status='active' 전이
+- [ ] 월말 cron (테스트 모의) → user_subscription_payments에 base+share 분해 기록
+- [ ] master 페이지 가격 변경 반영
+- [ ] 마이그레이션 스크립트 dry-run + apply 보고 일치
+EOF
+)"
+```
+
+main에 머지: `gh pr merge <number> --merge --admin`.
+
+---
+
+## Self-Review
+
+### Spec coverage
+- 5.1 데이터 모델 → Task 1
+- 6.1 게이팅 헬퍼 → Task 3
+- 6.2 결제 흐름 (서비스 + 라우트 4개) → Tasks 4, 5, 6, 8
+- 6.3 월말 청구 cron → Task 14 + Task 7 (user 수익 함수)
+- 6.4 사이드바 메뉴 변경 → Task 13 (자식 메뉴는 Plan 2에서)
+- 6.5 자동 이관 스크립트 → Task 15
+- C(7) master 가격 관리 UI → Tasks 9, 10
+- 11.2 인프라 테스트 항목 → Task 16
+- 12 출시 절차 → Task 16
+
+### 미커버 항목 점검
+- spec 11.2 "결제 실패 시 status 전이"는 Task 8 webhook으로 cover. 정식 검증은 PortOne 테스트 환경에서 수동 시뮬.
+- spec 13 "월 정액 시드 9,900"은 Task 1 시드에 포함.
+- spec 13 "수익 5%"는 Task 1 시드에 포함.
+
+### Type consistency
+- `UserSubscription`/`UserSubscriptionPlan` 사용처 일관 (Tasks 2, 3, 4, 5, 9, 10, 11, 12).
+- 게이팅 함수명 `checkInvestmentSubscription`/`requireInvestmentSubscription` 일관.
+- `calculateMonthlyProfitForUser(userId, year, month)` Task 7 정의 → Task 5, 14에서 사용.
+
+### Placeholder scan
+- 각 Step에 실제 코드 또는 명령 포함.
+- "TBD"/"TODO" 없음.
+- "Add validation" 같은 모호 지시 없음.

--- a/dental-clinic-manager/docs/superpowers/plans/2026-05-07-investment-psychology-analysis.md
+++ b/dental-clinic-manager/docs/superpowers/plans/2026-05-07-investment-psychology-analysis.md
@@ -1,0 +1,1990 @@
+# 군중심리 분석 기능 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 자동매매 사용자가 워치리스트에 등록한 종목의 군중심리(공포·탐욕·FOMO 등)를 LLM이 분석해 점수·태그·서술·차트 마커로 보여주고, 급등/급락/거래량 폭증 이벤트가 감지되면 자동 분석 + 푸시 알림을 발송한다.
+
+**Architecture:** 워치리스트(상한 10개) + 종목 클릭 시 온디맨드 분석 + Vercel Cron 1분 주기 이벤트 감시. 분봉 60개 + 호가 스냅샷(KR만)을 Anthropic Claude haiku 4.5에 전달하여 JSON 스키마 잠긴 응답을 받고, recharts로 차트 + ReferenceDot 마커를 표시. 게이팅은 Plan 1의 `requireInvestmentSubscription` 헬퍼 단일 사용.
+
+**Tech Stack:** Next.js 15, TypeScript, Supabase, Anthropic SDK (claude-haiku-4-5-20251001), recharts, KIS API, yahoo-finance2, Vercel Cron.
+
+**Spec:** [docs/superpowers/specs/2026-05-07-investment-personal-subscription-and-psychology-design.md](../specs/2026-05-07-investment-personal-subscription-and-psychology-design.md)
+
+**Prerequisite:** Plan 1(`2026-05-07-investment-personal-subscription-transition.md`) 완료 후 시작. `requireInvestmentSubscription` 헬퍼 사용.
+
+---
+
+## File Map
+
+### 신설
+- `supabase/migrations/20260507_psychology_analysis.sql` — 3개 테이블 + RLS
+- `src/types/psychology.ts` — 타입 정의
+- `src/lib/psychology/llmClient.ts` — Anthropic 호출 + JSON 스키마 검증
+- `src/lib/psychology/marketDataFetcher.ts` — 분봉/호가 수집 (KR/US)
+- `src/lib/psychology/marketHours.ts` — 시장 시간 체크
+- `src/app/api/investment/psychology/watchlist/route.ts` (GET, POST, DELETE)
+- `src/app/api/investment/psychology/watchlist/[id]/route.ts` (PATCH)
+- `src/app/api/investment/psychology/settings/route.ts` (GET, PUT)
+- `src/app/api/investment/psychology/analyze/route.ts` (POST)
+- `src/app/api/investment/psychology/analyses/route.ts` (GET)
+- `src/app/api/investment/psychology/cron/scan/route.ts` (GET — Vercel Cron)
+- `src/app/investment/psychology/page.tsx` — 메인 페이지
+- `src/components/Investment/Psychology/Watchlist.tsx`
+- `src/components/Investment/Psychology/AnalysisDetail.tsx`
+- `src/components/Investment/Psychology/ScoreGauge.tsx`
+- `src/components/Investment/Psychology/PsychologyChart.tsx`
+- `src/components/Investment/Psychology/OrderbookPressureBar.tsx`
+- `src/components/Investment/Psychology/AnalysisHistory.tsx`
+- `src/components/Investment/Psychology/AddTickerModal.tsx`
+
+### 수정
+- `src/app/investment/layout.tsx` — 사이드바에 "심리 분석" 자식 메뉴 추가
+- `vercel.json` — Cron 등록 (`/api/investment/psychology/cron/scan` 매분)
+
+---
+
+## Task 1: 데이터베이스 마이그레이션
+
+**Files:**
+- Create: `supabase/migrations/20260507_psychology_analysis.sql`
+
+- [ ] **Step 1: SQL 작성**
+
+```sql
+-- ============================================
+-- 군중심리 분석 (psychology_*)
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS psychology_watchlist (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  ticker TEXT NOT NULL,
+  market TEXT NOT NULL CHECK (market IN ('KR','US')),
+  monitoring_enabled BOOLEAN NOT NULL DEFAULT true,
+  trigger_price_change_pct NUMERIC NULL,
+  trigger_volume_multiplier NUMERIC NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_id, ticker, market)
+);
+
+CREATE TABLE IF NOT EXISTS psychology_settings (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  default_price_change_pct NUMERIC NOT NULL DEFAULT 2.0,
+  default_volume_multiplier NUMERIC NOT NULL DEFAULT 3.0,
+  push_notify_enabled BOOLEAN NOT NULL DEFAULT true,
+  cooldown_minutes INT NOT NULL DEFAULT 10,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS psychology_analyses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  ticker TEXT NOT NULL,
+  market TEXT NOT NULL CHECK (market IN ('KR','US')),
+  trigger_kind TEXT NOT NULL CHECK (trigger_kind IN ('manual','price_change','volume_spike')),
+  psychology_score INT NOT NULL CHECK (psychology_score BETWEEN 0 AND 100),
+  score_label TEXT NOT NULL,
+  tags TEXT[] NOT NULL,
+  narrative TEXT NOT NULL,
+  markers JSONB NOT NULL,
+  orderbook_pressure JSONB NULL,
+  input_snapshot JSONB NOT NULL,
+  llm_model TEXT NOT NULL,
+  llm_latency_ms INT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_psy_analyses_user_ticker_time
+  ON psychology_analyses (user_id, ticker, created_at DESC);
+
+ALTER TABLE psychology_watchlist ENABLE ROW LEVEL SECURITY;
+ALTER TABLE psychology_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE psychology_analyses ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY psy_watchlist_select_own ON psychology_watchlist
+  FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY psy_watchlist_insert_own ON psychology_watchlist
+  FOR INSERT WITH CHECK (user_id = auth.uid());
+CREATE POLICY psy_watchlist_update_own ON psychology_watchlist
+  FOR UPDATE USING (user_id = auth.uid());
+CREATE POLICY psy_watchlist_delete_own ON psychology_watchlist
+  FOR DELETE USING (user_id = auth.uid());
+
+CREATE POLICY psy_settings_select_own ON psychology_settings
+  FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY psy_settings_upsert_own ON psychology_settings
+  FOR ALL USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY psy_analyses_select_own ON psychology_analyses
+  FOR SELECT USING (user_id = auth.uid());
+-- INSERT는 service_role만
+```
+
+- [ ] **Step 2: Supabase MCP로 마이그레이션 적용**
+
+`mcp__supabase__apply_migration` (project_id=`beahjntkmkfhpcbhfnrr`, name=`20260507_psychology_analysis`).
+
+- [ ] **Step 3: 검증**
+
+```sql
+SELECT table_name FROM information_schema.tables
+WHERE table_schema='public'
+  AND table_name IN ('psychology_watchlist','psychology_settings','psychology_analyses');
+```
+Expected: 3 rows. `mcp__supabase__execute_sql` 사용.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/20260507_psychology_analysis.sql
+git commit -m "feat(psychology): 워치리스트/설정/분석 이력 테이블 신설"
+```
+
+---
+
+## Task 2: 타입 정의
+
+**Files:**
+- Create: `src/types/psychology.ts`
+
+- [ ] **Step 1: 타입 작성**
+
+```typescript
+// src/types/psychology.ts
+import type { Market } from '@/types/investment'
+
+export type PsychologyTriggerKind = 'manual' | 'price_change' | 'volume_spike'
+
+export type PsychologyMarkerKind =
+  | 'panic_sell'
+  | 'fomo_entry'
+  | 'accumulation'
+  | 'distribution'
+  | 'capitulation'
+  | 'indecision'
+
+export const PSYCHOLOGY_TAG_OPTIONS = [
+  '패닉 셀링', 'FOMO 매수', '익절 압력', '누적 매집',
+  '분산 매도', '관망', '반등 시도', '투매',
+] as const
+export type PsychologyTag = typeof PSYCHOLOGY_TAG_OPTIONS[number]
+
+export interface PsychologyMarker {
+  ts: string
+  kind: PsychologyMarkerKind
+  label: string
+  candle_index: number
+}
+
+export interface PsychologyOrderbookPressure {
+  bid_pct: number
+  ask_pct: number
+  interpretation: string
+}
+
+export interface PsychologyAnalysisOutput {
+  psychology_score: number
+  score_label: string
+  tags: string[]
+  narrative: string
+  markers: PsychologyMarker[]
+  orderbook_pressure: PsychologyOrderbookPressure | null
+}
+
+export interface PsychologyWatchlistItem {
+  id: string
+  user_id: string
+  ticker: string
+  market: Market
+  monitoring_enabled: boolean
+  trigger_price_change_pct: number | null
+  trigger_volume_multiplier: number | null
+  created_at: string
+}
+
+export interface PsychologySettings {
+  user_id: string
+  default_price_change_pct: number
+  default_volume_multiplier: number
+  push_notify_enabled: boolean
+  cooldown_minutes: number
+  updated_at: string
+}
+
+export interface PsychologyAnalysisRecord extends PsychologyAnalysisOutput {
+  id: string
+  user_id: string
+  ticker: string
+  market: Market
+  trigger_kind: PsychologyTriggerKind
+  input_snapshot: PsychologyInputSnapshot
+  llm_model: string
+  llm_latency_ms: number | null
+  created_at: string
+}
+
+export interface MinuteCandle {
+  ts: string  // ISO8601
+  open: number
+  high: number
+  low: number
+  close: number
+  volume: number
+}
+
+export interface OrderbookSnapshot {
+  bids: Array<{ price: number; qty: number }>
+  asks: Array<{ price: number; qty: number }>
+  totalBidQty: number
+  totalAskQty: number
+}
+
+export interface PsychologyInputSnapshot {
+  candles: MinuteCandle[]
+  orderbook: OrderbookSnapshot | null
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/psychology.ts
+git commit -m "feat(psychology): 타입 정의"
+```
+
+---
+
+## Task 3: 시장 시간 헬퍼
+
+**Files:**
+- Create: `src/lib/psychology/marketHours.ts`
+
+- [ ] **Step 1: 헬퍼 작성**
+
+```typescript
+// src/lib/psychology/marketHours.ts
+// 한국/미국 정규장 시간 체크 (Intl.DateTimeFormat으로 서머타임 처리)
+import type { Market } from '@/types/investment'
+
+function getZonedHourMinute(date: Date, timeZone: string): { h: number; m: number; weekday: number } {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    weekday: 'short',
+    hour: '2-digit', minute: '2-digit', hour12: false,
+  })
+  const parts = fmt.formatToParts(date)
+  const get = (t: string) => parts.find(p => p.type === t)?.value ?? ''
+  const weekdayMap: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 }
+  return {
+    h: Number(get('hour')),
+    m: Number(get('minute')),
+    weekday: weekdayMap[get('weekday')] ?? 0,
+  }
+}
+
+export function isMarketOpen(market: Market, now = new Date()): boolean {
+  if (market === 'KR') {
+    const z = getZonedHourMinute(now, 'Asia/Seoul')
+    if (z.weekday === 0 || z.weekday === 6) return false
+    const minutes = z.h * 60 + z.m
+    return minutes >= 9 * 60 && minutes <= 15 * 60 + 30
+  }
+  // US
+  const z = getZonedHourMinute(now, 'America/New_York')
+  if (z.weekday === 0 || z.weekday === 6) return false
+  const minutes = z.h * 60 + z.m
+  return minutes >= 9 * 60 + 30 && minutes <= 16 * 60
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/psychology/marketHours.ts
+git commit -m "feat(psychology): 시장 시간 체크 헬퍼"
+```
+
+---
+
+## Task 4: 분봉/호가 수집 헬퍼
+
+**Files:**
+- Create: `src/lib/psychology/marketDataFetcher.ts`
+
+- [ ] **Step 1: 수집 헬퍼 작성**
+
+KR은 KIS API, US는 yahoo-finance2. KIS 호가는 `inquire-asking-price-exp-ccn` 엔드포인트.
+
+```typescript
+// src/lib/psychology/marketDataFetcher.ts
+import yahooFinance from 'yahoo-finance2'
+import { getKRMinuteCandles, getKRAskingPrice } from '@/lib/kisApiService'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { investmentDecrypt } from '@/lib/investmentCrypto'
+import type { Market } from '@/types/investment'
+import type { MinuteCandle, OrderbookSnapshot, PsychologyInputSnapshot } from '@/types/psychology'
+
+interface KisCredentialResolved {
+  credentialId: string
+  appKey: string
+  appSecret: string
+  isPaperTrading: boolean
+}
+
+async function getUserKisCredential(userId: string): Promise<KisCredentialResolved | null> {
+  const admin = getSupabaseAdmin()
+  if (!admin) return null
+  const { data } = await admin
+    .from('user_broker_credentials')
+    .select('id, app_key_encrypted, app_secret_encrypted, is_paper_trading')
+    .eq('user_id', userId)
+    .eq('is_active', true)
+    .in('broker', ['kis', 'kis_kr', 'KIS', 'KIS_KR'])
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (!data) return null
+  const row = data as { id: string; app_key_encrypted: string; app_secret_encrypted: string; is_paper_trading: boolean }
+  return {
+    credentialId: row.id,
+    appKey: investmentDecrypt(row.app_key_encrypted),
+    appSecret: investmentDecrypt(row.app_secret_encrypted),
+    isPaperTrading: !!row.is_paper_trading,
+  }
+}
+
+async function fetchKRSnapshot(userId: string, ticker: string, count = 60): Promise<PsychologyInputSnapshot> {
+  const cred = await getUserKisCredential(userId)
+  if (!cred) throw new Error('KIS 계좌 연결이 필요합니다')
+
+  const candles = await getKRMinuteCandles({
+    credentialId: cred.credentialId,
+    credential: cred,
+    ticker,
+    count,
+  })
+  let orderbook: OrderbookSnapshot | null = null
+  try {
+    orderbook = await getKRAskingPrice({ credentialId: cred.credentialId, credential: cred, ticker })
+  } catch {
+    orderbook = null  // 호가 실패는 전체 실패로 이어지지 않음
+  }
+  return { candles, orderbook }
+}
+
+async function fetchUSSnapshot(ticker: string, count = 60): Promise<PsychologyInputSnapshot> {
+  const period2 = new Date()
+  const period1 = new Date(period2.getTime() - count * 60 * 1000)
+  const result = await yahooFinance.chart(ticker, {
+    period1, period2, interval: '1m',
+  })
+  const quotes = result.quotes ?? []
+  const candles: MinuteCandle[] = quotes
+    .filter(q => q.open != null && q.close != null)
+    .slice(-count)
+    .map(q => ({
+      ts: new Date(q.date as Date).toISOString(),
+      open: q.open as number,
+      high: q.high as number,
+      low: q.low as number,
+      close: q.close as number,
+      volume: q.volume as number,
+    }))
+  return { candles, orderbook: null }
+}
+
+export async function fetchPsychologySnapshot(
+  userId: string,
+  ticker: string,
+  market: Market,
+  count = 60
+): Promise<PsychologyInputSnapshot> {
+  if (market === 'KR') return fetchKRSnapshot(userId, ticker, count)
+  return fetchUSSnapshot(ticker, count)
+}
+```
+
+- [ ] **Step 2: KIS 호가 함수 확인**
+
+Run: `grep -n "getKRAskingPrice\|getKRMinuteCandles" src/lib/kisApiService.ts`
+
+`getKRMinuteCandles`는 존재하지만 `getKRAskingPrice`가 없으면 추가 필요.
+
+해당 함수가 없으면 `src/lib/kisApiService.ts`에 다음을 export로 추가:
+
+```typescript
+// KIS 호가 (10단계 매수/매도) — inquire-asking-price-exp-ccn TR ID: FHKST01010200
+export async function getKRAskingPrice(params: {
+  credentialId: string
+  credential: { appKey: string; appSecret: string; isPaperTrading: boolean }
+  ticker: string
+}): Promise<{ bids: Array<{price:number;qty:number}>, asks: Array<{price:number;qty:number}>, totalBidQty: number, totalAskQty: number }> {
+  const token = await ensureKRToken(params.credentialId, params.credential)
+  const baseUrl = params.credential.isPaperTrading ? 'https://openapivts.koreainvestment.com:29443' : 'https://openapi.koreainvestment.com:9443'
+  const url = `${baseUrl}/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn?fid_cond_mrkt_div_code=J&fid_input_iscd=${params.ticker}`
+  const res = await fetch(url, {
+    headers: {
+      'authorization': `Bearer ${token}`,
+      'appkey': params.credential.appKey,
+      'appsecret': params.credential.appSecret,
+      'tr_id': 'FHKST01010200',
+      'content-type': 'application/json; charset=utf-8',
+    },
+  })
+  if (!res.ok) throw new Error(`KIS 호가 조회 실패: ${res.status}`)
+  const json = await res.json() as { output1?: Record<string, string> }
+  const o = json.output1 ?? {}
+  const bids: Array<{price:number;qty:number}> = []
+  const asks: Array<{price:number;qty:number}> = []
+  for (let i = 1; i <= 10; i++) {
+    const bp = Number(o[`bidp${i}`] ?? 0); const bq = Number(o[`bidp_rsqn${i}`] ?? 0)
+    const ap = Number(o[`askp${i}`] ?? 0); const aq = Number(o[`askp_rsqn${i}`] ?? 0)
+    if (bp > 0) bids.push({ price: bp, qty: bq })
+    if (ap > 0) asks.push({ price: ap, qty: aq })
+  }
+  const totalBidQty = bids.reduce((s, x) => s + x.qty, 0)
+  const totalAskQty = asks.reduce((s, x) => s + x.qty, 0)
+  return { bids, asks, totalBidQty, totalAskQty }
+}
+```
+
+KIS API 헬퍼(`ensureKRToken` 등)는 기존 파일에 이미 있을 것. 없으면 기존 `getKRRealtimeQuote` 패턴 따라 작성.
+
+- [ ] **Step 3: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/psychology/marketDataFetcher.ts src/lib/kisApiService.ts
+git commit -m "feat(psychology): 분봉/호가 수집 헬퍼 (KR/US)"
+```
+
+---
+
+## Task 5: LLM 호출 헬퍼
+
+**Files:**
+- Create: `src/lib/psychology/llmClient.ts`
+
+- [ ] **Step 1: LLM 클라이언트 작성**
+
+```typescript
+// src/lib/psychology/llmClient.ts
+import Anthropic from '@anthropic-ai/sdk'
+import { z } from 'zod'
+import type { Market } from '@/types/investment'
+import type {
+  PsychologyAnalysisOutput,
+  PsychologyInputSnapshot,
+  PsychologyTriggerKind,
+} from '@/types/psychology'
+
+const MODEL_ID = 'claude-haiku-4-5-20251001'
+
+const ZAnalysis = z.object({
+  psychology_score: z.number().int().min(0).max(100),
+  score_label: z.string().min(1),
+  tags: z.array(z.string()).max(8),
+  narrative: z.string().min(1),
+  markers: z.array(z.object({
+    ts: z.string(),
+    kind: z.enum(['panic_sell','fomo_entry','accumulation','distribution','capitulation','indecision']),
+    label: z.string().min(1),
+    candle_index: z.number().int().min(0),
+  })).max(5),
+  orderbook_pressure: z.object({
+    bid_pct: z.number().min(0).max(100),
+    ask_pct: z.number().min(0).max(100),
+    interpretation: z.string(),
+  }).nullable(),
+})
+
+const TOOL_DEFINITION = {
+  name: 'submit_psychology_analysis',
+  description: '주식 군중심리 분석 결과를 제출합니다.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      psychology_score: { type: 'integer', minimum: 0, maximum: 100 },
+      score_label: { type: 'string', enum: ['극공포','공포','중립','탐욕','극탐욕'] },
+      tags: {
+        type: 'array',
+        items: { type: 'string', enum: ['패닉 셀링','FOMO 매수','익절 압력','누적 매집','분산 매도','관망','반등 시도','투매'] },
+        maxItems: 5,
+      },
+      narrative: { type: 'string' },
+      markers: {
+        type: 'array',
+        maxItems: 5,
+        items: {
+          type: 'object',
+          properties: {
+            ts: { type: 'string' },
+            kind: { type: 'string', enum: ['panic_sell','fomo_entry','accumulation','distribution','capitulation','indecision'] },
+            label: { type: 'string' },
+            candle_index: { type: 'integer', minimum: 0 },
+          },
+          required: ['ts','kind','label','candle_index'],
+        },
+      },
+      orderbook_pressure: {
+        oneOf: [
+          { type: 'null' },
+          {
+            type: 'object',
+            properties: {
+              bid_pct: { type: 'number', minimum: 0, maximum: 100 },
+              ask_pct: { type: 'number', minimum: 0, maximum: 100 },
+              interpretation: { type: 'string' },
+            },
+            required: ['bid_pct','ask_pct','interpretation'],
+          },
+        ],
+      },
+    },
+    required: ['psychology_score','score_label','tags','narrative','markers','orderbook_pressure'],
+  },
+}
+
+const SYSTEM_PROMPT = `당신은 주식 시장 군중심리 분석 전문가입니다. 주어진 분봉 시계열과 호가 스냅샷을 보고, 호가창과 차트를 수시로 보고 있는 일반 투자자(대중)가 지금 이 순간 느낄 심리를 분석합니다. 출력은 반드시 submit_psychology_analysis 도구를 통해 제출하며, 한국어로 작성합니다. 추측이 아닌 데이터에서 직접 관찰 가능한 패턴 위주로 분석하고, 단정적 매매 권유 표현은 사용하지 않습니다.`
+
+export interface AnalyzeArgs {
+  ticker: string
+  market: Market
+  triggerKind: PsychologyTriggerKind
+  triggerDetail?: string
+  snapshot: PsychologyInputSnapshot
+}
+
+export interface AnalyzeResult {
+  output: PsychologyAnalysisOutput
+  model: string
+  latencyMs: number
+}
+
+function buildUserPrompt(args: AnalyzeArgs): string {
+  const { ticker, market, triggerKind, triggerDetail, snapshot } = args
+  const candleLines = snapshot.candles.map((c, i) =>
+    `[${i}] ${c.ts} O=${c.open} H=${c.high} L=${c.low} C=${c.close} V=${c.volume}`
+  ).join('\n')
+  const orderbookSummary = snapshot.orderbook
+    ? `호가 (10단계): 매수총잔량=${snapshot.orderbook.totalBidQty}, 매도총잔량=${snapshot.orderbook.totalAskQty}\n` +
+      `매수: ${snapshot.orderbook.bids.map(b => `${b.price}@${b.qty}`).join(', ')}\n` +
+      `매도: ${snapshot.orderbook.asks.map(a => `${a.price}@${a.qty}`).join(', ')}`
+    : '호가 데이터 없음 (해외 종목)'
+  return [
+    `종목: ${ticker} (${market})`,
+    `분석 요청 사유: ${triggerKind}${triggerDetail ? ` - ${triggerDetail}` : ''}`,
+    `최근 ${snapshot.candles.length}개 1분봉:`,
+    candleLines,
+    orderbookSummary,
+    '',
+    '위 데이터를 바탕으로 군중심리를 분석하여 submit_psychology_analysis 도구를 호출해주세요.',
+    `markers의 candle_index는 위 분봉 배열의 [N] 번호와 정확히 일치해야 합니다. 최대 5개.`,
+  ].join('\n')
+}
+
+export async function analyzePsychology(args: AnalyzeArgs): Promise<AnalyzeResult> {
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY 환경변수 누락')
+  const client = new Anthropic({ apiKey })
+
+  const userPrompt = buildUserPrompt(args)
+  const start = Date.now()
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const res = await client.messages.create({
+      model: MODEL_ID,
+      max_tokens: 1200,
+      temperature: 0.3,
+      system: SYSTEM_PROMPT,
+      tools: [TOOL_DEFINITION],
+      tool_choice: { type: 'tool', name: TOOL_DEFINITION.name },
+      messages: [{ role: 'user', content: userPrompt }],
+    })
+
+    const toolUse = res.content.find(c => c.type === 'tool_use') as
+      | { type: 'tool_use'; name: string; input: unknown }
+      | undefined
+    if (!toolUse) {
+      if (attempt === 0) continue
+      throw new Error('LLM 응답에 tool_use 없음')
+    }
+
+    const parsed = ZAnalysis.safeParse(toolUse.input)
+    if (!parsed.success) {
+      if (attempt === 0) continue
+      throw new Error(`LLM 응답 스키마 검증 실패: ${parsed.error.message}`)
+    }
+
+    return {
+      output: parsed.data,
+      model: MODEL_ID,
+      latencyMs: Date.now() - start,
+    }
+  }
+  throw new Error('LLM 분석 실패 (재시도 한도 초과)')
+}
+```
+
+- [ ] **Step 2: 의존성 확인**
+
+```bash
+npm ls @anthropic-ai/sdk zod 2>&1 | head -5
+```
+
+둘 다 설치되어 있어야 함. 없으면 추가:
+```bash
+npm install @anthropic-ai/sdk zod
+```
+
+- [ ] **Step 3: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/psychology/llmClient.ts package.json package-lock.json
+git commit -m "feat(psychology): Claude haiku 4.5 LLM 분석 클라이언트"
+```
+
+---
+
+## Task 6: 워치리스트 라우트
+
+**Files:**
+- Create: `src/app/api/investment/psychology/watchlist/route.ts`
+- Create: `src/app/api/investment/psychology/watchlist/[id]/route.ts`
+
+- [ ] **Step 1: 목록/추가/삭제 라우트**
+
+```typescript
+// src/app/api/investment/psychology/watchlist/route.ts
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { requireInvestmentSubscription } from '@/lib/userSubscription'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+const WATCHLIST_LIMIT = 10
+
+export async function GET() {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  await requireInvestmentSubscription(auth.user.id)
+
+  const admin = getSupabaseAdmin()!
+  const { data: items } = await admin
+    .from('psychology_watchlist')
+    .select('*')
+    .eq('user_id', auth.user.id)
+    .order('created_at', { ascending: false })
+
+  // 각 워치리스트 항목의 최신 분석 1건씩 join
+  const tickers = (items ?? []).map(i => (i as { ticker: string }).ticker)
+  const { data: latestAnalyses } = tickers.length
+    ? await admin
+        .from('psychology_analyses')
+        .select('id, ticker, market, psychology_score, score_label, tags, created_at')
+        .eq('user_id', auth.user.id)
+        .in('ticker', tickers)
+        .order('created_at', { ascending: false })
+    : { data: [] }
+
+  const latestMap = new Map<string, unknown>()
+  for (const a of (latestAnalyses ?? []) as Array<{ ticker: string; market: string }>) {
+    const key = `${a.ticker}:${a.market}`
+    if (!latestMap.has(key)) latestMap.set(key, a)
+  }
+
+  const out = (items ?? []).map((it) => {
+    const item = it as { ticker: string; market: string }
+    return { ...item, latest_analysis: latestMap.get(`${item.ticker}:${item.market}`) ?? null }
+  })
+  return NextResponse.json(out)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  await requireInvestmentSubscription(auth.user.id)
+
+  const body = await req.json().catch(() => null) as { ticker?: string; market?: string } | null
+  const ticker = body?.ticker?.trim().toUpperCase()
+  const market = body?.market === 'KR' || body?.market === 'US' ? body.market : null
+  if (!ticker || !market) return NextResponse.json({ error: 'ticker, market 필수' }, { status: 400 })
+
+  const admin = getSupabaseAdmin()!
+  const { count } = await admin
+    .from('psychology_watchlist')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', auth.user.id)
+  if ((count ?? 0) >= WATCHLIST_LIMIT) {
+    return NextResponse.json({ error: `워치리스트는 최대 ${WATCHLIST_LIMIT}개까지 등록 가능합니다.` }, { status: 400 })
+  }
+
+  const { data, error } = await admin
+    .from('psychology_watchlist')
+    .insert({ user_id: auth.user.id, ticker, market })
+    .select('*')
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+  return NextResponse.json(data)
+}
+
+export async function DELETE(req: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  await requireInvestmentSubscription(auth.user.id)
+
+  const id = new URL(req.url).searchParams.get('id')
+  if (!id) return NextResponse.json({ error: 'id 필수' }, { status: 400 })
+  const admin = getSupabaseAdmin()!
+  const { error } = await admin.from('psychology_watchlist').delete()
+    .eq('id', id).eq('user_id', auth.user.id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+  return NextResponse.json({ ok: true })
+}
+```
+
+- [ ] **Step 2: 항목 수정 라우트**
+
+```typescript
+// src/app/api/investment/psychology/watchlist/[id]/route.ts
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { requireInvestmentSubscription } from '@/lib/userSubscription'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+export async function PATCH(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  await requireInvestmentSubscription(auth.user.id)
+
+  const { id } = await ctx.params
+  const body = await req.json().catch(() => null) as {
+    monitoring_enabled?: boolean
+    trigger_price_change_pct?: number | null
+    trigger_volume_multiplier?: number | null
+  } | null
+  if (!body) return NextResponse.json({ error: 'invalid body' }, { status: 400 })
+
+  const update: Record<string, unknown> = {}
+  if (typeof body.monitoring_enabled === 'boolean') update.monitoring_enabled = body.monitoring_enabled
+  if (body.trigger_price_change_pct !== undefined) update.trigger_price_change_pct = body.trigger_price_change_pct
+  if (body.trigger_volume_multiplier !== undefined) update.trigger_volume_multiplier = body.trigger_volume_multiplier
+
+  const admin = getSupabaseAdmin()!
+  const { data, error } = await admin
+    .from('psychology_watchlist')
+    .update(update)
+    .eq('id', id)
+    .eq('user_id', auth.user.id)
+    .select('*')
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+  return NextResponse.json(data)
+}
+```
+
+- [ ] **Step 3: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/investment/psychology/watchlist
+git commit -m "feat(psychology): 워치리스트 CRUD API"
+```
+
+---
+
+## Task 7: 설정 라우트
+
+**Files:**
+- Create: `src/app/api/investment/psychology/settings/route.ts`
+
+- [ ] **Step 1: 라우트 작성**
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { requireInvestmentSubscription } from '@/lib/userSubscription'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+export async function GET() {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  await requireInvestmentSubscription(auth.user.id)
+
+  const admin = getSupabaseAdmin()!
+  const { data } = await admin
+    .from('psychology_settings').select('*')
+    .eq('user_id', auth.user.id).maybeSingle()
+  return NextResponse.json(data ?? {
+    user_id: auth.user.id,
+    default_price_change_pct: 2.0,
+    default_volume_multiplier: 3.0,
+    push_notify_enabled: true,
+    cooldown_minutes: 10,
+    updated_at: null,
+  })
+}
+
+export async function PUT(req: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  await requireInvestmentSubscription(auth.user.id)
+
+  const body = await req.json().catch(() => ({})) as Record<string, unknown>
+  const update: Record<string, unknown> = { user_id: auth.user.id, updated_at: new Date().toISOString() }
+  if (typeof body.default_price_change_pct === 'number' && body.default_price_change_pct >= 0) update.default_price_change_pct = body.default_price_change_pct
+  if (typeof body.default_volume_multiplier === 'number' && body.default_volume_multiplier >= 0) update.default_volume_multiplier = body.default_volume_multiplier
+  if (typeof body.push_notify_enabled === 'boolean') update.push_notify_enabled = body.push_notify_enabled
+  if (typeof body.cooldown_minutes === 'number' && body.cooldown_minutes >= 0) update.cooldown_minutes = Math.floor(body.cooldown_minutes)
+
+  const admin = getSupabaseAdmin()!
+  const { data, error } = await admin
+    .from('psychology_settings')
+    .upsert(update, { onConflict: 'user_id' })
+    .select('*').single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+  return NextResponse.json(data)
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/investment/psychology/settings
+git commit -m "feat(psychology): 사용자 설정 API"
+```
+
+---
+
+## Task 8: 온디맨드 분석 라우트
+
+**Files:**
+- Create: `src/app/api/investment/psychology/analyze/route.ts`
+
+- [ ] **Step 1: 라우트 작성**
+
+```typescript
+// src/app/api/investment/psychology/analyze/route.ts
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { requireInvestmentSubscription } from '@/lib/userSubscription'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { fetchPsychologySnapshot } from '@/lib/psychology/marketDataFetcher'
+import { analyzePsychology } from '@/lib/psychology/llmClient'
+import type { Market } from '@/types/investment'
+import type { PsychologyTriggerKind } from '@/types/psychology'
+
+// 사용자당 분당 5회 상한 (메모리 카운터 — 멀티 인스턴스 정확도는 보장 안 됨)
+const RATE_BUCKET = new Map<string, { count: number; windowStart: number }>()
+const WINDOW_MS = 60_000
+const LIMIT = 5
+
+function rateLimit(userId: string): boolean {
+  const now = Date.now()
+  const b = RATE_BUCKET.get(userId)
+  if (!b || now - b.windowStart > WINDOW_MS) {
+    RATE_BUCKET.set(userId, { count: 1, windowStart: now })
+    return true
+  }
+  b.count++
+  return b.count <= LIMIT
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  await requireInvestmentSubscription(auth.user.id)
+
+  if (!rateLimit(auth.user.id)) {
+    return NextResponse.json({ error: '분당 분석 요청 한도(5회) 초과' }, { status: 429 })
+  }
+
+  const body = await req.json().catch(() => null) as {
+    ticker?: string; market?: Market;
+    triggerKind?: PsychologyTriggerKind; triggerDetail?: string;
+  } | null
+  const ticker = body?.ticker?.trim().toUpperCase()
+  const market = body?.market === 'KR' || body?.market === 'US' ? body.market : null
+  if (!ticker || !market) return NextResponse.json({ error: 'ticker, market 필수' }, { status: 400 })
+  const triggerKind = body.triggerKind ?? 'manual'
+
+  let snapshot
+  try {
+    snapshot = await fetchPsychologySnapshot(auth.user.id, ticker, market, 60)
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : '데이터 수집 실패'
+    return NextResponse.json({ error: msg }, { status: 502 })
+  }
+  if (!snapshot.candles?.length) {
+    return NextResponse.json({ error: '분봉 데이터가 없습니다 (휴장 또는 데이터 미공개)' }, { status: 502 })
+  }
+
+  let result
+  try {
+    result = await analyzePsychology({
+      ticker, market, triggerKind, triggerDetail: body.triggerDetail,
+      snapshot,
+    })
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : 'LLM 분석 실패' }, { status: 500 })
+  }
+
+  const admin = getSupabaseAdmin()!
+  const { data: inserted, error: insertErr } = await admin
+    .from('psychology_analyses')
+    .insert({
+      user_id: auth.user.id,
+      ticker, market, trigger_kind: triggerKind,
+      psychology_score: result.output.psychology_score,
+      score_label: result.output.score_label,
+      tags: result.output.tags,
+      narrative: result.output.narrative,
+      markers: result.output.markers,
+      orderbook_pressure: result.output.orderbook_pressure,
+      input_snapshot: snapshot,
+      llm_model: result.model,
+      llm_latency_ms: result.latencyMs,
+    })
+    .select('*').single()
+  if (insertErr) return NextResponse.json({ error: insertErr.message }, { status: 500 })
+  return NextResponse.json(inserted)
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/investment/psychology/analyze
+git commit -m "feat(psychology): 온디맨드 분석 API"
+```
+
+---
+
+## Task 9: 이력 조회 라우트
+
+**Files:**
+- Create: `src/app/api/investment/psychology/analyses/route.ts`
+
+- [ ] **Step 1: 라우트 작성**
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { requireInvestmentSubscription } from '@/lib/userSubscription'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  await requireInvestmentSubscription(auth.user.id)
+
+  const url = new URL(req.url)
+  const ticker = url.searchParams.get('ticker')
+  const market = url.searchParams.get('market')
+  const limit = Math.min(50, Math.max(1, Number(url.searchParams.get('limit') ?? 10)))
+
+  const admin = getSupabaseAdmin()!
+  let query = admin
+    .from('psychology_analyses')
+    .select('*')
+    .eq('user_id', auth.user.id)
+    .order('created_at', { ascending: false })
+    .limit(limit)
+  if (ticker) query = query.eq('ticker', ticker.toUpperCase())
+  if (market) query = query.eq('market', market)
+
+  const { data, error } = await query
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+  return NextResponse.json(data ?? [])
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/investment/psychology/analyses
+git commit -m "feat(psychology): 분석 이력 조회 API"
+```
+
+---
+
+## Task 10: Cron 스캔 라우트
+
+**Files:**
+- Create: `src/app/api/investment/psychology/cron/scan/route.ts`
+- Modify: `vercel.json`
+
+- [ ] **Step 1: vercel.json 확인**
+
+Run: `cat vercel.json`
+기존 cron 항목이 있다면 그 패턴을 따라 추가.
+
+- [ ] **Step 2: vercel.json에 cron 등록**
+
+기존 `crons` 배열에 다음 항목 추가:
+
+```json
+{
+  "path": "/api/investment/psychology/cron/scan",
+  "schedule": "* * * * *"
+}
+```
+
+- [ ] **Step 3: cron 라우트 작성**
+
+```typescript
+// src/app/api/investment/psychology/cron/scan/route.ts
+// 매분 실행. 활성 자동매매 구독자의 monitoring_enabled 워치리스트 종목만 폴링/트리거.
+
+import { NextResponse } from 'next/server'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { isMarketOpen } from '@/lib/psychology/marketHours'
+import { fetchPsychologySnapshot } from '@/lib/psychology/marketDataFetcher'
+import { analyzePsychology } from '@/lib/psychology/llmClient'
+import type { Market } from '@/types/investment'
+
+const ENABLED = process.env.PSYCHOLOGY_CRON_ENABLED !== 'false'
+const GLOBAL_LLM_PER_MINUTE = 30
+
+export async function GET(req: Request) {
+  if (!ENABLED) return NextResponse.json({ skipped: 'disabled' })
+
+  // Vercel Cron 호출 검증
+  const authHeader = req.headers.get('authorization')
+  if (process.env.CRON_SECRET && authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    // Vercel Cron는 자동으로 동일 헤더 추가. 로컬 테스트에서는 우회.
+    if (process.env.NODE_ENV === 'production') {
+      return new Response('Unauthorized', { status: 401 })
+    }
+  }
+
+  const krOpen = isMarketOpen('KR')
+  const usOpen = isMarketOpen('US')
+  if (!krOpen && !usOpen) return NextResponse.json({ skipped: 'market closed' })
+
+  const admin = getSupabaseAdmin()!
+
+  // 1. 활성 구독자의 워치리스트만 (JOIN user_subscriptions)
+  const { data: rows } = await admin
+    .from('psychology_watchlist')
+    .select(`
+      id, user_id, ticker, market,
+      trigger_price_change_pct, trigger_volume_multiplier,
+      sub:user_subscriptions!inner(status, plan:user_subscription_plans!inner(feature_id))
+    `)
+    .eq('monitoring_enabled', true)
+    .eq('sub.status', 'active')
+    .eq('sub.plan.feature_id', 'investment')
+
+  type Row = {
+    id: string; user_id: string; ticker: string; market: Market;
+    trigger_price_change_pct: number | null;
+    trigger_volume_multiplier: number | null;
+  }
+  const items = (rows ?? []) as unknown as Row[]
+  const filtered = items.filter(r => (r.market === 'KR' && krOpen) || (r.market === 'US' && usOpen))
+
+  // 2. 사용자 설정 일괄 조회
+  const userIds = Array.from(new Set(filtered.map(r => r.user_id)))
+  const { data: settingRows } = await admin
+    .from('psychology_settings').select('*').in('user_id', userIds)
+  const settings = new Map<string, { default_price_change_pct: number; default_volume_multiplier: number; cooldown_minutes: number; push_notify_enabled: boolean }>()
+  for (const s of (settingRows ?? []) as Array<{ user_id: string; default_price_change_pct: number; default_volume_multiplier: number; cooldown_minutes: number; push_notify_enabled: boolean }>) {
+    settings.set(s.user_id, s)
+  }
+  const defaults = { default_price_change_pct: 2.0, default_volume_multiplier: 3.0, cooldown_minutes: 10, push_notify_enabled: true }
+
+  // 3. 종목별 시세 캐시 (TTL 30초 — 함수 호출 단위. 매 분 새로 시작이므로 사실상 동일 (ticker, market) 중복 호출만 방지)
+  const cache = new Map<string, Awaited<ReturnType<typeof fetchPsychologySnapshot>>>()
+  const cooldownCutoff = (cooldownMin: number) => new Date(Date.now() - cooldownMin * 60_000).toISOString()
+
+  const triggered: Array<{ row: Row; reason: string; detail: string }> = []
+  for (const r of filtered) {
+    const s = settings.get(r.user_id) ?? defaults
+    const priceTh = r.trigger_price_change_pct ?? s.default_price_change_pct
+    const volTh = r.trigger_volume_multiplier ?? s.default_volume_multiplier
+
+    const key = `${r.ticker}:${r.market}`
+    let snapshot = cache.get(key)
+    if (!snapshot) {
+      try {
+        snapshot = await fetchPsychologySnapshot(r.user_id, r.ticker, r.market, 6)
+        cache.set(key, snapshot)
+      } catch { continue }
+    }
+    const candles = snapshot.candles
+    if (candles.length < 2) continue
+
+    const last = candles[candles.length - 1]
+    const priceChange = Math.abs(last.close - last.open) / last.open
+    const recent5 = candles.slice(-6, -1)
+    const avgVol = recent5.length ? recent5.reduce((a, c) => a + c.volume, 0) / recent5.length : 0
+    const volMul = avgVol > 0 ? last.volume / avgVol : 0
+
+    let reason: 'price_change' | 'volume_spike' | null = null
+    let detail = ''
+    if (priceChange * 100 >= priceTh) {
+      reason = 'price_change'
+      detail = `${(priceChange * 100).toFixed(2)}%`
+    } else if (volMul >= volTh) {
+      reason = 'volume_spike'
+      detail = `×${volMul.toFixed(2)}`
+    }
+    if (!reason) continue
+
+    // 쿨다운 체크
+    const { data: recent } = await admin
+      .from('psychology_analyses')
+      .select('id')
+      .eq('user_id', r.user_id).eq('ticker', r.ticker).eq('market', r.market)
+      .gte('created_at', cooldownCutoff(s.cooldown_minutes))
+      .limit(1)
+    if (recent && recent.length > 0) continue
+
+    triggered.push({ row: r, reason, detail })
+  }
+
+  // 4. 글로벌 분당 LLM 호출 상한: 가장 큰 변동/거래량 우선
+  triggered.sort((a, b) => Number(b.detail.replace(/[^0-9.]/g,'')) - Number(a.detail.replace(/[^0-9.]/g,'')))
+  const toRun = triggered.slice(0, GLOBAL_LLM_PER_MINUTE)
+
+  let analyzed = 0
+  for (const t of toRun) {
+    const { row, reason, detail } = t
+    const key = `${row.ticker}:${row.market}`
+    let snapshot = cache.get(key)
+    try {
+      // 분석은 60개 분봉이 필요. 트리거 감지에 6개만 받았으므로 확장 fetch.
+      snapshot = await fetchPsychologySnapshot(row.user_id, row.ticker, row.market, 60)
+    } catch { continue }
+
+    let result
+    try {
+      result = await analyzePsychology({
+        ticker: row.ticker, market: row.market,
+        triggerKind: reason, triggerDetail: detail,
+        snapshot,
+      })
+    } catch { continue }
+
+    const { data: inserted } = await admin
+      .from('psychology_analyses').insert({
+        user_id: row.user_id, ticker: row.ticker, market: row.market,
+        trigger_kind: reason,
+        psychology_score: result.output.psychology_score,
+        score_label: result.output.score_label,
+        tags: result.output.tags, narrative: result.output.narrative,
+        markers: result.output.markers,
+        orderbook_pressure: result.output.orderbook_pressure,
+        input_snapshot: snapshot,
+        llm_model: result.model, llm_latency_ms: result.latencyMs,
+      }).select('id').single()
+
+    const s = settings.get(row.user_id) ?? defaults
+    if (s.push_notify_enabled && inserted) {
+      // 알림 발송: 기존 in-app 알림 시스템 재사용
+      await admin.from('user_notifications').insert({
+        user_id: row.user_id,
+        type: 'psychology_trigger',
+        title: `${row.ticker} ${reason === 'price_change' ? '가격 변동' : '거래량 폭증'} 감지`,
+        message: `${reason === 'price_change' ? '가격 ' : '거래량 '}${detail} — 공포·탐욕 점수 ${result.output.psychology_score}`,
+        link: `/investment/psychology?ticker=${encodeURIComponent(row.ticker)}&market=${row.market}`,
+        is_read: false,
+      })
+    }
+    analyzed++
+  }
+
+  return NextResponse.json({ scanned: filtered.length, triggered: triggered.length, analyzed })
+}
+```
+
+`user_notifications` 테이블 스키마는 기존에 사용 중인 형태에 맞춰 컬럼 이름 검증 필수. 스키마가 다르면 해당 부분만 조정.
+
+- [ ] **Step 4: user_notifications 스키마 확인**
+
+```sql
+SELECT column_name FROM information_schema.columns
+WHERE table_name='user_notifications' ORDER BY ordinal_position;
+```
+
+스키마에 맞춰 INSERT 컬럼명 조정. 알림 시스템이 다른 형태(예: 푸시 토큰 직접 발송)면 그 패턴을 따른다. `mcp__supabase__execute_sql` 사용.
+
+- [ ] **Step 5: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/api/investment/psychology/cron/scan vercel.json
+git commit -m "feat(psychology): Cron 이벤트 감시 + 자동 분석"
+```
+
+---
+
+## Task 11: 점수 게이지 컴포넌트
+
+**Files:**
+- Create: `src/components/Investment/Psychology/ScoreGauge.tsx`
+
+- [ ] **Step 1: 컴포넌트 작성**
+
+```tsx
+// src/components/Investment/Psychology/ScoreGauge.tsx
+// 0~100 공포·탐욕 게이지. 0=극공포(빨강) → 50=중립(회색) → 100=극탐욕(파랑) 그라데이션.
+
+interface Props { score: number; label: string }
+
+export default function ScoreGauge({ score, label }: Props) {
+  const clamped = Math.max(0, Math.min(100, score))
+  return (
+    <div className="rounded-xl border bg-white p-4 space-y-2">
+      <div className="flex items-baseline justify-between">
+        <span className="text-xs text-gray-500">공포·탐욕 지수</span>
+        <span className="text-xs font-semibold">{label}</span>
+      </div>
+      <div className="relative h-3 rounded-full bg-gradient-to-r from-red-500 via-gray-300 to-blue-500">
+        <div
+          className="absolute top-1/2 -translate-y-1/2 w-4 h-4 rounded-full bg-white border-2 border-gray-700 shadow"
+          style={{ left: `calc(${clamped}% - 8px)` }}
+        />
+      </div>
+      <div className="flex justify-between text-[10px] text-gray-500">
+        <span>0 공포</span><span>50 중립</span><span>100 탐욕</span>
+      </div>
+      <div className="text-2xl font-bold text-center">{clamped}</div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/Investment/Psychology/ScoreGauge.tsx
+git commit -m "feat(psychology): 점수 게이지 컴포넌트"
+```
+
+---
+
+## Task 12: 분봉 차트 + 마커 컴포넌트
+
+**Files:**
+- Create: `src/components/Investment/Psychology/PsychologyChart.tsx`
+
+- [ ] **Step 1: 컴포넌트 작성**
+
+```tsx
+// src/components/Investment/Psychology/PsychologyChart.tsx
+'use client'
+
+import { LineChart, Line, XAxis, YAxis, ReferenceDot, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts'
+import type { MinuteCandle, PsychologyMarker } from '@/types/psychology'
+
+const MARKER_COLOR: Record<string, string> = {
+  panic_sell: '#ef4444',
+  fomo_entry: '#f59e0b',
+  accumulation: '#10b981',
+  distribution: '#6366f1',
+  capitulation: '#7c3aed',
+  indecision: '#9ca3af',
+}
+
+interface Props {
+  candles: MinuteCandle[]
+  markers: PsychologyMarker[]
+}
+
+export default function PsychologyChart({ candles, markers }: Props) {
+  const data = candles.map((c, i) => ({ idx: i, close: c.close, ts: c.ts.slice(11, 16) }))
+
+  return (
+    <div className="rounded-xl border bg-white p-3">
+      <ResponsiveContainer width="100%" height={240}>
+        <LineChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 8 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" />
+          <XAxis dataKey="ts" tick={{ fontSize: 10 }} interval={9} />
+          <YAxis domain={['auto', 'auto']} tick={{ fontSize: 10 }} width={48} />
+          <Tooltip />
+          <Line type="monotone" dataKey="close" stroke="#0ea5e9" dot={false} strokeWidth={1.5} />
+          {markers.map((m, i) => {
+            const c = candles[m.candle_index]
+            if (!c) return null
+            return (
+              <ReferenceDot
+                key={i}
+                x={c.ts.slice(11, 16)}
+                y={c.close}
+                r={6}
+                fill={MARKER_COLOR[m.kind] ?? '#374151'}
+                stroke="#fff"
+                strokeWidth={1.5}
+                label={{ value: m.label, position: 'top', fontSize: 10, fill: '#374151' }}
+              />
+            )
+          })}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/Investment/Psychology/PsychologyChart.tsx
+git commit -m "feat(psychology): 분봉 차트 + 심리 마커"
+```
+
+---
+
+## Task 13: 호가 압력 바 컴포넌트
+
+**Files:**
+- Create: `src/components/Investment/Psychology/OrderbookPressureBar.tsx`
+
+- [ ] **Step 1: 컴포넌트 작성**
+
+```tsx
+import type { PsychologyOrderbookPressure } from '@/types/psychology'
+
+export default function OrderbookPressureBar({ data }: { data: PsychologyOrderbookPressure }) {
+  return (
+    <div className="rounded-xl border bg-white p-4 space-y-2">
+      <div className="text-xs font-semibold text-gray-700">호가창 압력</div>
+      <div className="flex h-6 rounded-md overflow-hidden">
+        <div className="bg-red-500 text-white text-xs flex items-center justify-center" style={{ width: `${data.bid_pct}%` }}>
+          매수 {data.bid_pct.toFixed(0)}%
+        </div>
+        <div className="bg-blue-500 text-white text-xs flex items-center justify-center" style={{ width: `${data.ask_pct}%` }}>
+          매도 {data.ask_pct.toFixed(0)}%
+        </div>
+      </div>
+      <p className="text-xs text-gray-600">{data.interpretation}</p>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/Investment/Psychology/OrderbookPressureBar.tsx
+git commit -m "feat(psychology): 호가 압력 바 컴포넌트"
+```
+
+---
+
+## Task 14: 분석 상세 + 이력 + 종목 추가 모달
+
+**Files:**
+- Create: `src/components/Investment/Psychology/AnalysisDetail.tsx`
+- Create: `src/components/Investment/Psychology/AnalysisHistory.tsx`
+- Create: `src/components/Investment/Psychology/AddTickerModal.tsx`
+
+- [ ] **Step 1: AnalysisDetail**
+
+```tsx
+// src/components/Investment/Psychology/AnalysisDetail.tsx
+'use client'
+import { useState } from 'react'
+import { Loader2, Sparkles } from 'lucide-react'
+import ScoreGauge from './ScoreGauge'
+import PsychologyChart from './PsychologyChart'
+import OrderbookPressureBar from './OrderbookPressureBar'
+import type { PsychologyAnalysisRecord } from '@/types/psychology'
+import type { Market } from '@/types/investment'
+
+interface Props {
+  ticker: string
+  market: Market
+  latest: PsychologyAnalysisRecord | null
+  onAnalyzed: (record: PsychologyAnalysisRecord) => void
+}
+
+export default function AnalysisDetail({ ticker, market, latest, onAnalyzed }: Props) {
+  const [running, setRunning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const onAnalyze = async () => {
+    setRunning(true); setError(null)
+    try {
+      const res = await fetch('/api/investment/psychology/analyze', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ticker, market, triggerKind: 'manual' }),
+      })
+      const data = await res.json()
+      if (!res.ok) { setError(data.error ?? '분석 실패'); return }
+      onAnalyzed(data)
+    } finally { setRunning(false) }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-bold">{ticker} <span className="text-sm text-gray-500">({market})</span></h2>
+          {latest && (
+            <p className="text-xs text-gray-500">
+              마지막 분석: {new Date(latest.created_at).toLocaleString('ko-KR')}
+            </p>
+          )}
+        </div>
+        <button onClick={onAnalyze} disabled={running}
+          className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white px-4 py-2 rounded-lg">
+          {running ? <Loader2 className="w-4 h-4 animate-spin" /> : <Sparkles className="w-4 h-4" />}
+          지금 분석하기
+        </button>
+      </div>
+
+      {error && <div className="text-red-600 text-sm">{error}</div>}
+
+      {!latest && (
+        <div className="text-center text-gray-500 py-12 border rounded-xl bg-gray-50">
+          분석 이력이 없습니다. "지금 분석하기"를 눌러주세요.
+        </div>
+      )}
+
+      {latest && (
+        <>
+          <ScoreGauge score={latest.psychology_score} label={latest.score_label} />
+          <div className="flex flex-wrap gap-2">
+            {latest.tags.map((t, i) => (
+              <span key={i} className="inline-block px-2 py-1 rounded-full bg-amber-100 text-amber-800 text-xs font-medium">{t}</span>
+            ))}
+          </div>
+          <div className="rounded-xl border bg-white p-4 text-sm leading-relaxed text-gray-800 whitespace-pre-wrap">
+            {latest.narrative}
+          </div>
+          <PsychologyChart candles={latest.input_snapshot.candles} markers={latest.markers} />
+          {market === 'KR' && latest.orderbook_pressure && (
+            <OrderbookPressureBar data={latest.orderbook_pressure} />
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: AnalysisHistory**
+
+```tsx
+// src/components/Investment/Psychology/AnalysisHistory.tsx
+'use client'
+import type { PsychologyAnalysisRecord } from '@/types/psychology'
+
+export default function AnalysisHistory({ records, onSelect }: {
+  records: PsychologyAnalysisRecord[]
+  onSelect: (r: PsychologyAnalysisRecord) => void
+}) {
+  if (!records.length) return null
+  return (
+    <div className="rounded-xl border bg-white p-4">
+      <h3 className="text-sm font-semibold mb-2 text-gray-700">최근 분석 이력</h3>
+      <ul className="space-y-1 max-h-48 overflow-y-auto">
+        {records.map(r => (
+          <li key={r.id}>
+            <button onClick={() => onSelect(r)}
+              className="w-full text-left text-xs flex justify-between gap-2 px-2 py-1.5 rounded hover:bg-gray-50">
+              <span>{new Date(r.created_at).toLocaleString('ko-KR', { month:'2-digit', day:'2-digit', hour:'2-digit', minute:'2-digit' })}</span>
+              <span className="text-gray-500">{r.trigger_kind}</span>
+              <span className="font-mono">{r.psychology_score}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: AddTickerModal**
+
+```tsx
+// src/components/Investment/Psychology/AddTickerModal.tsx
+'use client'
+import { useState } from 'react'
+import { Loader2 } from 'lucide-react'
+
+export default function AddTickerModal({ onClose, onAdded }: {
+  onClose: () => void
+  onAdded: () => void
+}) {
+  const [ticker, setTicker] = useState('')
+  const [market, setMarket] = useState<'KR' | 'US'>('KR')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const onSubmit = async () => {
+    if (!ticker.trim()) return
+    setSubmitting(true); setError(null)
+    try {
+      const res = await fetch('/api/investment/psychology/watchlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ticker: ticker.trim(), market }),
+      })
+      const data = await res.json()
+      if (!res.ok) { setError(data.error ?? '추가 실패'); return }
+      onAdded()
+      onClose()
+    } finally { setSubmitting(false) }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" onClick={onClose}>
+      <div className="bg-white rounded-xl p-6 w-full max-w-md space-y-4" onClick={e => e.stopPropagation()}>
+        <h3 className="text-lg font-bold">종목 추가</h3>
+        <div>
+          <label className="block text-xs font-semibold mb-1">시장</label>
+          <div className="flex gap-2">
+            {(['KR','US'] as const).map(m => (
+              <button key={m} onClick={() => setMarket(m)}
+                className={`px-3 py-1.5 rounded-lg text-sm ${market === m ? 'bg-blue-600 text-white' : 'bg-gray-100'}`}>
+                {m === 'KR' ? '한국' : '미국'}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div>
+          <label className="block text-xs font-semibold mb-1">티커</label>
+          <input value={ticker} onChange={e => setTicker(e.target.value)}
+            placeholder={market === 'KR' ? '예: 005930' : '예: AAPL'}
+            className="w-full border rounded-lg px-3 py-2" />
+        </div>
+        {error && <div className="text-red-600 text-sm">{error}</div>}
+        <div className="flex gap-2 justify-end">
+          <button onClick={onClose} className="px-3 py-1.5 rounded-lg text-sm">취소</button>
+          <button onClick={onSubmit} disabled={submitting}
+            className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white px-4 py-1.5 rounded-lg text-sm inline-flex items-center gap-2">
+            {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+            추가
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: 빌드 + Commit**
+
+Run: `npm run build`. Expected: 성공.
+
+```bash
+git add src/components/Investment/Psychology/
+git commit -m "feat(psychology): 분석 상세/이력/추가 모달 컴포넌트"
+```
+
+---
+
+## Task 15: 워치리스트 컴포넌트 + 메인 페이지
+
+**Files:**
+- Create: `src/components/Investment/Psychology/Watchlist.tsx`
+- Create: `src/app/investment/psychology/page.tsx`
+
+- [ ] **Step 1: Watchlist**
+
+```tsx
+// src/components/Investment/Psychology/Watchlist.tsx
+'use client'
+import { Trash2, Eye, EyeOff } from 'lucide-react'
+import type { PsychologyWatchlistItem } from '@/types/psychology'
+
+interface ItemWithLatest extends PsychologyWatchlistItem {
+  latest_analysis?: { psychology_score: number; score_label: string; created_at: string } | null
+}
+
+export default function Watchlist({
+  items, selected, onSelect, onToggleMonitoring, onDelete,
+}: {
+  items: ItemWithLatest[]
+  selected: { ticker: string; market: string } | null
+  onSelect: (it: ItemWithLatest) => void
+  onToggleMonitoring: (it: ItemWithLatest) => void
+  onDelete: (id: string) => void
+}) {
+  if (!items.length) {
+    return <div className="text-sm text-gray-500 p-4 text-center">+ 버튼으로 종목을 추가해주세요.</div>
+  }
+  return (
+    <ul className="space-y-1">
+      {items.map(it => {
+        const isActive = selected?.ticker === it.ticker && selected.market === it.market
+        return (
+          <li key={it.id}
+            className={`group rounded-lg p-2 cursor-pointer ${isActive ? 'bg-blue-50 ring-1 ring-blue-300' : 'hover:bg-gray-50'}`}
+            onClick={() => onSelect(it)}>
+            <div className="flex items-center justify-between">
+              <div className="flex flex-col">
+                <span className="font-semibold text-sm">{it.ticker}</span>
+                <span className="text-[10px] text-gray-500">{it.market}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <button onClick={e => { e.stopPropagation(); onToggleMonitoring(it) }}
+                  className={`p-1 rounded ${it.monitoring_enabled ? 'text-blue-600' : 'text-gray-400'}`}
+                  title={it.monitoring_enabled ? '모니터링 중' : 'OFF'}>
+                  {it.monitoring_enabled ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
+                </button>
+                <button onClick={e => { e.stopPropagation(); onDelete(it.id) }}
+                  className="p-1 text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100">
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+            {it.latest_analysis && (
+              <div className="mt-1 flex justify-between text-[10px] text-gray-500">
+                <span>{it.latest_analysis.score_label}</span>
+                <span className="font-mono font-semibold">{it.latest_analysis.psychology_score}</span>
+              </div>
+            )}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+```
+
+- [ ] **Step 2: 메인 페이지**
+
+```tsx
+// src/app/investment/psychology/page.tsx
+'use client'
+
+import { useEffect, useState, useCallback } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { Plus, Loader2 } from 'lucide-react'
+import Watchlist from '@/components/Investment/Psychology/Watchlist'
+import AnalysisDetail from '@/components/Investment/Psychology/AnalysisDetail'
+import AnalysisHistory from '@/components/Investment/Psychology/AnalysisHistory'
+import AddTickerModal from '@/components/Investment/Psychology/AddTickerModal'
+import type { PsychologyWatchlistItem, PsychologyAnalysisRecord } from '@/types/psychology'
+import type { Market } from '@/types/investment'
+
+interface ItemWithLatest extends PsychologyWatchlistItem {
+  latest_analysis?: { psychology_score: number; score_label: string; created_at: string } | null
+}
+
+export default function PsychologyPage() {
+  const searchParams = useSearchParams()
+  const [items, setItems] = useState<ItemWithLatest[]>([])
+  const [loading, setLoading] = useState(true)
+  const [selected, setSelected] = useState<{ ticker: string; market: Market } | null>(null)
+  const [history, setHistory] = useState<PsychologyAnalysisRecord[]>([])
+  const [latest, setLatest] = useState<PsychologyAnalysisRecord | null>(null)
+  const [addOpen, setAddOpen] = useState(false)
+
+  const reloadList = useCallback(async () => {
+    const r = await fetch('/api/investment/psychology/watchlist')
+    if (r.ok) setItems(await r.json())
+  }, [])
+
+  const reloadHistory = useCallback(async (ticker: string, market: Market) => {
+    const r = await fetch(`/api/investment/psychology/analyses?ticker=${ticker}&market=${market}&limit=10`)
+    if (!r.ok) return
+    const arr = (await r.json()) as PsychologyAnalysisRecord[]
+    setHistory(arr)
+    setLatest(arr[0] ?? null)
+  }, [])
+
+  useEffect(() => {
+    reloadList().then(() => setLoading(false))
+  }, [reloadList])
+
+  // 알림 클릭으로 들어온 ticker 자동 선택
+  useEffect(() => {
+    const t = searchParams.get('ticker')
+    const m = searchParams.get('market') as Market | null
+    if (!t || !m) return
+    setSelected({ ticker: t.toUpperCase(), market: m })
+    reloadHistory(t.toUpperCase(), m)
+  }, [searchParams, reloadHistory])
+
+  const onSelect = (it: ItemWithLatest) => {
+    setSelected({ ticker: it.ticker, market: it.market })
+    reloadHistory(it.ticker, it.market)
+  }
+
+  const onToggleMonitoring = async (it: ItemWithLatest) => {
+    await fetch(`/api/investment/psychology/watchlist/${it.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ monitoring_enabled: !it.monitoring_enabled }),
+    })
+    reloadList()
+  }
+
+  const onDelete = async (id: string) => {
+    if (!confirm('삭제하시겠어요?')) return
+    await fetch(`/api/investment/psychology/watchlist?id=${id}`, { method: 'DELETE' })
+    reloadList()
+    if (selected) {
+      const stillExists = items.some(i => i.id !== id && i.ticker === selected.ticker && i.market === selected.market)
+      if (!stillExists) { setSelected(null); setLatest(null); setHistory([]) }
+    }
+  }
+
+  if (loading) {
+    return <div className="p-8"><Loader2 className="w-6 h-6 animate-spin" /></div>
+  }
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-4">
+      <aside className="rounded-xl border bg-white p-3">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-sm font-bold">워치리스트</h2>
+          <button onClick={() => setAddOpen(true)}
+            className="p-1 rounded hover:bg-gray-100" title="종목 추가">
+            <Plus className="w-4 h-4" />
+          </button>
+        </div>
+        <Watchlist
+          items={items}
+          selected={selected}
+          onSelect={onSelect}
+          onToggleMonitoring={onToggleMonitoring}
+          onDelete={onDelete}
+        />
+        <div className="text-[10px] text-gray-400 mt-2">{items.length}/10</div>
+      </aside>
+
+      <section className="space-y-4">
+        {!selected && (
+          <div className="rounded-xl border bg-gray-50 p-12 text-center text-gray-500 text-sm">
+            왼쪽에서 종목을 선택하세요.
+          </div>
+        )}
+        {selected && (
+          <>
+            <AnalysisDetail
+              ticker={selected.ticker}
+              market={selected.market}
+              latest={latest}
+              onAnalyzed={(rec) => {
+                setLatest(rec)
+                setHistory(prev => [rec, ...prev].slice(0, 10))
+              }}
+            />
+            <AnalysisHistory records={history} onSelect={(r) => setLatest(r)} />
+          </>
+        )}
+      </section>
+
+      {addOpen && <AddTickerModal onClose={() => setAddOpen(false)} onAdded={reloadList} />}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: 빌드 확인**
+
+Run: `npm run build`
+Expected: 성공.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Investment/Psychology/Watchlist.tsx src/app/investment/psychology/page.tsx
+git commit -m "feat(psychology): 워치리스트 컴포넌트 + 메인 페이지"
+```
+
+---
+
+## Task 16: 사이드바에 "심리 분석" 메뉴 추가
+
+**Files:**
+- Modify: `src/app/investment/layout.tsx`
+
+- [ ] **Step 1: NAV_ITEMS에 항목 추가**
+
+자동매매 항목 아래에 "심리 분석" 자식 표시(시각적 indent)를 추가:
+
+```typescript
+// src/app/investment/layout.tsx 상단 import에 Users 추가
+import { ..., Users } from 'lucide-react'
+
+// NAV_ITEMS 배열에 trading 다음 위치에 삽입
+const NAV_ITEMS: NavItem[] = [
+  // ... 기존 항목 유지
+  { id: 'trading', label: '자동매매', icon: TrendingUp, href: '/investment/trading' },
+  { id: 'psychology', label: '└ 심리 분석', icon: Users, href: '/investment/psychology' },
+  { id: 'portfolio', label: '포트폴리오', icon: Briefcase, href: '/investment/portfolio' },
+]
+```
+
+라벨에 `└` 접두사로 시각적 indent. lucide의 `Users` 아이콘 사용.
+
+- [ ] **Step 2: 빌드 + 브라우저 검증**
+
+Run: `npm run build`
+
+Chrome DevTools MCP:
+1. `whitedc0902@gmail.com`로 로그인 (Plan 1 완료 후 구독 활성 가정)
+2. `/investment` 진입 → 사이드바에 "└ 심리 분석" 항목 표시
+3. 클릭 → `/investment/psychology` 진입
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/investment/layout.tsx
+git commit -m "feat(psychology): 사이드바에 심리 분석 자식 메뉴 추가"
+```
+
+---
+
+## Task 17: 통합 검증 + develop 푸시
+
+- [ ] **Step 1: 빌드 + 린트**
+
+```bash
+npm run lint && npm run build
+```
+Expected: 둘 다 통과.
+
+- [ ] **Step 2: 워치리스트 CRUD 검증 (Chrome DevTools MCP)**
+
+테스트 계정 `whitedc0902@gmail.com`로 로그인 (구독 활성 상태 사전 확인).
+
+1. `/investment/psychology` 진입
+2. + 버튼 → KR/005930 추가 → 워치리스트에 표시
+3. + 버튼 → US/AAPL 추가
+4. 11번째 추가 시도 → "10개까지" 에러 표시
+5. 모니터링 토글 → DB 반영 확인 (`SELECT monitoring_enabled FROM psychology_watchlist`)
+6. 삭제 → 목록에서 제거
+
+- [ ] **Step 3: 온디맨드 분석 검증**
+
+1. 005930 선택 → "지금 분석하기" 클릭
+2. 분석 완료 → 점수 게이지, 태그 칩, 서술, 분봉 차트 + 마커, 호가 압력 바(KR) 모두 표시
+3. 차트의 ReferenceDot 좌표가 markers의 candle_index와 정확히 일치하는지 시각 확인
+4. AAPL 선택 → 분석 → 호가 압력 바 미표시 (US 종목)
+5. `SELECT * FROM psychology_analyses ORDER BY created_at DESC LIMIT 2;` → 2건 행 존재
+
+- [ ] **Step 4: 분당 5회 한도 검증**
+
+1. 1분 안에 같은 종목 "지금 분석하기" 6회 연속 → 6번째 호출 429 에러 확인
+
+- [ ] **Step 5: Cron 트리거 시뮬**
+
+장중 시간 + 임계값을 강제로 낮춰서 트리거:
+
+```sql
+UPDATE psychology_watchlist
+SET trigger_price_change_pct = 0.001, trigger_volume_multiplier = 0.001
+WHERE user_id = '<test_user_id>' AND ticker = '005930';
+```
+
+dev에서 `curl http://localhost:3000/api/investment/psychology/cron/scan` 실행 → 응답에 `analyzed >= 1` 확인 + DB 신규 분석 행 + `user_notifications` 알림 행 확인.
+
+장외 시간이라면 응답에 `skipped: 'market closed'` 확인. 시뮬은 production 검증으로.
+
+- [ ] **Step 6: 미구독자 차단 검증**
+
+구독 없는 임시 계정으로 `/investment/psychology` 직접 URL 진입 → Plan 1의 layout 게이팅이 `/investment/subscribe`로 리다이렉트하는지 확인.
+
+- [ ] **Step 7: 모바일 레이아웃 검증**
+
+`mcp__chrome-devtools__resize_page` 375x812(iPhone) → 좌측 워치리스트가 상단 가로 스크롤로 변환되거나 적어도 페이지가 깨지지 않는지 확인. 1차에선 데스크톱 그리드를 그대로 두고 모바일에선 1-column으로 자동 스택되는 것까지 OK.
+
+- [ ] **Step 8: develop 푸시**
+
+```bash
+git push origin develop
+```
+
+푸시 실패 시 `git pull --rebase origin develop && git push origin develop` 재시도.
+
+- [ ] **Step 9: PR 생성 → main 머지**
+
+```bash
+gh pr create --title "feat: 군중심리 분석 기능" \
+  --base main --head develop \
+  --body "$(cat <<'EOF'
+## Summary
+- 자동매매 사용자 대상 군중심리 분석 신기능
+- 워치리스트(상한 10개) + 온디맨드/Cron 이벤트 트리거 분석
+- Claude haiku 4.5로 점수·태그·서술·차트 마커 생성
+- KR 종목은 호가 압력 분석 추가
+
+## Test plan
+- [ ] /investment/psychology 워치리스트 CRUD
+- [ ] 온디맨드 분석 → 차트 마커 + 호가 압력
+- [ ] 분당 5회 rate limit
+- [ ] Cron 트리거 시뮬 → DB 행 + 알림
+- [ ] 미구독자 차단 게이팅
+EOF
+)"
+```
+
+main 머지: `gh pr merge <number> --merge --admin`.
+
+---
+
+## Self-Review
+
+### Spec coverage
+- 5.2 데이터 모델 → Task 1
+- 8.1 메뉴/사이드바 → Task 16
+- 8.2 페이지 레이아웃 → Tasks 11-15
+- 8.3 API 라우트 6개 → Tasks 6-10
+- 8.4 LLM 호출 + 스키마 → Tasks 5
+- 8.5 Cron 이벤트 트리거 → Task 10
+- 10 시장 시간/비용 가드 → Tasks 3, 8, 10
+- 11.3 Plan 2 테스트 → Task 17
+
+### 미커버 점검
+- 8.6 자동매매 시그널 후크는 1차에 미포함이라고 spec에 명시. 인덱스(5.2)는 Task 1에서 생성되어 후크 마련 완료.
+- spec 11.4 회귀 가드(자동매매 외 다른 메뉴)는 Task 17 Step 1 빌드+린트로 부분 커버. 추가 수동 점검은 PR 리뷰 단계에서.
+
+### Type consistency
+- `PsychologyAnalysisRecord`/`PsychologyWatchlistItem`/`PsychologyMarker` Task 2 정의 → Tasks 6, 8, 9, 11-15 일관 사용.
+- `Market` 타입은 기존 `@/types/investment` import.
+- LLM 출력 `markers[i].candle_index`가 `input_snapshot.candles[i]` 인덱스 일치 — 스키마(Task 5) + 차트(Task 12) 일치.
+
+### Placeholder scan
+- 모든 step에 실제 코드 또는 명령 포함.
+- `user_notifications` 스키마 점검(Task 10 Step 4)은 실제 행동 지시이므로 placeholder가 아님.

--- a/dental-clinic-manager/docs/superpowers/specs/2026-05-07-investment-personal-subscription-and-psychology-design.md
+++ b/dental-clinic-manager/docs/superpowers/specs/2026-05-07-investment-personal-subscription-and-psychology-design.md
@@ -1,0 +1,499 @@
+# 자동매매 개인 구독 전환 + 군중심리 분석 기능 설계
+
+작성일: 2026-05-07
+
+## 1. 개요
+
+이 문서는 두 가지 변경을 한 번에 다룬다. 두 변경은 결합도가 높아 함께 출시되어야 한다.
+
+- **A. 자동매매 모듈 구독 모델을 clinic 단위 → 개인(user) 단위로 전환** (인프라 변경)
+- **B. 군중심리 분석 신기능 추가** — 자동매매의 서브메뉴, 자동매매 구독자에게 무료로 포함
+- **C. master 페이지의 자동매매 구독료 변경 UI** (A의 일부)
+
+## 2. 동기
+
+- **B의 출발점:** 사용자가 호가창과 분봉을 보며 느끼는 군중심리(공포·탐욕·FOMO·익절 압력 등)를 LLM이 분석해 점수·태그·서술·차트 마커로 제공. 단독 도구로 보조하면서 추후 자동매매 시그널로 발전 가능.
+- **A의 출발점:** 자동매매는 본질적으로 개인의 자산 운용이라 clinic 단위 구독이 부자연스럽다. 같은 병원의 여러 직원이 각자 KIS 계좌를 연결해 운용하는 경우가 정상이며, 각자 결제해야 한다.
+- **B의 게이팅을 새로 만들지 않는 이유:** 개인 구독 게이팅을 A에서 마련하므로 B는 그 헬퍼 한 줄로 게이팅된다. 별도 권한 시스템(`psychology_view`) 추가 없음.
+
+## 3. 결정 요약 (브레인스토밍 기록)
+
+| 질문 | 결정 |
+|---|---|
+| 1차 목적 | 분석/표시 + 자동매매 시그널 후크 (Phase 2) |
+| 입력 데이터 | 분봉 OHLCV(60개) + 호가창 10단계(KR만) |
+| 호출 빈도 | 온디맨드 + 이벤트 트리거 |
+| 시장 | 한국 + 미국 (호가창은 한국만) |
+| 출력 형태 | 점수(0~100) + 태그 + 서술 + 분봉 차트 위 마커 |
+| 모니터링 종목 | 군중심리 전용 워치리스트(상한 10개) |
+| 트리거 인프라 | Vercel Cron 1분 주기 (smart-money 패턴) |
+| 구독 모델 | 월 정액 + 수익 5% 하이브리드 |
+| 기존 clinic 사용자 | 자동 이관 |
+| 동일 병원 다중 직원 | 각자 개인 구독 |
+| 무료 체험 | 없음 (즉시 결제) |
+
+## 4. 작업 영역 분해
+
+| 영역 | 내용 | Plan |
+|---|---|---|
+| A | 자동매매 구독 인프라 전환 (테이블·게이팅·결제·청구·마이그레이션) | Plan 1 |
+| C | master 가격 관리 UI | Plan 1 (A에 포함) |
+| B | 군중심리 분석 신기능 | Plan 2 |
+
+A → B 의존: B는 A의 `requireActiveInvestmentSubscription` 헬퍼를 재사용한다. A 완료 후 B 시작.
+
+## 5. 데이터 모델
+
+### 5.1 개인 구독 (A)
+
+```sql
+CREATE TABLE user_subscription_plans (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  feature_id TEXT UNIQUE NOT NULL,             -- 'investment' (1차 유일 플랜)
+  display_name TEXT NOT NULL,                   -- '주식 자동매매'
+  monthly_base_price INT NOT NULL,              -- 월 정액 (원). master에서 변경
+  revenue_share_pct NUMERIC NOT NULL DEFAULT 0, -- 수익 공유 % (예: 5.0)
+  description TEXT,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE user_subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  plan_id UUID NOT NULL REFERENCES user_subscription_plans(id),
+  status TEXT NOT NULL CHECK (status IN ('active','past_due','cancelled','suspended','expired')),
+  billing_key TEXT,
+  card_name TEXT,
+  card_number_last4 TEXT,
+  current_period_start TIMESTAMPTZ,
+  current_period_end TIMESTAMPTZ,
+  next_billing_date TIMESTAMPTZ,
+  cancel_at_period_end BOOLEAN NOT NULL DEFAULT false,
+  cancelled_at TIMESTAMPTZ,
+  retry_count INT NOT NULL DEFAULT 0,
+  next_retry_at TIMESTAMPTZ,
+  -- 마이그레이션 흔적
+  migrated_from_clinic_id UUID NULL,
+  migrated_at TIMESTAMPTZ NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_id, plan_id)
+);
+
+CREATE TABLE user_subscription_payments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  subscription_id UUID REFERENCES user_subscriptions(id),
+  portone_payment_id TEXT NOT NULL,
+  portone_tx_id TEXT,
+  amount INT NOT NULL,
+  base_amount INT NOT NULL,                     -- 월 정액 부분
+  revenue_share_amount INT NOT NULL DEFAULT 0,  -- 수익 공유 부분
+  realized_profit_basis INT NOT NULL DEFAULT 0, -- 청구 기준 실현 수익
+  status TEXT NOT NULL CHECK (status IN ('pending','paid','failed','cancelled','refunded')),
+  paid_at TIMESTAMPTZ,
+  failed_at TIMESTAMPTZ,
+  fail_reason TEXT,
+  billing_period_start DATE,
+  billing_period_end DATE,
+  order_name TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_user_subs_user_status ON user_subscriptions (user_id, status);
+CREATE INDEX idx_user_sub_payments_user_time ON user_subscription_payments (user_id, created_at DESC);
+```
+
+RLS: `user_subscriptions`, `user_subscription_payments`는 `user_id = auth.uid()`로 본인만 SELECT. INSERT/UPDATE/DELETE는 service role(API 라우트)만. `user_subscription_plans`는 SELECT 모두 허용, UPDATE는 master_admin만.
+
+### 5.2 군중심리 (B)
+
+```sql
+CREATE TABLE psychology_watchlist (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  ticker TEXT NOT NULL,
+  market TEXT NOT NULL CHECK (market IN ('KR','US')),
+  monitoring_enabled BOOLEAN NOT NULL DEFAULT true,
+  trigger_price_change_pct NUMERIC NULL,
+  trigger_volume_multiplier NUMERIC NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_id, ticker, market)
+);
+
+CREATE TABLE psychology_settings (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  default_price_change_pct NUMERIC NOT NULL DEFAULT 2.0,
+  default_volume_multiplier NUMERIC NOT NULL DEFAULT 3.0,
+  push_notify_enabled BOOLEAN NOT NULL DEFAULT true,
+  cooldown_minutes INT NOT NULL DEFAULT 10,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE psychology_analyses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  ticker TEXT NOT NULL,
+  market TEXT NOT NULL CHECK (market IN ('KR','US')),
+  trigger_kind TEXT NOT NULL CHECK (trigger_kind IN ('manual','price_change','volume_spike')),
+  psychology_score INT NOT NULL CHECK (psychology_score BETWEEN 0 AND 100),
+  score_label TEXT NOT NULL,
+  tags TEXT[] NOT NULL,
+  narrative TEXT NOT NULL,
+  markers JSONB NOT NULL,
+  orderbook_pressure JSONB NULL,
+  input_snapshot JSONB NOT NULL,
+  llm_model TEXT NOT NULL,
+  llm_latency_ms INT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_psy_analyses_user_ticker_time
+  ON psychology_analyses (user_id, ticker, created_at DESC);
+```
+
+RLS: 세 테이블 모두 `user_id = auth.uid()` 정책.
+
+## 6. A — 자동매매 구독 인프라 전환
+
+### 6.1 게이팅 헬퍼 (단일 진실 원천)
+
+```ts
+// src/lib/userSubscription.ts
+export type GateResult =
+  | { ok: true; subscription: UserSubscription }
+  | { ok: false; reason: 'NO_SUBSCRIPTION' | 'PAST_DUE' | 'EXPIRED' | 'CANCELLED' }
+
+// 결과를 그대로 반환. 호출 측이 분기 처리.
+export async function checkInvestmentSubscription(userId: string): Promise<GateResult>
+
+// API 라우트 전용. ok=false면 NextResponse(401 또는 402)를 throw해서 라우트 핸들러를 즉시 종료.
+// 사용 예: const sub = await requireInvestmentSubscription(userId)  // 통과 시 subscription 반환
+export async function requireInvestmentSubscription(userId: string): Promise<UserSubscription>
+```
+
+자동매매 모듈의 모든 페이지/API는 이 한 함수로 게이팅. 권한 시스템(`investment_view`)에서는 분리한다.
+
+### 6.2 결제 흐름
+
+기존 PortOne 빌링키 인프라(`src/lib/portone.ts`, `src/lib/subscriptionService.ts`)의 패턴을 그대로 따른다. clinic 변형이 아닌 user 변형이라는 점만 다르다.
+
+**신규 라우트:**
+```
+/api/investment/subscription/
+├── status/route.ts      GET   → 내 구독 상태 + 플랜 정보 + 다음 청구 예정액
+├── register/route.ts    POST  → 빌링키 받아 첫 결제 + 다음 달 예약
+├── cancel/route.ts      POST  → 기간 만료 후 취소(기본) / 즉시 취소(옵션)
+└── webhook/route.ts     POST  → PortOne 결제 결과 webhook
+```
+
+**서비스 모듈:** `src/lib/userSubscriptionService.ts` — 기존 `subscriptionService.ts`와 동등한 시그니처를 user_id 기반으로 제공.
+
+### 6.3 월말 청구 cron
+
+기존 `src/app/api/investment/profit-snapshot/route.ts`를 재작성:
+
+```
+1. user_subscriptions.status='active' 전체 조회 (RLS 우회: service role)
+2. 각 사용자별:
+   - calculateMonthlyProfitForUser(user_id, year, month) — clinic 버전과 동일 로직, user 단위 집계
+   - charge_amount = monthly_base_price + max(0, realized_profit) * revenue_share_pct/100
+   - PortOne chargeBillingKey 호출
+   - user_subscription_payments INSERT (base_amount, revenue_share_amount, realized_profit_basis 분해 저장)
+   - investment_profit_snapshots는 user_id 기준으로도 저장 (병원 단위 통계용으로 clinic_id 컬럼은 nullable로 유지)
+3. 결제 실패:
+   - retry_count++
+   - status='past_due', next_retry_at = +N시간
+   - 3회 실패 시 status='suspended' (자동매매 게이팅 차단)
+```
+
+수익이 음수인 달은 정액만 청구, 수익 공유 0원. 정확한 양수 절단 기준은 일자별 실현수익 합계 기준.
+
+기존 `clinic_id` 기반 cron 코드는 마이그레이션 완료 후 제거.
+
+### 6.4 사이드바 메뉴 변경
+
+`src/config/menuConfig.ts`:
+- 자동매매 항목의 `permissions: ['investment_view']` 제거 (모든 사용자에게 노출)
+- 메뉴 클릭 시 게이팅 헬퍼가 미구독자를 `/investment/subscribe`로 안내
+- "심리 분석"은 자동매매의 자식 메뉴로 추가 (사이드바에 들여쓰기)
+
+`src/types/permissions.ts`의 `investment_view`/`investment_manage`는 **즉시 제거하지 않고** 1주기 후 정리 (다른 곳에서 잔존 참조가 있을 수 있어 안전 마진).
+
+### 6.5 기존 clinic 구독 자동 이관 (1회성 스크립트)
+
+`scripts/migrate-investment-subscriptions-to-user.ts`:
+
+```
+1. SELECT s.* FROM subscriptions s
+   JOIN subscription_plans p ON p.id = s.plan_id
+   WHERE p.feature_id = 'investment' AND s.status IN ('active','past_due','trialing')
+
+2. 각 clinic 구독에 대해:
+   a) 활동 사용자 추출:
+      - SELECT DISTINCT user_id FROM investment_strategies WHERE clinic_id = ?
+      - UNION SELECT DISTINCT user_id FROM user_broker_credentials
+        WHERE user_id IN (SELECT id FROM users WHERE clinic_id = ?)
+      - 둘 다 비어 있으면 clinic의 owner를 후보로
+   b) 후보 사용자 각각에 대해 user_subscriptions 생성:
+      - **첫 후보 선정 기준:** 활동 사용자 중 users.created_at이 가장 오래된 1명 (clinic의 owner가 보통 여기 해당). 활동 흔적이 비면 clinic의 owner.
+      - 첫 후보: 기존 billing_key 승계 + current_period_end 승계
+      - 추가 후보: billing_key=NULL, status='active', current_period_end는 기존 clinic 구독과 동일
+        (이번 주기 무료 grandfather, 다음 주기 결제 전 결제 수단 등록 안내)
+      - migrated_from_clinic_id, migrated_at 기록
+   c) 기존 clinic 구독: status='cancelled', cancelled_at=now()
+3. 마이그레이션 보고서 (이관 N건 / 활동 사용자 없음 N건 / 다중 사용자 N건)
+4. 알림 발송: 이관된 모든 사용자에게 in-app 알림 + (가능하면) 이메일
+```
+
+PortOne 빌링키는 카드 1장당 1키. 같은 clinic의 추가 후보는 본인 카드를 새로 등록해야 한다는 점을 알림에 명시.
+
+마이그레이션 실행 전 dry-run 모드 필수. `--dry-run` 플래그로 보고서만 출력 후, 검토 완료 시 `--apply`로 실제 실행.
+
+## 7. C — master 가격 관리 UI
+
+### 7.1 경로 및 권한
+
+- 경로: `/master/subscription/investment`
+- 권한: master_admin (기존 master 페이지 권한 시스템 재사용)
+
+### 7.2 기능
+
+`user_subscription_plans` 1행(feature_id='investment')의 단일 폼:
+
+- 월 정액 가격 (원, 정수)
+- 수익 공유 % (소수 2자리, 0~50)
+- 플랜 활성 토글
+- 변경 시 UPDATE → 다음 청구 주기부터 반영. 진행 중인 결제 영향 없음.
+
+API: `PUT /api/master/user-subscription-plans/[id]`. master 권한 검증 필수.
+
+### 7.3 UI 컴포넌트
+
+`src/app/master/subscription/investment/page.tsx`. master 페이지 기존 디자인 시스템(shadcn/ui Card, Input, Button) 사용.
+
+## 8. B — 군중심리 분석 기능
+
+### 8.1 메뉴 / 사이드바
+
+- 사이드바 라벨: "심리 분석", 아이콘: `Users` (lucide-react)
+- 위치: 자동매매 바로 아래에 시각적 indent로 표시. `menuConfig.ts`의 자식 메뉴 구조를 지원하면 그대로, 미지원이면 평면 배열에 자동매매 다음 항목으로 두되 라벨에 indent 처리.
+- 경로: `/investment/psychology`
+- 게이팅: `requireInvestmentSubscription` (A의 헬퍼)
+
+### 8.2 페이지 레이아웃 (반응형 2-column)
+
+좌측: 워치리스트(상한 10개), 각 항목에 모니터링 토글 + 임계값 설정 버튼.
+우측 상단: 선택 종목 정보, "지금 분석하기" 버튼, 마지막 분석 시각.
+우측 본문 (분석 결과):
+- 공포·탐욕 게이지(0~100, 색상은 빨강→회색→파랑 그라데이션)
+- 핵심 심리 태그 칩 2~3개
+- 서술(2~3 문단 한국어)
+- 분봉 차트(recharts LineChart, 60개 1분봉, ReferenceDot으로 마커)
+- 호가창 압력 바(KR만, 매수/매도 비율)
+- 최근 분석 이력 목록 (최근 10건)
+
+모바일: 좌측 워치리스트가 상단 가로 스크롤 칩으로 변환.
+
+### 8.3 API 라우트
+
+```
+/api/investment/psychology/
+├── watchlist/route.ts          GET, POST, DELETE
+├── watchlist/[id]/route.ts     PATCH (monitoring_enabled, 종목별 임계값)
+├── settings/route.ts           GET, PUT
+├── analyze/route.ts            POST  (온디맨드 분석)
+├── analyses/route.ts           GET   (이력 조회)
+└── cron/scan/route.ts          GET   (Vercel Cron 1분 주기)
+```
+
+모든 라우트 진입 시 `requireInvestmentSubscription` 통과 필수.
+
+### 8.4 LLM 호출
+
+- 모델: `claude-haiku-4-5-20251001`
+- max_tokens: 800, temperature: 0.3
+- 응답은 Anthropic tool use로 JSON 스키마 강제 (zod 사후 validation)
+
+**시스템 프롬프트:**
+> 당신은 주식 시장 군중심리 분석 전문가입니다. 주어진 분봉 시계열과 호가 스냅샷을 보고, 호가창과 차트를 수시로 보고 있는 일반 투자자(대중)가 지금 이 순간 느낄 심리를 분석합니다. 출력은 반드시 지정된 JSON 스키마를 따르며, 한국어로 작성합니다. 추측이 아닌 데이터에서 직접 관찰 가능한 패턴 위주로 분석하고, 단정적 매매 권유 표현은 사용하지 않습니다.
+
+**유저 프롬프트 입력:**
+- 종목명/티커/시장
+- 최근 60개 1분봉 `[{ts, open, high, low, close, volume}, ...]`
+- 호가 스냅샷(KR만) `{ bids: [{price, qty}×10], asks: [{price, qty}×10], totalBidQty, totalAskQty }`
+- 분석 요청 사유: `manual` / `price_change(±X%)` / `volume_spike(×N)`
+
+**응답 스키마:**
+
+```json
+{
+  "psychology_score": 0~100,
+  "score_label": "극공포 | 공포 | 중립 | 탐욕 | 극탐욕",
+  "tags": ["FOMO 매수", "익절 압력", "..."],
+  "narrative": "2~3 문단 한국어 서술",
+  "markers": [
+    {
+      "ts": "10:18",
+      "kind": "panic_sell | fomo_entry | accumulation | distribution | capitulation | indecision",
+      "label": "FOMO 진입",
+      "candle_index": 38
+    }
+  ],
+  "orderbook_pressure": {
+    "bid_pct": 0~100,
+    "ask_pct": 0~100,
+    "interpretation": "한 줄 해석"
+  } | null
+}
+```
+
+**`tags` enum (8종, 다중 선택):** `패닉 셀링`, `FOMO 매수`, `익절 압력`, `누적 매집`, `분산 매도`, `관망`, `반등 시도`, `투매`
+
+**`markers` 제약:** 최대 5개. `candle_index`는 입력 분봉 배열의 인덱스(0-based)와 일치해야 한다.
+
+**검증:** API 라우트에서 응답 받자마자 zod로 validate. 실패 시 1회 재호출, 그래도 실패면 500 + DB 미저장.
+
+### 8.5 이벤트 트리거 (Cron)
+
+`/api/investment/psychology/cron/scan/route.ts`, Vercel Cron `* * * * *`:
+
+```
+1. 시장 시간 체크 (KR 09:00~15:30 KST / US 09:30~16:00 ET). 둘 다 외 시간이면 즉시 return.
+2. monitoring_enabled=true 워치리스트 전체 조회. 활성 자동매매 구독자만 (JOIN user_subscriptions).
+3. 시장별 종목 그룹핑. 종목별 시세는 (ticker, market) 글로벌 캐시 (TTL 30초)로 중복 제거.
+4. 각 종목 직전 1분봉 + 5분 평균 거래량 조회.
+   - KR: kisApiService.getKRMinuteCandles(count=6)
+   - US: yahoo-finance2 1m candles, range=10m
+5. 트리거 판정:
+   - price_change: |close-open|/open >= 사용자 임계값(기본 2%)
+   - volume_spike: 직전 1분 거래량 >= 5분 평균 × 사용자 임계값(기본 3배)
+6. 쿨다운 체크: 같은 (user_id, ticker)에서 최근 N분(기본 10분) 내 분석이 있으면 skip.
+7. 트리거 발동: analyze 라우트와 동일 로직 → DB 저장 + 푸시 알림 발송.
+8. 글로벌 LLM 분당 호출 상한(예: 30건) 초과 시 가장 큰 변동 우선순위로 잘라내고 잔여는 다음 슬롯.
+```
+
+환경변수 `PSYCHOLOGY_CRON_ENABLED=false`로 즉시 차단 가능.
+
+### 8.6 자동매매 시그널 후크 (Phase 2 준비만)
+
+1차에서는 **노출만 하고 실제 매매 연결은 하지 않는다.** 후크 마련:
+
+- `psychology_analyses (user_id, ticker, market, created_at DESC)` 인덱스로 자동매매 워커가 최신 분석을 빠르게 조회 가능 (5.2의 인덱스에 이미 포함).
+- `psychology_score`가 0~100 정수로 잠긴 스키마 → 워커 쿼리 시 정수 비교만 하면 됨.
+- TTL: 자동매매가 분석 결과를 사용할 때 "최근 N분 내 분석만 유효". N은 Phase 2 시점에 결정.
+
+Phase 2에서 추가 예정 (1차 미포함):
+```sql
+-- Phase 2에서만 적용
+ALTER TABLE investment_strategies ADD COLUMN psychology_filter JSONB NULL;
+-- 예: { "enabled": true, "score_max": 30, "score_min": null }
+```
+
+## 9. 구현 순서 (의존성)
+
+### Plan 1 — 인프라 전환 (A + C)
+
+1. 마이그레이션: 5.1의 3개 테이블 신설 + RLS
+2. `userSubscriptionService` 모듈 작성 (PortOne 재사용)
+3. 게이팅 헬퍼 `userSubscription.ts` 작성
+4. 결제 라우트 4개(`status`/`register`/`cancel`/`webhook`)
+5. master 가격 관리 UI(`/master/subscription/investment`) + 라우트
+6. profit-snapshot cron을 user 기반으로 재작성
+7. 자동 이관 스크립트(dry-run + apply 모드) — 검토 후 실제 실행
+8. 자동매매 페이지/API 게이팅을 새 헬퍼로 일괄 교체
+9. 사이드바 메뉴에서 `investment_view` 제거, "심리 분석" 자식 항목 자리 잡기 (B 진입 시 활성)
+10. 기존 clinic 구독 cron 코드 제거
+
+### Plan 2 — 군중심리 분석 (B)
+
+11. 마이그레이션: 5.2의 3개 테이블 + RLS
+12. 워치리스트/설정 라우트
+13. 온디맨드 analyze 라우트 (LLM 호출 + 스키마 검증)
+14. 이력 조회 라우트
+15. Cron 스캔 라우트 + vercel.json 등록
+16. UI 페이지 `/investment/psychology` (좌측 리스트, 우측 분석, 차트, 호가 압력 바)
+17. 푸시 알림 연동
+18. 사이드바 자식 메뉴 활성화
+
+## 10. 시장 시간·비용 가드
+
+### 10.1 비용
+
+- 온디맨드 분석: 사용자당 분당 5회 상한 (메모리 기반 카운터, 멀티 인스턴스에서는 정확하지 않지만 1차 보호 목적)
+- Cron 트리거: 종목별 쿨다운(기본 10분)
+- LLM 응답 max_tokens=800
+- Cron에서 글로벌 분당 LLM 호출 상한(예: 30건)
+
+### 10.2 시장 시간
+
+- KR 정규장: 09:00~15:30 KST (실제 휴장일 캘린더 미반영, 1차 단순화)
+- US 정규장: 09:30~16:00 ET (서머타임 처리 `Intl.DateTimeFormat` 사용)
+- 외 시간 Cron은 즉시 return
+
+## 11. 검증 / 테스트
+
+### 11.1 빌드/타입
+
+- `npm run build` 통과
+- `npm run check:permissions`는 자동매매 메뉴의 권한 제거 후에도 통과해야 함
+
+### 11.2 Plan 1 (인프라) 테스트
+
+테스트 계정: `whitedc0902@gmail.com` (일반), `sani81@gmail.com` (master).
+
+1. 미구독자가 `/investment/dashboard` 접근 → `/investment/subscribe`로 안내
+2. PortOne 테스트 카드로 구독 등록 → user_subscriptions.status='active' 확인
+3. status 라우트 응답 확인 (다음 청구 예정액에 정액+예상 수익 5% 분해 표시)
+4. master 계정으로 `/master/subscription/investment` → 가격 변경 → user_subscription_plans UPDATE 확인
+5. 마이그레이션 스크립트 dry-run → 보고서 확인
+6. 마이그레이션 스크립트 apply → 기존 clinic 구독자가 user_subscriptions로 이동, billing_key 승계 확인
+7. profit-snapshot cron 강제 실행 (월말 시뮬) → 수익 양수/음수 모두 청구 정확성 확인
+8. 결제 실패 시 status='past_due', 3회 실패 시 'suspended' 전이 확인 (PortOne webhook 시뮬)
+
+### 11.3 Plan 2 (심리 분석) 테스트
+
+1. 구독자 계정으로 워치리스트 CRUD (KR/US 1개씩, 10개 상한 검증, 모니터링 토글)
+2. 미구독자 계정으로 `/investment/psychology` 접근 → 차단 확인
+3. "지금 분석하기" → 점수·태그·서술·차트 마커·호가 압력(KR만) 표시
+4. 분봉 차트의 ReferenceDot이 markers[i].candle_index와 정확히 일치
+5. zod validation 실패 시뮬 → 1회 재시도 후 500 (분석 미저장)
+6. Cron 강제 트리거 (`PSYCHOLOGY_CRON_ENABLED=true`, 임계값 0.1%/×1.1로 강제 발동) → DB 저장 + 푸시 도달
+7. 같은 종목 즉시 재트리거 → 쿨다운으로 skip
+8. 장외 시간 Cron 실행 → 즉시 return 로그
+9. US 종목 분석 시 호가창 섹션 자동 숨김
+10. 모바일 뷰포트에서 워치리스트 가로 칩 + 본문 레이아웃 정상
+
+### 11.4 회귀 가드
+
+- 기존 clinic 구독 결제(`subscription_plans.feature_id !== 'investment'`)는 영향 없어야 함
+- 자동매매 외 다른 메뉴(인사관리·스케줄·재무 등) 권한 동작 영향 없음
+
+## 12. 배포 / 출시 절차
+
+1. Plan 1 develop 푸시 → PR → main 머지 → production 배포
+2. master 계정으로 가격 시드 값 입력 (월 정액 / 수익 % — 사용자가 추후 결정)
+3. 마이그레이션 스크립트 dry-run → 검토 → apply
+4. 이관된 사용자에게 알림 발송 확인
+5. Plan 2 develop 푸시 → PR → main 머지 → production 배포
+6. 사이드바에서 "심리 분석" 자식 메뉴 노출 확인
+
+## 13. 미해결/추후 결정
+
+- **월 정액 시드 값**: master에서 변경 가능하므로 코드에는 placeholder(예: 9,900원)로 두고 실제 운영 값은 master에서 설정.
+- **수익 공유 % 시드 값**: 5%로 시드.
+- **결제 통화**: KRW 단일.
+- **세금계산서**: 기존 clinic 구독 시스템에 `tax_invoice_num` 필드가 있으나 개인 구독 1차에서는 발행하지 않음.
+- **Phase 2(자동매매 시그널 통합)**: 별도 spec/plan으로 추후 다룸.
+- **psychology_analyses retention**: input_snapshot에 60개 분봉 + 호가가 들어가 행 크기가 큼. 1차에선 무한 보존, 누적 후 90일 retention 정책 도입 검토.
+
+## 14. 참고 / 재사용 자산
+
+- `src/lib/portone.ts` — 빌링키 결제·예약·취소 (그대로 재사용)
+- `src/lib/subscriptionService.ts` — clinic 버전. user 버전 작성 시 시그니처 참고
+- `src/app/api/investment/smart-money/` — LLM 호출 + JSON 스키마 강제 패턴 참고
+- `src/lib/kisApiService.ts` — KR 분봉/호가 호출
+- `src/lib/stockDataService.ts` — US 분봉 (yahoo-finance2)
+- 푸시 알림 시스템 (기존 in-app 알림 + 모바일 푸시)

--- a/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
@@ -150,8 +150,7 @@ export async function POST(request: NextRequest) {
   let recent20DayLow = 0
   let investorHistory: KRInvestorDay[] = []
   let intradayUnavailableReason: string | null = null
-  // KST 기준 — 서버 timezone(UTC) 영향 받지 않음
-  const asOfDate = toKstDateString(new Date())
+  const asOfDate = marketDateString(new Date(), market)
 
   try {
     if (market === 'KR' && kisCredential) {
@@ -672,7 +671,32 @@ export async function POST(request: NextRequest) {
   const lastByDay = byDay.length > 0
     ? byDay.filter((d) => !/ \(Pre\)$/.test(d.asOfDate)).slice(-1)[0]
     : null
-  const alignedAsOfDate = lastByDay?.asOfDate ?? asOfDate
+  const preferredByDay = findPreferredAnalysisDay(byDay, market, includePreMarket)
+
+  if (preferredByDay) {
+    currentPrice = preferredByDay.closePrice
+    vwap = preferredByDay.vwap
+    wyckoff = preferredByDay.wyckoff
+    wyckoffIntraday = preferredByDay.wyckoffIntraday
+    algoFootprint = preferredByDay.algoFootprint
+    wyckoffPhase = preferredByDay.wyckoffPhase
+    liquidity = preferredByDay.liquidity
+    marketStructure = preferredByDay.marketStructure
+    orderBlocksFvg = preferredByDay.orderBlocksFvg
+    traps = preferredByDay.traps
+    vsa = preferredByDay.vsa
+    session = preferredByDay.session
+    newsContext = preferredByDay.newsContext
+    scoreResult = {
+      ...scoreResult,
+      manipulationRiskScore: preferredByDay.manipulationRiskScore,
+      overallScore: preferredByDay.overallScore,
+      interpretation: preferredByDay.interpretation,
+      signalDetails: preferredByDay.signalDetails,
+    }
+  }
+
+  const alignedAsOfDate = preferredByDay?.asOfDate ?? lastByDay?.asOfDate ?? asOfDate
 
   const analysis: SmartMoneyAnalysis = {
     ticker,
@@ -704,11 +728,11 @@ export async function POST(request: NextRequest) {
   // 6. LLM 코멘트 (옵션) — byDay 모든 일자별로 그날 데이터 기준 코멘트 병렬 생성
   if (includeLLM) {
     if (byDay.length > 0) {
-      const tasks = byDay.map(async (day, idx) => {
-        const isLast = idx === byDay.length - 1
-        // 가장 최근 일자(byDay 마지막)는 메인 analysis와 동일 → analysis 그대로 사용
-        // 그 외 과거 일자는 DailyAnalysis → SmartMoneyAnalysis 호환 객체로 변환
-        const target: SmartMoneyAnalysis = isLast
+      const tasks = byDay.map(async (day) => {
+        const isMainDay = day.asOfDate === analysis.asOfDate
+        // 메인 분석과 같은 일자는 analysis 그대로 사용
+        // 그 외 일자는 DailyAnalysis → SmartMoneyAnalysis 호환 객체로 변환
+        const target: SmartMoneyAnalysis = isMainDay
           ? analysis
           : {
               ticker: day.ticker,
@@ -738,7 +762,7 @@ export async function POST(request: NextRequest) {
         try {
           const result = await generateLLMComment(target)
           day.naturalLanguageComment = result.comment
-          if (isLast) {
+          if (isMainDay) {
             analysis.naturalLanguageComment = result.comment
             analysis.perCardComments = result.perCard
           }
@@ -1026,6 +1050,21 @@ function toDateString(d: Date): string {
   return `${y}-${m}-${day}`
 }
 
+function marketDateString(d: Date, market: Market): string {
+  const tz = market === 'US' ? 'America/New_York' : 'Asia/Seoul'
+  try {
+    const fmt = new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+    return fmt.format(d)
+  } catch {
+    return market === 'KR' ? toKstDateString(d) : toDateString(d)
+  }
+}
+
 /** Asia/Seoul timezone 기준 YYYY-MM-DD — Vercel(UTC)에서도 한국 사용자 "오늘"을 정확히 반영 */
 function toKstDateString(d: Date): string {
   const kst = new Date(d.getTime() + 9 * 3600_000)
@@ -1077,4 +1116,38 @@ function tzMinutesOf(dt: string, market: Market): number | null {
   } catch {
     return null
   }
+}
+
+function findPreferredAnalysisDay(
+  byDay: DailyAnalysis[],
+  market: Market,
+  includePreMarket: boolean,
+  now: Date = new Date(),
+): DailyAnalysis | null {
+  if (!byDay || byDay.length === 0) return null
+
+  const regularDays = byDay.filter((day) => !/ \(Pre\)$/.test(day.asOfDate))
+  const latestRegular = regularDays.length > 0 ? regularDays[regularDays.length - 1] : null
+  if (!latestRegular) return null
+
+  const today = marketDateString(now, market)
+  const currentMinutes = tzMinutesOf(now.toISOString(), market)
+  const todayRegular = [...regularDays].reverse().find((day) => day.asOfDate === today) ?? null
+
+  if (market === 'KR') {
+    if (currentMinutes !== null && currentMinutes >= 9 * 60 && todayRegular) return todayRegular
+    return latestRegular
+  }
+
+  const todayPre = includePreMarket
+    ? [...byDay].reverse().find((day) => day.asOfDate === `${today} (Pre)`) ?? null
+    : null
+
+  if (currentMinutes !== null && currentMinutes >= 4 * 60 && currentMinutes < 9 * 60 + 30 && todayPre) {
+    return todayPre
+  }
+  if (currentMinutes !== null && currentMinutes >= 4 * 60 && todayRegular) {
+    return todayRegular
+  }
+  return latestRegular
 }

--- a/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
@@ -168,6 +168,11 @@ function formatDayRelative(date: string, market: Market): string {
   return ''
 }
 
+function findDefaultDayIndex(byDay: NonNullable<SmartMoneyAnalysis['byDay']>, asOfDate: string): number {
+  const matchedIdx = byDay.findIndex((day) => day.asOfDate === asOfDate)
+  return matchedIdx >= 0 ? matchedIdx : Math.max(0, byDay.length - 1)
+}
+
 export function SmartMoneyContent() {
   const [selected, setSelected] = useState<Selected | null>(null)
   const [analysis, setAnalysis] = useState<SmartMoneyAnalysis | null>(null)
@@ -279,14 +284,11 @@ export function SmartMoneyContent() {
     if (!analysis) return null
     const byDay = analysis.byDay ?? []
     if (byDay.length === 0) return analysis
-    const idx = activeDayIdx ?? byDay.length - 1
+    const defaultIdx = findDefaultDayIndex(byDay, analysis.asOfDate)
+    const idx = activeDayIdx ?? defaultIdx
     const day = byDay[Math.max(0, Math.min(byDay.length - 1, idx))]
     if (!day) return analysis
-    // byDay 마지막 일자(가장 최근 정규장)는 메인 분석과 동일 — 효율을 위해 메인을 그대로 사용.
-    // 단, (Pre) 항목은 별도 데이터를 가지므로 메인 analysis를 반환하면 안 됨.
-    const isPreDay = / \(Pre\)$/.test(day.asOfDate ?? "")
-    const latestRegularDay = [...byDay].reverse().find((d) => !/ \(Pre\)$/.test(d.asOfDate ?? ""))
-    if (!isPreDay && latestRegularDay && day.asOfDate === latestRegularDay.asOfDate) return analysis
+    if (day.asOfDate === analysis.asOfDate) return analysis
     return {
       ...analysis,
       asOfDate: day.asOfDate,
@@ -308,8 +310,8 @@ export function SmartMoneyContent() {
       interpretation: day.interpretation,
       signalDetails: day.signalDetails,
       naturalLanguageComment: day.naturalLanguageComment,
-      // byDay 항목은 카드별 코멘트를 갖지 않음(가장 최근 일자만 메인에 보유)
-      perCardComments: (!isPreDay && latestRegularDay && day.asOfDate === latestRegularDay.asOfDate) ? analysis.perCardComments : undefined,
+      // byDay 항목은 카드별 코멘트를 갖지 않음(메인 분석 일자만 보유)
+      perCardComments: day.asOfDate === analysis.asOfDate ? analysis.perCardComments : undefined,
     }
   }, [analysis, activeDayIdx])
 
@@ -444,7 +446,8 @@ export function SmartMoneyContent() {
               <section className="bg-white rounded-2xl border border-slate-200 p-2 shadow-sm">
                 <div role="tablist" className="flex gap-1">
                   {analysis.byDay.map((day, i) => {
-                    const isActive = (activeDayIdx ?? analysis.byDay!.length - 1) === i
+                    const defaultIdx = findDefaultDayIndex(analysis.byDay!, analysis.asOfDate)
+                    const isActive = (activeDayIdx ?? defaultIdx) === i
                     return (
                       <button
                         key={day.asOfDate}

--- a/dental-clinic-manager/src/types/userSubscription.ts
+++ b/dental-clinic-manager/src/types/userSubscription.ts
@@ -1,0 +1,84 @@
+// 개인 구독 시스템 타입
+// 기존 src/types/subscription.ts(clinic 단위)와 분리하여 user 단위 타입 정의
+
+export type UserSubscriptionStatus =
+  | 'active'
+  | 'past_due'
+  | 'cancelled'
+  | 'suspended'
+  | 'expired'
+
+export type UserSubscriptionPaymentStatus =
+  | 'pending'
+  | 'paid'
+  | 'failed'
+  | 'cancelled'
+  | 'refunded'
+
+export interface UserSubscriptionPlan {
+  id: string
+  feature_id: string
+  display_name: string
+  monthly_base_price: number
+  revenue_share_pct: number
+  description: string | null
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface UserSubscription {
+  id: string
+  user_id: string
+  plan_id: string
+  status: UserSubscriptionStatus
+  billing_key: string | null
+  card_name: string | null
+  card_number_last4: string | null
+  current_period_start: string | null
+  current_period_end: string | null
+  next_billing_date: string | null
+  cancel_at_period_end: boolean
+  cancelled_at: string | null
+  retry_count: number
+  next_retry_at: string | null
+  migrated_from_clinic_id: string | null
+  migrated_at: string | null
+  created_at: string
+  updated_at: string
+  plan?: UserSubscriptionPlan | null
+}
+
+export interface UserSubscriptionPayment {
+  id: string
+  user_id: string
+  subscription_id: string | null
+  portone_payment_id: string
+  portone_tx_id: string | null
+  amount: number
+  base_amount: number
+  revenue_share_amount: number
+  realized_profit_basis: number
+  status: UserSubscriptionPaymentStatus
+  paid_at: string | null
+  failed_at: string | null
+  fail_reason: string | null
+  billing_period_start: string | null
+  billing_period_end: string | null
+  order_name: string | null
+  created_at: string
+}
+
+// API 응답
+export interface UserSubscriptionStatusResponse {
+  subscription: UserSubscription | null
+  plan: UserSubscriptionPlan | null
+  payments: UserSubscriptionPayment[]
+  daysUntilExpiry: number | null
+  nextChargeEstimate: {
+    base: number
+    revenueShareEstimate: number
+    total: number
+    realizedProfitMonthToDate: number
+  } | null
+}

--- a/dental-clinic-manager/supabase/migrations/20260507_user_subscriptions.sql
+++ b/dental-clinic-manager/supabase/migrations/20260507_user_subscriptions.sql
@@ -1,0 +1,97 @@
+-- ============================================
+-- 개인 구독 시스템 (user_subscriptions)
+-- 자동매매 모듈을 clinic → 개인 구독으로 전환하기 위한 신규 테이블
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS user_subscription_plans (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  feature_id TEXT UNIQUE NOT NULL,
+  display_name TEXT NOT NULL,
+  monthly_base_price INT NOT NULL DEFAULT 0,
+  revenue_share_pct NUMERIC(5,2) NOT NULL DEFAULT 0,
+  description TEXT,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS user_subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  plan_id UUID NOT NULL REFERENCES user_subscription_plans(id),
+  status TEXT NOT NULL CHECK (status IN ('active','past_due','cancelled','suspended','expired')),
+  billing_key TEXT,
+  card_name TEXT,
+  card_number_last4 TEXT,
+  current_period_start TIMESTAMPTZ,
+  current_period_end TIMESTAMPTZ,
+  next_billing_date TIMESTAMPTZ,
+  cancel_at_period_end BOOLEAN NOT NULL DEFAULT false,
+  cancelled_at TIMESTAMPTZ,
+  retry_count INT NOT NULL DEFAULT 0,
+  next_retry_at TIMESTAMPTZ,
+  migrated_from_clinic_id UUID NULL,
+  migrated_at TIMESTAMPTZ NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_id, plan_id)
+);
+
+CREATE TABLE IF NOT EXISTS user_subscription_payments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  subscription_id UUID REFERENCES user_subscriptions(id) ON DELETE SET NULL,
+  portone_payment_id TEXT NOT NULL,
+  portone_tx_id TEXT,
+  amount INT NOT NULL,
+  base_amount INT NOT NULL DEFAULT 0,
+  revenue_share_amount INT NOT NULL DEFAULT 0,
+  realized_profit_basis INT NOT NULL DEFAULT 0,
+  status TEXT NOT NULL CHECK (status IN ('pending','paid','failed','cancelled','refunded')),
+  paid_at TIMESTAMPTZ,
+  failed_at TIMESTAMPTZ,
+  fail_reason TEXT,
+  billing_period_start DATE,
+  billing_period_end DATE,
+  order_name TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_subs_user_status
+  ON user_subscriptions (user_id, status);
+CREATE INDEX IF NOT EXISTS idx_user_sub_payments_user_time
+  ON user_subscription_payments (user_id, created_at DESC);
+
+-- RLS
+ALTER TABLE user_subscription_plans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_subscription_payments ENABLE ROW LEVEL SECURITY;
+
+-- 플랜은 모두 SELECT 가능, 변경은 master_admin만 (service_role 우회 필요)
+CREATE POLICY "user_subscription_plans_select_all"
+  ON user_subscription_plans FOR SELECT
+  USING (true);
+
+-- 본인 구독만 SELECT
+CREATE POLICY "user_subscriptions_select_own"
+  ON user_subscriptions FOR SELECT
+  USING (user_id = auth.uid());
+
+-- 본인 결제 내역만 SELECT
+CREATE POLICY "user_sub_payments_select_own"
+  ON user_subscription_payments FOR SELECT
+  USING (user_id = auth.uid());
+
+-- INSERT/UPDATE/DELETE는 모두 service_role(API 라우트)에서만 수행 → 별도 정책 추가 안 함
+
+-- 시드: 자동매매 플랜 (운영자가 master UI에서 가격 변경)
+INSERT INTO user_subscription_plans (feature_id, display_name, monthly_base_price, revenue_share_pct, description, is_active)
+VALUES (
+  'investment',
+  '주식 자동매매',
+  9900,
+  5.00,
+  '월 정액 + 실현 수익의 5%. 군중심리 분석 기능 포함.',
+  true
+)
+ON CONFLICT (feature_id) DO NOTHING;

--- a/dental-clinic-manager/supabase/migrations/20260507_user_subscriptions_amendments.sql
+++ b/dental-clinic-manager/supabase/migrations/20260507_user_subscriptions_amendments.sql
@@ -1,0 +1,33 @@
+-- ============================================
+-- 개인 구독 시스템 보강
+-- - RLS 정책에 TO authenticated 추가 (프로젝트 컨벤션 정렬)
+-- - portone_payment_id UNIQUE (webhook 멱등성)
+-- - next_billing_date 부분 인덱스 (월말 청구 cron 지원)
+-- ============================================
+
+-- 1) RLS 정책 재생성 (TO authenticated)
+DROP POLICY IF EXISTS user_subscription_plans_select_all ON user_subscription_plans;
+DROP POLICY IF EXISTS user_subscriptions_select_own ON user_subscriptions;
+DROP POLICY IF EXISTS user_sub_payments_select_own ON user_subscription_payments;
+
+CREATE POLICY user_subscription_plans_select_authenticated
+  ON user_subscription_plans FOR SELECT TO authenticated
+  USING (true);
+
+CREATE POLICY user_subscriptions_select_own
+  ON user_subscriptions FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY user_sub_payments_select_own
+  ON user_subscription_payments FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+-- 2) webhook 멱등성: portone_payment_id UNIQUE
+ALTER TABLE user_subscription_payments
+  ADD CONSTRAINT user_subscription_payments_portone_payment_id_key
+  UNIQUE (portone_payment_id);
+
+-- 3) 월말 청구 cron 부분 인덱스
+CREATE INDEX IF NOT EXISTS idx_user_subs_billing_due
+  ON user_subscriptions (next_billing_date)
+  WHERE status IN ('active','past_due');


### PR DESCRIPTION
## Summary
- 스마트머니 분석 시작 시 전 거래일이 아닌 오늘 날짜가 기본으로 표시되도록 수정
- `findPreferredAnalysisDay()` 로직 추가: KST 09:00 이후(한국장) / ET 04:00 이후(미국장)이면 오늘 우선 선택
- `analysis.asOfDate`와 UI 기본 탭을 동일 소스로 통일하여 "현재가" / "분석 일자" 불일치 해소

## Root Cause (5 Whys)
- 기존 코드가 byDay 배열의 마지막 항목(= 마지막 완전히 닫힌 일봉)을 무조건 기본값으로 사용
- 장중/장마감 후 당일 미완성 바(intraday)가 있어도 완전한 일봉 아니면 무시
- 세션 진행 중 여부를 판단하는 로직 부재

## Changes
- `src/app/api/investment/smart-money/analyze/route.ts`: `findPreferredAnalysisDay()` 함수 추가, KR/US 마켓 타임존 기반 today 우선 선택 로직
- `src/components/Investment/SmartMoney/SmartMoneyContent.tsx`: 기본 탭을 `analysis.asOfDate` 기준으로 변경

## Test plan
- [ ] 한국 주식: KST 09:00~15:30 장중에 분석 시작 → 오늘 날짜 탭 기본 선택 확인
- [ ] 한국 주식: KST 15:30 이후 장마감 후 → 오늘 날짜 탭 기본 선택 확인
- [ ] 한국 주식: KST 09:00 이전 장 시작 전 → 직전 거래일 선택 허용 확인
- [ ] 미국 주식: ET 09:30~16:00 정규장 → 오늘 날짜 탭 기본 선택 확인
- [ ] 과거 날짜 탭 클릭 → 과거 데이터 정상 표시 확인
- [ ] npm run build 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)