### PR TITLE
fix: tossPayments/errors 모듈 누락 (Vercel 빌드 실패)

### DIFF
--- a/dental-clinic-manager/src/lib/tossPayments/__tests__/errors.test.ts
+++ b/dental-clinic-manager/src/lib/tossPayments/__tests__/errors.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { TossPaymentsError } from '../client'
+import { classifyTossError, ErrorClass } from '../errors'
+
+describe('classifyTossError', () => {
+  const cases: Array<[string, number, ErrorClass]> = [
+    ['INVALID_CARD', 400, 'permanent'],
+    ['EXPIRED_CARD', 400, 'permanent'],
+    ['STOLEN_CARD', 400, 'permanent'],
+    ['EXCEED_MAX_AMOUNT', 400, 'permanent'],
+    ['EXCEED_MAX_DAILY_AMOUNT', 400, 'permanent'],
+    ['EXCEED_MAX_PAYMENT_AMOUNT', 400, 'transient'],
+    ['PAY_PROCESS_CANCELED', 400, 'transient'],
+    ['NETWORK_ERROR', 0, 'transient'],
+    ['UNKNOWN', 500, 'transient'],
+    ['UNKNOWN', 502, 'transient'],
+    ['UNKNOWN', 400, 'permanent'],
+  ]
+
+  for (const [code, status, expected] of cases) {
+    it(`${code} (HTTP ${status}) → ${expected}`, () => {
+      const err = new TossPaymentsError(code, 'msg', status)
+      expect(classifyTossError(err)).toBe(expected)
+    })
+  }
+})

--- a/dental-clinic-manager/src/lib/tossPayments/errors.ts
+++ b/dental-clinic-manager/src/lib/tossPayments/errors.ts
@@ -1,0 +1,37 @@
+import { TossPaymentsError } from './client'
+
+export type ErrorClass = 'permanent' | 'transient'
+
+const PERMANENT_CODES = new Set([
+  'INVALID_CARD',
+  'EXPIRED_CARD',
+  'STOLEN_CARD',
+  'EXCEED_MAX_AMOUNT',
+  'EXCEED_MAX_DAILY_AMOUNT',
+  'CARD_LIMIT_EXCEEDED',
+  'NOT_REGISTERED_CARD',
+  'INVALID_CARD_NUMBER',
+])
+
+export function classifyTossError(err: TossPaymentsError): ErrorClass {
+  if (PERMANENT_CODES.has(err.code)) return 'permanent'
+  if (err.httpStatus >= 500) return 'transient'
+  if (err.httpStatus === 0) return 'transient' // network error
+  if (err.code === 'NETWORK_ERROR') return 'transient'
+  if (err.code === 'EXCEED_MAX_PAYMENT_AMOUNT') return 'transient' // 잔고부족
+  if (err.code === 'PAY_PROCESS_CANCELED') return 'transient'
+  return 'permanent'
+}
+
+export function userMessageForCode(code: string): string {
+  const map: Record<string, string> = {
+    INVALID_CARD: '카드 정보가 올바르지 않습니다. 다른 카드로 다시 시도해 주세요.',
+    EXPIRED_CARD: '카드 유효기간이 만료되었습니다. 새 카드를 등록해 주세요.',
+    STOLEN_CARD: '분실/도난 카드입니다. 카드사에 문의해 주세요.',
+    EXCEED_MAX_AMOUNT: '결제 한도를 초과했습니다.',
+    EXCEED_MAX_DAILY_AMOUNT: '일일 결제 한도를 초과했습니다.',
+    EXCEED_MAX_PAYMENT_AMOUNT: '카드 잔고가 부족합니다.',
+    PAY_PROCESS_CANCELED: '결제가 취소되었습니다.',
+  }
+  return map[code] ?? '결제 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'
+}


### PR DESCRIPTION
## Summary
- src/lib/tossPayments/errors.ts 와 errors.test.ts 가 git에 커밋되지 않아 Vercel 빌드가 실패해온 문제 수정
- billingService / userBillingService 가 import 하는 userMessageForCode export 포함
- PR #534, #535 가 모두 ERROR 상태로 배포되었던 원인

🤖 Generated with [Claude Code](https://claude.com/claude-code)