### PR TITLE
feat(presets): 피보나치 전략 3종 + RSI cross 30/70 반등

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778345060553'
+const SW_VERSION = 'v1778346949891'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets-metadata.ts
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets-metadata.ts
@@ -238,4 +238,79 @@ export const PRESET_METADATA: Record<string, PresetMetadata> = {
     cons: ['횡보장 가짜 신호 多', '즉각 반전 시 손실'],
     source: 'Gerald Appel — MACD 변형',
   },
+
+  'rsi-rebound-cross': {
+    longDescription:
+      'RSI(14) 가 30 이하 → 30 이상으로 올라오는 정확한 시점에 매수, 70 이상 → 70 이하로 내려오는 시점에 매도. 단순 "RSI < 30 이면 매수" 와의 차이는 한 번 통과 후엔 다시 30 아래로 떨어졌다가 다시 올라와야 신호가 발생한다는 점. 같은 과매도 구간에서 매번 매수가 반복되는 현상 방지.',
+    bestFor: ['중간 변동성 종목', '횡보~약상승 구간', '시장 ETF'],
+    marketConditions: ['sideways', 'oversold-bounce'],
+    typicalHolding: '수일~3주',
+    pros: [
+      '임계값 통과 시점에 한 번만 발동 → 잦은 진입 방지',
+      '"바닥 확인 후 매수" 의 직관적 구현',
+      '단일 지표로 운용 가능',
+    ],
+    cons: [
+      '강한 하락 추세에서 30 통과 후 다시 급락 시 손절',
+      '과매도가 깊지 않으면(30 미터치) 평생 진입 안 함',
+      '단일 지표 의존',
+    ],
+    source: 'J. Welles Wilder (1978) RSI + Cross 시그널 응용',
+  },
+
+  // 🔢 피보나치 시리즈
+  'fib-ema-trend-8-21-55': {
+    longDescription:
+      '피보나치 수 8·21·55 를 EMA 기간으로 사용해 단기·중기·장기 추세를 동시에 점검. 세 EMA 가 EMA(8) > EMA(21) > EMA(55) 순서로 정렬되면 강한 상승 추세로 판단해 매수, 단기/중기 또는 중기/장기 라인이 하향 돌파하면 매도. Daryl Guppy 의 Multiple Moving Averages(MMA) 와 피보나치 비율 결합 변형.',
+    bestFor: ['장기 추세가 형성되는 대형 우량주', '지수 ETF', '강한 추세 보이는 성장주'],
+    marketConditions: ['weak-uptrend', 'strong-uptrend'],
+    typicalHolding: '1~3개월',
+    pros: [
+      '추세 정렬 확인으로 가짜 신호 ↓',
+      '피보나치 수가 시장 자연 주기에 부합한다는 가설',
+      '여러 시간대의 모멘텀을 동시 검증',
+    ],
+    cons: [
+      '횡보장에서 진입 신호가 거의 없음',
+      '추세 끝물 진입 위험 (3중 정렬 후엔 이미 충분히 상승)',
+      'EMA 후행성으로 진입이 늦음',
+    ],
+    source: 'Daryl Guppy "Trend Trading" + Robert Fischer "Fibonacci Applications" (1993)',
+  },
+  'fib-cross-13-55': {
+    longDescription:
+      '클래식 골든크로스(SMA 20/50) 의 피보나치 변형. SMA(13) 이 SMA(55) 를 상향 돌파 시 매수, 하향 돌파(데드크로스) 시 매도. 13·55 조합은 20·50 보다 노이즈가 적어 더 의미있는 추세 전환만 포착하는 경향이 있다. 일봉/주봉 모두 적용 가능.',
+    bestFor: ['추세 명확한 대형주', '지수 ETF', '저변동성 우량주'],
+    marketConditions: ['weak-uptrend', 'strong-uptrend'],
+    typicalHolding: '2~6개월',
+    pros: [
+      '20/50 골든크로스보다 가짜 신호 적음',
+      '단순한 진입/청산 규칙',
+      '심리적으로 따르기 쉬움',
+    ],
+    cons: [
+      '강한 추세 반전 시 진입/이탈 매우 늦음',
+      '거래 빈도가 낮아 횡보장 활용 어려움',
+      '큰 손절 폭 (장기 추세 전제)',
+    ],
+    source: 'Robert Fischer (1993, "Fibonacci Applications and Strategies for Traders")',
+  },
+  'fib-rsi-retracement': {
+    longDescription:
+      'RSI 의 임계값을 단순 30/70 대신 피보나치 황금비 38.2/61.8 로 적용. RSI(13, 피보나치 기간) 가 38.2 이하로 떨어지면 황금 되돌림 영역으로 보고 매수, 61.8 위로 올라가면 매도. Constance Brown 이 제안한 RSI 의 피보나치 영역 분석 응용. 횡보~약상승장에서 매매 빈도가 적당히 발생하는 균형형 평균 회귀 전략.',
+    bestFor: ['중대형 변동성 종목', '횡보 또는 약한 추세 시장', '시장 ETF'],
+    marketConditions: ['sideways', 'oversold-bounce', 'weak-uptrend'],
+    typicalHolding: '1~4주',
+    pros: [
+      '엄격한 30/70 보다 진입 기회 많음',
+      '피보나치 비율의 자연 회귀 가설',
+      '단순 RSI 1지표로 운용 가능',
+    ],
+    cons: [
+      '강한 하락 추세에서 연속 손절',
+      '단일 지표 의존 — 거래량/추세 미고려',
+      '임계값 선택의 자의성',
+    ],
+    source: 'Constance Brown (1999, "Technical Analysis for the Trading Professional")',
+  },
 }

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets.ts
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets.ts
@@ -1352,4 +1352,182 @@ export const PRESET_STRATEGIES: PresetStrategy[] = [
       maxHoldingDays: 14,
     },
   },
