### PR TITLE
fix(investment): yahoo-finance2 v3 호환 패턴 일괄 적용

### DIFF
--- a/dental-clinic-manager/package-lock.json
+++ b/dental-clinic-manager/package-lock.json
@@ -86,7 +86,7 @@
         "technicalindicators": "^3.1.0",
         "uuid": "^13.0.0",
         "xlsx": "^0.18.5",
-        "yahoo-finance2": "^2.14.2",
+        "yahoo-finance2": "^3.14.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -142,6 +142,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@deno/shim-deno": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno/-/shim-deno-0.18.2.tgz",
+      "integrity": "sha512-oQ0CVmOio63wlhwQF75zA4ioolPvOwAoK0yuzcS5bDC1JUvH3y1GS8xPh8EOpcoDQRU4FTG8OQfxhpR+c6DrzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deno/shim-deno-test": "^0.5.0",
+        "which": "^4.0.0"
+      }
+    },
+    "node_modules/@deno/shim-deno-test": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno-test/-/shim-deno-test-0.5.0.tgz",
+      "integrity": "sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==",
+      "license": "MIT"
+    },
+    "node_modules/@deno/shim-deno/node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@deno/shim-deno/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -3769,12 +3809,6 @@
       "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
       "license": "MIT"
     },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.32.35",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.35.tgz",
-      "integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA==",
-      "license": "MIT"
-    },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
@@ -4978,12 +5012,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/tough-cookie": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
@@ -7922,6 +7950,16 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fetch-mock-cache": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock-cache/-/fetch-mock-cache-2.3.1.tgz",
+      "integrity": "sha512-hDk+Nbt0Y8Aq7KTEU6ASQAcpB34UjhkpD3QjzD6yvEKP4xVElAqXrjQ7maL+LYMGafx51Zq6qUfDM57PNu/qMw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "filenamify-url": "2.1.2"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -7951,6 +7989,48 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify-url": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-2.1.2.tgz",
+      "integrity": "sha512-3rMbAr7vDNMOGsj1aMniQFl749QjgM+lMJ/77ZRSPTIgxvolZwoQbn8dXLs7xfd+hAdli+oTnSWZNkJJLWQFEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "filenamify": "^4.3.0",
+        "humanize-url": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fill-range": {
@@ -8559,6 +8639,18 @@
         "node": ">= 14"
       }
     },
+    "node_modules/humanize-url": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-2.1.1.tgz",
+      "integrity": "sha512-V4nxsPGNE7mPjr1qDp471YfW8nhBiTRWrG/4usZlpvFU8I7gsV7Jvrrzv/snbLm5dWO3dr1ennu2YqnhTWFmYA==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-url": "^4.5.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -9160,6 +9252,12 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
@@ -9994,6 +10092,15 @@
       "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/npm-normalize-package-bin": {
       "version": "5.0.0",
@@ -12164,6 +12271,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-outer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -12485,6 +12613,24 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12530,6 +12676,27 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-repeated/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
@@ -13365,22 +13532,34 @@
       "license": "ISC"
     },
     "node_modules/yahoo-finance2": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-2.14.2.tgz",
