### PR TITLE
feat: ATR 기반 손절 (Turtle Trading 정통)

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778350974330'
+const SW_VERSION = 'v1778382086666'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/components/Investment/PresetDetailView.tsx
+++ b/dental-clinic-manager/src/components/Investment/PresetDetailView.tsx
@@ -184,6 +184,13 @@ export default function PresetDetailView({ presetId, variant = 'page' }: Props) 
           {preset.riskSettings.stopLossPercent !== undefined && preset.riskSettings.stopLossPercent > 0 && (
             <RiskBox label="손절" value={`${preset.riskSettings.stopLossPercent}%`} color="rose" />
           )}
+          {(preset.riskSettings.stopLossAtrMultiplier ?? 0) > 0 && (
+            <RiskBox
+              label="ATR 손절 (Turtle)"
+              value={`${preset.riskSettings.stopLossAtrMultiplier}N · ATR${preset.riskSettings.stopLossAtrPeriod ?? 20}`}
+              color="rose"
+            />
+          )}
           {preset.riskSettings.takeProfitPercent !== undefined && preset.riskSettings.takeProfitPercent > 0 && (
             <RiskBox label="익절" value={`${preset.riskSettings.takeProfitPercent}%`} color="emerald" />
           )}

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/RiskSettingsPanel.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/RiskSettingsPanel.tsx
@@ -86,6 +86,24 @@ export default function RiskSettingsPanel({ riskSettings, onChange }: Props) {
     onChange({ ...riskSettings, [key]: value })
   }
 
