### PR TITLE
fix(sms): Aligo API 스펙 정합성 강화

### DIFF
--- a/dental-clinic-manager/src/app/api/cron/referral-thanks/route.ts
+++ b/dental-clinic-manager/src/app/api/cron/referral-thanks/route.ts
@@ -106,6 +106,11 @@ export async function GET(request: NextRequest) {
         .replace(/\{\{병원명\}\}/g, clinicName)
 
       const byteSize = new Blob([message]).size
+      if (byteSize > 2000) {
+        summary.totalFailed++
+        summary.errors.push(`${clinicName}: ${r.referrer.patient_name} - 메시지 길이가 2000바이트를 초과합니다.`)
+        continue
+      }
       const msgType = byteSize > 90 ? 'LMS' : 'SMS'
 
       const fd = new FormData()
@@ -120,7 +125,9 @@ export async function GET(request: NextRequest) {
       try {
         const res = await fetch(`${ALIGO_API_URL}/send/`, { method: 'POST', body: fd })
         const json = await res.json()
-        const ok = json.result_code === '1'
+        // Aligo 스펙: result_code 는 Integer, >= 1 이면 성공.
+        const codeNum = Number(json.result_code)
+        const ok = Number.isFinite(codeNum) && codeNum >= 1
         await supabase.from('referral_sms_logs').insert({
           clinic_id: s.clinic_id,
           referral_id: r.id,

--- a/dental-clinic-manager/src/app/api/recall/sms/route.ts
+++ b/dental-clinic-manager/src/app/api/recall/sms/route.ts
@@ -76,6 +76,12 @@ export async function POST(request: NextRequest) {
     // 메시지 길이에 따른 타입 자동 결정
     let actualMsgType = msg_type
     const msgLength = new Blob([message]).size  // 바이트 길이
+    if (msgLength > 2000) {
+      return NextResponse.json(
+        { success: false, error: '메시지 길이가 2000바이트를 초과합니다.' },
+        { status: 400 }
+      )
+    }
     if (msgLength > 90 && msg_type === 'SMS') {
       actualMsgType = 'LMS'
     }
@@ -89,6 +95,13 @@ export async function POST(request: NextRequest) {
     formData.append('msg', message)
     formData.append('msg_type', actualMsgType)
     if (title && actualMsgType !== 'SMS') {
+      const titleBytes = new Blob([title]).size
+      if (titleBytes > 44) {
+        return NextResponse.json(
+          { success: false, error: '문자 제목은 44바이트 이하여야 합니다.' },
+          { status: 400 }
+        )
+      }
       formData.append('title', title)
     }
     // 테스트 모드 (개발 환경에서만)
@@ -104,8 +117,12 @@ export async function POST(request: NextRequest) {
 
     const aligoResult: AligoResponse = await aligoResponse.json()
 
+    // Aligo 스펙: result_code 는 Integer, >= 1 이면 성공, < 0 이면 실패. 문자열 응답에도 안전하도록 Number 변환.
+    const resultCodeNum = Number(aligoResult.result_code)
+    const isSuccess = Number.isFinite(resultCodeNum) && resultCodeNum >= 1
+
     // 결과 반환
-    if (aligoResult.result_code === '1') {
+    if (isSuccess) {
       return NextResponse.json({
         success: true,
         message: '문자 발송이 완료되었습니다.',
@@ -116,10 +133,15 @@ export async function POST(request: NextRequest) {
         }
       })
     } else {
-      // IP 인증 오류 체크 - 알리고 관리자 페이지에서 IP 등록 필요
+      // IP 인증 오류 체크 - 알리고 관리자 페이지에서 IP 등록 필요 (스펙: -101 = 인증오류)
       let errorMessage = aligoResult.message || '문자 발송에 실패했습니다.'
-      if (errorMessage.includes('ip') || errorMessage.includes('IP') || errorMessage.includes('인증오류')) {
-        errorMessage = 'IP 인증 오류: 알리고 관리자 페이지(smartsms.aligo.in)에서 서버 IP를 등록해주세요.'
+      if (
+        resultCodeNum === -101 ||
+        errorMessage.includes('ip') ||
+        errorMessage.includes('IP') ||
+        errorMessage.includes('인증오류')
+      ) {
+        errorMessage = 'IP 인증 오류: 알리고 관리자 페이지(smartsms.aligo.in)에서 서버 IP를 등록하거나 API 인증 IP를 해제해주세요.'
       }
 
       return NextResponse.json({
@@ -199,8 +221,10 @@ export async function GET(request: NextRequest) {
     })
 
     const aligoResult = await aligoResponse.json()
+    const remainCodeNum = Number(aligoResult.result_code)
+    const isRemainSuccess = Number.isFinite(remainCodeNum) && remainCodeNum >= 1
 
-    if (aligoResult.result_code === '1') {
+    if (isRemainSuccess) {
       return NextResponse.json({
         success: true,
         data: {

--- a/dental-clinic-manager/src/app/api/referrals/sms/route.ts
+++ b/dental-clinic-manager/src/app/api/referrals/sms/route.ts
@@ -39,6 +39,9 @@ export async function POST(req: NextRequest) {
     }
 
     const msgBytes = new Blob([message]).size
+    if (msgBytes > 2000) {
+      return NextResponse.json({ success: false, error: '메시지 길이가 2000바이트를 초과합니다.' }, { status: 400 })
+    }
     const actualType = msgBytes > 90 && msg_type === 'SMS' ? 'LMS' : msg_type
 
     const formData = new FormData()
@@ -48,17 +51,25 @@ export async function POST(req: NextRequest) {
     formData.append('receiver', phone_number)
     formData.append('msg', message)
     formData.append('msg_type', actualType)
-    if (title && actualType !== 'SMS') formData.append('title', title)
+    if (title && actualType !== 'SMS') {
+      const titleBytes = new Blob([title]).size
+      if (titleBytes > 44) {
+        return NextResponse.json({ success: false, error: '문자 제목은 44바이트 이하여야 합니다.' }, { status: 400 })
+      }
+      formData.append('title', title)
+    }
     if (process.env.NODE_ENV === 'development') formData.append('testmode_yn', 'Y')
 
     const aligoRes = await fetch(`${ALIGO_API_URL}/send/`, { method: 'POST', body: formData })
-    const aligoJson = (await aligoRes.json()) as { result_code: string; message: string; msg_id?: string }
+    const aligoJson = (await aligoRes.json()) as { result_code: string | number; message: string; msg_id?: string | number }
 
     if (process.env.NODE_ENV !== 'production') {
       console.log('[referral sms]', JSON.stringify(aligoJson), 'type:', actualType, 'bytes:', msgBytes)
     }
 
-    const ok = aligoJson.result_code === '1'
+    // Aligo 스펙: result_code 는 Integer, >= 1 이면 성공, < 0 이면 실패. 문자열 응답에도 안전하도록 Number 변환.
+    const codeNum = Number(aligoJson.result_code)
+    const ok = Number.isFinite(codeNum) && codeNum >= 1
 
     await supabase.from('referral_sms_logs').insert({
       clinic_id,
@@ -87,7 +98,9 @@ export async function POST(req: NextRequest) {
     // 알리고 원본 메시지를 그대로 노출 — 발신번호 LMS 미등록·잔액 부족 등 실제 원인 확인용
     const aligoMsg = aligoJson.message || '문자 발송에 실패했습니다.'
     const lower = aligoMsg.toLowerCase()
+    // 스펙: -101 은 인증오류(IP 미등록 포함). 메시지 문자열 휴리스틱과 함께 사용.
     const isIpError =
+      codeNum === -101 ||
       lower.includes('인증오류') ||
       lower.includes('인증되지') ||
       lower.includes('등록되지 않은 ip') ||


### PR DESCRIPTION
## Summary
공식 Aligo API 명세(https://smartsms.aligo.in/admin/api/spec.html) 와 비교하여 SMS 발송 관련 라우트 3종을 점검·수정.

- **result_code 정수 안전 비교**: 스펙은 Integer 이며 `>= 1` 성공인데 기존 `=== '1'` 문자열 비교라 응답 타입이 정수로 변경되는 순간 모든 정상 발송이 실패로 분류되는 위험을 제거 (`Number(...) >= 1`)
- **메시지 길이 가드**: 1~2000 byte 초과 시 사전 400 응답
- **title 길이 가드**: LMS/MMS 의 title 1~44 byte 초과 시 사전 400 응답
- **IP 인증 오류(-101) 명시 처리**: 메시지 문자열 휴리스틱과 함께 코드 기반 식별 추가

영향 위치: referrals/sms, recall/sms (send + remain), cron/referral-thanks

## Test plan
- [x] `npm run build` 통과
- [x] result_code 정수/문자열/이상값 8케이스 단위 검증
- [ ] (Aligo) smartsms.aligo.in 보안설정에서 API 인증 IP 해제 후 실제 발송 검증 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)