### PR TITLE
feat(investment): 최근 종목 서버 영속 + 비교 히스토리 limit 수정

### DIFF
--- a/dental-clinic-manager/.claude/WORK_LOG.md
+++ b/dental-clinic-manager/.claude/WORK_LOG.md
@@ -10,6 +10,38 @@
 
 ---
 
+## 2026-05-09 [기능 개발] 부동산 경매 투자 분석 도구 (MVP)
+
+**키워드:** #investment #auction #real-estate #ai-analysis #scraping-worker #court-auction #molit
+
+### 📋 작업 내용
+- 투자 카테고리에 `/investment/auction` 추가 (목록/상세 5탭/관심물건)
+- ROI 3단계 다층 모델: 1차(객관 — 할인율/유찰/D-day/㎡당가) / 2차(시세 매칭) / 3차(임대 시뮬)
+- DB 7개 테이블: `auction_items`, `auction_history`, `auction_market_prices`, `auction_rights_analysis`, `auction_ai_comments`, `auction_user_favorites`, `auction_user_filters`
+- AI 권리분석 코멘트 — Claude Haiku 4.5 + 24h DB 캐시 + prompt caching (사용자 클릭 트리거)
+- 5개 신규 API: `/api/auction/items`, `/[itemId]`, `/[itemId]/complex-stats`, `/favorites`, `/ai-comment/[itemId]`
+- 권한 3종 (auction_view/favorite/ai) + 메뉴(투자 사이드바 + 중앙 menuConfig)
+- Mac mini M4 워커 (`scraping-worker/auction/`): Playwright 스크래퍼 + PDF 파서 + 국토부 OpenAPI 시세 매칭 + cron 진입점 (TDD 10개 테스트 통과)
+
+### ✅ 검증
+- `npm run build` 통과 (auction 라우트 8개 모두 등록)
+- `npm run check:permissions` 통과 (Permission union 92 / GROUPS 92 / DESCRIPTIONS 92)
+- `roiCalculator` 21개 단위 테스트 통과
+- 워커 `noticeParser`/`marketPriceMatcher` 10개 단위 테스트 통과
+- develop 푸시 → main PR #544 머지 (`9dfcf27a`)
+
+### 🔍 후속 작업 (Phase 2)
+- `resolveLawdCd` placeholder — 행정안전부 OpenAPI 매핑 테이블 추가 필요 (현재 시세 매칭 스킵)
+- courtauction.go.kr 셀렉터 캘리브레이션 (Mac mini M4 첫 실행 시)
+- 지도 클러스터링 / 임장 노트 / 공동투자 메모 / 토지 시세 추정
+
+### 💡 배운 점
+- 한국 법원경매 OpenAPI는 사실상 부재 → courtauction.go.kr 자체 스크래핑 + 국토부 OpenAPI 보조 하이브리드가 시장 표준
+- ROI 종류별 정확도 차이를 신뢰도(High/Mid/Low)로 명시 노출 → 사용자 오해 방지
+- AI 권리분석은 룰 기반 1차 추출 + 사용자 클릭 시 보강 → 비용 통제 + 의도된 호출만 발생
+
+---
+
 ## 2026-05-06 [기능 개발] 종목 상세 모달 + 즐겨찾기 시스템
 
 **키워드:** #investment #favorites #ticker-info #screener #yahoo-finance2 #broadcast-channel

