### PR TITLE
fix(strategy): RSI ID 깨짐 버그 + 프리셋 변형 UX + 전략 세부 보기

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778341982448'
+const SW_VERSION = 'v1778345060553'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/IndicatorPanel.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/IndicatorPanel.tsx
@@ -131,11 +131,12 @@ export default function IndicatorPanel({ indicators, onChange }: Props) {
       alert('지표는 최대 8개까지 추가 가능합니다')
       return
     }
-    const id = generateId(template.type, template.defaultParams)
-    // 중복 체크
-    if (indicators.some(i => i.id === id)) {
-      alert('이미 추가된 지표입니다')
-      return
+    // 동일 type 추가 시 ID 충돌 자동 회피 (RSI_14 → RSI_14_2 → ...)
+    let baseId = generateId(template.type, template.defaultParams)
+    let id = baseId
+    let seq = 2
+    while (indicators.some(i => i.id === id)) {
+      id = `${baseId}_${seq++}`
     }
     onChange([...indicators, { id, type: template.type, params: { ...template.defaultParams } }])
     setShowAdd(false)
@@ -146,11 +147,11 @@ export default function IndicatorPanel({ indicators, onChange }: Props) {
   }
 
   const updateParam = (id: string, key: string, value: number) => {
+    // ⚠️ ID 는 변경하지 않음 — 매수/매도 조건이 indicator.id 를 참조하므로
+    // params 변경 때마다 ID 가 바뀌면 조건 ref 가 끊겨 시그널이 동작 안 함 (사용자 보고 RSI 버그).
     onChange(indicators.map(ind => {
       if (ind.id !== id) return ind
-      const newParams = { ...ind.params, [key]: value }
-      const newId = generateId(ind.type, newParams)
-      return { ...ind, id: newId, params: newParams }
+      return { ...ind, params: { ...ind.params, [key]: value } }
     }))
   }
 

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/StrategyBuilder.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/StrategyBuilder.tsx
@@ -47,13 +47,16 @@ export default function StrategyBuilder({ onSaved, onCancel }: Props) {
   }
 
   const applyPreset = (preset: PresetStrategy) => {
-    setName(preset.name)
+    // 프리셋 이름에 (커스텀) suffix — 사용자가 자기 색깔로 이름/설명 수정 후 진행하도록 유도.
+    setName(`${preset.name} (커스텀)`)
     setDescription(preset.description)
     setIndicators(preset.indicators)
     setBuyConditions(preset.buyConditions)
     setSellConditions(preset.sellConditions)
     setSourcePresetId(preset.id)
-    setStep('indicators')
+    // step 을 'basic' 으로 유지 → 사용자가 이름/시장/주기 수정 가능
+    setStep('basic')
+    // 프리셋 적용 안내 toast 대신 시각적으로 표시 (아래 안내문 추가)
   }
 
   const handleSave = async () => {
@@ -185,16 +188,27 @@ export default function StrategyBuilder({ onSaved, onCancel }: Props) {
           {/* 기본 설정 */}
           <div className="bg-white rounded-2xl shadow-sm border border-at-border p-5 space-y-4">
             <h2 className="font-semibold text-at-text">기본 설정</h2>
+            {sourcePresetId && (
+              <div className="bg-purple-50 border border-purple-200 rounded-xl p-3 text-xs text-purple-900">
+                <span className="font-semibold">✨ 프리셋이 적용되었습니다.</span> 아래에서 이름·시장·주기를 자유롭게 수정한 뒤
+                <span className="font-semibold"> 「지표 선택」</span> 단계에서 RSI 기간 등 지표 파라미터도 변형할 수 있습니다.
+              </div>
+            )}
             <div>
               <label className="block text-sm text-at-text-secondary mb-1">전략 이름 *</label>
               <input
                 type="text"
                 value={name}
                 onChange={e => setName(e.target.value)}
-                placeholder="예: RSI 과매도 반등"
+                placeholder="예: RSI 과매도 반등 — 21일 변형"
                 className="w-full px-3 py-2 rounded-xl border border-at-border bg-at-bg text-at-text text-sm focus:outline-none focus:border-at-accent"
                 maxLength={100}
               />
+              {sourcePresetId && (
+                <p className="text-[11px] text-at-text-weak mt-1">
+                  💡 같은 프리셋에서 여러 변형을 만들 때는 이름에 변형 포인트(예: "RSI 21일", "MACD 12/26 변형")를 함께 넣으면 구분이 쉽습니다.
+                </p>
+              )}
             </div>
             <div>
               <label className="block text-sm text-at-text-secondary mb-1">설명</label>

--- a/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
@@ -11,7 +11,9 @@ import RecentTickersButtons from './RecentTickersButtons'
 import FavoritesButtons from './FavoritesButtons'
 import StrategyStatsBlock, { type StrategyBacktestStats } from './StrategyStatsBlock'
 import { useRecentTickers } from '@/hooks/useRecentTickers'
-import type { InvestmentStrategy, Market } from '@/types/investment'
+import type {
+  InvestmentStrategy, Market, ConditionGroup, ConditionLeaf, IndicatorRef, ConstantRef,
+} from '@/types/investment'
 
 interface WatchlistItem {
   id: string
@@ -226,9 +228,12 @@ export default function StrategyCard({ strategy, hasCredential, onRefresh, onBac
         </div>
       )}
 
-      {/* 확장 영역: 감시 종목 관리 */}
+      {/* 확장 영역: 전략 세부 + 감시 종목 관리 */}
       {expanded && (
         <div className="mt-4 pt-4 border-t border-at-border space-y-4">
+          {/* 전략 세부 내용 — 지표/매수조건/매도조건/리스크 */}
+          <StrategyDetailsSummary strategy={strategy} />
+
           <div>
             <div className="flex items-center justify-between mb-2">
               <h4 className="text-sm font-semibold text-at-text">감시 종목 (자동매매 대상)</h4>
@@ -297,6 +302,138 @@ export default function StrategyCard({ strategy, hasCredential, onRefresh, onBac
           </div>
         </div>
       )}
+    </div>
+  )
+}
+
+// ============================================
+// 전략 세부 내용 요약 — 지표 / 매수조건 / 매도조건 / 리스크
+// ============================================
+
+const OPERATOR_LABELS: Record<string, string> = {
+  '>': '>', '<': '<', '>=': '≥', '<=': '≤', '==': '=', '!=': '≠',
+  'crosses_above': '↗ 상향돌파', 'crosses_below': '↘ 하향돌파',
+}
+
+function formatRef(ref: IndicatorRef | ConstantRef): string {
+  if (ref.type === 'constant') return String(ref.value)
+  return ref.property ? `${ref.id}.${ref.property}` : ref.id
+}
+
+function ConditionTreeSummary({ tree, depth = 0 }: { tree: ConditionGroup; depth?: number }) {
+  if (!tree.conditions || tree.conditions.length === 0) {
+    return <p className="text-[11px] text-at-text-weak italic">조건 없음</p>
+  }
+  const opLabel = tree.operator === 'AND' ? '모두 충족 (AND)' : '하나라도 충족 (OR)'
+  const opCls = tree.operator === 'AND' ? 'bg-blue-50 text-blue-700' : 'bg-purple-50 text-purple-700'
+  return (
+    <div className={`pl-2 ${depth > 0 ? 'border-l border-at-border' : ''} space-y-1`}>
+      <span className={`inline-block text-[10px] px-1.5 py-0.5 rounded ${opCls} font-medium`}>{opLabel}</span>
+      {tree.conditions.map((node, i) => {
+        if (node.type === 'leaf') {
+          const leaf = node as ConditionLeaf
+          const left = formatRef(leaf.left)
+          const right = formatRef(leaf.right)
+          const op = OPERATOR_LABELS[leaf.operator] || leaf.operator
+          return (
+            <div key={i} className="font-mono text-[11px] bg-white rounded px-2 py-1 border border-at-border">
+              <span className="text-at-text">{left}</span>
+              <span className="mx-1.5 text-at-accent font-semibold">{op}</span>
+              <span className="text-at-text">{right}</span>
+            </div>
+          )
+        }
+        return <ConditionTreeSummary key={i} tree={node} depth={depth + 1} />
+      })}
+    </div>
+  )
+}
+
+function StrategyDetailsSummary({ strategy }: { strategy: InvestmentStrategy }) {
+  const indicators = (strategy.indicators ?? []) as Array<{ id: string; type: string; params?: Record<string, number> }>
+  const buy = (strategy.buy_conditions ?? { type: 'group', operator: 'AND', conditions: [] }) as ConditionGroup
+  const sell = (strategy.sell_conditions ?? { type: 'group', operator: 'AND', conditions: [] }) as ConditionGroup
+  const risk = strategy.risk_settings ?? {}
+  const rk = risk as { stopLossPercent?: number; takeProfitPercent?: number; maxHoldingDays?: number; maxPositionSizePercent?: number }
+
+  return (
+    <div className="bg-at-surface-alt rounded-xl p-3 space-y-3">
+      <h4 className="text-sm font-semibold text-at-text">⚙️ 전략 세부 내용</h4>
+
+      {/* 지표 */}
+      <div>
+        <p className="text-xs font-semibold text-at-text-secondary mb-1.5">📊 기술 지표 ({indicators.length}개)</p>
+        {indicators.length === 0 ? (
+          <p className="text-[11px] text-at-text-weak italic">지표 없음</p>
+        ) : (
+          <ul className="space-y-1">
+            {indicators.map((ind) => (
+              <li key={ind.id} className="font-mono text-[11px] bg-white rounded px-2 py-1 border border-at-border">
+                <span className="font-semibold text-at-accent">{ind.type}</span>
+                <span className="mx-1.5 text-at-text-weak">→</span>
+                <span className="text-at-text">id={ind.id}</span>
+                {ind.params && Object.keys(ind.params).length > 0 && (
+                  <span className="ml-2 text-at-text-secondary">
+                    ({Object.entries(ind.params).map(([k, v]) => `${k}=${v}`).join(', ')})
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* 매수 조건 */}
+      <div>
+        <p className="text-xs font-semibold text-at-text-secondary mb-1.5">📈 매수 조건</p>
+        <ConditionTreeSummary tree={buy} />
+      </div>
+
+      {/* 매도 조건 */}
+      <div>
+        <p className="text-xs font-semibold text-at-text-secondary mb-1.5">📉 매도 조건</p>
+        <ConditionTreeSummary tree={sell} />
+      </div>
+
+      {/* 리스크 설정 */}
+      <div>
+        <p className="text-xs font-semibold text-at-text-secondary mb-1.5">🛡 리스크 설정</p>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+          {rk.stopLossPercent != null && rk.stopLossPercent > 0 && (
+            <RiskPill label="손절" value={`${rk.stopLossPercent}%`} tone="rose" />
+          )}
+          {rk.takeProfitPercent != null && rk.takeProfitPercent > 0 && (
+            <RiskPill label="익절" value={`${rk.takeProfitPercent}%`} tone="emerald" />
+          )}
+          {rk.maxHoldingDays != null && rk.maxHoldingDays > 0 && (
+            <RiskPill label="최대 보유" value={`${rk.maxHoldingDays}일`} tone="amber" />
+          )}
+          {rk.maxPositionSizePercent != null && rk.maxPositionSizePercent > 0 && (
+            <RiskPill label="최대 포지션" value={`${rk.maxPositionSizePercent}%`} tone="slate" />
+          )}
+        </div>
+      </div>
+
+      {strategy.source_preset_id && (
+        <p className="text-[11px] text-at-text-weak">
+          ✨ 원본 프리셋: <span className="font-mono">{strategy.source_preset_id}</span>
+        </p>
+      )}
+    </div>
+  )
+}
+
+function RiskPill({ label, value, tone }: { label: string; value: string; tone: 'rose' | 'emerald' | 'amber' | 'slate' }) {
+  const cls = {
+    rose: 'bg-rose-50 border-rose-200 text-rose-900',
+    emerald: 'bg-emerald-50 border-emerald-200 text-emerald-900',
+    amber: 'bg-amber-50 border-amber-200 text-amber-900',
+    slate: 'bg-slate-50 border-slate-200 text-slate-900',
+  }[tone]
+  return (
+    <div className={`rounded-lg border px-2 py-1.5 ${cls}`}>
+      <p className="text-[10px] font-medium opacity-80">{label}</p>
+      <p className="text-sm font-bold font-mono">{value}</p>
     </div>
   )
 }


### PR DESCRIPTION
RSI 등 지표 파라미터 변경 시 ID 가 바뀌어 매수/매도 조건 ref 가 끊기던 버그 수정 (1). applyPreset 시 이름 (커스텀) 자동 + step 'basic' 유지해 사용자 이름 수정 유도 (2). 전략 카드 펼침 영역에 지표/조건/리스크 세부 표시 (3).