### PR TITLE
fix(sms): IP 인증 안내 명확화 — Vercel 서버리스 IP 가변성 강조

### DIFF
--- a/dental-clinic-manager/src/app/api/recall/sms/route.ts
+++ b/dental-clinic-manager/src/app/api/recall/sms/route.ts
@@ -133,7 +133,8 @@ export async function POST(request: NextRequest) {
         }
       })
     } else {
-      // IP 인증 오류 체크 - 알리고 관리자 페이지에서 IP 등록 필요 (스펙: -101 = 인증오류)
+      // IP 인증 오류 체크 (스펙: -101 = 인증오류). 본 서비스는 Vercel 서버리스라 호출마다 IP가 달라
+      // IP 등록 방식은 안정적이지 않음 → "API 인증 IP 해제"를 1순위로 안내.
       let errorMessage = aligoResult.message || '문자 발송에 실패했습니다.'
       if (
         resultCodeNum === -101 ||
@@ -141,7 +142,9 @@ export async function POST(request: NextRequest) {
         errorMessage.includes('IP') ||
         errorMessage.includes('인증오류')
       ) {
-        errorMessage = 'IP 인증 오류: 알리고 관리자 페이지(smartsms.aligo.in)에서 서버 IP를 등록하거나 API 인증 IP를 해제해주세요.'
+        errorMessage =
+          'IP 인증 오류: 알리고 관리자(smartsms.aligo.in) → 보안설정에서 "API 인증 IP"를 해제해주세요. ' +
+          '본 서비스는 Vercel 서버리스로 동작하여 호출마다 발송 IP가 달라지므로 특정 IP 등록 방식은 권장되지 않습니다.'
       }
 
       return NextResponse.json({

--- a/dental-clinic-manager/src/app/api/referrals/sms/route.ts
+++ b/dental-clinic-manager/src/app/api/referrals/sms/route.ts
@@ -120,9 +120,12 @@ export async function POST(req: NextRequest) {
       } catch {
         /* IP 조회 실패는 무시 — 안내 본문만 표시 */
       }
-      const ipLine = serverIp ? `\n현재 발송 서버 IP: ${serverIp}` : ''
+      // Vercel 서버리스는 호출마다 IP가 달라질 수 있어 "API 인증 IP 해제"가 사실상 유일한 안정적 해법.
+      // PC IP를 등록해도 발송 호출은 항상 Vercel 서버에서 나가므로 매칭되지 않습니다.
+      const ipLine = serverIp ? `\n(참고: 이번 호출 시 Vercel 서버 IP = ${serverIp} — 호출마다 달라질 수 있음)` : ''
       hint =
-        '알리고 관리자(smartsms.aligo.in) → 보안설정에서 "API 인증 IP"를 해제하거나, 아래 IP를 등록해주세요.' +
+        '알리고 관리자(smartsms.aligo.in) → 보안설정에서 "API 인증 IP"를 해제해주세요.\n' +
+        '※ 본 서비스는 Vercel 서버리스로 동작해 호출마다 발송 IP가 달라지므로, 특정 IP만 등록하는 방식은 권장되지 않습니다. PC IP를 등록해도 발송은 Vercel에서 나가 매칭되지 않습니다.' +
         ipLine
     } else if (lower.includes('발신번호') || lower.includes('sender')) {
       hint = `발신번호(${aligo.sender_number})가 알리고에 사전 등록되지 않았거나 LMS/MMS용으로 등록되지 않았습니다.`


### PR DESCRIPTION
## Summary
- 코드 호출 흐름은 정상(서버사이드 호출, 스펙 준수). 본 PR 은 안내 메시지만 다듬는 수정
- Vercel 서버리스는 호출마다 발송 IP가 달라져 IP 등록 방식이 안정적이지 않음을 사용자에게 명확히 안내
- "API 인증 IP 해제" 를 1순위로 강조, IP 노출은 디버깅 보조로 격하

## Test plan
- [x] `npm run build` 통과
- [x] 호출 경로 검증: 클라이언트는 자체 API 라우트만 호출, Aligo 호출은 서버사이드 3곳에서만 발생

🤖 Generated with [Claude Code](https://claude.com/claude-code)