--- a/dental-clinic-manager/src/app/api/investment/recent-tickers/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/recent-tickers/route.ts
@@ -1,0 +1,159 @@
+/**
+ * 사용자 최근 사용 종목 — 서버 영속(투자 모듈 공용).
+ *
+ *   GET    /api/investment/recent-tickers
+ *   POST   /api/investment/recent-tickers          { ticker, market, ticker_name? }
+ *                                                  (upsert: last_used_at = now())
+ *   POST   /api/investment/recent-tickers          { items: [...] }   (배치 업로드 — 마이그레이션용)
+ *   DELETE /api/investment/recent-tickers?ticker=...&market=KR|US
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+
+interface Row {
+  ticker: string
+  market: 'KR' | 'US'
+  ticker_name: string | null
+  last_used_at: string
+}
+
+const MAX_ITEMS = 24
+
+function isMarket(v: unknown): v is 'KR' | 'US' {
+  return v === 'KR' || v === 'US'
+}
+
+export async function GET() {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 필요' }, { status: auth.status || 401 })
+  }
+
+  const supabase = await createClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase as any)
+    .from('investment_recent_tickers')
+    .select('ticker, market, ticker_name, last_used_at')
+    .order('last_used_at', { ascending: false })
+    .limit(MAX_ITEMS)
+
+  if (error) {
+    console.error('[recent-tickers] GET error:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const items = ((data ?? []) as Row[]).map((r) => ({
+    ticker: r.ticker,
+    market: r.market,
+    name: r.ticker_name ?? r.ticker,
+    lastUsed: new Date(r.last_used_at).getTime(),
+  }))
+  return NextResponse.json({ items })
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 필요' }, { status: auth.status || 401 })
+  }
+
+  let body: { ticker?: string; market?: string; ticker_name?: string | null; items?: Array<{ ticker: string; market: string; ticker_name?: string | null; last_used_at?: string }> }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: '본문 파싱 실패' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const userId = auth.user.id
+
+  // 배치 업로드 — localStorage 마이그레이션용
+  if (Array.isArray(body.items)) {
+    const rows = body.items
+      .map((it) => ({
+        ticker: (it.ticker ?? '').trim().toUpperCase(),
+        market: it.market,
+        ticker_name: it.ticker_name ?? null,
+        last_used_at: it.last_used_at ?? new Date().toISOString(),
+      }))
+      .filter((r) => r.ticker && isMarket(r.market))
+      .map((r) => ({ user_id: userId, ...r }))
+      .slice(0, MAX_ITEMS * 4)
+    if (rows.length === 0) return NextResponse.json({ ok: true, imported: 0 })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error } = await (supabase as any)
+      .from('investment_recent_tickers')
+      .upsert(rows, { onConflict: 'user_id,ticker,market', ignoreDuplicates: false })
+    if (error) {
+      console.error('[recent-tickers] batch upsert error:', error)
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+    return NextResponse.json({ ok: true, imported: rows.length })
+  }
+
+  const ticker = (body.ticker ?? '').trim().toUpperCase()
+  const market = body.market
+  if (!ticker) return NextResponse.json({ error: 'ticker 누락' }, { status: 400 })
+  if (!isMarket(market)) return NextResponse.json({ error: 'market 잘못됨' }, { status: 400 })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase as any)
+    .from('investment_recent_tickers')
+    .upsert(
+      {
+        user_id: userId,
+        ticker,
+        market,
+        ticker_name: body.ticker_name ?? null,
+        last_used_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id,ticker,market', ignoreDuplicates: false },
+    )
+    .select('ticker, market, ticker_name, last_used_at')
+    .single()
+
+  if (error) {
+    console.error('[recent-tickers] POST error:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({
+    ok: true,
+    item: {
+      ticker: data.ticker,
+      market: data.market,
+      name: data.ticker_name ?? data.ticker,
+      lastUsed: new Date(data.last_used_at).getTime(),
+    },
+  })
+}
+
+export async function DELETE(req: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 필요' }, { status: auth.status || 401 })
+  }
+
+  const { searchParams } = new URL(req.url)
+  const ticker = (searchParams.get('ticker') ?? '').trim().toUpperCase()
+  const market = searchParams.get('market')
+  if (!ticker) return NextResponse.json({ error: 'ticker 누락' }, { status: 400 })
+  if (!isMarket(market)) return NextResponse.json({ error: 'market 잘못됨' }, { status: 400 })
+
+  const supabase = await createClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (supabase as any)
+    .from('investment_recent_tickers')
+    .delete()
+    .eq('user_id', auth.user.id)
+    .eq('ticker', ticker)
+    .eq('market', market)
+
+  if (error) {
+    console.error('[recent-tickers] DELETE error:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ ok: true })
+}

--- a/dental-clinic-manager/src/components/Investment/CompareHistory/HistoryTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/CompareHistory/HistoryTab.tsx
@@ -49,7 +49,8 @@ const daysAgo = (n: number) => {
 const DEFAULT_FILTER: HistoryFilterState = {
   strategyId: '',     // '전체'
   ticker: '',
-  preset: '30d',
+  preset: 'all',      // 기본은 전체 — 다중 종목·다중 전략 비교 시 한 세션이 50건을 쉽게 넘어
+                      // 좁은 기간 필터 + 작은 limit 조합으로 옛 기록이 가려지던 문제를 막는다.
 }
 
 function presetToSince(preset: HistoryFilterState['preset']): string | null {
@@ -93,7 +94,9 @@ export default function HistoryTab() {
         if (filter.ticker.trim()) params.set('ticker', filter.ticker.trim())
         const since = presetToSince(filter.preset)
         if (since) params.set('since', since)
-        params.set('limit', '50')
+        // 비교 한 번에 N종목 × M전략(예: 10×5=50) 행이 생성될 수 있어 작은 limit이면
+        // 오늘 세션이 차지하고 옛 기록이 잘려 보인다. 서버 캡(500)에 가깝게 충분히 키운다.
+        params.set('limit', '500')
         const r = await fetch(`/api/investment/backtest?${params.toString()}`)
         if (!r.ok) {
           const err = (await r.json().catch(() => ({}))) as { error?: string }

--- a/dental-clinic-manager/src/hooks/useRecentTickers.ts
+++ b/dental-clinic-manager/src/hooks/useRecentTickers.ts
@@ -1,75 +1,131 @@
 'use client'
 
 /**
- * 사용자가 입력했던 종목을 localStorage에 보관 → 다른 페이지에서 빠른 추가 버튼으로 활용.
+ * 사용자가 입력했던 종목을 서버(Supabase `investment_recent_tickers`)에 영속.
  * 모든 종목 입력 페이지(전략관리/단타/비교/스마트머니)에서 통합 사용.
+ *
+ * 디바이스/브라우저에 무관하게 계정 단위로 동일하게 유지된다.
+ * 이전 localStorage(`dcm.recentTickers.v1`) 데이터는 첫 로드 시 1회 서버에 업로드 후 정리.
  */
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Market } from '@/types/investment'
 
 export interface RecentTicker {
   ticker: string
   name: string
   market: Market
-  /** 마지막 사용 시각 (ms) — 정렬용 */
+  /** 마지막 사용 시각 (ms) */
   lastUsed: number
 }
 