+  const atrEnabled = (riskSettings.stopLossAtrMultiplier ?? 0) > 0
+  const atrMult = riskSettings.stopLossAtrMultiplier ?? 0
+  const atrPeriod = riskSettings.stopLossAtrPeriod ?? 20
+
+  const setAtrEnabled = (enabled: boolean) => {
+    onChange({
+      ...riskSettings,
+      stopLossAtrMultiplier: enabled ? (atrMult > 0 ? atrMult : 2) : 0,
+      stopLossAtrPeriod: enabled ? atrPeriod : (riskSettings.stopLossAtrPeriod ?? 20),
+    })
+  }
+  const setAtrMult = (v: number) => {
+    onChange({ ...riskSettings, stopLossAtrMultiplier: Math.max(0, Math.min(10, v)) })
+  }
+  const setAtrPeriod = (v: number) => {
+    onChange({ ...riskSettings, stopLossAtrPeriod: Math.max(2, Math.min(100, Math.floor(v))) })
+  }
+
   return (
     <div className="bg-white rounded-2xl shadow-sm border border-at-border p-5">
       <h2 className="font-semibold text-at-text mb-1">리스크 관리</h2>
@@ -104,7 +122,7 @@ export default function RiskSettingsPanel({ riskSettings, onChange }: Props) {
 
       <div className="space-y-6">
         {FIELDS.map(field => {
-          const value = riskSettings[field.key]
+          const value = riskSettings[field.key] ?? 0
           const percent = ((value - field.min) / (field.max - field.min)) * 100
           return (
             <div key={field.key}>
@@ -163,6 +181,64 @@ export default function RiskSettingsPanel({ riskSettings, onChange }: Props) {
             </div>
           )
         })}
+      </div>
+
+      {/* ATR 기반 손절 (Turtle Trading) */}
+      <div className="mt-6 pt-5 border-t border-at-border">
+        <div className="flex items-center justify-between mb-2">
+          <div>
+            <h3 className="text-sm font-semibold text-at-text">🐢 ATR 기반 손절 (Turtle Trading)</h3>
+            <p className="text-xs text-at-text-secondary mt-0.5">진입 시점 ATR(N일 평균 진폭) 기반 변동성 손절. 활성 시 위 % 손절보다 우선.</p>
+          </div>
+          <label className="inline-flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={atrEnabled}
+              onChange={(e) => setAtrEnabled(e.target.checked)}
+              className="w-4 h-4 rounded border-at-border text-at-accent focus:ring-at-accent"
+            />
+            <span className="text-xs font-medium text-at-text">{atrEnabled ? '사용' : '미사용'}</span>
+          </label>
+        </div>
+
+        {atrEnabled && (
+          <div className="grid grid-cols-2 gap-3 mt-3">
+            <div>
+              <label className="block text-xs font-medium text-at-text mb-1">ATR 배수 (multiplier)</label>
+              <input
+                type="number"
+                value={atrMult}
+                onChange={(e) => setAtrMult(Number(e.target.value))}
+                min={0.5}
+                max={10}
+                step={0.5}
+                className="w-full px-2 py-1 rounded-lg border border-at-border bg-white text-at-text text-sm font-mono focus:outline-none focus:border-at-accent"
+              />
+              <p className="text-[11px] text-at-text-weak mt-1">손절가 = 진입가 − {atrMult}×ATR. Turtle 정통 = 2N (2배)</p>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-at-text mb-1">ATR 기간 (일)</label>
+              <input
+                type="number"
+                value={atrPeriod}
+                onChange={(e) => setAtrPeriod(Number(e.target.value))}
+                min={2}
+                max={100}
+                step={1}
+                className="w-full px-2 py-1 rounded-lg border border-at-border bg-white text-at-text text-sm font-mono focus:outline-none focus:border-at-accent"
+              />
+              <p className="text-[11px] text-at-text-weak mt-1">ATR 계산 기간. Turtle 정통 = 20일</p>
+            </div>
+          </div>
+        )}
+
+        {atrEnabled && (
+          <div className="mt-3 p-3 rounded-xl bg-amber-50 border border-amber-200 text-[11px] text-amber-900 leading-relaxed">
+            <strong>📘 Turtle Trading 손절</strong>: Richard Dennis 가 사용한 정통 방식. 종목별 변동성(ATR)에
+            맞춰 손절폭을 조정 → 변동성 큰 종목은 더 멀리, 작은 종목은 더 가까이 손절. percent 손절보다
+            wing(가짜 손절) 가 줄고 큰 추세를 더 오래 보유 가능.
+          </div>
+        )}
       </div>
     </div>
   )

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets-metadata.ts
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets-metadata.ts
@@ -258,7 +258,7 @@ export const PRESET_METADATA: Record<string, PresetMetadata> = {
     cons: [
       '가짜 돌파(whipsaw) 빈번 — 횡보장에서 연속 손절',
       '큰 추세 1~2회로 1년 수익 만드는 구조 → 인내 필요',
-      '원전은 ATR 기반 손절·포지션 사이징 — 본 시스템은 percent 손절로 근사',
+      'ATR 기반 손절(2N)은 본 시스템 옵션으로 적용. 포지션 사이징은 미적용',
     ],
     source: 'Richard Dennis & William Eckhardt (1983, "Turtle Traders" — Curtis Faith 정리)',
   },
@@ -276,7 +276,7 @@ export const PRESET_METADATA: Record<string, PresetMetadata> = {
     cons: [
       '진입 자체가 매우 드물어 자본이 놀고 있을 가능성',
       '추세 반전 시 큰 평가손 가능',
-      'percent 기반 손절은 원전 ATR 방식과 차이가 있음',
+      '진입 빈도 매우 낮아 한 해 거래 1~3회',
     ],
     source: 'Curtis Faith (2007, "Way of the Turtle")',
   },

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets.ts
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets.ts
@@ -1496,8 +1496,10 @@ export const PRESET_STRATEGIES: PresetStrategy[] = [
       ],
     },
     riskSettings: {
-      stopLossPercent: 8,        // Turtle 원전은 ATR(20) × 2N 기반 — 본 시스템은 percent 근사
-      takeProfitPercent: 0,      // 추세 추종이라 익절 미설정 (Donchian 이탈로만 청산)
+      stopLossPercent: 0,                  // ATR 손절 사용 (아래 옵션)
+      stopLossAtrMultiplier: 2,            // 2N — Turtle 정통
+      stopLossAtrPeriod: 20,               // ATR(20)
+      takeProfitPercent: 0,                // 추세 추종이라 익절 미설정 (Donchian 이탈로만 청산)
       maxHoldingDays: 90,
     },
   },
@@ -1536,7 +1538,9 @@ export const PRESET_STRATEGIES: PresetStrategy[] = [
       ],
     },
     riskSettings: {
-      stopLossPercent: 12,
+      stopLossPercent: 0,
+      stopLossAtrMultiplier: 2,            // System 2 도 동일하게 2N (장기는 변동성 더 크지만 비율은 유지)
+      stopLossAtrPeriod: 20,
       takeProfitPercent: 0,
       maxHoldingDays: 180,
     },

