### PR TITLE
chore(cron): 텔레그램 일일요약을 다음날 KST 10시 발송으로 분리

### DIFF
--- a/dental-clinic-manager/src/app/api/cron/daily-tasks/route.ts
+++ b/dental-clinic-manager/src/app/api/cron/daily-tasks/route.ts
@@ -1,9 +1,8 @@
-// 일일 작업 통합 크론 (뉴스 크롤링 + 텔레그램 요약)
-// Vercel Hobby 플랜 크론 2개 제한으로 인해 news + telegram-summary 통합
+// 일일 작업 크론 (뉴스 크롤링)
+// 텔레그램 요약은 다음날 KST 10시 발송 정책에 따라 /api/cron/telegram-summary 로 분리됨.
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { runNewsCrawl } from '@/lib/newsCrawlService'
-import { runTelegramSummary } from '@/lib/telegramSummaryCron'
 
 export const maxDuration = 60
 
@@ -22,20 +21,18 @@ export async function GET(request: Request) {
 
   const supabase = createClient(supabaseUrl, supabaseServiceKey)
 
-  // 뉴스 + 텔레그램 요약을 병렬 실행
-  const [newsResult, summaryResult] = await Promise.allSettled([
-    runNewsCrawl(supabase),
-    runTelegramSummary(supabase),
-  ])
-
-  return NextResponse.json({
-    success: true,
-    news: newsResult.status === 'fulfilled'
-      ? { success: true, results: newsResult.value }
-      : { success: false, error: newsResult.reason?.message ?? 'Unknown error' },
-    telegramSummary: summaryResult.status === 'fulfilled'
-      ? { success: true, results: summaryResult.value }
-      : { success: false, error: summaryResult.reason?.message ?? 'Unknown error' },
-    timestamp: new Date().toISOString(),
-  })
+  try {
+    const news = await runNewsCrawl(supabase)
+    return NextResponse.json({
+      success: true,
+      news: { success: true, results: news },
+      timestamp: new Date().toISOString(),
+    })
+  } catch (error) {
+    return NextResponse.json({
+      success: false,
+      news: { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      timestamp: new Date().toISOString(),
+    }, { status: 500 })
+  }
 }

--- a/dental-clinic-manager/vercel.json
+++ b/dental-clinic-manager/vercel.json
@@ -15,6 +15,10 @@
       "schedule": "30 15 * * *"
     },
     {
+      "path": "/api/cron/telegram-summary",
+      "schedule": "0 1 * * *"
+    },
+    {
       "path": "/api/cron/generate-approved-posts",
       "schedule": "0 18 * * *"
     },


### PR DESCRIPTION
## Summary
- 텔레그램 방 일일요약 발송 시점을 다음날 오전 10시(KST)로 변경
- \`vercel.json\`에 \`/api/cron/telegram-summary\` 별도 등록 (\`0 1 * * *\` UTC = KST 10:00)
- \`daily-tasks\` 크론은 뉴스 크롤링만 담당하도록 정리(요약 실행 제거)

## Test plan
- [x] \`npm run build\` 성공
- [ ] Vercel 크론 대시보드에서 \`/api/cron/telegram-summary\` 신규 항목이 KST 10:00에 등록됐는지 확인
- [ ] 발송 다음날 오전 10시 이후 텔레그램 그룹에 어제 요약이 1회 게시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)