-const STORAGE_KEY = 'dcm.recentTickers.v1'
-const MAX_ITEMS = 24
-const STORAGE_EVENT = 'dcm:recent-tickers-changed'
+const LEGACY_STORAGE_KEY = 'dcm.recentTickers.v1'
+const MIGRATION_FLAG_KEY = 'dcm.recentTickers.migratedAt'
+const BROADCAST_CHANNEL = 'dcm-recent-tickers-v1'
 
-function readStorage(): RecentTicker[] {
+interface ListResponse {
+  items?: RecentTicker[]
+  error?: string
+}
+
+function readLegacy(): RecentTicker[] {
   if (typeof window === 'undefined') return []
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY)
+    const raw = window.localStorage.getItem(LEGACY_STORAGE_KEY)
     if (!raw) return []
     const parsed = JSON.parse(raw)
     if (!Array.isArray(parsed)) return []
-    // 스키마 정합성 + 최신순
-    return parsed
-      .filter((x): x is RecentTicker =>
-        x && typeof x.ticker === 'string' && typeof x.name === 'string'
-        && (x.market === 'KR' || x.market === 'US')
-        && typeof x.lastUsed === 'number',
-      )
-      .sort((a, b) => b.lastUsed - a.lastUsed)
-      .slice(0, MAX_ITEMS)
+    return parsed.filter((x): x is RecentTicker =>
+      x && typeof x.ticker === 'string' && typeof x.name === 'string'
+      && (x.market === 'KR' || x.market === 'US')
+      && typeof x.lastUsed === 'number',
+    )
   } catch {
     return []
   }
 }
 
