### PR TITLE
release: develop → main (psychology 디자인+검색+게이팅 수정)

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778213435196'
+const SW_VERSION = 'v1778225631022'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/app/api/investment/psychology/analyses/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/psychology/analyses/route.ts
@@ -6,7 +6,8 @@ import { getSupabaseAdmin } from '@/lib/supabase/admin'
 export async function GET(req: NextRequest) {
   const auth = await requireAuth()
   if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
-  await requireInvestmentSubscription(auth.user.id)
+  const gate = await requireInvestmentSubscription(auth.user.id)
+  if (gate instanceof NextResponse) return gate
 
   const url = new URL(req.url)
   const ticker = url.searchParams.get('ticker')

--- a/dental-clinic-manager/src/app/api/investment/psychology/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/psychology/analyze/route.ts
@@ -25,7 +25,8 @@ function rateLimit(userId: string): boolean {
 export async function POST(req: NextRequest) {
   const auth = await requireAuth()
   if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
-  await requireInvestmentSubscription(auth.user.id)
+  const gate = await requireInvestmentSubscription(auth.user.id)
+  if (gate instanceof NextResponse) return gate
 
   if (!rateLimit(auth.user.id)) {
     return NextResponse.json({ error: '분당 분석 요청 한도(5회) 초과' }, { status: 429 })

--- a/dental-clinic-manager/src/app/api/investment/psychology/settings/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/psychology/settings/route.ts
@@ -6,7 +6,8 @@ import { getSupabaseAdmin } from '@/lib/supabase/admin'
 export async function GET() {
   const auth = await requireAuth()
   if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
-  await requireInvestmentSubscription(auth.user.id)
+  const gate = await requireInvestmentSubscription(auth.user.id)
+  if (gate instanceof NextResponse) return gate
 
   const admin = getSupabaseAdmin()!
   const { data } = await admin
@@ -25,7 +26,8 @@ export async function GET() {
 export async function PUT(req: NextRequest) {
   const auth = await requireAuth()
   if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
-  await requireInvestmentSubscription(auth.user.id)
+  const gate = await requireInvestmentSubscription(auth.user.id)
+  if (gate instanceof NextResponse) return gate
 
   const body = await req.json().catch(() => ({})) as Record<string, unknown>
   const update: Record<string, unknown> = { user_id: auth.user.id, updated_at: new Date().toISOString() }

--- a/dental-clinic-manager/src/app/api/investment/psychology/watchlist/[id]/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/psychology/watchlist/[id]/route.ts
@@ -6,7 +6,8 @@ import { getSupabaseAdmin } from '@/lib/supabase/admin'
 export async function PATCH(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
   const auth = await requireAuth()
   if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
-  await requireInvestmentSubscription(auth.user.id)
+  const gate = await requireInvestmentSubscription(auth.user.id)
+  if (gate instanceof NextResponse) return gate
 
   const { id } = await ctx.params
   const body = await req.json().catch(() => null) as {

--- a/dental-clinic-manager/src/app/api/investment/psychology/watchlist/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/psychology/watchlist/route.ts
@@ -8,7 +8,8 @@ const WATCHLIST_LIMIT = 10
 export async function GET() {
   const auth = await requireAuth()
   if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
-  await requireInvestmentSubscription(auth.user.id)
+  const gate = await requireInvestmentSubscription(auth.user.id)
+  if (gate instanceof NextResponse) return gate
 
   const admin = getSupabaseAdmin()!
   const { data: items } = await admin
@@ -43,7 +44,8 @@ export async function GET() {
 export async function POST(req: NextRequest) {
   const auth = await requireAuth()
   if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
-  await requireInvestmentSubscription(auth.user.id)
+  const gate = await requireInvestmentSubscription(auth.user.id)
+  if (gate instanceof NextResponse) return gate
 
   const body = await req.json().catch(() => null) as { ticker?: string; market?: string } | null
   const ticker = body?.ticker?.trim().toUpperCase()
@@ -71,7 +73,8 @@ export async function POST(req: NextRequest) {
 export async function DELETE(req: NextRequest) {
   const auth = await requireAuth()
   if (auth.error || !auth.user) return NextResponse.json({ error: auth.error }, { status: auth.status })
-  await requireInvestmentSubscription(auth.user.id)
+  const gate = await requireInvestmentSubscription(auth.user.id)
+  if (gate instanceof NextResponse) return gate
 
   const id = new URL(req.url).searchParams.get('id')
   if (!id) return NextResponse.json({ error: 'id 필수' }, { status: 400 })

--- a/dental-clinic-manager/src/app/api/referrals/sms/route.ts
+++ b/dental-clinic-manager/src/app/api/referrals/sms/route.ts
@@ -87,9 +87,30 @@ export async function POST(req: NextRequest) {
     // 알리고 원본 메시지를 그대로 노출 — 발신번호 LMS 미등록·잔액 부족 등 실제 원인 확인용
     const aligoMsg = aligoJson.message || '문자 발송에 실패했습니다.'
     const lower = aligoMsg.toLowerCase()
+    const isIpError =
+      lower.includes('인증오류') ||
+      lower.includes('인증되지') ||
+      lower.includes('등록되지 않은 ip') ||
+      lower.includes('등록된 ip') ||
+      lower.includes('-ip') ||
+      /(?:^|[^a-z])ip(?:[^a-z]|$)/.test(lower)
+
     let hint: string | null = null
-    if (lower.includes('인증되지') || lower.includes('등록되지 않은 ip') || lower.includes('등록된 ip')) {
-      hint = '알리고 관리자(smartsms.aligo.in)에서 발송 서버 IP 인증을 해제하거나 현재 IP를 등록해주세요.'
+    if (isIpError) {
+      let serverIp: string | null = null
+      try {
+        const ipRes = await fetch('https://api.ipify.org?format=json', { cache: 'no-store' })
+        if (ipRes.ok) {
+          const ipJson = (await ipRes.json()) as { ip?: string }
+          serverIp = ipJson.ip ?? null
+        }
+      } catch {
+        /* IP 조회 실패는 무시 — 안내 본문만 표시 */
+      }
+      const ipLine = serverIp ? `\n현재 발송 서버 IP: ${serverIp}` : ''
+      hint =
+        '알리고 관리자(smartsms.aligo.in) → 보안설정에서 "API 인증 IP"를 해제하거나, 아래 IP를 등록해주세요.' +
+        ipLine
     } else if (lower.includes('발신번호') || lower.includes('sender')) {
       hint = `발신번호(${aligo.sender_number})가 알리고에 사전 등록되지 않았거나 LMS/MMS용으로 등록되지 않았습니다.`
     } else if (lower.includes('잔액') || lower.includes('충전') || lower.includes('포인트')) {

--- a/dental-clinic-manager/src/components/Investment/Psychology/AddTickerModal.tsx
+++ b/dental-clinic-manager/src/components/Investment/Psychology/AddTickerModal.tsx
@@ -1,58 +1,117 @@
 'use client'
 import { useState } from 'react'
-import { Loader2 } from 'lucide-react'
+import { Loader2, X, AlertCircle } from 'lucide-react'
+import TickerSearch from '@/components/Investment/TickerSearch'
+import RecentTickersButtons from '@/components/Investment/RecentTickersButtons'
+import FavoritesButtons from '@/components/Investment/FavoritesButtons'
+import { useRecentTickers } from '@/hooks/useRecentTickers'
+import type { Market } from '@/types/investment'
+
+interface Selected {
+  ticker: string
+  name: string
+  market: Market
+}
 
 export default function AddTickerModal({ onClose, onAdded }: {
   onClose: () => void
   onAdded: () => void
 }) {
-  const [ticker, setTicker] = useState('')
-  const [market, setMarket] = useState<'KR' | 'US'>('KR')
+  const [selected, setSelected] = useState<Selected | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { add: rememberTicker } = useRecentTickers()
+
+  const handlePick = (ticker: string, name?: string, market?: Market) => {
+    if (!market) return
+    setSelected({ ticker, name: name || ticker, market })
+    setError(null)
+  }
 
   const onSubmit = async () => {
-    if (!ticker.trim()) return
+    if (!selected) return
     setSubmitting(true); setError(null)
     try {
       const res = await fetch('/api/investment/psychology/watchlist', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ticker: ticker.trim(), market }),
+        body: JSON.stringify({ ticker: selected.ticker, market: selected.market }),
       })
       const data = await res.json()
       if (!res.ok) { setError(data.error ?? '추가 실패'); return }
+      rememberTicker(selected.ticker, selected.name, selected.market)
       onAdded()
       onClose()
     } finally { setSubmitting(false) }
   }
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" onClick={onClose}>
-      <div className="bg-white rounded-xl p-6 w-full max-w-md space-y-4" onClick={e => e.stopPropagation()}>
-        <h3 className="text-lg font-bold">종목 추가</h3>
-        <div>
-          <label className="block text-xs font-semibold mb-1">시장</label>
-          <div className="flex gap-2">
-            {(['KR','US'] as const).map(m => (
-              <button key={m} onClick={() => setMarket(m)}
-                className={`px-3 py-1.5 rounded-lg text-sm ${market === m ? 'bg-blue-600 text-white' : 'bg-gray-100'}`}>
-                {m === 'KR' ? '한국' : '미국'}
-              </button>
-            ))}
+    <div
+      className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-3xl shadow-lg w-full max-w-md overflow-hidden"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-at-border">
+          <h3 className="text-lg font-bold text-at-text">종목 추가</h3>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg text-at-text-weak hover:bg-at-surface-alt transition-colors"
+            title="닫기"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-6 space-y-4">
+          <div>
+            <label className="block text-xs font-semibold text-at-text-secondary mb-2">종목 검색</label>
+            <TickerSearch
+              onSelect={handlePick}
+              market="ALL"
+              placeholder="종목명 또는 티커 (예: 삼성전자, AAPL)"
+              clearOnSelect={false}
+            />
           </div>
+
+          <div className="space-y-2">
+            <FavoritesButtons market="ALL" onSelect={handlePick} />
+            <RecentTickersButtons market="ALL" onSelect={handlePick} />
+          </div>
+
+          {selected && (
+            <div className="flex items-center gap-2 p-3 rounded-xl bg-at-accent-light text-at-accent text-sm">
+              <span className="font-semibold">{selected.ticker}</span>
+              <span className="text-at-text-secondary">·</span>
+              <span className="truncate">{selected.name}</span>
+              <span className="ml-auto text-[11px] text-at-text-secondary">
+                {selected.market === 'KR' ? '한국' : '미국'}
+              </span>
+            </div>
+          )}
+
+          {error && (
+            <div className="flex items-center gap-2 p-3 rounded-xl bg-rose-50 border border-rose-200 text-rose-700 text-sm">
+              <AlertCircle className="w-4 h-4 flex-shrink-0" />
+              {error}
+            </div>
+          )}
         </div>
-        <div>
-          <label className="block text-xs font-semibold mb-1">티커</label>
-          <input value={ticker} onChange={e => setTicker(e.target.value)}
-            placeholder={market === 'KR' ? '예: 005930' : '예: AAPL'}
-            className="w-full border rounded-lg px-3 py-2" />
-        </div>
-        {error && <div className="text-red-600 text-sm">{error}</div>}
-        <div className="flex gap-2 justify-end">
-          <button onClick={onClose} className="px-3 py-1.5 rounded-lg text-sm">취소</button>
-          <button onClick={onSubmit} disabled={submitting}
-            className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white px-4 py-1.5 rounded-lg text-sm inline-flex items-center gap-2">
+
+        <div className="flex gap-2 justify-end px-6 py-4 border-t border-at-border bg-at-surface-alt">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded-xl text-sm font-medium text-at-text-secondary hover:bg-white transition-colors"
+          >
+            취소
+          </button>
+          <button
+            onClick={onSubmit}
+            disabled={submitting || !selected}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-at-accent text-white rounded-xl text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+          >
             {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
             추가
           </button>

--- a/dental-clinic-manager/src/components/Investment/Psychology/AnalysisDetail.tsx
+++ b/dental-clinic-manager/src/components/Investment/Psychology/AnalysisDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState } from 'react'
-import { Loader2, Sparkles } from 'lucide-react'
+import { Loader2, Sparkles, AlertCircle, Brain } from 'lucide-react'
 import ScoreGauge from './ScoreGauge'
 import PsychologyChart from './PsychologyChart'
 import OrderbookPressureBar from './OrderbookPressureBar'
@@ -34,40 +34,59 @@ export default function AnalysisDetail({ ticker, market, latest, onAnalyzed }: P
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-xl font-bold">{ticker} <span className="text-sm text-gray-500">({market})</span></h2>
-          {latest && (
-            <p className="text-xs text-gray-500">
+      <div className="bg-white rounded-3xl shadow-sm border border-at-border p-5 flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-xl font-bold text-at-text truncate">{ticker}</h2>
+          {latest ? (
+            <p className="text-xs text-at-text-secondary mt-0.5">
               마지막 분석: {new Date(latest.created_at).toLocaleString('ko-KR')}
             </p>
+          ) : (
+            <p className="text-xs text-at-text-weak mt-0.5">아직 분석 이력이 없습니다</p>
           )}
         </div>
         <button onClick={onAnalyze} disabled={running}
-          className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white px-4 py-2 rounded-lg">
+          className="inline-flex items-center gap-2 px-4 py-2 bg-at-accent text-white rounded-xl text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity flex-shrink-0">
           {running ? <Loader2 className="w-4 h-4 animate-spin" /> : <Sparkles className="w-4 h-4" />}
           지금 분석하기
         </button>
       </div>
 
-      {error && <div className="text-red-600 text-sm">{error}</div>}
+      {error && (
+        <div className="flex items-center gap-2 p-3 rounded-2xl bg-rose-50 border border-rose-200 text-rose-700 text-sm">
+          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+          {error}
+        </div>
+      )}
 
       {!latest && (
-        <div className="text-center text-gray-500 py-12 border rounded-xl bg-gray-50">
-          분석 이력이 없습니다. &ldquo;지금 분석하기&rdquo;를 눌러주세요.
+        <div className="bg-white rounded-3xl shadow-sm border border-at-border p-12 text-center">
+          <div className="w-14 h-14 rounded-2xl bg-at-accent-light flex items-center justify-center mx-auto mb-3">
+            <Brain className="w-7 h-7 text-at-accent" />
+          </div>
+          <p className="text-sm text-at-text-secondary">
+            &ldquo;지금 분석하기&rdquo;를 눌러 첫 분석을 실행하세요.
+          </p>
         </div>
       )}
 
       {latest && (
         <>
           <ScoreGauge score={latest.psychology_score} label={latest.score_label} />
-          <div className="flex flex-wrap gap-2">
-            {latest.tags.map((t, i) => (
-              <span key={i} className="inline-block px-2 py-1 rounded-full bg-amber-100 text-amber-800 text-xs font-medium">{t}</span>
-            ))}
-          </div>
-          <div className="rounded-xl border bg-white p-4 text-sm leading-relaxed text-gray-800 whitespace-pre-wrap">
-            {latest.narrative}
+          {latest.tags.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {latest.tags.map((t, i) => (
+                <span key={i} className="inline-block px-3 py-1 rounded-full bg-amber-100 text-amber-800 text-xs font-medium">
+                  {t}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="bg-white rounded-3xl shadow-sm border border-at-border p-5">
+            <h3 className="text-sm font-semibold text-at-text mb-2">해석</h3>
+            <p className="text-sm leading-relaxed text-at-text-secondary whitespace-pre-wrap">
+              {latest.narrative}
+            </p>
           </div>
           <PsychologyChart candles={latest.input_snapshot.candles} markers={latest.markers} />
           {market === 'KR' && latest.orderbook_pressure && (

--- a/dental-clinic-manager/src/components/Investment/Psychology/AnalysisHistory.tsx
+++ b/dental-clinic-manager/src/components/Investment/Psychology/AnalysisHistory.tsx
@@ -1,22 +1,38 @@
 'use client'
 import type { PsychologyAnalysisRecord } from '@/types/psychology'
 
+const TRIGGER_LABEL: Record<string, string> = {
+  manual: '수동',
+  cron: '자동',
+  event: '이벤트',
+}
+
 export default function AnalysisHistory({ records, onSelect }: {
   records: PsychologyAnalysisRecord[]
   onSelect: (r: PsychologyAnalysisRecord) => void
 }) {
   if (!records.length) return null
   return (
-    <div className="rounded-xl border bg-white p-4">
-      <h3 className="text-sm font-semibold mb-2 text-gray-700">최근 분석 이력</h3>
-      <ul className="space-y-1 max-h-48 overflow-y-auto">
+    <div className="bg-white rounded-3xl shadow-sm border border-at-border overflow-hidden">
+      <div className="px-5 py-3 border-b border-at-border">
+        <h3 className="text-sm font-semibold text-at-text">최근 분석 이력</h3>
+      </div>
+      <ul className="divide-y divide-at-border max-h-56 overflow-y-auto">
         {records.map(r => (
           <li key={r.id}>
-            <button onClick={() => onSelect(r)}
-              className="w-full text-left text-xs flex justify-between gap-2 px-2 py-1.5 rounded hover:bg-gray-50">
-              <span>{new Date(r.created_at).toLocaleString('ko-KR', { month:'2-digit', day:'2-digit', hour:'2-digit', minute:'2-digit' })}</span>
-              <span className="text-gray-500">{r.trigger_kind}</span>
-              <span className="font-mono">{r.psychology_score}</span>
+            <button
+              onClick={() => onSelect(r)}
+              className="w-full text-left flex items-center justify-between gap-3 px-5 py-2.5 text-xs hover:bg-at-surface-alt transition-colors"
+            >
+              <span className="text-at-text-secondary tabular-nums">
+                {new Date(r.created_at).toLocaleString('ko-KR', {
+                  month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit',
+                })}
+              </span>
+              <span className="text-at-text-weak">
+                {TRIGGER_LABEL[r.trigger_kind] ?? r.trigger_kind}
+              </span>
+              <span className="font-mono font-semibold text-at-text">{r.psychology_score}</span>
             </button>
           </li>
         ))}

--- a/dental-clinic-manager/src/components/Investment/Psychology/OrderbookPressureBar.tsx
+++ b/dental-clinic-manager/src/components/Investment/Psychology/OrderbookPressureBar.tsx
@@ -2,17 +2,23 @@ import type { PsychologyOrderbookPressure } from '@/types/psychology'
 
 export default function OrderbookPressureBar({ data }: { data: PsychologyOrderbookPressure }) {
   return (
-    <div className="rounded-xl border bg-white p-4 space-y-2">
-      <div className="text-xs font-semibold text-gray-700">호가창 압력</div>
-      <div className="flex h-6 rounded-md overflow-hidden">
-        <div className="bg-red-500 text-white text-xs flex items-center justify-center" style={{ width: `${data.bid_pct}%` }}>
+    <div className="bg-white rounded-3xl shadow-sm border border-at-border p-5 space-y-3">
+      <h3 className="text-sm font-semibold text-at-text">호가창 압력</h3>
+      <div className="flex h-7 rounded-xl overflow-hidden">
+        <div
+          className="bg-rose-500 text-white text-xs font-medium flex items-center justify-center"
+          style={{ width: `${data.bid_pct}%` }}
+        >
           매수 {data.bid_pct.toFixed(0)}%
         </div>
-        <div className="bg-blue-500 text-white text-xs flex items-center justify-center" style={{ width: `${data.ask_pct}%` }}>
+        <div
+          className="bg-blue-500 text-white text-xs font-medium flex items-center justify-center"
+          style={{ width: `${data.ask_pct}%` }}
+        >
           매도 {data.ask_pct.toFixed(0)}%
         </div>
       </div>
-      <p className="text-xs text-gray-600">{data.interpretation}</p>
+      <p className="text-xs text-at-text-secondary leading-relaxed">{data.interpretation}</p>
     </div>
   )
 }

--- a/dental-clinic-manager/src/components/Investment/Psychology/PsychologyChart.tsx
+++ b/dental-clinic-manager/src/components/Investment/Psychology/PsychologyChart.tsx
@@ -21,13 +21,20 @@ export default function PsychologyChart({ candles, markers }: Props) {
   const data = candles.map((c, i) => ({ idx: i, close: c.close, ts: c.ts.slice(11, 16) }))
 
   return (
-    <div className="rounded-xl border bg-white p-3">
+    <div className="bg-white rounded-3xl shadow-sm border border-at-border p-5">
+      <h3 className="text-sm font-semibold text-at-text mb-3">분봉 차트 · 심리 마커</h3>
       <ResponsiveContainer width="100%" height={240}>
         <LineChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 8 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" />
-          <XAxis dataKey="ts" tick={{ fontSize: 10 }} interval={9} />
-          <YAxis domain={['auto', 'auto']} tick={{ fontSize: 10 }} width={48} />
-          <Tooltip />
+          <XAxis dataKey="ts" tick={{ fontSize: 10, fill: '#64748b' }} interval={9} />
+          <YAxis domain={['auto', 'auto']} tick={{ fontSize: 10, fill: '#64748b' }} width={48} />
+          <Tooltip
+            contentStyle={{
+              borderRadius: 12,
+              border: '1px solid #e2e8f0',
+              fontSize: 12,
+            }}
+          />
           <Line type="monotone" dataKey="close" stroke="#0ea5e9" dot={false} strokeWidth={1.5} />
           {markers.map((m, i) => {
             const c = candles[m.candle_index]

--- a/dental-clinic-manager/src/components/Investment/Psychology/PsychologyContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/Psychology/PsychologyContent.tsx
@@ -73,33 +73,46 @@ function PsychologyContentInner() {
   }
 
   if (loading) {
-    return <div className="p-8"><Loader2 className="w-6 h-6 animate-spin" /></div>
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="w-6 h-6 animate-spin text-at-accent" />
+      </div>
+    )
   }
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-4">
-      <aside className="rounded-xl border bg-white p-3">
-        <div className="flex items-center justify-between mb-2">
-          <h2 className="text-sm font-bold">워치리스트</h2>
-          <button onClick={() => setAddOpen(true)}
-            className="p-1 rounded hover:bg-gray-100" title="종목 추가">
+      <aside className="bg-white rounded-3xl shadow-sm border border-at-border overflow-hidden self-start">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-at-border">
+          <h2 className="text-sm font-semibold text-at-text">워치리스트</h2>
+          <button
+            onClick={() => setAddOpen(true)}
+            className="p-1.5 rounded-lg text-at-text-secondary hover:bg-at-surface-alt hover:text-at-accent transition-colors"
+            title="종목 추가"
+          >
             <Plus className="w-4 h-4" />
           </button>
         </div>
-        <Watchlist
-          items={items}
-          selected={selected}
-          onSelect={onSelect}
-          onToggleMonitoring={onToggleMonitoring}
-          onDelete={onDelete}
-        />
-        <div className="text-[10px] text-gray-400 mt-2">{items.length}/10</div>
+        <div className="p-2">
+          <Watchlist
+            items={items}
+            selected={selected}
+            onSelect={onSelect}
+            onToggleMonitoring={onToggleMonitoring}
+            onDelete={onDelete}
+          />
+        </div>
+        <div className="px-4 py-2 border-t border-at-border text-[11px] text-at-text-weak text-right">
+          {items.length}/10
+        </div>
       </aside>
 
-      <section className="space-y-4">
+      <section className="space-y-4 min-w-0">
         {!selected && (
-          <div className="rounded-xl border bg-gray-50 p-12 text-center text-gray-500 text-sm">
-            왼쪽에서 종목을 선택하세요.
+          <div className="bg-white rounded-3xl shadow-sm border border-at-border p-12 text-center">
+            <p className="text-sm text-at-text-secondary">
+              왼쪽에서 종목을 선택하세요.
+            </p>
           </div>
         )}
         {selected && (

--- a/dental-clinic-manager/src/components/Investment/Psychology/ScoreGauge.tsx
+++ b/dental-clinic-manager/src/components/Investment/Psychology/ScoreGauge.tsx
@@ -3,21 +3,23 @@ interface Props { score: number; label: string }
 export default function ScoreGauge({ score, label }: Props) {
   const clamped = Math.max(0, Math.min(100, score))
   return (
-    <div className="rounded-xl border bg-white p-4 space-y-2">
+    <div className="bg-white rounded-3xl shadow-sm border border-at-border p-5 space-y-3">
       <div className="flex items-baseline justify-between">
-        <span className="text-xs text-gray-500">공포·탐욕 지수</span>
-        <span className="text-xs font-semibold">{label}</span>
+        <span className="text-xs font-medium text-at-text-secondary">공포 · 탐욕 지수</span>
+        <span className="text-xs font-semibold text-at-text">{label}</span>
       </div>
-      <div className="relative h-3 rounded-full bg-gradient-to-r from-red-500 via-gray-300 to-blue-500">
+      <div className="relative h-3 rounded-full bg-gradient-to-r from-rose-500 via-at-border to-blue-500">
         <div
-          className="absolute top-1/2 -translate-y-1/2 w-4 h-4 rounded-full bg-white border-2 border-gray-700 shadow"
+          className="absolute top-1/2 -translate-y-1/2 w-4 h-4 rounded-full bg-white border-2 border-at-text shadow"
           style={{ left: `calc(${clamped}% - 8px)` }}
         />
       </div>
-      <div className="flex justify-between text-[10px] text-gray-500">
-        <span>0 공포</span><span>50 중립</span><span>100 탐욕</span>
+      <div className="flex justify-between text-[10px] text-at-text-weak">
+        <span>0 공포</span>
+        <span>50 중립</span>
+        <span>100 탐욕</span>
       </div>
-      <div className="text-2xl font-bold text-center">{clamped}</div>
+      <div className="text-3xl font-bold text-center text-at-text tabular-nums">{clamped}</div>
     </div>
   )
 }

--- a/dental-clinic-manager/src/components/Investment/Psychology/Watchlist.tsx
+++ b/dental-clinic-manager/src/components/Investment/Psychology/Watchlist.tsx
@@ -16,7 +16,11 @@ export default function Watchlist({
   onDelete: (id: string) => void
 }) {
   if (!items.length) {
-    return <div className="text-sm text-gray-500 p-4 text-center">+ 버튼으로 종목을 추가해주세요.</div>
+    return (
+      <div className="text-sm text-at-text-weak p-4 text-center">
+        + 버튼으로 종목을 추가해주세요.
+      </div>
+    )
   }
   return (
     <ul className="space-y-1">
@@ -24,29 +28,37 @@ export default function Watchlist({
         const isActive = selected?.ticker === it.ticker && selected.market === it.market
         return (
           <li key={it.id}
-            className={`group rounded-lg p-2 cursor-pointer ${isActive ? 'bg-blue-50 ring-1 ring-blue-300' : 'hover:bg-gray-50'}`}
+            className={`group rounded-xl p-2.5 cursor-pointer transition-colors ${
+              isActive
+                ? 'bg-at-accent-light ring-1 ring-at-accent'
+                : 'hover:bg-at-surface-alt'
+            }`}
             onClick={() => onSelect(it)}>
-            <div className="flex items-center justify-between">
-              <div className="flex flex-col">
-                <span className="font-semibold text-sm">{it.ticker}</span>
-                <span className="text-[10px] text-gray-500">{it.market}</span>
-              </div>
-              <div className="flex items-center gap-1">
+            <div className="flex items-center justify-between gap-2">
+              <span className={`font-semibold text-sm truncate ${isActive ? 'text-at-accent' : 'text-at-text'}`}>
+                {it.ticker}
+              </span>
+              <div className="flex items-center gap-0.5 flex-shrink-0">
                 <button onClick={e => { e.stopPropagation(); onToggleMonitoring(it) }}
-                  className={`p-1 rounded ${it.monitoring_enabled ? 'text-blue-600' : 'text-gray-400'}`}
-                  title={it.monitoring_enabled ? '모니터링 중' : 'OFF'}>
+                  className={`p-1 rounded-lg transition-colors ${
+                    it.monitoring_enabled
+                      ? 'text-at-accent hover:bg-at-accent-light'
+                      : 'text-at-text-weak hover:bg-at-surface-alt'
+                  }`}
+                  title={it.monitoring_enabled ? '모니터링 중' : '모니터링 OFF'}>
                   {it.monitoring_enabled ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
                 </button>
                 <button onClick={e => { e.stopPropagation(); onDelete(it.id) }}
-                  className="p-1 text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100">
+                  className="p-1 rounded-lg text-at-text-weak hover:text-rose-500 hover:bg-rose-50 opacity-0 group-hover:opacity-100 transition-all"
+                  title="삭제">
                   <Trash2 className="w-4 h-4" />
                 </button>
               </div>
             </div>
             {it.latest_analysis && (
-              <div className="mt-1 flex justify-between text-[10px] text-gray-500">
-                <span>{it.latest_analysis.score_label}</span>
-                <span className="font-mono font-semibold">{it.latest_analysis.psychology_score}</span>
+              <div className="mt-1 flex items-center justify-between text-[11px]">
+                <span className="text-at-text-secondary truncate">{it.latest_analysis.score_label}</span>
+                <span className="font-mono font-semibold text-at-text">{it.latest_analysis.psychology_score}</span>
               </div>
             )}
           </li>

--- a/dental-clinic-manager/src/lib/userSubscription.ts
+++ b/dental-clinic-manager/src/lib/userSubscription.ts
@@ -47,13 +47,18 @@ export async function checkInvestmentSubscription(userId: string): Promise<GateR
 }
 
 /**
- * API 라우트 전용. 통과 시 구독 객체 반환, 실패 시 NextResponse를 throw.
- * 사용 예:
- *   const sub = await requireInvestmentSubscription(userId)
+ * API 라우트 전용 게이팅. 통과 시 구독 객체, 실패 시 NextResponse 401/402를 반환.
+ * 호출 측에서 instanceof NextResponse로 분기한다.
+ *   const gate = await requireInvestmentSubscription(userId)
+ *   if (gate instanceof NextResponse) return gate
+ *   const sub = gate
+ *
+ * 이전에는 throw 패턴이었으나 Next.js App Router는 throw된 NextResponse를
+ * 자동 처리하지 않아 500이 발생하므로 결과 반환형으로 변경.
  */
 export async function requireInvestmentSubscription(
   userId: string
-): Promise<UserSubscription & { plan: UserSubscriptionPlan }> {
+): Promise<(UserSubscription & { plan: UserSubscriptionPlan }) | NextResponse> {
   const result = await checkInvestmentSubscription(userId)
   if (result.ok) return result.subscription
 
@@ -67,7 +72,7 @@ export async function requireInvestmentSubscription(
     SUSPENDED: '결제 실패로 구독이 일시 정지되었습니다.',
   }[result.reason]
 
-  throw NextResponse.json(
+  return NextResponse.json(
     { error: message, code: result.reason },
     { status }
   )


### PR DESCRIPTION
## Summary

- **fix(psychology)**: 종목 추가가 안 되던 직접 원인 — `requireInvestmentSubscription`의 `throw NextResponse.json(...)` 패턴이 Next.js App Router에서 500을 발생시키던 문제 — 결과 반환형으로 변경
- **feat(psychology)**: AddTickerModal에 종목명 검색(TickerSearch) + 즐겨찾기/최근 종목 버튼(FavoritesButtons/RecentTickersButtons) 통합, 시장 자동 결정
- **style(psychology)**: 8개 컴포넌트 디자인 시스템(at-* 토큰) 일관 적용, 워치리스트의 KR/US 시장 라벨 표시 제거

## Test plan

- [x] 로컬 빌드 통과 (`npm run build` exit 0)
- [x] Chrome DevTools E2E (whitedc0902 로그인, dev):
  - [x] 심리 분석 탭 정상 로드
  - [x] "삼성전자" 검색 → 005930 선택 → 추가 성공 (워치리스트 1/10)
  - [x] 추가된 종목 클릭 → 분석 패널 정상 렌더
  - [x] 콘솔 에러 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)