### PR TITLE
release: develop → main (Fixie 프록시 + 누적 변경)

### DIFF
--- a/dental-clinic-manager/src/app/api/cron/referral-thanks/route.ts
+++ b/dental-clinic-manager/src/app/api/cron/referral-thanks/route.ts
@@ -4,6 +4,7 @@
 // 미발송 + (referred_at + auto_thanks_after_days <= today) 인 소개 건에 일괄 발송
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { aligoFetch } from '@/lib/aligoFetch'
 
 export const maxDuration = 60
 
@@ -123,7 +124,7 @@ export async function GET(request: NextRequest) {
       if (msgType === 'LMS') fd.append('title', '소개 감사 인사')
 
       try {
-        const res = await fetch(`${ALIGO_API_URL}/send/`, { method: 'POST', body: fd })
+        const res = await aligoFetch(`${ALIGO_API_URL}/send/`, { method: 'POST', body: fd })
         const json = await res.json()
         // Aligo 스펙: result_code 는 Integer, >= 1 이면 성공.
         const codeNum = Number(json.result_code)

--- a/dental-clinic-manager/src/app/api/recall/sms/route.ts
+++ b/dental-clinic-manager/src/app/api/recall/sms/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { aligoFetch } from '@/lib/aligoFetch'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
@@ -110,7 +111,7 @@ export async function POST(request: NextRequest) {
     }
 
     // 알리고 API 호출
-    const aligoResponse = await fetch(`${ALIGO_API_URL}/send/`, {
+    const aligoResponse = await aligoFetch(`${ALIGO_API_URL}/send/`, {
       method: 'POST',
       body: formData
     })
@@ -173,8 +174,8 @@ export async function GET(request: NextRequest) {
     // IP 확인 요청인 경우
     if (checkIp === 'true') {
       try {
-        // 외부 서비스로 서버의 공인 IP 확인
-        const ipResponse = await fetch('https://api.ipify.org?format=json')
+        // 알리고가 보는 실제 발신 IP 를 알기 위해 알리고 호출과 동일한 프록시 경로로 조회
+        const ipResponse = await aligoFetch('https://api.ipify.org?format=json')
         const ipData = await ipResponse.json()
         return NextResponse.json({
           success: true,
@@ -218,7 +219,7 @@ export async function GET(request: NextRequest) {
     formData.append('key', aligoSettings.api_key)
     formData.append('user_id', aligoSettings.user_id)
 
-    const aligoResponse = await fetch(`${ALIGO_API_URL}/remain/`, {
+    const aligoResponse = await aligoFetch(`${ALIGO_API_URL}/remain/`, {
       method: 'POST',
       body: formData
     })

--- a/dental-clinic-manager/src/app/api/referrals/sms/route.ts
+++ b/dental-clinic-manager/src/app/api/referrals/sms/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { aligoFetch } from '@/lib/aligoFetch'
 
 const ALIGO_API_URL = 'https://apis.aligo.in'
 
@@ -60,7 +61,7 @@ export async function POST(req: NextRequest) {
     }
     if (process.env.NODE_ENV === 'development') formData.append('testmode_yn', 'Y')
 
-    const aligoRes = await fetch(`${ALIGO_API_URL}/send/`, { method: 'POST', body: formData })
+    const aligoRes = await aligoFetch(`${ALIGO_API_URL}/send/`, { method: 'POST', body: formData })
     const aligoJson = (await aligoRes.json()) as { result_code: string | number; message: string; msg_id?: string | number }
 
     if (process.env.NODE_ENV !== 'production') {
@@ -112,7 +113,8 @@ export async function POST(req: NextRequest) {
     if (isIpError) {
       let serverIp: string | null = null
       try {
-        const ipRes = await fetch('https://api.ipify.org?format=json', { cache: 'no-store' })
+        // 알리고가 본 발신 IP 를 정확히 확인하기 위해 동일한 프록시 경로(aligoFetch) 로 ipify 조회
+        const ipRes = await aligoFetch('https://api.ipify.org?format=json', { cache: 'no-store' })
         if (ipRes.ok) {
           const ipJson = (await ipRes.json()) as { ip?: string }
           serverIp = ipJson.ip ?? null

--- a/dental-clinic-manager/src/lib/aligoFetch.ts
+++ b/dental-clinic-manager/src/lib/aligoFetch.ts
@@ -1,0 +1,20 @@
+// 알리고 API 호출용 fetch 래퍼.
+// FIXIE_URL 이 설정돼 있으면 undici ProxyAgent 를 거쳐 Fixie 고정 IP 로 발신.
+// 미설정이면 기본 fetch 동작과 동일.
+//
+// 알리고는 발송 IP 화이트리스트(IP 인증) 정책을 운영하지만 Vercel 서버리스는
+// outbound IP 가 매 호출마다 달라져 화이트리스트를 유지할 수 없다. Fixie 가
+// 발급하는 고정 IP 풀로 모든 알리고 호출을 우회시키면 화이트리스트가 안정화된다.
+
+import { fetch as undiciFetch, ProxyAgent } from 'undici'
+
+const FIXIE_URL = process.env.FIXIE_URL?.trim()
+const dispatcher = FIXIE_URL ? new ProxyAgent(FIXIE_URL) : undefined
+
+export const aligoFetch = ((input, init) => {
+  if (!dispatcher) return globalThis.fetch(input, init)
+  return undiciFetch(
+    input as Parameters<typeof undiciFetch>[0],
+    { ...(init as object | undefined ?? {}), dispatcher }
+  ) as unknown as Promise<Response>
+}) as typeof fetch


### PR DESCRIPTION
## Summary
- 알리고 SMS 호출에 **Fixie 프록시(고정 IP) 경유** 옵션을 도입해 Vercel 서버리스의 동적 outbound IP 문제 해결
- \`FIXIE_URL\` 환경변수 미설정 시 기존 동작 유지(fallback) — 즉시 머지해도 안전
- \`src/lib/aligoFetch.ts\` 헬퍼(undici ProxyAgent) + 3개 API 라우트(\`referrals/sms\`, \`recall/sms\`, \`cron/referral-thanks\`) 모두 호출 경로 통일
- 동일 PR 에 develop 의 누적 변경(자동 구현 task 결과 등) 함께 포함

## 운영 시 후속 작업 (Vercel/알리고 측)
1. **Fixie 가입** — https://usefixie.com (무료 tricycle 부터, 운영 시 commuter \$5/mo 권장)
2. **Vercel 환경변수**: \`FIXIE_URL=http://fixie:<password>@criterium.usefixie.com:80\` (Production · Preview 모두)
3. **알리고 IP 화이트리스트**: Fixie 발급 고정 IP 2~3개를 알리고 고객센터(1661-1565)에 등록

## Test plan
- [x] \`npm run build\` 통과
- [ ] Vercel 환경변수 등록 후 재배포
- [ ] 알리고 IP 등록 후 \`/api/recall/sms?clinic_id=...&check_ip=true\` 로 발신 IP 가 Fixie 고정 IP 와 일치하는지 확인
- [ ] 리콜 SMS 1건 실제 발송 → 정상 수신 확인
- [ ] 소개 감사 SMS 1건 실제 발송 → 정상 수신 확인
- [ ] cron 자동 발송(매일 KST 09:00) 다음 날 결과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)