-      "integrity": "sha512-qmqWv2OE5uFAHl0Cjpt+0lJQ7lxnXI65HZCgN9l3wUEKHuderYqL24+oy/g7jIhcsESz9C+uG8tbLcWyE1FN5A==",
-      "deprecated": "v2 has not been supported for some time; please see https://github.com/gadicc/yahoo-finance2/blob/dev/docs/UPGRADING.md for migration info",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-3.14.0.tgz",
+      "integrity": "sha512-gsT/tqgeizKtMxbIIWFiFyuhM/6MZE4yEyNLmPekr88AX14JL2HWw0/QNMOR081jVtzTjihqDW0zV7IayH1Wcw==",
       "license": "MIT",
       "dependencies": {
-        "@sinclair/typebox": "^0.32.27",
-        "@types/tough-cookie": "^4.0.2",
-        "tough-cookie": "^4.1.2",
-        "tough-cookie-file-store": "^2.0.3"
+        "@deno/shim-deno": "~0.18.0",
+        "fetch-mock-cache": "npm:fetch-mock-cache@^2.1.3",
+        "json-schema": "^0.4.0",
+        "tough-cookie": "npm:tough-cookie@^5.1.1",
+        "tough-cookie-file-store": "npm:tough-cookie-file-store@^2.0.3"
       },
       "bin": {
-        "yahoo-finance": "bin/yahoo-finance.js"
+        "yahoo-finance": "esm/bin/yahoo-finance.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/yahoo-finance2/node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/yallist": {

--- a/dental-clinic-manager/package.json
+++ b/dental-clinic-manager/package.json
@@ -92,7 +92,7 @@
     "technicalindicators": "^3.1.0",
     "uuid": "^13.0.0",
     "xlsx": "^0.18.5",
-    "yahoo-finance2": "^2.14.2",
+    "yahoo-finance2": "^3.14.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778225631022'
+const SW_VERSION = 'v1778230795692'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/scripts/create-test-owner.js
+++ b/dental-clinic-manager/scripts/create-test-owner.js
@@ -1,0 +1,112 @@
+const { createClient } = require('@supabase/supabase-js');
+require('dotenv').config({ path: '.env.local' });
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceRoleKey) {
+  console.error('NEXT_PUBLIC_SUPABASE_URL 또는 SUPABASE_SERVICE_ROLE_KEY 가 설정되지 않았습니다.');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { autoRefreshToken: false, persistSession: false }
+});
+
+const EMAIL = process.env.TEST_OWNER_EMAIL || 'testowner@test.com';
+const PASSWORD = process.env.TEST_OWNER_PASSWORD || 'test1234!';
+const NAME = process.env.TEST_OWNER_NAME || '테스트원장';
+const CLINIC_NAME = process.env.TEST_CLINIC_NAME || '테스트치과';
+const CLINIC_PHONE = '02-0000-0000';
+const CLINIC_ADDRESS = '서울시 테스트구 테스트동';
+
+async function main() {
+  console.log('▶ 테스트 원장 계정 생성 시작');
+
+  // 1) 기존 auth 사용자 확인
+  const { data: listResp, error: listErr } = await supabase.auth.admin.listUsers({ page: 1, perPage: 1000 });
+  if (listErr) throw listErr;
+  let authUser = listResp.users.find((u) => u.email === EMAIL);
+
+  if (authUser) {
+    console.log(`• 기존 auth 사용자 발견: ${authUser.id}`);
+    // 비밀번호 재설정 + 이메일 확인
+    const { error: upErr } = await supabase.auth.admin.updateUserById(authUser.id, {
+      password: PASSWORD,
+      email_confirm: true,
+    });
+    if (upErr) throw upErr;
+  } else {
+    const { data: created, error: createErr } = await supabase.auth.admin.createUser({
+      email: EMAIL,
+      password: PASSWORD,
+      email_confirm: true,
+      user_metadata: { name: NAME, role: 'owner' },
+    });
+    if (createErr) throw createErr;
+    authUser = created.user;
+    console.log(`• auth 사용자 생성 완료: ${authUser.id}`);
+  }
+
+  // 2) 병원 레코드 확보 (이메일 기준 upsert)
+  const { data: existingClinic } = await supabase
+    .from('clinics')
+    .select('id, name')
+    .eq('email', EMAIL)
+    .maybeSingle();
+
+  let clinicId;
+  if (existingClinic) {
+    clinicId = existingClinic.id;
+    console.log(`• 기존 병원 사용: ${existingClinic.name} (${clinicId})`);
+  } else {
+    const { data: clinic, error: clinicErr } = await supabase
+      .from('clinics')
+      .insert({
+        name: CLINIC_NAME,
+        owner_name: NAME,
+        address: CLINIC_ADDRESS,
+        phone: CLINIC_PHONE,
+        email: EMAIL,
+        is_public: false,
+      })
+      .select('id')
+      .single();
+    if (clinicErr) throw clinicErr;
+    clinicId = clinic.id;
+    console.log(`• 병원 생성 완료: ${clinicId}`);
+  }
+
+  // 3) users 테이블 upsert (role=owner, status=active)
+  const { error: userErr } = await supabase
+    .from('users')
+    .upsert(
+      {
+        id: authUser.id,
+        email: EMAIL,
+        name: NAME,
+        role: 'owner',
+        status: 'active',
+        clinic_id: clinicId,
+        approved_at: new Date().toISOString(),
+      },
+      { onConflict: 'id' }
+    );
+  if (userErr) throw userErr;
+
+  console.log('\n========================================');
+  console.log('✅ 테스트 원장 계정 준비 완료');
+  console.log('----------------------------------------');
+  console.log(`이메일   : ${EMAIL}`);
+  console.log(`비밀번호 : ${PASSWORD}`);
+  console.log(`이름     : ${NAME}`);
+  console.log(`역할     : owner (대표원장)`);
+  console.log(`병원     : ${CLINIC_NAME} (${clinicId})`);
+  console.log(`User ID  : ${authUser.id}`);
+  console.log('========================================');
+}
+
+main().catch((err) => {
+  console.error('❌ 오류:', err);
+  process.exit(1);
+});

