### PR TITLE
release: develop → main (psychology menu relocation + 누적 변경)

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778084070562'
+const SW_VERSION = 'v1778213435196'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/config/menuConfig.ts
+++ b/dental-clinic-manager/src/config/menuConfig.ts
@@ -386,18 +386,6 @@ export const MENU_CONFIG: MenuConfigItem[] = [
     ownerOnly: true,  // 대표 원장 전용 (권한 위임 시에도 owner만 표시 유지)
     premiumFeature: true,  // 프리미엄 기능
   },
-  {
-    id: 'psychology',
-    label: '└ 심리 분석',
-    icon: 'Users',
-    route: '/investment/psychology',
-    permissions: [],   // 자동매매 구독자만 진입 가능 (페이지 자체 게이팅)
-    categoryId: 'investment',
-    order: 16.6,
-    visible: true,
-    ownerOnly: true,
-    premiumFeature: true,
-  },
 
   // === 하단 고정 메뉴 ===
   {


### PR DESCRIPTION
## Summary

- **fix(psychology)**: 대시보드 사이드바에서 심리 분석 메뉴 제거 → 투자 레이아웃 사이드바에서만 노출 (`f0ae8baf`)
- **feat(smart-money)**: 장중 실시간 분석 새로고침 버튼 + 세션 상태 표시 (`3b9e04ea`)
- **fix(psychology)**: analyze 라우트 body null narrowing TS 에러 수정 (`94b1ae64`)
- **fix(deps)**: zod 패키지 추가 — psychology llmClient 빌드 실패 수정 (`020a0ee7`)

## Test plan

- [x] 로컬 빌드 통과 (`npm run build` exit 0)
- [x] Chrome DevTools 테스트 — 대시보드 사이드바에 심리 분석 미노출 확인
- [x] Chrome DevTools 테스트 — `/investment` 진입 시 좌측 사이드바에 "└ 심리 분석" 노출 확인
- [x] 비구독자 `/investment` 접근 시 `/investment/subscribe` 리다이렉트 정상
- [x] 콘솔 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)