### PR TITLE
fix(notifications): 프로토콜 검토 알림 클릭 라우팅 수정

### DIFF
--- a/dental-clinic-manager/src/components/Layout/UserNotificationDropdown.tsx
+++ b/dental-clinic-manager/src/components/Layout/UserNotificationDropdown.tsx
@@ -73,14 +73,23 @@ const DEFAULT_NOTIFICATION_LINKS: Partial<Record<UserNotificationType, string>> 
   telegram_board_pending: '/dashboard/community/admin?tab=telegram',
   task_assigned: '/dashboard/tasks',
   task_completed: '/dashboard/tasks',
-  protocol_review_requested: '/management?tab=protocols',
-  protocol_review_approved: '/management?tab=protocols',
-  protocol_review_rejected: '/management?tab=protocols',
+  protocol_review_requested: '/dashboard?tab=protocols',
+  protocol_review_approved: '/dashboard?tab=protocols',
+  protocol_review_rejected: '/dashboard?tab=protocols',
+}
+
+// 과거에 저장된 잘못된 링크(/management?tab=protocols...)를 정상 경로로 보정
+function normalizeNotificationLink(link: string): string {
+  if (link.startsWith('/management?tab=protocols')) {
+    return link.replace('/management?tab=protocols', '/dashboard?tab=protocols')
+  }
+  return link
 }
 
 // 알림의 이동 링크 결정 (명시적 link > 타입별 기본 link)
 function getNotificationLink(notification: UserNotification): string | null {
-  return notification.link || DEFAULT_NOTIFICATION_LINKS[notification.type] || null
+  const raw = notification.link || DEFAULT_NOTIFICATION_LINKS[notification.type] || null
+  return raw ? normalizeNotificationLink(raw) : null
 }
 
 // 상대 시간 계산

--- a/dental-clinic-manager/src/components/Management/ProtocolManagement.tsx
+++ b/dental-clinic-manager/src/components/Management/ProtocolManagement.tsx
@@ -509,7 +509,7 @@ export default function ProtocolManagement({ currentUser, hideHeader = false }: 
                 type: 'protocol_review_requested',
                 title: '프로토콜 검토 요청',
                 content: `${userName}님이 "${editingProtocol.title}" 프로토콜의 검토를 요청했습니다`,
-                link: `/management?tab=protocols&review=${editingProtocol.id}`,
+                link: `/dashboard?tab=protocols&review=${editingProtocol.id}`,
                 reference_type: 'protocol_review',
                 reference_id: reviewResult.data.id,
               }))

--- a/dental-clinic-manager/src/components/Protocol/ProtocolDetail.tsx
+++ b/dental-clinic-manager/src/components/Protocol/ProtocolDetail.tsx
@@ -159,7 +159,7 @@ export default function ProtocolDetail({
             type: 'protocol_review_requested',
             title: '프로토콜 검토 요청',
             content: `${userName}님이 "${protocol.title}" 프로토콜의 검토를 요청했습니다`,
-            link: `/management?tab=protocols&review=${protocolId}`,
+            link: `/dashboard?tab=protocols&review=${protocolId}`,
             reference_type: 'protocol_review',
             reference_id: result.data.id,
           }))
@@ -197,7 +197,7 @@ export default function ProtocolDetail({
             type: 'protocol_review_approved',
             title: '프로토콜 검토 승인',
             content: `"${protocol.title}" 프로토콜이 승인되어 활성화되었습니다`,
-            link: `/management?tab=protocols&view=${protocolId}`,
+            link: `/dashboard?tab=protocols&view=${protocolId}`,
             reference_type: 'protocol_review',
             reference_id: pendingReview.id,
           }]
@@ -235,7 +235,7 @@ export default function ProtocolDetail({
             type: 'protocol_review_rejected',
             title: '프로토콜 검토 반려',
             content: rejectContent,
-            link: `/management?tab=protocols&view=${protocolId}`,
+            link: `/dashboard?tab=protocols&view=${protocolId}`,
             reference_type: 'protocol_review',
             reference_id: pendingReview.id,
           }]

--- a/dental-clinic-manager/src/lib/userNotificationService.ts
+++ b/dental-clinic-manager/src/lib/userNotificationService.ts
@@ -550,7 +550,7 @@ export const userNotificationService = {
       type: 'protocol_review_requested',
       title: '프로토콜 검토 요청',
       content: `${requesterName}님이 "${protocolTitle}" 프로토콜의 검토를 요청했습니다`,
-      link: `/management?tab=protocols&review=${protocolId}`,
+      link: `/dashboard?tab=protocols&review=${protocolId}`,
       reference_type: 'protocol_review',
       reference_id: reviewId,
     })
@@ -570,7 +570,7 @@ export const userNotificationService = {
       type: 'protocol_review_approved',
       title: '프로토콜 검토 승인',
       content: `"${protocolTitle}" 프로토콜이 승인되어 활성화되었습니다`,
-      link: `/management?tab=protocols&view=${protocolId}`,
+      link: `/dashboard?tab=protocols&view=${protocolId}`,
       reference_type: 'protocol_review',
       reference_id: reviewId,
     })
@@ -594,7 +594,7 @@ export const userNotificationService = {
       content: reason
         ? `"${protocolTitle}" 프로토콜이 반려되었습니다. 사유: ${reason}`
         : `"${protocolTitle}" 프로토콜이 반려되었습니다`,
-      link: `/management?tab=protocols&view=${protocolId}`,
+      link: `/dashboard?tab=protocols&view=${protocolId}`,
       reference_type: 'protocol_review',
       reference_id: reviewId,
     })


### PR DESCRIPTION
## Summary
- 알림 링크가 `/management?tab=protocols`였으나 해당 페이지에 protocols 서브탭이 없어 빈 화면이 노출되던 문제 수정 → `/dashboard?tab=protocols`로 변경
- 기존 DB에 누적된 알림도 동작하도록 클릭 시점에 legacy URL 정규화 추가
- 검토 요청 / 승인 / 반려 알림 모두 동일 경로 사용

## Test plan
- [x] `npm run build` 성공
- [ ] owner 계정으로 알림 클릭 → 프로토콜 상세 모달 자동 오픈, 승인/반려 버튼 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)