--- a/dental-clinic-manager/scripts/test-daytrading.ts
+++ b/dental-clinic-manager/scripts/test-daytrading.ts
@@ -5,12 +5,14 @@
  * 2) yahoo-finance2로 AAPL 5분봉 7일치 가져와 실데이터 백테스트
  */
 
-import yf from 'yahoo-finance2'
+import YahooFinance from 'yahoo-finance2'
 import { calculateIndicators } from '../src/lib/indicatorEngine'
 import { runDayTradingBacktest } from '../src/lib/dayTradingBacktestEngine'
 import type {
   OHLCV, IndicatorConfig, ConditionGroup, RiskSettings,
 } from '../src/types/investment'
+
+const yf = new YahooFinance()
 
 // ============================================
 // 합성 데이터 헬퍼

--- a/dental-clinic-manager/scripts/test-smart-money-real.ts
+++ b/dental-clinic-manager/scripts/test-smart-money-real.ts
@@ -1,9 +1,11 @@
 /**
  * 실제 데이터로 Smart Money 지표 검증 (Yahoo Finance)
  */
-import yahooFinance from 'yahoo-finance2'
+import YahooFinance from 'yahoo-finance2'
 import { calculateIndicators } from '../src/lib/indicatorEngine'
 import type { OHLCV, IndicatorConfig } from '../src/types/investment'
