### PR TITLE
fix: yahoo period2 — 오늘 시점 데이터 누락

### DIFF
--- a/dental-clinic-manager/src/lib/intradayDataService.ts
+++ b/dental-clinic-manager/src/lib/intradayDataService.ts
@@ -121,8 +121,11 @@ async function fetchFromYahooIntraday(
   // 한국 종목은 .KS / .KQ 접미사 필요
   const symbol = market === 'KR' ? `${ticker}.KS` : ticker
 
-  const period1 = startDate
-  const period2 = endDate
+  // period2 를 'YYYY-MM-DD' 문자열로 넘기면 yahoo가 UTC 00:00으로 해석해
+  // endDate 당일 데이터(특히 ET 정규장 13:30~20:00 UTC)가 모두 누락됨.
+  // → endDate 의 23:59:59.999Z Date 객체로 명시해 당일 봉까지 포함.
+  const period1 = new Date(`${startDate}T00:00:00.000Z`)
+  const period2 = new Date(`${endDate}T23:59:59.999Z`)
 
   const tryFetch = async (sym: string): Promise<OHLCV[]> => {
     const result = await yahooFinance.chart(sym, {

--- a/dental-clinic-manager/src/lib/stockDataService.ts
+++ b/dental-clinic-manager/src/lib/stockDataService.ts
@@ -86,9 +86,14 @@ async function fetchFromYahooFinance(
   // 한국 종목은 .KS (KOSPI) 또는 .KQ (KOSDAQ) 접미사 필요
   const symbol = market === 'KR' ? `${ticker}.KS` : ticker
 
+  // period2 를 'YYYY-MM-DD' 문자열로 넘기면 yahoo가 UTC 00:00으로 해석해 endDate 당일 일봉이 누락될 수 있음.
+  // → 23:59:59.999Z Date 객체로 명시해 endDate 일봉도 포함.
+  const period1 = new Date(`${startDate}T00:00:00.000Z`)
+  const period2 = new Date(`${endDate}T23:59:59.999Z`)
+
   const result = await yahooFinance.chart(symbol, {
-    period1: startDate,
-    period2: endDate,
+    period1,
+    period2,
     interval: '1d',
   })
 
@@ -96,8 +101,8 @@ async function fetchFromYahooFinance(
     // KOSPI에서 못 찾으면 KOSDAQ 시도
     if (market === 'KR') {
       const kosdaqResult = await yahooFinance.chart(`${ticker}.KQ`, {
-        period1: startDate,
-        period2: endDate,
+        period1,
+        period2,
         interval: '1d',
       })
       if (kosdaqResult?.quotes && kosdaqResult.quotes.length > 0) {


### PR DESCRIPTION
## Summary
- yahoo-finance2 chart 의 period2 를 'YYYY-MM-DD' 문자열로 전달해 endDate 당일 데이터(특히 ET 정규장 전체)가 누락되던 버그
- intradayDataService / stockDataService 둘 다 Date 객체로 명시 (endDate 23:59:59.999Z)
- 스마트머니 분석 byDay 의 "오늘" 탭이 정상 노출되어 사용자가 today 분석 결과를 볼 수 있음

🤖 Generated with [Claude Code](https://claude.com/claude-code)