### PR TITLE
feat: 백테스트 페이지 이동해도 백그라운드 유지

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778382086666'
+const SW_VERSION = 'v1778384163539'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/components/Investment/BacktestPanel.tsx
+++ b/dental-clinic-manager/src/components/Investment/BacktestPanel.tsx
@@ -7,23 +7,11 @@ import {
 } from 'lucide-react'
 import TickerSearch from '@/components/Investment/TickerSearch'
 import DateRangePicker from '@/components/Investment/DateRangePicker'
-import type { InvestmentStrategy, BacktestMetrics, BacktestTrade, EquityCurvePoint, Market } from '@/types/investment'
-
-interface BuyHoldData {
-  totalReturn: number
-  annualizedReturn: number
-  equityCurve: EquityCurvePoint[]
-}
-
-interface BacktestResultData {
-  ticker: string
-  tickerName?: string
-  market: Market
-  metrics: BacktestMetrics
-  trades: BacktestTrade[]
-  equityCurve: EquityCurvePoint[]
-  buyHold?: BuyHoldData
-}
+import type { InvestmentStrategy, Market, EquityCurvePoint } from '@/types/investment'
+import {
+  startJob, getJob, subscribe as subscribeJob,
+  type BacktestResultData,
+} from '@/lib/investment/backtestJobStore'
 
 interface TickerEntry {
   ticker: string
@@ -132,7 +120,28 @@ export default function BacktestPanel({ strategyId, onBack }: BacktestPanelProps
     setTickers(prev => prev.filter((_, i) => i !== idx))
   }
 
-  const runAllBacktests = async () => {
+  // 글로벌 store 의 작업 상태를 BacktestPanel state 에 반영 — 페이지 이동/재방문에도 결과 유지
+  const syncFromStore = useCallback(() => {
+    const job = getJob(strategyId)
+    if (!job) return
+    setRunningTickers(new Set(job.runningTickers))
+    setResults(job.results.slice())
+    setError(job.errors.length > 0 ? job.errors.join('\n') : null)
+    // 결과가 처음 도착했고 아직 선택된 결과가 없으면 1위 자동 선택
+    setSelectedResultIdx(prev => {
+      if (prev != null) return prev
+      return job.results.length > 0 ? 0 : null
+    })
+  }, [strategyId])
+
+  // mount 시 기존 작업 있으면 즉시 복원 + 변경 알림 구독
+  useEffect(() => {
+    syncFromStore()
+    const unsub = subscribeJob(strategyId, syncFromStore)
+    return unsub
+  }, [strategyId, syncFromStore])
+
+  const runAllBacktests = () => {
     if (tickers.length === 0) { setError('종목을 추가해주세요'); return }
     if (!startDate || !endDate) { setError('기간을 설정해주세요'); return }
     // 사전 검증: 미래 날짜/역순/너무 짧은 기간을 RL 서버 호출 전에 차단해
@@ -145,50 +154,11 @@ export default function BacktestPanel({ strategyId, onBack }: BacktestPanelProps
     if (spanDays < 7) { setError('백테스트 기간은 최소 7일 이상이어야 합니다 (현재: ' + spanDays + '일)'); return }
 
     setError(null)
-    setResults([])
     setSelectedResultIdx(null)
 
-    const allTickers = new Set(tickers.map(t => t.ticker))
-    setRunningTickers(allTickers)
-
-    const promises = tickers.map(async (entry) => {
-      try {
-        const res = await fetch('/api/investment/backtest', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ strategyId, ticker: entry.ticker, market: entry.market, startDate, endDate, initialCapital }),
-        })
-        const json = await res.json()
-        if (!res.ok) return { ticker: entry.ticker, error: json.error }
-        const data = json.data
-        return {
-          ticker: entry.ticker,
-          tickerName: entry.name,
-          market: entry.market,
-          metrics: data.metrics || data.full_metrics,
-          trades: data.trades || [],
-          equityCurve: data.equityCurve || data.equity_curve || [],
-          buyHold: data.buyHold || data.buy_hold || undefined,
-        }
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : '네트워크 오류'
-        return { ticker: entry.ticker, error: reason }
-      } finally {
-        setRunningTickers(prev => { const next = new Set(prev); next.delete(entry.ticker); return next })
-      }
-    })
-
-    const settled = await Promise.all(promises)
-    const successes: BacktestResultData[] = []
-    const errors: string[] = []
-    for (const result of settled) {
-      if ('error' in result && result.error) errors.push(`${result.ticker}: ${result.error}`)
-      else if ('metrics' in result && result.metrics) successes.push(result as BacktestResultData)
-    }
-    successes.sort((a, b) => b.metrics.totalReturn - a.metrics.totalReturn)
-    setResults(successes)
-    if (successes.length > 0) setSelectedResultIdx(0)
-    if (errors.length > 0) setError(errors.join('\n'))
+    // 글로벌 store 에서 실행 — 컴포넌트 unmount 와 무관하게 백그라운드 진행
+    startJob({ strategyId, tickers, startDate, endDate, initialCapital })
+    syncFromStore()
   }
 
   const isRunning = runningTickers.size > 0