+
+  // ============================================
+  // 🔢 피보나치 수열 기반 전략 — 8 / 13 / 21 / 34 / 55 / 89 시퀀스 활용
+  // 피보나치 비율(38.2%, 50%, 61.8%) 또는 피보나치 수를 기간(period)으로 사용.
+  // ============================================
+
+  {
+    id: 'fib-ema-trend-8-21-55',
+    name: '🔢 피보나치 EMA 추세 정렬 (8/21/55)',
+    description: '피보나치 수 8·21·55 EMA가 단→중→장기 순서로 정렬되어 강한 추세를 형성할 때 매수, 단기 EMA가 중기 EMA를 하향 돌파 시 매도',
+    indicators: [
+      { id: 'EMA_8', type: 'EMA', params: { period: 8 } },
+      { id: 'EMA_21', type: 'EMA', params: { period: 21 } },
+      { id: 'EMA_55', type: 'EMA', params: { period: 55 } },
+    ],
+    buyConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        // EMA(8) > EMA(21): 단기가 중기 위
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'EMA_8' },
+          operator: '>',
+          right: { type: 'indicator', id: 'EMA_21' },
+        },
+        // EMA(21) > EMA(55): 중기가 장기 위 — 추세 정렬 완성
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'EMA_21' },
+          operator: '>',
+          right: { type: 'indicator', id: 'EMA_55' },
+        },
+      ],
+    },
+    sellConditions: {
+      type: 'group',
+      operator: 'OR',
+      conditions: [
+        // 단기 EMA 가 중기 EMA 를 하향 돌파 — 추세 약화 시그널
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'EMA_8' },
+          operator: 'crossUnder',
+          right: { type: 'indicator', id: 'EMA_21' },
+        },
+        // 중기 EMA 가 장기 EMA 를 하향 돌파 — 추세 종료
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'EMA_21' },
+          operator: 'crossUnder',
+          right: { type: 'indicator', id: 'EMA_55' },
+        },
+      ],
+    },
+    riskSettings: {
+      stopLossPercent: 6,
+      takeProfitPercent: 18,
+      maxHoldingDays: 60,
+    },
+  },
+
+  {
+    id: 'fib-cross-13-55',
+    name: '🔢 피보나치 크로스 (13/55)',
+    description: '클래식 골든크로스의 피보나치 변형 — SMA(13)이 SMA(55)를 상향 돌파 시 매수, 하향 돌파 시 매도. 20/50 보다 노이즈가 적고 의미있는 전환점 포착',
+    indicators: [
+      { id: 'SMA_13', type: 'SMA', params: { period: 13 } },
+      { id: 'SMA_55', type: 'SMA', params: { period: 55 } },
+    ],
+    buyConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'SMA_13' },
+          operator: 'crossOver',
+          right: { type: 'indicator', id: 'SMA_55' },
+        },
+      ],
+    },
+    sellConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'SMA_13' },
+          operator: 'crossUnder',
+          right: { type: 'indicator', id: 'SMA_55' },
+        },
+      ],
+    },
+    riskSettings: {
+      stopLossPercent: 7,
+      takeProfitPercent: 20,
+      maxHoldingDays: 90,
+    },
+  },
+
+  {
+    id: 'rsi-rebound-cross',
+    name: 'RSI 임계값 반등 매매 (30/70 통과)',
+    description: 'RSI(14)가 30 이하에서 30 이상으로 올라오는 순간 매수, 70 이상에서 70 이하로 내려오는 순간 매도. 단순 RSI<30/>70 비교와 달리 임계값 통과 시점에서 단 한 번만 신호 발생 — 가짜 진입/청산 ↓',
+    indicators: [
+      { id: 'RSI_14', type: 'RSI', params: { period: 14 } },
+    ],
+    buyConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        // RSI 가 30 을 상향 돌파 — 과매도 → 회복 전환점
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'RSI_14' },
+          operator: 'crossOver',
+          right: { type: 'constant', value: 30 },
+        },
+      ],
+    },
+    sellConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        // RSI 가 70 을 하향 돌파 — 과매수 → 조정 전환점
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'RSI_14' },
+          operator: 'crossUnder',
+          right: { type: 'constant', value: 70 },
+        },
+      ],
+    },
+    riskSettings: {
+      stopLossPercent: 5,
+      takeProfitPercent: 12,
+      maxHoldingDays: 30,
+    },
+  },
+
+  {
+    id: 'fib-rsi-retracement',
+    name: '🔢 피보나치 RSI 되돌림 (38.2 / 61.8)',
+    description: 'RSI(13, 피보나치 기간)가 38.2 황금비 이하로 떨어지면 매수, 61.8 황금비 위로 올라가면 매도. 단순 30/70보다 정교한 되돌림 영역 포착',
+    indicators: [
+      { id: 'RSI_13', type: 'RSI', params: { period: 13 } },
+    ],
+    buyConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'RSI_13' },
+          operator: '<',
+          right: { type: 'constant', value: 38.2 },
+        },
+      ],
+    },
+    sellConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'RSI_13' },
+          operator: '>',
+          right: { type: 'constant', value: 61.8 },
+        },
+      ],
+    },
+    riskSettings: {
+      stopLossPercent: 5,
+      takeProfitPercent: 12,
+      maxHoldingDays: 30,
+    },
+  },
 ]


### PR DESCRIPTION
피보나치 수 기반 EMA(8/21/55), SMA cross(13/55), RSI(13) 황금비 38.2/61.8 되돌림 + 사용자 요청 RSI(14) crossOver/crossUnder 30/70 임계값 반등 전략 4종 추가. PRESET_METADATA 도 동시 갱신.