-function writeStorage(items: RecentTicker[]): void {
-  if (typeof window === 'undefined') return
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items))
-    // 같은 탭의 다른 hook 인스턴스 동기화용 — 'storage' 이벤트는 다른 탭만 발생
-    window.dispatchEvent(new CustomEvent(STORAGE_EVENT))
-  } catch {
-    /* quota exceeded 등 — 무시 */
-  }
-}
-
 export function useRecentTickers(): {
   items: RecentTicker[]
+  loading: boolean
   add: (ticker: string, name: string, market: Market) => void
   remove: (ticker: string, market: Market) => void
   clear: () => void
+  refresh: () => Promise<void>
 } {
-  const [items, setItems] = useState<RecentTicker[]>(() => readStorage())
+  const [items, setItems] = useState<RecentTicker[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const channelRef = useRef<BroadcastChannel | null>(null)
+  const migratedRef = useRef<boolean>(false)
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch('/api/investment/recent-tickers', { cache: 'no-store' })
+      if (!res.ok) {
+        if (res.status === 401) setItems([])
+        return
+      }
+      const data: ListResponse = await res.json()
+      setItems(data.items ?? [])
+    } catch {
+      /* 네트워크 오류 — 무시 (다음 호출에서 복구) */
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // 첫 마운트 시: legacy localStorage → 서버 1회 업로드 후 정리, 그리고 서버에서 목록 로드
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      if (typeof window !== 'undefined' && !migratedRef.current) {
+        migratedRef.current = true
+        const legacy = readLegacy()
+        const alreadyMigrated = window.localStorage.getItem(MIGRATION_FLAG_KEY)
+        if (legacy.length > 0 && !alreadyMigrated) {
+          try {
+            const res = await fetch('/api/investment/recent-tickers', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                items: legacy.map((it) => ({
+                  ticker: it.ticker,
+                  market: it.market,
+                  ticker_name: it.name,
+                  last_used_at: new Date(it.lastUsed).toISOString(),
+                })),
+              }),
+            })
+            if (res.ok) {
+              window.localStorage.setItem(MIGRATION_FLAG_KEY, new Date().toISOString())
+              window.localStorage.removeItem(LEGACY_STORAGE_KEY)
+            }
+          } catch { /* 다음 마운트에서 재시도 */ }
+        } else if (legacy.length === 0 && !alreadyMigrated) {
+          window.localStorage.setItem(MIGRATION_FLAG_KEY, new Date().toISOString())
+        }
+      }
+      if (!cancelled) await refresh()
+    })()
+    return () => { cancelled = true }
+  }, [refresh])
 
   // 다른 탭/같은 탭의 다른 인스턴스 변경 동기화
   useEffect(() => {
-    if (typeof window === 'undefined') return
-    const sync = () => setItems(readStorage())
-    window.addEventListener('storage', sync)
-    window.addEventListener(STORAGE_EVENT, sync)
-    return () => {
-      window.removeEventListener('storage', sync)
-      window.removeEventListener(STORAGE_EVENT, sync)
+    if (typeof window === 'undefined' || typeof BroadcastChannel === 'undefined') return
+    const ch = new BroadcastChannel(BROADCAST_CHANNEL)
+    channelRef.current = ch
+    ch.onmessage = (ev) => {
+      if (ev?.data === 'changed') refresh()
     }
+    return () => {
+      ch.close()
+      channelRef.current = null
+    }
+  }, [refresh])
+
+  const broadcast = useCallback(() => {
+    try { channelRef.current?.postMessage('changed') } catch { /* noop */ }
   }, [])
 
   const add = useCallback((ticker: string, name: string, market: Market) => {
@@ -77,26 +133,54 @@ export function useRecentTickers(): {
     const tickerUpper = ticker.trim().toUpperCase()
     if (!tickerUpper) return
     const cleanName = (name && name.trim()) || tickerUpper
+
+    // optimistic — UI 즉시 반영
     setItems((prev) => {
       const filtered = prev.filter((x) => !(x.ticker === tickerUpper && x.market === market))
-      const next = [{ ticker: tickerUpper, name: cleanName, market, lastUsed: Date.now() }, ...filtered].slice(0, MAX_ITEMS)
-      writeStorage(next)
-      return next
+      return [{ ticker: tickerUpper, name: cleanName, market, lastUsed: Date.now() }, ...filtered]
     })
-  }, [])
+
+    // 서버 동기화 (fire-and-forget)
+    void (async () => {
+      try {
+        const res = await fetch('/api/investment/recent-tickers', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ticker: tickerUpper, market, ticker_name: cleanName }),
+        })
+        if (res.ok) broadcast()
+      } catch { /* 무시 */ }
+    })()
+  }, [broadcast])
 
   const remove = useCallback((ticker: string, market: Market) => {
-    setItems((prev) => {
-      const next = prev.filter((x) => !(x.ticker === ticker.toUpperCase() && x.market === market))
-      writeStorage(next)
-      return next
-    })
-  }, [])
+    if (!ticker) return
+    const tickerUpper = ticker.toUpperCase()
+    const before = items
+    setItems((prev) => prev.filter((x) => !(x.ticker === tickerUpper && x.market === market)))
+    void (async () => {
+      try {
+        const res = await fetch(`/api/investment/recent-tickers?ticker=${encodeURIComponent(tickerUpper)}&market=${market}`, {
+          method: 'DELETE',
+        })
+        if (res.ok) broadcast()
+        else setItems(before)
+      } catch { setItems(before) }
+    })()
+  }, [items, broadcast])
 
   const clear = useCallback(() => {
+    const before = items
     setItems([])
-    writeStorage([])
-  }, [])
+    void (async () => {
+      try {
+        await Promise.all(before.map((it) =>
+          fetch(`/api/investment/recent-tickers?ticker=${encodeURIComponent(it.ticker)}&market=${it.market}`, { method: 'DELETE' }),
+        ))
+        broadcast()
+      } catch { /* 무시 */ }
+    })()
+  }, [items, broadcast])
 