--- a/dental-clinic-manager/src/lib/investment/backtestJobStore.ts
+++ b/dental-clinic-manager/src/lib/investment/backtestJobStore.ts
@@ -1,0 +1,165 @@
+'use client'
+
+/**
+ * 백테스트 작업 글로벌 store
+ *
+ * 사용자가 백테스트 도중 다른 페이지로 이동했다가 돌아와도 결과를 잃지 않도록
+ * 모듈 레벨에서 진행 중인 작업/완료된 결과를 보관한다.
+ *
+ * 동작:
+ * - startJob: strategyId 별로 작업 등록. 각 ticker 별로 fetch 시작.
+ * - 컴포넌트는 subscribe 로 결과 변경 알림 수신 → re-render
+ * - fetch 는 컴포넌트 mount/unmount 와 무관하게 백그라운드 실행
+ * - 새로고침 시에는 모듈 상태가 사라지지만, 진행 중 작업은 Vercel maxDuration(60s)
+ *   안에 끝나므로 새로고침 후 backtest_runs 테이블에서 결과 복구 가능 (별도 흐름)
+ */
+
+import type { BacktestMetrics, BacktestTrade, EquityCurvePoint, Market } from '@/types/investment'
+
+export interface BuyHoldData {
+  totalReturn: number
+  annualizedReturn: number
+  equityCurve: EquityCurvePoint[]
+}
+
+export interface BacktestResultData {
+  ticker: string
+  tickerName?: string
+  market: Market
+  metrics: BacktestMetrics
+  trades: BacktestTrade[]
+  equityCurve: EquityCurvePoint[]
+  buyHold?: BuyHoldData
+}
+
+export interface BacktestJobParams {
+  strategyId: string
+  tickers: Array<{ ticker: string; name: string; market: Market }>
+  startDate: string
+  endDate: string
+  initialCapital: number
+}
+
+export interface BacktestJob {
+  /** 작업이 시작된 시각 (ms) — 새 작업이 시작되면 갱신 */
+  startedAt: number
+  params: BacktestJobParams
+  /** 현재 진행 중인 ticker 들 */
+  runningTickers: Set<string>
+  /** 완료된 결과 (성공만) */
+  results: BacktestResultData[]
+  /** 실패한 ticker 들의 에러 메시지 */
+  errors: string[]
+  /** 모든 ticker 가 끝났는지 */
+  done: boolean
+}
+
+type Listener = () => void
+
+const jobs = new Map<string, BacktestJob>()
+const listeners = new Map<string, Set<Listener>>()
+
+function notify(strategyId: string) {
+  const set = listeners.get(strategyId)
+  if (!set) return
+  for (const cb of set) {
+    try { cb() } catch { /* ignore */ }
+  }
+}
+
+export function getJob(strategyId: string): BacktestJob | undefined {
+  return jobs.get(strategyId)
+}
+
+export function subscribe(strategyId: string, listener: Listener): () => void {
+  let set = listeners.get(strategyId)
+  if (!set) {
+    set = new Set()
+    listeners.set(strategyId, set)
+  }
+  set.add(listener)
+  return () => {
+    const s = listeners.get(strategyId)
+    if (!s) return
+    s.delete(listener)
+    if (s.size === 0) listeners.delete(strategyId)
+  }
+}
+
+/** 진행 중 작업이 있어도 새 작업으로 덮어쓰며 시작 (사용자가 명시적으로 재실행) */
+export function startJob(params: BacktestJobParams): BacktestJob {
+  const { strategyId, tickers, startDate, endDate, initialCapital } = params
+
+  const job: BacktestJob = {
+    startedAt: Date.now(),
+    params,
+    runningTickers: new Set(tickers.map(t => t.ticker)),
+    results: [],
+    errors: [],
+    done: tickers.length === 0,
+  }
+  jobs.set(strategyId, job)
+  notify(strategyId)
+
+  // 각 ticker 별 fetch 실행 — Promise 는 모듈 레벨이라 컴포넌트 unmount 영향 없음
+  for (const entry of tickers) {
+    fetch('/api/investment/backtest', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        strategyId,
+        ticker: entry.ticker,
+        market: entry.market,
+        startDate,
+        endDate,
+        initialCapital,
+      }),
+    })
+      .then(async (res) => {
+        const json = await res.json().catch(() => ({}))
+        // 백테스트가 진행되는 동안 사용자가 새 백테스트를 시작했다면 startedAt 이 바뀜 — 옛 결과 무시
+        const cur = jobs.get(strategyId)
+        if (!cur || cur.startedAt !== job.startedAt) return
+
+        if (!res.ok) {
+          cur.errors.push(`${entry.ticker}: ${json.error || res.statusText}`)
+        } else {
+          const data = json.data
+          if (data && (data.metrics || data.full_metrics)) {
+            cur.results.push({
+              ticker: entry.ticker,
+              tickerName: entry.name,
+              market: entry.market,
+              metrics: data.metrics || data.full_metrics,
+              trades: data.trades || [],
+              equityCurve: data.equityCurve || data.equity_curve || [],
+              buyHold: data.buyHold || data.buy_hold || undefined,
+            })
+            // 결과 정렬 — 수익률 내림차순
+            cur.results.sort((a, b) => b.metrics.totalReturn - a.metrics.totalReturn)
+          }
+        }
+      })
+      .catch((err) => {
+        const cur = jobs.get(strategyId)
+        if (!cur || cur.startedAt !== job.startedAt) return
+        const reason = err instanceof Error ? err.message : '네트워크 오류'
+        cur.errors.push(`${entry.ticker}: ${reason}`)
+      })
+      .finally(() => {
+        const cur = jobs.get(strategyId)
+        if (!cur || cur.startedAt !== job.startedAt) return
+        cur.runningTickers.delete(entry.ticker)
+        if (cur.runningTickers.size === 0) cur.done = true
+        notify(strategyId)
+      })
+  }
+
+  return job
+}
+
+/** 작업 결과만 클리어 (예: 사용자가 "새로 백테스트" 시작 직전). */
+export function clearJob(strategyId: string) {
+  jobs.delete(strategyId)
+  notify(strategyId)
+}


### PR DESCRIPTION
글로벌 jobStore 로 백테스트 fetch 를 컴포넌트 unmount 와 무관하게 백그라운드 실행. 다시 들어오면 결과/진행상황 즉시 복원.