### PR TITLE
fix(investment/compare): 모바일 최근/즐겨찾기 종목 노출 수정

### DIFF
--- a/dental-clinic-manager/src/components/Investment/FavoritesButtons.tsx
+++ b/dental-clinic-manager/src/components/Investment/FavoritesButtons.tsx
@@ -42,8 +42,8 @@ export default function FavoritesButtons({
   if (filtered.length === 0) return null
 
   return (
-    <div className="flex flex-wrap gap-1.5 items-center">
-      <span className="text-xs text-at-text-weak inline-flex items-center gap-1 mr-1">
+    <div className="flex flex-nowrap sm:flex-wrap gap-1.5 items-center overflow-x-auto sm:overflow-visible -mx-1 px-1 sm:mx-0 sm:px-0 pb-1 sm:pb-0 scrollbar-thin">
+      <span className="text-xs text-at-text-weak inline-flex items-center gap-1 mr-1 flex-shrink-0">
         <Star className="w-3 h-3 text-amber-500" />
         {label}:
       </span>
@@ -54,7 +54,7 @@ export default function FavoritesButtons({
         return (
           <span
             key={key}
-            className={`inline-flex items-center rounded text-xs ${
+            className={`inline-flex items-center rounded text-xs flex-shrink-0 ${
               compact
                 ? 'px-1.5 py-0.5 bg-amber-50 text-at-text-secondary border border-amber-200/60'
                 : 'px-2 py-1 bg-amber-50 text-at-text-secondary border border-amber-200/60'

--- a/dental-clinic-manager/src/components/Investment/RecentTickersButtons.tsx
+++ b/dental-clinic-manager/src/components/Investment/RecentTickersButtons.tsx
@@ -41,8 +41,8 @@ export default function RecentTickersButtons({
   if (filtered.length === 0) return null
 
   return (
-    <div className="flex flex-wrap gap-1.5 items-center">
-      <span className="text-xs text-at-text-weak inline-flex items-center gap-1 mr-1">
+    <div className="flex flex-nowrap sm:flex-wrap gap-1.5 items-center overflow-x-auto sm:overflow-visible -mx-1 px-1 sm:mx-0 sm:px-0 pb-1 sm:pb-0 scrollbar-thin">
+      <span className="text-xs text-at-text-weak inline-flex items-center gap-1 mr-1 flex-shrink-0">
         <History className="w-3 h-3" />
         {label}:
       </span>
@@ -52,7 +52,7 @@ export default function RecentTickersButtons({
         return (
           <span
             key={key}
-            className={`inline-flex items-center rounded text-xs ${
+            className={`inline-flex items-center rounded text-xs flex-shrink-0 ${
               compact
                 ? 'px-1.5 py-0.5 bg-at-bg text-at-text-secondary'
                 : 'px-2 py-1 bg-at-bg text-at-text-secondary'


### PR DESCRIPTION
## Summary
- 모바일에서 \`RecentTickersButtons\` / \`FavoritesButtons\` 의 chip들이 1개만 노출되던 현상 수정
- 모바일은 가로 스크롤(flex-nowrap + overflow-x-auto), sm 이상은 기존 flex-wrap 유지
- 각 chip에 \`flex-shrink-0\` 적용해 폭 보장

## Test plan
- [x] \`npm run build\` 성공
- [ ] 모바일 뷰포트에서 전략 비교 페이지 → 최근/즐겨찾기 종목 가로 스크롤로 모두 노출되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)