### PR TITLE
fix(sms): IP 인증 오류 안내를 중립 표현으로 변경

### DIFF
--- a/dental-clinic-manager/src/app/api/recall/sms/route.ts
+++ b/dental-clinic-manager/src/app/api/recall/sms/route.ts
@@ -133,8 +133,8 @@ export async function POST(request: NextRequest) {
         }
       })
     } else {
-      // IP 인증 오류 체크 (스펙: -101 = 인증오류). 본 서비스는 Vercel 서버리스라 호출마다 IP가 달라
-      // IP 등록 방식은 안정적이지 않음 → "API 인증 IP 해제"를 1순위로 안내.
+      // IP 인증 오류 체크 (스펙: -101 = 인증오류). 알리고 IP 보안 정책의 정확한 메뉴 명칭은 공식 문서에 없어
+      // 고객센터 문의로 안내. 본 서비스는 Vercel 서버리스라 호출마다 IP가 달라질 수 있다는 사실은 고지.
       let errorMessage = aligoResult.message || '문자 발송에 실패했습니다.'
       if (
         resultCodeNum === -101 ||
@@ -143,8 +143,8 @@ export async function POST(request: NextRequest) {
         errorMessage.includes('인증오류')
       ) {
         errorMessage =
-          'IP 인증 오류: 알리고 관리자(smartsms.aligo.in) → 보안설정에서 "API 인증 IP"를 해제해주세요. ' +
-          '본 서비스는 Vercel 서버리스로 동작하여 호출마다 발송 IP가 달라지므로 특정 IP 등록 방식은 권장되지 않습니다.'
+          'IP 인증 오류로 보입니다. 알리고 고객센터(1661-1565 또는 smartsms.aligo.in 문의하기)에 IP 인증 해제 또는 IP 등록 절차를 문의해주세요. ' +
+          '본 서비스는 Vercel 서버리스로 동작하여 호출마다 발송 IP가 달라질 수 있어 특정 IP 등록 방식은 안정적이지 않습니다.'
       }
 
       return NextResponse.json({

--- a/dental-clinic-manager/src/app/api/referrals/sms/route.ts
+++ b/dental-clinic-manager/src/app/api/referrals/sms/route.ts
@@ -120,12 +120,12 @@ export async function POST(req: NextRequest) {
       } catch {
         /* IP 조회 실패는 무시 — 안내 본문만 표시 */
       }
-      // Vercel 서버리스는 호출마다 IP가 달라질 수 있어 "API 인증 IP 해제"가 사실상 유일한 안정적 해법.
-      // PC IP를 등록해도 발송 호출은 항상 Vercel 서버에서 나가므로 매칭되지 않습니다.
-      const ipLine = serverIp ? `\n(참고: 이번 호출 시 Vercel 서버 IP = ${serverIp} — 호출마다 달라질 수 있음)` : ''
+      // 알리고 IP 보안 정책의 정확한 메뉴 명칭/위치는 공식 문서에 명시되지 않아 고객센터 문의로 안내.
+      // 본 서비스는 Vercel 서버리스로 동작해 호출마다 발송 IP가 달라질 수 있다는 사실은 고지.
+      const ipLine = serverIp ? `\n(참고: 이번 호출 시 발송 서버 IP = ${serverIp} — 호출마다 달라질 수 있음)` : ''
       hint =
-        '알리고 관리자(smartsms.aligo.in) → 보안설정에서 "API 인증 IP"를 해제해주세요.\n' +
-        '※ 본 서비스는 Vercel 서버리스로 동작해 호출마다 발송 IP가 달라지므로, 특정 IP만 등록하는 방식은 권장되지 않습니다. PC IP를 등록해도 발송은 Vercel에서 나가 매칭되지 않습니다.' +
+        '알리고 측에서 발송 IP 인증을 검증한 것으로 보입니다. 알리고 고객센터(1661-1565 또는 smartsms.aligo.in 문의하기)에 IP 인증 해제 또는 IP 등록 절차를 문의해주세요.\n' +
+        '※ 본 서비스는 Vercel 서버리스로 동작해 호출마다 발송 IP가 달라질 수 있어, 특정 IP만 등록하는 방식은 안정적이지 않습니다.' +
         ipLine
     } else if (lower.includes('발신번호') || lower.includes('sender')) {
       hint = `발신번호(${aligo.sender_number})가 알리고에 사전 등록되지 않았거나 LMS/MMS용으로 등록되지 않았습니다.`


### PR DESCRIPTION
## Summary
- 알리고 공식 문서에 "API 인증 IP" 명칭의 메뉴/기능이 명시되지 않아 부정확한 안내 위험 제거
- "알리고 고객센터(1661-1565 또는 smartsms.aligo.in 문의하기)에 IP 인증 해제/등록 절차 문의" 형태로 중립화
- Vercel 서버리스 IP 가변성 컨텍스트는 유지
- referrals/sms, recall/sms 양쪽 안내 통일

## Test plan
- [x] `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)