-  return { items, add, remove, clear }
+  return { items, loading, add, remove, clear, refresh }
 }

--- a/dental-clinic-manager/supabase/migrations/20260509_investment_recent_tickers.sql
+++ b/dental-clinic-manager/supabase/migrations/20260509_investment_recent_tickers.sql
@@ -1,0 +1,45 @@
+-- ============================================
+-- 투자 모듈 — 사용자별 최근 사용 종목 (서버 영속)
+-- - investment_recent_tickers: (user_id, ticker, market) UNIQUE, last_used_at 기준 정렬
+-- 기존 localStorage 기반(`dcm.recentTickers.v1`)에서 서버 백엔드로 이행하여
+-- 디바이스 간 동일하게 유지되도록 함.
+-- Migration: 20260509_investment_recent_tickers.sql
+-- Created: 2026-05-09
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS investment_recent_tickers (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  ticker        VARCHAR(20) NOT NULL,
+  market        VARCHAR(2)  NOT NULL CHECK (market IN ('KR','US')),
+  ticker_name   TEXT,
+  last_used_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, ticker, market)
+);
+
+CREATE INDEX IF NOT EXISTS idx_inv_recent_user_last_used
+  ON investment_recent_tickers (user_id, last_used_at DESC);
+
+ALTER TABLE investment_recent_tickers ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "inv_recent_select_own" ON investment_recent_tickers;
+CREATE POLICY "inv_recent_select_own" ON investment_recent_tickers
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "inv_recent_insert_own" ON investment_recent_tickers;
+CREATE POLICY "inv_recent_insert_own" ON investment_recent_tickers
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "inv_recent_update_own" ON investment_recent_tickers;
+CREATE POLICY "inv_recent_update_own" ON investment_recent_tickers
+  FOR UPDATE TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "inv_recent_delete_own" ON investment_recent_tickers;
+CREATE POLICY "inv_recent_delete_own" ON investment_recent_tickers
+  FOR DELETE TO authenticated
+  USING (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- 최근 사용 종목 — localStorage → Supabase 서버 영속으로 이행해 계정별 동일 유지
  - 신규 테이블 \`investment_recent_tickers\` + RLS, \`/api/investment/recent-tickers\`
  - \`useRecentTickers\` 훅 서버 백엔드로 교체, 기존 localStorage 1회 자동 마이그레이션
- 비교 히스토리 — 옛 기록이 가려지던 문제 수정
  - 기본 기간 필터 30일 → 전체
  - 클라이언트 limit 50 → 500 (서버 캡)

## Test plan
- [x] \`npm run build\` 성공, DB 마이그레이션 적용 완료
- [ ] 두 디바이스에서 같은 계정으로 종목 입력 시 양쪽 \"최근 사용 종목\"에 동일 노출
- [ ] 비교 페이지 히스토리 탭에서 30일 이전 기록도 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)