+
+const yahooFinance = new YahooFinance()
 
 async function fetchOHLCV(symbol: string, days: number): Promise<OHLCV[]> {
   const end = new Date()

--- a/dental-clinic-manager/src/app/api/investment/ticker-analysis/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/ticker-analysis/route.ts
@@ -51,7 +51,8 @@ interface ProfileSummary {
 }
 
 async function fetchProfile(symbol: string): Promise<ProfileSummary | null> {
-  const yahoo = (await import('yahoo-finance2')).default
+  const YahooFinance = (await import('yahoo-finance2')).default
+  const yahoo = new YahooFinance()
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sum: any = await yahoo.quoteSummary(symbol, {
@@ -94,7 +95,8 @@ async function resolveSymbol(ticker: string, market: 'KR' | 'US'): Promise<strin
   const t = ticker.toUpperCase().trim()
   if (!t) return null
   if (market === 'US') return t
-  const yahoo = (await import('yahoo-finance2')).default
+  const YahooFinance = (await import('yahoo-finance2')).default
+  const yahoo = new YahooFinance()
   for (const suffix of ['.KS', '.KQ']) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/dental-clinic-manager/src/app/api/investment/ticker-info/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/ticker-info/route.ts
@@ -33,8 +33,9 @@ function rangeToInterval(range: Range): { period: number; interval: '1d' | '1wk'
 }
 
 async function getYahoo() {
-  // yahoo-finance2 v2: default export가 싱글톤 인스턴스
-  return (await import('yahoo-finance2')).default
+  // yahoo-finance2 v3: default export가 클래스 — 인스턴스화 필수
+  const YahooFinance = (await import('yahoo-finance2')).default
+  return new YahooFinance()
 }
 
 async function resolveSymbol(yahoo: any, ticker: string, market: 'KR' | 'US'): Promise<string | null> {

--- a/dental-clinic-manager/src/app/api/investment/ticker-search/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/ticker-search/route.ts
@@ -84,7 +84,8 @@ export async function GET(request: NextRequest) {
 
     // 영문/숫자 쿼리는 yahoo로 KR/US 모두 보강
     try {
-      const yahooFinance = (await import('yahoo-finance2')).default
+      const YahooFinance = (await import('yahoo-finance2')).default
+      const yahooFinance = new YahooFinance()
       const searchResult = await yahooFinance.search(query, { newsCount: 0, quotesCount: 50 })
 
       const yahooQuotes = (searchResult.quotes || [])
@@ -165,7 +166,8 @@ export async function GET(request: NextRequest) {
 
   // yahoo-finance2 fallback (영문 쿼리 또는 미국 시장)
   try {
-    const yahooFinance = (await import('yahoo-finance2')).default
+    const YahooFinance = (await import('yahoo-finance2')).default
+    const yahooFinance = new YahooFinance()
 
     const searchResult = await yahooFinance.search(query, {
       newsCount: 0,

--- a/dental-clinic-manager/src/lib/intradayDataService.ts
+++ b/dental-clinic-manager/src/lib/intradayDataService.ts
@@ -114,8 +114,9 @@ async function fetchFromYahooIntraday(
   startDate: string,
   endDate: string,
 ): Promise<OHLCV[]> {
-  // yahoo-finance2는 동적 import (서버 사이드 전용)
-  const yahooFinance = (await import('yahoo-finance2')).default
+  // yahoo-finance2는 동적 import (서버 사이드 전용) — v3 클래스 인스턴스화
+  const YahooFinance = (await import('yahoo-finance2')).default
+  const yahooFinance = new YahooFinance()
 
   // 한국 종목은 .KS / .KQ 접미사 필요
   const symbol = market === 'KR' ? `${ticker}.KS` : ticker

--- a/dental-clinic-manager/src/lib/psychology/marketDataFetcher.ts
+++ b/dental-clinic-manager/src/lib/psychology/marketDataFetcher.ts
@@ -4,8 +4,11 @@
 //   - KR: KIS API (분봉 + 호가 10단계)
 //   - US: yahoo-finance2 (분봉만, 호가 미지원)
 
-import yahooFinance from 'yahoo-finance2'
+import YahooFinance from 'yahoo-finance2'
 import { getKRMinutePrices, getKRAskingPrice } from '@/lib/kisApiService'
+
+// yahoo-finance2 v3: default export가 클래스 — 모듈 레벨에서 1회 인스턴스화
+const yahooFinance = new YahooFinance()
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { investmentDecrypt } from '@/lib/investmentCrypto'
 import type { Market } from '@/types/investment'

--- a/dental-clinic-manager/src/lib/stockDataService.ts
+++ b/dental-clinic-manager/src/lib/stockDataService.ts
@@ -80,7 +80,8 @@ async function fetchFromYahooFinance(
   endDate: string,
 ): Promise<OHLCV[]> {
   // yahoo-finance2는 동적 import (서버 사이드 전용)
-  const yahooFinance = (await import('yahoo-finance2')).default
+  const YahooFinance = (await import('yahoo-finance2')).default
+  const yahooFinance = new YahooFinance()
 
   // 한국 종목은 .KS (KOSPI) 또는 .KQ (KOSDAQ) 접미사 필요
   const symbol = market === 'KR' ? `${ticker}.KS` : ticker
@@ -249,7 +250,8 @@ interface YahooQuoteResult {
  * KR은 자동으로 .KS/.KQ suffix 처리 (기존 fetchPrices와 동일 규칙)
  */
 export async function fetchCurrentQuote(ticker: string, market: Market): Promise<CurrentQuote> {
-  const yahooFinance = (await import('yahoo-finance2')).default
+  const YahooFinance = (await import('yahoo-finance2')).default
+  const yahooFinance = new YahooFinance()
 
   const trySymbols = market === 'KR' ? [`${ticker}.KS`, `${ticker}.KQ`] : [ticker]
 


### PR DESCRIPTION
## Summary

- **fix**: 이전 PR #525 v2 다운그레이드는 잘못된 방향 — yahoo-finance2 측에서 v2 클라이언트 요청 차단(\"v2 is no longer supported\")
- v3 유지 + 모든 호출처에서 \`new YahooFinance()\` 패턴 정확히 적용
- **결정적 누락**: \`src/lib/psychology/marketDataFetcher.ts\`가 \`import yahooFinance from 'yahoo-finance2'\` 직접 호출 → 미국 종목 분석 시 502 직접 원인

## Test plan

- [x] 로컬 빌드 통과
- [ ] Vercel 배포 후 AAPL 분석 실행 — 정상 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)