### PR TITLE
feat(psychology): 과거 시점 분석 지원 (asOf)

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778230795692'
+const SW_VERSION = 'v1778232697674'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/app/api/investment/psychology/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/psychology/analyze/route.ts
@@ -35,15 +35,34 @@ export async function POST(req: NextRequest) {
   const body = await req.json().catch(() => null) as {
     ticker?: string; market?: Market;
     triggerKind?: PsychologyTriggerKind; triggerDetail?: string;
+    asOf?: string;
   } | null
   const ticker = body?.ticker?.trim().toUpperCase()
   const market = body?.market === 'KR' || body?.market === 'US' ? body.market : null
   if (!ticker || !market) return NextResponse.json({ error: 'ticker, market 필수' }, { status: 400 })
   const triggerKind: PsychologyTriggerKind = body?.triggerKind ?? 'manual'
 
+  // asOf — 과거 시점 분석. ISO string 파싱, 미래/너무 오래된 시점 차단
+  let asOf: Date | undefined = undefined
+  if (body?.asOf) {
+    const d = new Date(body.asOf)
+    if (Number.isNaN(d.getTime())) {
+      return NextResponse.json({ error: 'asOf 형식 오류 (ISO 8601 필요)' }, { status: 400 })
+    }
+    const now = Date.now()
+    if (d.getTime() > now + 60_000) {
+      return NextResponse.json({ error: 'asOf는 미래 시점일 수 없습니다' }, { status: 400 })
+    }
+    // yahoo 1m 차트는 7일 이내만 / KIS는 약 3거래일 — 7일 한도
+    if (now - d.getTime() > 7 * 24 * 3600_000) {
+      return NextResponse.json({ error: '과거 7일 이내 시점만 분석 가능합니다' }, { status: 400 })
+    }
+    asOf = d
+  }
+
   let snapshot
   try {
-    snapshot = await fetchPsychologySnapshot(auth.user.id, ticker, market, 60)
+    snapshot = await fetchPsychologySnapshot(auth.user.id, ticker, market, 60, asOf)
   } catch (e) {
     const msg = e instanceof Error ? e.message : '데이터 수집 실패'
     return NextResponse.json({ error: msg }, { status: 502 })
@@ -57,12 +76,17 @@ export async function POST(req: NextRequest) {
     result = await analyzePsychology({
       ticker, market, triggerKind, triggerDetail: body?.triggerDetail,
       snapshot,
+      asOf: asOf?.toISOString(),
     })
   } catch (e) {
     return NextResponse.json({ error: e instanceof Error ? e.message : 'LLM 분석 실패' }, { status: 500 })
   }
 
   const admin = getSupabaseAdmin()!
+  // input_snapshot에 asOf 표기 (응답에서 클라이언트가 사용)
+  const inputSnapshotWithAsOf = asOf
+    ? { ...snapshot, as_of: asOf.toISOString() }
+    : snapshot
   const { data: inserted, error: insertErr } = await admin
     .from('psychology_analyses')
     .insert({
@@ -74,7 +98,7 @@ export async function POST(req: NextRequest) {
       narrative: result.output.narrative,
       markers: result.output.markers,
       orderbook_pressure: result.output.orderbook_pressure,
-      input_snapshot: snapshot,
+      input_snapshot: inputSnapshotWithAsOf,
       llm_model: result.model,
       llm_latency_ms: result.latencyMs,
     })

--- a/dental-clinic-manager/src/components/Investment/Psychology/AnalysisDetail.tsx
+++ b/dental-clinic-manager/src/components/Investment/Psychology/AnalysisDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState } from 'react'
-import { Loader2, Sparkles, AlertCircle, Brain } from 'lucide-react'
+import { Loader2, Sparkles, AlertCircle, Brain, Clock, History } from 'lucide-react'
 import ScoreGauge from './ScoreGauge'
 import PsychologyChart from './PsychologyChart'
 import OrderbookPressureBar from './OrderbookPressureBar'
@@ -14,17 +14,55 @@ interface Props {
   onAnalyzed: (record: PsychologyAnalysisRecord) => void
 }
 
+type Mode = 'now' | 'past'
+
+/** datetime-local 입력값 (YYYY-MM-DDTHH:mm) → ISO string. 로컬 시간으로 해석. */
+function localInputToIso(value: string): string | null {
+  if (!value) return null
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return null
+  return d.toISOString()
+}
+
+/** Date → datetime-local 입력값 형식 */
+function dateToLocalInput(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
 export default function AnalysisDetail({ ticker, market, latest, onAnalyzed }: Props) {
   const [running, setRunning] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [mode, setMode] = useState<Mode>('now')
+  // 기본값: 어제 같은 시간
+  const [asOfLocal, setAsOfLocal] = useState<string>(() => {
+    const d = new Date(Date.now() - 24 * 3600 * 1000)
+    return dateToLocalInput(d)
+  })
+
+  const minLocal = (() => {
+    // 7일 전 (yahoo / KIS 한도)
+    return dateToLocalInput(new Date(Date.now() - 7 * 24 * 3600 * 1000))
+  })()
+  const maxLocal = dateToLocalInput(new Date())
 
   const onAnalyze = async () => {
     setRunning(true); setError(null)
     try {
+      const body: Record<string, unknown> = {
+        ticker,
+        market,
+        triggerKind: 'manual',
+      }
+      if (mode === 'past') {
+        const iso = localInputToIso(asOfLocal)
+        if (!iso) { setError('분석 시점이 올바르지 않습니다'); return }
+        body.asOf = iso
+      }
       const res = await fetch('/api/investment/psychology/analyze', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ticker, market, triggerKind: 'manual' }),
+        body: JSON.stringify(body),
       })
       const data = await res.json()
       if (!res.ok) { setError(data.error ?? '분석 실패'); return }
@@ -32,24 +70,74 @@ export default function AnalysisDetail({ ticker, market, latest, onAnalyzed }: P
     } finally { setRunning(false) }
   }
 
+  // latest record에서 분석 시점 추출
+  const latestAsOf = (() => {
+    const snap = latest?.input_snapshot as { as_of?: string } | undefined
+    return snap?.as_of ?? null
+  })()
+
   return (
     <div className="space-y-4">
-      <div className="bg-white rounded-3xl shadow-sm border border-at-border p-5 flex items-center justify-between gap-3">
-        <div className="min-w-0">
-          <h2 className="text-xl font-bold text-at-text truncate">{ticker}</h2>
-          {latest ? (
-            <p className="text-xs text-at-text-secondary mt-0.5">
-              마지막 분석: {new Date(latest.created_at).toLocaleString('ko-KR')}
-            </p>
-          ) : (
-            <p className="text-xs text-at-text-weak mt-0.5">아직 분석 이력이 없습니다</p>
+      <div className="bg-white rounded-3xl shadow-sm border border-at-border p-5 space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h2 className="text-xl font-bold text-at-text truncate">{ticker}</h2>
+            {latest ? (
+              <p className="text-xs text-at-text-secondary mt-0.5">
+                마지막 분석: {new Date(latest.created_at).toLocaleString('ko-KR')}
+                {latestAsOf && (
+                  <span className="ml-2 inline-flex items-center gap-1 text-at-accent">
+                    <History className="w-3 h-3" />
+                    분석 시점 {new Date(latestAsOf).toLocaleString('ko-KR')}
+                  </span>
+                )}
+              </p>
+            ) : (
+              <p className="text-xs text-at-text-weak mt-0.5">아직 분석 이력이 없습니다</p>
+            )}
+          </div>
+          <button onClick={onAnalyze} disabled={running}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-at-accent text-white rounded-xl text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity flex-shrink-0">
+            {running ? <Loader2 className="w-4 h-4 animate-spin" /> : <Sparkles className="w-4 h-4" />}
+            분석 실행
+          </button>
+        </div>
+
+        <div className="flex flex-col sm:flex-row sm:items-center gap-2 pt-3 border-t border-at-border">
+          <div className="inline-flex rounded-xl bg-at-surface-alt p-0.5 self-start">
+            {(['now', 'past'] as const).map(m => {
+              const active = mode === m
+              return (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => setMode(m)}
+                  className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors inline-flex items-center gap-1 ${
+                    active
+                      ? 'bg-white text-at-accent shadow-sm'
+                      : 'text-at-text-secondary hover:text-at-text'
+                  }`}
+                >
+                  {m === 'now' ? <Clock className="w-3.5 h-3.5" /> : <History className="w-3.5 h-3.5" />}
+                  {m === 'now' ? '현재' : '과거 시점'}
+                </button>
+              )
+            })}
+          </div>
+          {mode === 'past' && (
+            <div className="flex items-center gap-2 flex-1">
+              <input
+                type="datetime-local"
+                value={asOfLocal}
+                onChange={e => setAsOfLocal(e.target.value)}
+                min={minLocal}
+                max={maxLocal}
+                className="flex-1 sm:flex-none border border-at-border rounded-xl px-3 py-1.5 text-sm text-at-text bg-white focus:outline-none focus:ring-2 focus:ring-at-accent focus:border-transparent"
+              />
+              <span className="text-[11px] text-at-text-weak">기준 직전 60분 분석 (최근 7일 이내)</span>
+            </div>
           )}
         </div>
-        <button onClick={onAnalyze} disabled={running}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-at-accent text-white rounded-xl text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity flex-shrink-0">
-          {running ? <Loader2 className="w-4 h-4 animate-spin" /> : <Sparkles className="w-4 h-4" />}
-          지금 분석하기
-        </button>
       </div>
 
       {error && (
@@ -65,7 +153,7 @@ export default function AnalysisDetail({ ticker, market, latest, onAnalyzed }: P
             <Brain className="w-7 h-7 text-at-accent" />
           </div>
           <p className="text-sm text-at-text-secondary">
-            &ldquo;지금 분석하기&rdquo;를 눌러 첫 분석을 실행하세요.
+            현재 또는 과거 시점을 선택하고 &ldquo;분석 실행&rdquo;을 눌러주세요.
           </p>
         </div>
       )}

--- a/dental-clinic-manager/src/lib/kisApiService.ts
+++ b/dental-clinic-manager/src/lib/kisApiService.ts
@@ -562,6 +562,8 @@ interface MinutePriceParams {
   intervalMinutes?: 1 | 5 | 10 | 30
   /** 반환할 봉 개수 (기본 30) — KIS 한 번 호출 당 최대 30개 */
   count?: number
+  /** 과거 시점 분석용 — 이 시각 이전의 분봉을 받아옴 (KST). 미지정 시 현재 시각 사용. */
+  endTime?: Date
 }
 
 /**
@@ -578,17 +580,19 @@ interface MinutePriceParams {
  * 5/10/30분봉이 요청되면 1분봉을 N개 단위로 집계하여 반환.
  */
 export async function getKRMinutePrices(params: MinutePriceParams): Promise<KRMinuteBar[]> {
-  const { credentialId, credential, ticker, intervalMinutes = 1, count = 30 } = params
+  const { credentialId, credential, ticker, intervalMinutes = 1, count = 30, endTime } = params
 
   const accumulated = new Map<string, KRMinuteBar>()
   const REQUEST_DELAY_MS = 60 // KIS rate limit 회피 (20 req/sec)
+  // endTime이 주어지면 그 시점 기준으로 cursor 시작 (과거 분석용)
+  const cursorBase = endTime ?? new Date()
 
   if (!credential.isPaperTrading) {
     // ===== 실전계좌: FHKST03010230 (date+hour cursor, 120봉/req) =====
     // 1200봉(≈3거래일) ≤ 11회 호출 + 안전 마진 = 16회
     const MAX_REQUESTS = 16
-    let cursorDate = kstYyyymmdd(new Date())
-    let cursorHour = kstHhmmss(new Date())
+    let cursorDate = kstYyyymmdd(cursorBase)
+    let cursorHour = kstHhmmss(cursorBase)
 
     for (let i = 0; i < MAX_REQUESTS; i++) {
       if (i > 0) await new Promise((r) => setTimeout(r, REQUEST_DELAY_MS))

--- a/dental-clinic-manager/src/lib/psychology/llmClient.ts
+++ b/dental-clinic-manager/src/lib/psychology/llmClient.ts
@@ -93,6 +93,8 @@ export interface AnalyzeArgs {
   triggerKind: PsychologyTriggerKind
   triggerDetail?: string
   snapshot: PsychologyInputSnapshot
+  /** 과거 시점 분석인 경우 ISO 8601 — LLM 프롬프트에 명시해 시제 정합성 확보 */
+  asOf?: string
 }
 
 export interface AnalyzeResult {
@@ -102,7 +104,7 @@ export interface AnalyzeResult {
 }
 
 function buildUserPrompt(args: AnalyzeArgs): string {
-  const { ticker, market, triggerKind, triggerDetail, snapshot } = args
+  const { ticker, market, triggerKind, triggerDetail, snapshot, asOf } = args
   const candleLines = snapshot.candles.map((c, i) =>
     `[${i}] ${c.ts} O=${c.open} H=${c.high} L=${c.low} C=${c.close} V=${c.volume}`
   ).join('\n')
@@ -110,17 +112,21 @@ function buildUserPrompt(args: AnalyzeArgs): string {
     ? `호가 (10단계): 매수총잔량=${snapshot.orderbook.totalBidQty}, 매도총잔량=${snapshot.orderbook.totalAskQty}\n` +
       `매수: ${snapshot.orderbook.bids.map(b => `${b.price}@${b.qty}`).join(', ')}\n` +
       `매도: ${snapshot.orderbook.asks.map(a => `${a.price}@${a.qty}`).join(', ')}`
-    : '호가 데이터 없음 (해외 종목)'
+    : '호가 데이터 없음 (해외 종목 또는 과거 시점 분석)'
+  const asOfLine = asOf
+    ? `분석 시점 (asOf): ${asOf} — 이 시각 기준으로 그 직전 ${snapshot.candles.length}분 동안의 흐름을 분석합니다. 과거 시점이므로 narrative는 과거형으로 작성하세요.`
+    : null
   return [
     `종목: ${ticker} (${market})`,
     `분석 요청 사유: ${triggerKind}${triggerDetail ? ` - ${triggerDetail}` : ''}`,
+    asOfLine,
     `최근 ${snapshot.candles.length}개 1분봉:`,
     candleLines,
     orderbookSummary,
     '',
     '위 데이터를 바탕으로 군중심리를 분석하여 submit_psychology_analysis 도구를 호출해주세요.',
     `markers의 candle_index는 위 분봉 배열의 [N] 번호와 정확히 일치해야 합니다. 최대 5개.`,
-  ].join('\n')
+  ].filter((line): line is string => line !== null).join('\n')
 }
 
 export async function analyzePsychology(args: AnalyzeArgs): Promise<AnalyzeResult> {

--- a/dental-clinic-manager/src/lib/psychology/marketDataFetcher.ts
+++ b/dental-clinic-manager/src/lib/psychology/marketDataFetcher.ts
@@ -55,10 +55,22 @@ async function getUserKisCredential(userId: string): Promise<KisCredentialResolv
 async function fetchKRSnapshot(
   userId: string,
   ticker: string,
-  count = 60
+  count = 60,
+  asOf?: Date
 ): Promise<PsychologyInputSnapshot> {
   const cred = await getUserKisCredential(userId)
   if (!cred) throw new Error('KIS 계좌 연결이 필요합니다')
+
+  // 모의계좌는 당일 데이터만 조회 가능 — 과거 일자 분석 차단
+  if (asOf && cred.isPaperTrading) {
+    const today = new Date()
+    const sameKstDay =
+      asOf.toLocaleDateString('en-CA', { timeZone: 'Asia/Seoul' }) ===
+      today.toLocaleDateString('en-CA', { timeZone: 'Asia/Seoul' })
+    if (!sameKstDay) {
+      throw new Error('모의 계좌는 당일 데이터만 조회 가능합니다. 과거 일자 분석은 실전 계좌가 필요합니다.')
+    }
+  }
 
   const krCredential = {
     appKey: cred.appKey,
@@ -72,6 +84,7 @@ async function fetchKRSnapshot(
     ticker,
     intervalMinutes: 1,
     count,
+    endTime: asOf,
   })
 
   const candles: MinuteCandle[] = bars.map((b) => ({
@@ -83,28 +96,35 @@ async function fetchKRSnapshot(
     volume: b.volume,
   }))
 
+  // 호가는 실시간 정보라 과거 시점은 의미 없음 → asOf 지정 시 호가 생략
   let orderbook: OrderbookSnapshot | null = null
-  try {
-    const ob = await getKRAskingPrice({
-      credentialId: cred.credentialId,
-      credential: krCredential,
-      ticker,
-    })
-    orderbook = {
-      bids: ob.bids,
-      asks: ob.asks,
-      totalBidQty: ob.totalBidQty,
-      totalAskQty: ob.totalAskQty,
+  if (!asOf) {
+    try {
+      const ob = await getKRAskingPrice({
+        credentialId: cred.credentialId,
+        credential: krCredential,
+        ticker,
+      })
+      orderbook = {
+        bids: ob.bids,
+        asks: ob.asks,
+        totalBidQty: ob.totalBidQty,
+        totalAskQty: ob.totalAskQty,
+      }
+    } catch {
+      orderbook = null
     }
-  } catch {
-    orderbook = null
   }
 
   return { candles, orderbook }
 }
 
-async function fetchUSSnapshot(ticker: string, count = 60): Promise<PsychologyInputSnapshot> {
-  const period2 = new Date()
+async function fetchUSSnapshot(
+  ticker: string,
+  count = 60,
+  asOf?: Date
+): Promise<PsychologyInputSnapshot> {
+  const period2 = asOf ?? new Date()
   // yahoo-finance2 1m 차트는 보통 거래일 7일 이내만 허용 — 안전하게 충분히 받음
   const period1 = new Date(period2.getTime() - Math.max(count, 60) * 60 * 1000)
 
@@ -145,13 +165,16 @@ async function fetchUSSnapshot(ticker: string, count = 60): Promise<PsychologyIn
  * @param ticker 종목 코드 (KR: 6자리, US: 심볼)
  * @param market 'KR' | 'US'
  * @param count 분봉 개수 (기본 60)
+ * @param asOf  과거 시점 분석용 — 이 시각까지의 분봉을 받아옴. 미지정 시 현재 시각.
+ *              KR 모의계좌는 당일만 / yahoo는 거래일 7일 이내만 지원.
  */
 export async function fetchPsychologySnapshot(
   userId: string,
   ticker: string,
   market: Market,
-  count = 60
+  count = 60,
+  asOf?: Date
 ): Promise<PsychologyInputSnapshot> {
-  if (market === 'KR') return fetchKRSnapshot(userId, ticker, count)
-  return fetchUSSnapshot(ticker, count)
+  if (market === 'KR') return fetchKRSnapshot(userId, ticker, count, asOf)
+  return fetchUSSnapshot(ticker, count, asOf)
 }


### PR DESCRIPTION
## Summary

- **feat**: 심리 분석 시 사용자가 지정한 과거 시점(최근 7일 이내)의 60분 데이터로 분석 가능
  - 백엔드: \`fetchPsychologySnapshot\`에 \`asOf?: Date\` 도입, KIS/yahoo 모두 cursor 적용
  - API: POST \`/api/investment/psychology/analyze\` body에 \`asOf?: string\` (ISO 8601). 미래/7일 초과 차단
  - LLM 프롬프트: \"분석 시점: {asOf} — 과거형으로 작성\" 명시
  - UI: AnalysisDetail에 \"현재\" / \"과거 시점\" 토글 + datetime-local 입력. 마지막 분석 헤더에 분석 시점 레이블

## Test plan

- [x] 빌드 통과
- [ ] 프로덕션 — \"과거 시점\" 모드로 어제 시간 지정 → 분석 정상 응답 + narrative 과거형

🤖 Generated with [Claude Code](https://claude.com/claude-code)