--- a/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyCard.tsx
@@ -354,7 +354,10 @@ function StrategyDetailsSummary({ strategy }: { strategy: InvestmentStrategy }) 
   const buy = (strategy.buy_conditions ?? { type: 'group', operator: 'AND', conditions: [] }) as ConditionGroup
   const sell = (strategy.sell_conditions ?? { type: 'group', operator: 'AND', conditions: [] }) as ConditionGroup
   const risk = strategy.risk_settings ?? {}
-  const rk = risk as { stopLossPercent?: number; takeProfitPercent?: number; maxHoldingDays?: number; maxPositionSizePercent?: number }
+  const rk = risk as {
+    stopLossPercent?: number; takeProfitPercent?: number; maxHoldingDays?: number; maxPositionSizePercent?: number
+    stopLossAtrMultiplier?: number; stopLossAtrPeriod?: number
+  }
 
   return (
     <div className="bg-at-surface-alt rounded-xl p-3 space-y-3">
@@ -401,6 +404,9 @@ function StrategyDetailsSummary({ strategy }: { strategy: InvestmentStrategy }) 
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
           {rk.stopLossPercent != null && rk.stopLossPercent > 0 && (
             <RiskPill label="손절" value={`${rk.stopLossPercent}%`} tone="rose" />
+          )}
+          {rk.stopLossAtrMultiplier != null && rk.stopLossAtrMultiplier > 0 && (
+            <RiskPill label="ATR 손절" value={`${rk.stopLossAtrMultiplier}N (ATR${rk.stopLossAtrPeriod ?? 20})`} tone="rose" />
           )}
           {rk.takeProfitPercent != null && rk.takeProfitPercent > 0 && (
             <RiskPill label="익절" value={`${rk.takeProfitPercent}%`} tone="emerald" />

--- a/dental-clinic-manager/src/lib/backtestEngine.ts
+++ b/dental-clinic-manager/src/lib/backtestEngine.ts
@@ -17,7 +17,7 @@ import type {
   BacktestTrade, BacktestMetrics, EquityCurvePoint,
   SignalSnapshot,
 } from '@/types/investment'
-import { calculateIndicators, type IndicatorResultMap } from './indicatorEngine'
+import { calculateIndicators, calcATR, type IndicatorResultMap } from './indicatorEngine'
 import { evaluateConditionTreeWithMatches, type EvaluationContext } from './signalEngine'
 
 // ============================================
@@ -77,6 +77,9 @@ interface SimPosition {
   quantity: number
   holdingDays: number
   entrySignal?: SignalSnapshot
+  /** ATR 기반 손절가 (Turtle Trading) — 진입 시점에 계산되고 보유 동안 고정.
+   *  null/undefined 면 ATR 손절 비활성. */
+  stopPrice?: number | null
 }
 
 /**
@@ -133,6 +136,14 @@ export function runBacktest(params: BacktestParams, signal?: AbortSignal): Backt
   // 1. 지표 계산
   const indicatorResults = calculateIndicators(prices, indicators)
 
+  // 1b. ATR 손절(Turtle 방식) — 옵트인. 활성 시 별도 ATR 시리즈 계산.
+  const atrMult = riskSettings.stopLossAtrMultiplier ?? 0
+  const atrPeriod = riskSettings.stopLossAtrPeriod ?? 20
+  const atrStopEnabled = atrMult > 0 && atrPeriod > 1
+  const atrSeries: number[] | null = atrStopEnabled
+    ? calcATR(prices, { period: atrPeriod })
+    : null
+
   // 2. 시뮬레이션 변수
   let cash = initialCapital
   let position: SimPosition | null = null
@@ -160,6 +171,42 @@ export function runBacktest(params: BacktestParams, signal?: AbortSignal): Backt
       if (position) {
         position.holdingDays++
 
+        // === ATR 기반 손절 체크 (Turtle Trading 방식, 옵트인) ===
+        // 우선순위: ATR stop > 전략 매도 신호. 손절가가 당일 저가보다 위면 트리거.
+        // 체결가는 손절가(갭다운 시 시가) 기준 — 보수적으로 worst-of(시가, 손절가) 사용.
+        if (position.stopPrice != null && bar.low <= position.stopPrice) {
+          const exitPrice = Math.min(bar.open, position.stopPrice)
+          const sellAmount = exitPrice * position.quantity
+          const sellFee = sellAmount * (commissionRate.sellCommission + commissionRate.sellTax)
+          const pnl = (exitPrice - position.entryPrice) * position.quantity - sellFee
+            - (position.entryPrice * position.quantity * commissionRate.buyCommission)
+          cash += sellAmount - sellFee
+
+          const exitSignal: SignalSnapshot = {
+            reason: 'stopLoss',
+            indicators: buildIndicatorSnapshot(indicators, indicatorResults, i - 1),
+            matchedConditions: [],
+          }
+
+          trades.push({
+            entryDate: position.entryDate,
+            exitDate: bar.date,
+            ticker,
+            direction: 'buy',
+            entryPrice: position.entryPrice,
+            exitPrice,
+            quantity: position.quantity,
+            pnl,
+            pnlPercent: ((exitPrice - position.entryPrice) / position.entryPrice) * 100,
+            holdingDays: position.holdingDays,
+            entrySignal: position.entrySignal,
+            exitSignal,
+          })
+          position = null
+        }
+      }
+
+      if (position) {
         // 백테스트는 전략의 매도 조건으로만 매매 — 손절/익절/최대보유는 비활성화
         const sellResult = evaluateConditionTreeWithMatches(sellConditions, prevCtx)
 
@@ -216,11 +263,21 @@ export function runBacktest(params: BacktestParams, signal?: AbortSignal): Backt
             const totalCost = entryPrice * quantity + (entryPrice * quantity * commissionRate.buyCommission)
             cash -= totalCost
 
+            // ATR 손절가 계산 (활성 시) — 진입 봉(i)의 ATR 사용. NaN 이면 손절 비활성.
+            let stopPrice: number | null = null
+            if (atrStopEnabled && atrSeries) {
+              const atr = atrSeries[i]
+              if (Number.isFinite(atr) && atr > 0) {
+                stopPrice = entryPrice - atrMult * atr
+              }
+            }
+
             position = {
               entryDate: bar.date,
               entryPrice,
               quantity,
               holdingDays: 0,
+              stopPrice,
               entrySignal: {
                 reason: 'signal',
                 indicators: buildIndicatorSnapshot(indicators, indicatorResults, i - 1),

--- a/dental-clinic-manager/src/lib/indicatorEngine.ts
+++ b/dental-clinic-manager/src/lib/indicatorEngine.ts
@@ -148,7 +148,7 @@ function calcStochastic(prices: OHLCV[], params: Record<string, number>): Record
   return padLeft(mapped, prices.length, { k: NaN, d: NaN })
 }
 
-function calcATR(prices: OHLCV[], params: Record<string, number>): number[] {
+export function calcATR(prices: OHLCV[], params: Record<string, number>): number[] {
   const period = params.period || 14
   const result = ATR.calculate({
     high: prices.map(p => p.high),

--- a/dental-clinic-manager/src/types/investment.ts
+++ b/dental-clinic-manager/src/types/investment.ts
@@ -142,9 +142,14 @@ export interface RiskSettings {
   maxDailyLossPercent: number     // 일일 최대 손실율 (예: 2)
   maxPositions: number            // 최대 동시 보유 종목 수
   maxPositionSizePercent: number  // 종목당 최대 비중 (예: 20)
-  stopLossPercent: number         // 손절 기준 (예: 5)
+  stopLossPercent: number         // 손절 기준 % (예: 5). 0 = 비활성
   takeProfitPercent: number       // 익절 기준 (예: 10)
   maxHoldingDays: number          // 최대 보유 기간 (0 = 무제한)
+  /** ATR 기반 손절 (Turtle Trading 방식) — 활성 시 백테스트/실거래 모두에서 동작.
+   *  손절가 = 진입가 - (multiplier × ATR_at_entry). 0 또는 undefined 면 비활성. */
+  stopLossAtrMultiplier?: number  // 예: 2 = 2N (Turtle 정통)
+  /** ATR 손절에 사용할 ATR 기간 (기본 20) */
+  stopLossAtrPeriod?: number      // 예: 20
 }
 
 // ============================================


### PR DESCRIPTION
RiskSettings 에 stopLossAtrMultiplier/stopLossAtrPeriod 추가. 백테스트 엔진에 ATR 손절 트리거 로직 (옵트인). 터틀 프리셋 2종 ATR 손절(2N · ATR20)로 갱신. UI 패널·카드·프리셋 상세에 표시.