### PR TITLE
release: develop → main (psychology LLM 스키마 + 다중 추가)

### DIFF
--- a/dental-clinic-manager/src/components/Investment/Psychology/AddTickerModal.tsx
+++ b/dental-clinic-manager/src/components/Investment/Psychology/AddTickerModal.tsx
@@ -1,48 +1,79 @@
 'use client'
-import { useState } from 'react'
-import { Loader2, X, AlertCircle } from 'lucide-react'
+import { useState, useMemo } from 'react'
+import { Loader2, X, AlertCircle, Check } from 'lucide-react'
 import TickerSearch from '@/components/Investment/TickerSearch'
 import RecentTickersButtons from '@/components/Investment/RecentTickersButtons'
 import FavoritesButtons from '@/components/Investment/FavoritesButtons'
 import { useRecentTickers } from '@/hooks/useRecentTickers'
 import type { Market } from '@/types/investment'
 
-interface Selected {
+interface QueueItem {
   ticker: string
   name: string
   market: Market
 }
 
+const keyOf = (it: { ticker: string; market: Market }) => `${it.market}:${it.ticker}`
+
 export default function AddTickerModal({ onClose, onAdded }: {
   onClose: () => void
   onAdded: () => void
 }) {
-  const [selected, setSelected] = useState<Selected | null>(null)
+  const [queue, setQueue] = useState<QueueItem[]>([])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [results, setResults] = useState<{ ticker: string; ok: boolean; reason?: string }[]>([])
   const { add: rememberTicker } = useRecentTickers()
 
-  const handlePick = (ticker: string, name?: string, market?: Market) => {
+  const queueKeys = useMemo(() => new Set(queue.map(keyOf)), [queue])
+
+  const pickToQueue = (ticker: string, name?: string, market?: Market) => {
     if (!market) return
-    setSelected({ ticker, name: name || ticker, market })
+    const item: QueueItem = { ticker, name: name || ticker, market }
+    if (queueKeys.has(keyOf(item))) return
+    setQueue(prev => [...prev, item])
     setError(null)
   }
 
+  const removeFromQueue = (key: string) => {
+    setQueue(prev => prev.filter(it => keyOf(it) !== key))
+  }
+
   const onSubmit = async () => {
-    if (!selected) return
-    setSubmitting(true); setError(null)
-    try {
-      const res = await fetch('/api/investment/psychology/watchlist', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ticker: selected.ticker, market: selected.market }),
-      })
-      const data = await res.json()
-      if (!res.ok) { setError(data.error ?? '추가 실패'); return }
-      rememberTicker(selected.ticker, selected.name, selected.market)
-      onAdded()
+    if (!queue.length) return
+    setSubmitting(true); setError(null); setResults([])
+    const localResults: { ticker: string; ok: boolean; reason?: string }[] = []
+    let successCount = 0
+    for (const it of queue) {
+      try {
+        const res = await fetch('/api/investment/psychology/watchlist', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ticker: it.ticker, market: it.market }),
+        })
+        const data = await res.json().catch(() => ({}))
+        if (res.ok) {
+          rememberTicker(it.ticker, it.name, it.market)
+          localResults.push({ ticker: it.ticker, ok: true })
+          successCount++
+        } else {
+          localResults.push({ ticker: it.ticker, ok: false, reason: data?.error ?? `HTTP ${res.status}` })
+        }
+      } catch {
+        localResults.push({ ticker: it.ticker, ok: false, reason: '네트워크 오류' })
+      }
+    }
+    setResults(localResults)
+    setSubmitting(false)
+
+    if (successCount > 0) onAdded()
+    // 성공한 종목만 큐에서 제거하고, 실패한 종목은 유지하여 사용자가 재시도/조정 가능
+    setQueue(prev => prev.filter(it => !localResults.some(r => r.ticker === it.ticker && r.ok)))
+
+    const failed = localResults.filter(r => !r.ok)
+    if (failed.length === 0) {
       onClose()
-    } finally { setSubmitting(false) }
+    }
   }
 
   return (
@@ -69,26 +100,71 @@ export default function AddTickerModal({ onClose, onAdded }: {
           <div>
             <label className="block text-xs font-semibold text-at-text-secondary mb-2">종목 검색</label>
             <TickerSearch
-              onSelect={handlePick}
+              onSelect={pickToQueue}
               market="ALL"
               placeholder="종목명 또는 티커 (예: 삼성전자, AAPL)"
-              clearOnSelect={false}
+              clearOnSelect
             />
+            <p className="mt-1.5 text-[11px] text-at-text-weak">
+              여러 종목을 검색해서 한 번에 추가할 수 있습니다.
+            </p>
           </div>
 
           <div className="space-y-2">
-            <FavoritesButtons market="ALL" onSelect={handlePick} />
-            <RecentTickersButtons market="ALL" onSelect={handlePick} />
+            <FavoritesButtons market="ALL" onSelect={pickToQueue} excludeKeys={queueKeys} />
+            <RecentTickersButtons market="ALL" onSelect={pickToQueue} excludeKeys={queueKeys} />
           </div>
 
-          {selected && (
-            <div className="flex items-center gap-2 p-3 rounded-xl bg-at-accent-light text-at-accent text-sm">
-              <span className="font-semibold">{selected.ticker}</span>
-              <span className="text-at-text-secondary">·</span>
-              <span className="truncate">{selected.name}</span>
-              <span className="ml-auto text-[11px] text-at-text-secondary">
-                {selected.market === 'KR' ? '한국' : '미국'}
-              </span>
+          {queue.length > 0 && (
+            <div>
+              <div className="text-xs font-semibold text-at-text-secondary mb-2">
+                추가 대기 ({queue.length})
+              </div>
+              <ul className="space-y-1.5 max-h-44 overflow-y-auto">
+                {queue.map(it => {
+                  const k = keyOf(it)
+                  const result = results.find(r => r.ticker === it.ticker)
+                  return (
+                    <li
+                      key={k}
+                      className={`flex items-center gap-2 p-2.5 rounded-xl text-sm ${
+                        result?.ok
+                          ? 'bg-emerald-50 text-emerald-700'
+                          : result && !result.ok
+                          ? 'bg-rose-50 text-rose-700'
+                          : 'bg-at-accent-light text-at-accent'
+                      }`}
+                    >
+                      <span className="font-semibold">{it.ticker}</span>
+                      <span className="text-at-text-secondary">·</span>
+                      <span className="truncate">{it.name}</span>
+                      <span className="ml-auto text-[11px] text-at-text-secondary">
+                        {it.market === 'KR' ? '한국' : '미국'}
+                      </span>
+                      {result?.ok ? (
+                        <Check className="w-4 h-4 text-emerald-600 flex-shrink-0" />
+                      ) : result && !result.ok ? (
+                        <span className="text-[11px] text-rose-600 flex-shrink-0" title={result.reason}>
+                          실패
+                        </span>
+                      ) : (
+                        <button
+                          onClick={() => removeFromQueue(k)}
+                          className="p-0.5 rounded-md text-at-text-weak hover:text-rose-500 transition-colors flex-shrink-0"
+                          title="제거"
+                        >
+                          <X className="w-3.5 h-3.5" />
+                        </button>
+                      )}
+                    </li>
+                  )
+                })}
+              </ul>
+              {results.some(r => !r.ok) && (
+                <p className="mt-2 text-[11px] text-rose-600">
+                  실패한 종목: {results.filter(r => !r.ok).map(r => `${r.ticker}(${r.reason ?? '오류'})`).join(', ')}
+                </p>
+              )}
             </div>
           )}
 
@@ -105,15 +181,15 @@ export default function AddTickerModal({ onClose, onAdded }: {
             onClick={onClose}
             className="px-4 py-2 rounded-xl text-sm font-medium text-at-text-secondary hover:bg-white transition-colors"
           >
-            취소
+            닫기
           </button>
           <button
             onClick={onSubmit}
-            disabled={submitting || !selected}
+            disabled={submitting || queue.length === 0}
             className="inline-flex items-center gap-2 px-4 py-2 bg-at-accent text-white rounded-xl text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
           >
             {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
-            추가
+            {queue.length > 1 ? `${queue.length}개 추가` : '추가'}
           </button>
         </div>
       </div>

--- a/dental-clinic-manager/src/lib/psychology/llmClient.ts
+++ b/dental-clinic-manager/src/lib/psychology/llmClient.ts
@@ -10,22 +10,30 @@ import type {
 
 const MODEL_ID = 'claude-haiku-4-5-20251001'
 
+const VALID_MARKER_KINDS = ['panic_sell','fomo_entry','accumulation','distribution','capitulation','indecision'] as const
+
 const ZAnalysis = z.object({
-  psychology_score: z.number().int().min(0).max(100),
+  // 모델이 점수를 문자열/소수로 반환할 수 있어 coerce 처리 + clamp
+  psychology_score: z.coerce.number().transform(n => Math.max(0, Math.min(100, Math.round(n)))),
   score_label: z.string().min(1),
-  tags: z.array(z.string()).max(8),
+  tags: z.array(z.string()).max(8).default([]),
   narrative: z.string().min(1),
   markers: z.array(z.object({
-    ts: z.string(),
-    kind: z.enum(['panic_sell','fomo_entry','accumulation','distribution','capitulation','indecision']),
+    ts: z.string().default(''),
+    // 알 수 없는 kind는 'indecision'으로 fallback (전체 분석 폐기 방지)
+    kind: z.string().transform(v => (VALID_MARKER_KINDS as readonly string[]).includes(v) ? v as typeof VALID_MARKER_KINDS[number] : 'indecision'),
     label: z.string().min(1),
-    candle_index: z.number().int().min(0),
-  })).max(5),
-  orderbook_pressure: z.object({
-    bid_pct: z.number().min(0).max(100),
-    ask_pct: z.number().min(0).max(100),
-    interpretation: z.string(),
-  }).nullable(),
+    candle_index: z.coerce.number().int().min(0),
+  })).max(5).default([]),
+  // null 또는 객체 모두 허용 — 모델이 누락 시 null로 정규화
+  orderbook_pressure: z.union([
+    z.null(),
+    z.object({
+      bid_pct: z.coerce.number().min(0).max(100),
+      ask_pct: z.coerce.number().min(0).max(100),
+      interpretation: z.string(),
+    }),
+  ]).nullable().default(null),
 })
 
 const TOOL_DEFINITION = {
@@ -56,8 +64,10 @@ const TOOL_DEFINITION = {
           required: ['ts','kind','label','candle_index'],
         },
       },
+      // Anthropic tools input_schema는 'oneOf' 미지원 — anyOf로 표현
+      // 호가 데이터가 없는 해외 종목은 null 허용
       orderbook_pressure: {
-        oneOf: [
+        anyOf: [
           { type: 'null' },
           {
             type: 'object',
@@ -143,7 +153,9 @@ export async function analyzePsychology(args: AnalyzeArgs): Promise<AnalyzeResul
     const parsed = ZAnalysis.safeParse(toolUse.input)
     if (!parsed.success) {
       if (attempt === 0) continue
-      throw new Error(`LLM 응답 스키마 검증 실패: ${parsed.error.message}`)
+      console.error('[psychology llm] schema fail. raw:', JSON.stringify(toolUse.input))
+      const issues = parsed.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join(' / ')
+      throw new Error(`LLM 응답 스키마 검증 실패: ${issues}`)
     }
 
     return {


### PR DESCRIPTION
## Summary

- **fix(psychology)**: "지금 분석하기" 시 "LLM 응답 스키마 검증 실패" — input_schema의 `oneOf` → `anyOf`로 변경 + zod 관대화 (markers.kind fallback, score clamp, default 추가), 실패 시 어느 필드인지 식별 가능
- **feat(psychology)**: 워치리스트 종목 다중 추가 — 검색/즐겨찾기/최근 종목 클릭 시 큐에 누적, "N개 추가" 한 번에 일괄 POST + 성공/실패 표시

## Test plan

- [x] 빌드 통과
- [x] dev — apple, nvidia 검색해서 큐 누적 → 2개 일괄 추가 성공
- [x] dev — 005930 분석 실행 → 점수 62 + narrative + 마커 4개 + 차트 정상 렌더, 콘솔 에러 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)