### PR TITLE
release: develop → main (누적 변경 통합)

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778384163539'
+const SW_VERSION = 'v1778429869091'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/app/api/investment/backtest/results/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/backtest/results/route.ts
@@ -1,0 +1,75 @@
+/**
+ * 백테스트 결과 조회 — strategyId + since(ISO timestamp) 이후의 완료된 run 들.
+ *
+ * GET /api/investment/backtest/results?strategyId=...&tickers=AAPL,MSFT&since=2026-05-11T...&market=US
+ *
+ * 사용처: 사용자가 백테스트 시작 후 페이지 새로고침/탭 종료 → 다시 진입 시
+ * sessionStorage 의 잡 메타로 이 endpoint 를 polling 해 결과 복원.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const { searchParams } = new URL(req.url)
+  const strategyId = searchParams.get('strategyId')
+  const since = searchParams.get('since')
+  const tickersParam = searchParams.get('tickers')
+  const market = searchParams.get('market')
+  if (!strategyId || !since) {
+    return NextResponse.json({ error: 'strategyId, since 필수' }, { status: 400 })
+  }
+
+  const supabase = getSupabaseAdmin()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server config error' }, { status: 500 })
+  }
+
+  let q = supabase
+    .from('backtest_runs')
+    .select('ticker, market, executed_at, total_return, win_rate, max_drawdown, sharpe_ratio, profit_factor, total_trades, equity_curve, trades, full_metrics, status')
+    .eq('strategy_id', strategyId)
+    .eq('user_id', auth.user.id)
+    .eq('status', 'completed')
+    .gte('executed_at', since)
+    .order('executed_at', { ascending: false })
+
+  if (market === 'KR' || market === 'US') {
+    q = q.eq('market', market)
+  }
+  if (tickersParam) {
+    const tickers = tickersParam.split(',').map(t => t.trim()).filter(Boolean)
+    if (tickers.length > 0) q = q.in('ticker', tickers)
+  }
+
+  const { data, error } = await q.limit(50)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  // (ticker, market) 별로 가장 최근 1건만
+  const latestByTicker = new Map<string, typeof data[number]>()
+  for (const row of data ?? []) {
+    const key = `${row.market}:${row.ticker}`
+    if (!latestByTicker.has(key)) latestByTicker.set(key, row)
+  }
+
+  return NextResponse.json({
+    data: Array.from(latestByTicker.values()).map(r => ({
+      ticker: r.ticker,
+      market: r.market,
+      executedAt: r.executed_at,
+      metrics: r.full_metrics,
+      trades: r.trades || [],
+      equityCurve: r.equity_curve || [],
+    })),
+  })
+}

--- a/dental-clinic-manager/src/app/dashboard/consultations/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/consultations/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import ConsultationManagementContainer from '@/components/Consultations/ConsultationManagementContainer'
+
+export default function ConsultationsPage() {
+  return <ConsultationManagementContainer />
+}

--- a/dental-clinic-manager/src/components/Consultations/ConsultationManagementContainer.tsx
+++ b/dental-clinic-manager/src/components/Consultations/ConsultationManagementContainer.tsx
@@ -1,0 +1,469 @@
+'use client'
+
+import { useEffect, useMemo, useState, useCallback } from 'react'
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
+import { ChevronLeft, ChevronRight, Search, X, MessageSquare, AlertCircle, Check, Pencil, Save } from 'lucide-react'
+import { useAuth } from '@/contexts/AuthContext'
+import { usePermissions } from '@/hooks/usePermissions'
+import { createClient } from '@/lib/supabase/client'
+import { applyClinicFilter } from '@/lib/clinicScope'
+import type { ConsultLog } from '@/types'
+import { appAlert } from '@/components/ui/AppDialog'
+
+type StatusFilter = 'all' | 'confirmed' | 'unconfirmed' | 'undecided'
+
+const STATUS_TO_FILTER: Record<NonNullable<ConsultLog['consult_status']>, Exclude<StatusFilter, 'all'>> = {
+  O: 'confirmed',
+  X: 'unconfirmed',
+  '△': 'undecided',
+}
+
+const STATUS_LABEL: Record<NonNullable<ConsultLog['consult_status']>, string> = {
+  O: '확정',
+  X: '미확정',
+  '△': '미결정',
+}
+
+const STATUS_ORDER: NonNullable<ConsultLog['consult_status']>[] = ['△', 'O', 'X']
+
+function pad(n: number) {
+  return String(n).padStart(2, '0')
+}
+
+function formatYM(year: number, month: number) {
+  return `${year}-${pad(month)}`
+}
+
+function getMonthRange(year: number, month: number) {
+  const start = `${year}-${pad(month)}-01`
+  const next = month === 12 ? { y: year + 1, m: 1 } : { y: year, m: month + 1 }
+  const endExclusive = `${next.y}-${pad(next.m)}-01`
+  return { start, endExclusive }
+}
+
+export default function ConsultationManagementContainer() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const { user } = useAuth()
+  const { hasPermission, isLoading: permLoading } = usePermissions()
+
+  const today = useMemo(() => new Date(), [])
+  const initialYear = parseInt(searchParams.get('year') || '', 10) || today.getFullYear()
+  const initialMonth = parseInt(searchParams.get('month') || '', 10) || today.getMonth() + 1
+
+  const [year, setYear] = useState<number>(initialYear)
+  const [month, setMonth] = useState<number>(initialMonth)
+  const [logs, setLogs] = useState<ConsultLog[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [filter, setFilter] = useState<StatusFilter>('all')
+  const [search, setSearch] = useState('')
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editingText, setEditingText] = useState('')
+  const [savingId, setSavingId] = useState<number | null>(null)
+
+  const canManage = hasPermission('consult_manage')
+
+  // URL 동기화 (year/month 변경 시 query string 갱신)
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('year', String(year))
+    params.set('month', String(month))
+    const next = `${pathname}?${params.toString()}`
+    if (typeof window !== 'undefined' && `${pathname}?${searchParams.toString()}` !== next) {
+      router.replace(next, { scroll: false })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [year, month])
+
+  const loadLogs = useCallback(async () => {
+    if (!user?.clinic_id) return
+    setLoading(true)
+    setError(null)
+    try {
+      const supabase = createClient()
+      const { start, endExclusive } = getMonthRange(year, month)
+      const query = supabase
+        .from('consult_logs')
+        .select('*')
+        .gte('date', start)
+        .lt('date', endExclusive)
+        .order('date', { ascending: false })
+        .order('id', { ascending: false })
+      const { data, error: fetchError } = await applyClinicFilter(query, user.clinic_id)
+      if (fetchError) throw fetchError
+      setLogs((data ?? []) as ConsultLog[])
+    } catch (e) {
+      console.error('[ConsultationManagement] loadLogs error', e)
+      setError(e instanceof Error ? e.message : '상담 기록을 불러오지 못했습니다.')
+    } finally {
+      setLoading(false)
+    }
+  }, [user?.clinic_id, year, month])
+
+  useEffect(() => {
+    if (permLoading) return
+    if (!hasPermission('consult_view')) return
+    loadLogs()
+    // hasPermission은 매 렌더 새 인스턴스가 생성되므로 deps에서 제외 (permLoading=false 시점에 한 번만 평가)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loadLogs, permLoading])
+
+  const counts = useMemo(() => {
+    const c = { all: logs.length, confirmed: 0, unconfirmed: 0, undecided: 0 }
+    for (const l of logs) {
+      const k = STATUS_TO_FILTER[l.consult_status as keyof typeof STATUS_TO_FILTER]
+      if (k) c[k]++
+    }
+    return c
+  }, [logs])
+
+  const filteredLogs = useMemo(() => {
+    let result = logs
+    if (filter !== 'all') {
+      result = result.filter(
+        (l) => STATUS_TO_FILTER[l.consult_status as keyof typeof STATUS_TO_FILTER] === filter,
+      )
+    }
+    const q = search.trim().toLowerCase()
+    if (q) {
+      result = result.filter(
+        (l) =>
+          (l.patient_name || '').toLowerCase().includes(q) ||
+          (l.consult_content || '').toLowerCase().includes(q),
+      )
+    }
+    return result
+  }, [logs, filter, search])
+
+  const goPrevMonth = () => {
+    if (month === 1) {
+      setYear((y) => y - 1)
+      setMonth(12)
+    } else {
+      setMonth((m) => m - 1)
+    }
+  }
+  const goNextMonth = () => {
+    if (month === 12) {
+      setYear((y) => y + 1)
+      setMonth(1)
+    } else {
+      setMonth((m) => m + 1)
+    }
+  }
+  const goCurrentMonth = () => {
+    setYear(today.getFullYear())
+    setMonth(today.getMonth() + 1)
+  }
+
+  const cycleStatus = async (log: ConsultLog) => {
+    if (!canManage || !log.id) return
+    const current = (log.consult_status || '△') as NonNullable<ConsultLog['consult_status']>
+    const idx = STATUS_ORDER.indexOf(current)
+    const next = STATUS_ORDER[(idx + 1) % STATUS_ORDER.length]
+    setSavingId(log.id)
+    try {
+      const supabase = createClient()
+      const { error: updateError } = await supabase
+        .from('consult_logs')
+        .update({ consult_status: next })
+        .eq('id', log.id)
+      if (updateError) throw updateError
+      setLogs((prev) =>
+        prev.map((l) => (l.id === log.id ? { ...l, consult_status: next } : l)),
+      )
+    } catch (e) {
+      console.error('[ConsultationManagement] update status error', e)
+      await appAlert(e instanceof Error ? e.message : '상태 변경에 실패했습니다.')
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  const startEditMemo = (log: ConsultLog) => {
+    if (!canManage || !log.id) return
+    setEditingId(log.id)
+    setEditingText(log.remarks || '')
+  }
+
+  const cancelEditMemo = () => {
+    setEditingId(null)
+    setEditingText('')
+  }
+
+  const saveMemo = async (log: ConsultLog) => {
+    if (!canManage || !log.id) return
+    setSavingId(log.id)
+    try {
+      const supabase = createClient()
+      const { error: updateError } = await supabase
+        .from('consult_logs')
+        .update({ remarks: editingText })
+        .eq('id', log.id)
+      if (updateError) throw updateError
+      setLogs((prev) => prev.map((l) => (l.id === log.id ? { ...l, remarks: editingText } : l)))
+      setEditingId(null)
+      setEditingText('')
+    } catch (e) {
+      console.error('[ConsultationManagement] save memo error', e)
+      await appAlert(e instanceof Error ? e.message : '메모 저장에 실패했습니다.')
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  if (permLoading) {
+    return (
+      <div className="p-6 flex items-center justify-center min-h-[300px]">
+        <div className="w-8 h-8 border-4 border-at-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  if (!hasPermission('consult_view')) {
+    return (
+      <div className="p-6">
+        <div className="max-w-xl mx-auto text-center py-12 px-6 bg-white border border-at-border rounded-2xl">
+          <AlertCircle className="w-10 h-10 text-at-warning mx-auto mb-3" />
+          <h2 className="text-lg font-semibold text-at-text mb-1">권한이 없습니다</h2>
+          <p className="text-sm text-at-text-secondary">
+            상담 관리 기능을 사용할 권한이 없습니다. 관리자에게 문의하세요.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4 sm:p-6 bg-white min-h-screen">
+      {/* 헤더 + 월 선택 */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <div className="flex items-center gap-2">
+          <MessageSquare className="w-5 h-5 text-at-accent" />
+          <h1 className="text-xl sm:text-2xl font-semibold text-at-text">상담 관리</h1>
+        </div>
+        <div className="flex items-center gap-1 bg-at-surface-alt rounded-xl p-1">
+          <button
+            onClick={goPrevMonth}
+            className="p-1.5 rounded-lg hover:bg-white text-at-text-secondary"
+            aria-label="이전 달"
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+          <span className="px-3 text-sm font-medium text-at-text min-w-[90px] text-center">
+            {formatYM(year, month)}
+          </span>
+          <button
+            onClick={goNextMonth}
+            className="p-1.5 rounded-lg hover:bg-white text-at-text-secondary"
+            aria-label="다음 달"
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+          <button
+            onClick={goCurrentMonth}
+            className="ml-1 px-2 py-1 text-xs font-medium text-at-accent hover:bg-white rounded-lg"
+          >
+            이번 달
+          </button>
+        </div>
+      </div>
+
+      {/* 상태 카드 */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-3 mb-4">
+        <StatCard label="전체" value={counts.all} active={filter === 'all'} onClick={() => setFilter('all')} tone="neutral" />
+        <StatCard label="확정" value={counts.confirmed} active={filter === 'confirmed'} onClick={() => setFilter('confirmed')} tone="success" />
+        <StatCard label="미확정" value={counts.unconfirmed} active={filter === 'unconfirmed'} onClick={() => setFilter('unconfirmed')} tone="warning" />
+        <StatCard label="미결정" value={counts.undecided} active={filter === 'undecided'} onClick={() => setFilter('undecided')} tone="info" />
+      </div>
+
+      {/* 검색 */}
+      <div className="flex items-center gap-2 mb-3">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-at-text-weak" />
+          <input
+            type="text"
+            placeholder="환자명 또는 상담내용 검색..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-10 pr-9 py-2 text-sm border border-at-border rounded-xl focus:ring-2 focus:ring-at-accent focus:border-at-accent"
+          />
+          {search && (
+            <button
+              onClick={() => setSearch('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-at-text-weak hover:text-at-text rounded-full hover:bg-at-surface-hover"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+        <span className="text-xs text-at-text-weak">{filteredLogs.length}건</span>
+      </div>
+
+      {/* 에러 */}
+      {error && (
+        <div className="flex items-center gap-2 p-3 mb-3 bg-at-error-bg text-at-error rounded-xl text-sm">
+          <AlertCircle className="w-4 h-4" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {/* 테이블 */}
+      <div className="border border-at-border rounded-2xl overflow-hidden bg-white">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm text-left min-w-[800px]">
+            <thead className="bg-at-surface-alt text-at-text sticky top-0 z-10">
+              <tr>
+                <th className="p-3 font-medium whitespace-nowrap w-24">날짜</th>
+                <th className="p-3 font-medium whitespace-nowrap w-24">환자명</th>
+                <th className="p-3 font-medium">상담내용</th>
+                <th className="p-3 font-medium whitespace-nowrap w-24 text-center">상태</th>
+                <th className="p-3 font-medium">메모</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td colSpan={5} className="p-8 text-center">
+                    <div className="inline-block w-6 h-6 border-3 border-at-accent border-t-transparent rounded-full animate-spin" />
+                  </td>
+                </tr>
+              ) : filteredLogs.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="p-10 text-center text-at-text-weak">
+                    <MessageSquare className="w-8 h-8 mx-auto mb-2 text-at-text-weak/60" />
+                    {logs.length === 0
+                      ? `${formatYM(year, month)}에 등록된 상담 기록이 없습니다.`
+                      : '조건에 맞는 상담이 없습니다.'}
+                  </td>
+                </tr>
+              ) : (
+                filteredLogs.map((log) => {
+                  const status = (log.consult_status || '△') as NonNullable<ConsultLog['consult_status']>
+                  const statusLabel = STATUS_LABEL[status]
+                  const statusClass =
+                    status === 'O'
+                      ? 'bg-at-success-bg text-at-success'
+                      : status === 'X'
+                        ? 'bg-at-warning-bg text-at-warning'
+                        : 'bg-at-surface-alt text-at-text-secondary'
+                  const isSaving = savingId === log.id
+                  const isEditing = editingId === log.id
+                  return (
+                    <tr key={log.id} className="border-b border-at-border last:border-0 hover:bg-at-surface-hover">
+                      <td className="p-3 whitespace-nowrap text-at-text-secondary">{log.date}</td>
+                      <td className="p-3 whitespace-nowrap font-medium">{log.patient_name}</td>
+                      <td className="p-3 text-at-text-secondary">{log.consult_content}</td>
+                      <td className="p-3 whitespace-nowrap text-center">
+                        <button
+                          onClick={() => cycleStatus(log)}
+                          disabled={!canManage || isSaving}
+                          className={`px-2 py-1 rounded text-xs font-medium transition-colors ${statusClass} ${
+                            canManage ? 'cursor-pointer hover:opacity-80' : 'cursor-default'
+                          } ${isSaving ? 'opacity-50' : ''}`}
+                          title={canManage ? '클릭하여 상태 변경' : statusLabel}
+                        >
+                          {statusLabel}
+                        </button>
+                      </td>
+                      <td className="p-3">
+                        {isEditing ? (
+                          <div className="flex items-start gap-1">
+                            <textarea
+                              value={editingText}
+                              onChange={(e) => setEditingText(e.target.value)}
+                              rows={2}
+                              autoFocus
+                              className="flex-1 px-2 py-1 text-sm border border-at-accent rounded-lg focus:ring-1 focus:ring-at-accent"
+                              placeholder="메모 입력..."
+                            />
+                            <div className="flex flex-col gap-1">
+                              <button
+                                onClick={() => saveMemo(log)}
+                                disabled={isSaving}
+                                className="p-1 text-at-success hover:bg-at-success-bg rounded disabled:opacity-50"
+                                title="저장"
+                              >
+                                {isSaving ? (
+                                  <span className="block w-4 h-4 border-2 border-at-success border-t-transparent rounded-full animate-spin" />
+                                ) : (
+                                  <Check className="w-4 h-4" />
+                                )}
+                              </button>
+                              <button
+                                onClick={cancelEditMemo}
+                                disabled={isSaving}
+                                className="p-1 text-at-text-weak hover:bg-at-surface-hover rounded"
+                                title="취소"
+                              >
+                                <X className="w-4 h-4" />
+                              </button>
+                            </div>
+                          </div>
+                        ) : (
+                          <button
+                            onClick={() => startEditMemo(log)}
+                            disabled={!canManage}
+                            className={`group inline-flex items-start gap-1 text-left w-full ${
+                              canManage ? 'cursor-text' : 'cursor-default'
+                            }`}
+                            title={canManage ? '클릭하여 메모 편집' : ''}
+                          >
+                            <span
+                              className={`flex-1 ${log.remarks ? 'text-at-text-secondary' : 'text-at-text-weak italic'}`}
+                            >
+                              {log.remarks || (canManage ? '메모 추가...' : '-')}
+                            </span>
+                            {canManage && (
+                              <Pencil className="w-3.5 h-3.5 text-at-text-weak opacity-0 group-hover:opacity-100 mt-0.5 flex-shrink-0" />
+                            )}
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* 도움말 */}
+      {canManage && filteredLogs.length > 0 && (
+        <p className="mt-3 text-xs text-at-text-weak">
+          상태 배지 또는 메모 영역을 클릭하면 인라인으로 수정할 수 있습니다.
+        </p>
+      )}
+    </div>
+  )
+}
+
+interface StatCardProps {
+  label: string
+  value: number
+  active: boolean
+  onClick: () => void
+  tone: 'neutral' | 'success' | 'warning' | 'info'
+}
+
+function StatCard({ label, value, active, onClick, tone }: StatCardProps) {
+  const toneClass = {
+    neutral: active ? 'bg-at-text text-white border-at-text' : 'border-at-border text-at-text',
+    success: active ? 'bg-at-success text-white border-at-success' : 'border-at-border text-at-text',
+    warning: active ? 'bg-at-warning text-white border-at-warning' : 'border-at-border text-at-text',
+    info: active ? 'bg-at-accent text-white border-at-accent' : 'border-at-border text-at-text',
+  }[tone]
+  return (
+    <button
+      onClick={onClick}
+      className={`flex items-center justify-between gap-2 px-3 py-3 rounded-xl border-2 transition-colors text-left ${toneClass}`}
+    >
+      <span className="text-xs sm:text-sm font-medium">{label}</span>
+      <span className="text-lg sm:text-xl font-bold">{value}</span>
+    </button>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/BacktestPanel.tsx
+++ b/dental-clinic-manager/src/components/Investment/BacktestPanel.tsx
@@ -9,7 +9,7 @@ import TickerSearch from '@/components/Investment/TickerSearch'
 import DateRangePicker from '@/components/Investment/DateRangePicker'
 import type { InvestmentStrategy, Market, EquityCurvePoint } from '@/types/investment'
 import {
-  startJob, getJob, subscribe as subscribeJob,
+  startJob, getJob, subscribe as subscribeJob, restoreFromStorage,
   type BacktestResultData,
 } from '@/lib/investment/backtestJobStore'
 
@@ -134,8 +134,11 @@ export default function BacktestPanel({ strategyId, onBack }: BacktestPanelProps
     })
   }, [strategyId])
 
-  // mount 시 기존 작업 있으면 즉시 복원 + 변경 알림 구독
+  // mount 시 기존 작업 있으면 즉시 복원 + 변경 알림 구독.
+  // 새로고침/탭 종료 후 진입 시에는 restoreFromStorage 가 sessionStorage 의 잡 메타로
+  // DB 폴링을 시작해 결과를 회수.
   useEffect(() => {
+    restoreFromStorage(strategyId)
     syncFromStore()
     const unsub = subscribeJob(strategyId, syncFromStore)
     return unsub

--- a/dental-clinic-manager/src/config/menuConfig.ts
+++ b/dental-clinic-manager/src/config/menuConfig.ts
@@ -189,6 +189,16 @@ export const MENU_CONFIG: MenuConfigItem[] = [
     visible: true,
   },
   {
+    id: 'consult-management',
+    label: '상담 관리',
+    icon: 'MessageSquare',
+    route: '/dashboard/consultations',
+    permissions: ['consult_view'],
+    categoryId: 'work',
+    order: 5.5,
+    visible: true,
+  },
+  {
     id: 'ai-analysis',
     label: 'AI 데이터 분석',
     icon: 'Sparkles',
@@ -436,6 +446,7 @@ export const KNOWN_NON_MENU_ROUTES: string[] = [
   '/test-protocol',      // 테스트 프로토콜
   '/guide',              // 가이드 (별도 라우트, 메뉴는 /dashboard?tab=guide)
   '/dashboard/ai-analysis', // AI 분석 (별도 라우트, 메뉴는 /dashboard?tab=ai-analysis)
+  '/dashboard/consultations', // 상담 관리 (consult-management 메뉴와 매칭)
 ]
 
 // ============================================

--- a/dental-clinic-manager/src/lib/investment/backtestJobStore.ts
+++ b/dental-clinic-manager/src/lib/investment/backtestJobStore.ts
@@ -14,7 +14,11 @@
  *   안에 끝나므로 새로고침 후 backtest_runs 테이블에서 결과 복구 가능 (별도 흐름)
  */
 
-import type { BacktestMetrics, BacktestTrade, EquityCurvePoint, Market } from '@/types/investment'
+import type {
+  BacktestMetrics, BacktestTrade, EquityCurvePoint, Market,
+} from '@/types/investment'
+// Re-import (used in restoreFromStorage)
+export type { BacktestMetrics, BacktestTrade } from '@/types/investment'
 
 export interface BuyHoldData {
   totalReturn: number
@@ -59,6 +63,56 @@ type Listener = () => void
 const jobs = new Map<string, BacktestJob>()
 const listeners = new Map<string, Set<Listener>>()
 
+// sessionStorage 키 포맷
+const SS_KEY = 'backtest-jobs-v1'
+
+interface PersistedJobMeta {
+  strategyId: string
+  startedAt: number
+  params: BacktestJobParams
+  /** DB 폴링이 아직 진행 중인 ticker 들 */
+  pendingTickers: string[]
+}
+
+function loadPersisted(): Record<string, PersistedJobMeta> {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = window.sessionStorage.getItem(SS_KEY)
+    if (!raw) return {}
+    return JSON.parse(raw) as Record<string, PersistedJobMeta>
+  } catch {
+    return {}
+  }
+}
+
+function savePersisted(map: Record<string, PersistedJobMeta>) {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(SS_KEY, JSON.stringify(map))
+  } catch {
+    /* ignore quota */
+  }
+}
+
+function persistJob(strategyId: string, job: BacktestJob) {
+  const all = loadPersisted()
+  all[strategyId] = {
+    strategyId,
+    startedAt: job.startedAt,
+    params: job.params,
+    pendingTickers: Array.from(job.runningTickers),
+  }
+  savePersisted(all)
+}
+
+function clearPersisted(strategyId: string) {
+  const all = loadPersisted()
+  if (all[strategyId]) {
+    delete all[strategyId]
+    savePersisted(all)
+  }
+}
+
 function notify(strategyId: string) {
   const set = listeners.get(strategyId)
   if (!set) return
@@ -99,6 +153,7 @@ export function startJob(params: BacktestJobParams): BacktestJob {
     done: tickers.length === 0,
   }
   jobs.set(strategyId, job)
+  persistJob(strategyId, job)
   notify(strategyId)
 
   // 각 ticker 별 fetch 실행 — Promise 는 모듈 레벨이라 컴포넌트 unmount 영향 없음
@@ -150,11 +205,126 @@ export function startJob(params: BacktestJobParams): BacktestJob {
         const cur = jobs.get(strategyId)
         if (!cur || cur.startedAt !== job.startedAt) return
         cur.runningTickers.delete(entry.ticker)
-        if (cur.runningTickers.size === 0) cur.done = true
+        if (cur.runningTickers.size === 0) {
+          cur.done = true
+          clearPersisted(strategyId)
+        } else {
+          persistJob(strategyId, cur)
+        }
         notify(strategyId)
       })
   }
 
+  return job
+}
+
+/**
+ * 새로고침/탭 종료 후 다시 진입했을 때 sessionStorage 의 진행 중 잡을 DB 폴링으로 복구.
+ * Vercel function 은 클라이언트 disconnect 후에도 maxDuration 까지 실행되므로
+ * 백테스트 결과는 backtest_runs 에 저장됨 → 폴링으로 회수 가능.
+ */
+export function restoreFromStorage(strategyId: string): BacktestJob | undefined {
+  // 이미 in-memory 잡이 있으면 그대로 사용
+  const existing = jobs.get(strategyId)
+  if (existing) return existing
+
+  const all = loadPersisted()
+  const meta = all[strategyId]
+  if (!meta) return undefined
+
+  // 너무 오래된 잡은 stale 로 간주 (3분 timeout)
+  const ageMs = Date.now() - meta.startedAt
+  if (ageMs > 3 * 60_000) {
+    clearPersisted(strategyId)
+    return undefined
+  }
+
+  // in-memory 잡 재생성 (DB 폴링 모드)
+  const job: BacktestJob = {
+    startedAt: meta.startedAt,
+    params: meta.params,
+    runningTickers: new Set(meta.pendingTickers),
+    results: [],
+    errors: [],
+    done: meta.pendingTickers.length === 0,
+  }
+  jobs.set(strategyId, job)
+  notify(strategyId)
+
+  if (meta.pendingTickers.length === 0) return job
+
+  // 백그라운드 폴링 시작 — 5초마다 결과 확인, 최대 90초
+  const pollIntervalMs = 5_000
+  const pollTimeoutMs = 90_000
+  const startedAt = meta.startedAt
+  const sinceIso = new Date(meta.startedAt - 1000).toISOString() // 1초 여유
+  const tickersParam = meta.pendingTickers.join(',')
+  const market = meta.params.tickers[0]?.market
+
+  const poll = async () => {
+    const cur = jobs.get(strategyId)
+    if (!cur || cur.startedAt !== startedAt) return
+
+    try {
+      const res = await fetch(
+        `/api/investment/backtest/results?strategyId=${encodeURIComponent(strategyId)}` +
+          `&tickers=${encodeURIComponent(tickersParam)}` +
+          (market ? `&market=${market}` : '') +
+          `&since=${encodeURIComponent(sinceIso)}`,
+        { cache: 'no-store' },
+      )
+      if (res.ok) {
+        const json = await res.json().catch(() => ({}))
+        const items = (json.data ?? []) as Array<{
+          ticker: string
+          market: 'KR' | 'US'
+          metrics?: BacktestMetrics
+          trades?: BacktestTrade[]
+          equityCurve?: EquityCurvePoint[]
+        }>
+        const tickerNameMap = new Map(meta.params.tickers.map(t => [t.ticker, t.name]))
+        for (const it of items) {
+          if (!cur.runningTickers.has(it.ticker)) continue
+          if (!it.metrics) continue
+          cur.results.push({
+            ticker: it.ticker,
+            tickerName: tickerNameMap.get(it.ticker) || it.ticker,
+            market: it.market,
+            metrics: it.metrics,
+            trades: it.trades ?? [],
+            equityCurve: it.equityCurve ?? [],
+          })
+          cur.runningTickers.delete(it.ticker)
+        }
+        cur.results.sort((a, b) => b.metrics.totalReturn - a.metrics.totalReturn)
+        if (cur.runningTickers.size === 0) {
+          cur.done = true
+          clearPersisted(strategyId)
+        } else {
+          persistJob(strategyId, cur)
+        }
+        notify(strategyId)
+      }
+    } catch {
+      /* 일시 네트워크 오류 — 다음 tick 에서 재시도 */
+    }
+
+    // 계속 폴링
+    if (cur.runningTickers.size > 0 && Date.now() - startedAt < pollTimeoutMs) {
+      setTimeout(poll, pollIntervalMs)
+    } else if (cur.runningTickers.size > 0) {
+      // timeout
+      for (const t of cur.runningTickers) {
+        cur.errors.push(`${t}: 결과 폴링 시간 초과 (서버 측 백테스트가 완료되지 않았거나 실패)`)
+      }
+      cur.runningTickers.clear()
+      cur.done = true
+      clearPersisted(strategyId)
+      notify(strategyId)
+    }
+  }
+
+  setTimeout(poll, pollIntervalMs) // 첫 폴링은 5초 후 (서버에 결과 도착할 시간)
   return job
 }
 

--- a/dental-clinic-manager/src/types/permissions.ts
+++ b/dental-clinic-manager/src/types/permissions.ts
@@ -8,6 +8,8 @@ export type Permission =
   | 'stats_monthly_view'     // 월간 통계 보기
   | 'stats_annual_view'      // 연간 통계 보기
   | 'logs_view'              // 상세 기록 보기
+  | 'consult_view'           // 상담 관리 보기 (월별)
+  | 'consult_manage'         // 상담 관리 메모/상태 수정
   | 'inventory_view'         // 재고 관리 보기
   | 'inventory_manage'       // 재고 관리 수정
   | 'staff_view'             // 직원 목록 보기
@@ -121,7 +123,7 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     // 대표원장은 모든 권한
     'daily_report_view', 'daily_report_create', 'daily_report_edit', 'daily_report_delete',
     'stats_weekly_view', 'stats_monthly_view', 'stats_annual_view',
-    'logs_view', 'inventory_view', 'inventory_manage',
+    'logs_view', 'consult_view', 'consult_manage', 'inventory_view', 'inventory_manage',
     'staff_view', 'staff_manage', 'clinic_settings', 'guide_view',
     'protocol_view', 'protocol_create', 'protocol_edit', 'protocol_delete',
     'protocol_version_restore', 'protocol_history_view', 'protocol_category_manage',
@@ -174,7 +176,7 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     // 유료 기능(리콜/AI/경영현황/월간보고서/소개환자/마케팅/투자)은 기본 제외 — 대표원장만 보유
     'daily_report_view', 'daily_report_create', 'daily_report_edit', 'daily_report_delete',
     'stats_weekly_view', 'stats_monthly_view', 'stats_annual_view',
-    'logs_view', 'inventory_view', 'inventory_manage',
+    'logs_view', 'consult_view', 'consult_manage', 'inventory_view', 'inventory_manage',
     'staff_view', 'guide_view',
     'protocol_view', 'protocol_create', 'protocol_edit',
     'protocol_version_restore', 'protocol_history_view', 'protocol_category_manage',
@@ -209,7 +211,7 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     // 유료 기능(리콜/AI/경영현황/월간보고서/소개환자/마케팅/투자)은 기본 제외 — 대표원장만 보유
     'daily_report_view', 'daily_report_create', 'daily_report_edit', 'daily_report_delete',
     'stats_weekly_view', 'stats_monthly_view', 'stats_annual_view',
-    'logs_view', 'inventory_view', 'inventory_manage',
+    'logs_view', 'consult_view', 'consult_manage', 'inventory_view', 'inventory_manage',
     'staff_view', 'guide_view',
     'protocol_view', 'protocol_history_view',
     // 근로계약서 관리 (조회만)
@@ -241,7 +243,7 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     // 유료 기능(리콜/AI/경영현황/월간보고서/소개환자/마케팅/투자)은 기본 제외 — 대표원장만 보유
     'daily_report_view', 'daily_report_create', 'daily_report_edit',
     'stats_weekly_view', 'stats_monthly_view',
-    'logs_view', 'inventory_view', 'guide_view',
+    'logs_view', 'consult_view', 'inventory_view', 'guide_view',
     'protocol_view', 'protocol_history_view',
     // 근로계약서 관리 (본인 것만 조회)
     'contract_view',
@@ -302,6 +304,7 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
 // 기존 직원의 저장된 커스텀 권한에 해당 prefix 권한이 하나도 없으면
 // 역할 기본 권한에서 자동 보충 (usePermissions / PermissionSelector 공용)
 export const NEW_FEATURE_PREFIXES = [
+  'consult_',
   'payroll_',
   'task_checklist_',
   'task_directive_',
@@ -338,6 +341,10 @@ export const PERMISSION_GROUPS = {
     { key: 'logs_view', label: '상세 기록 보기' },
     { key: 'inventory_view', label: '재고 현황 보기' },
     { key: 'inventory_manage', label: '재고 관리' }
+  ],
+  '상담 관리': [
+    { key: 'consult_view', label: '상담 관리 조회 (월별)' },
+    { key: 'consult_manage', label: '상담 메모/상태 수정' }
   ],
   '직원 관리': [
     { key: 'staff_view', label: '직원 목록 보기' },
@@ -477,6 +484,8 @@ export const PERMISSION_DESCRIPTIONS: Record<Permission, string> = {
   'stats_monthly_view': '월간 통계를 조회할 수 있습니다.',
   'stats_annual_view': '연간 통계를 조회할 수 있습니다.',
   'logs_view': '상세 기록을 조회할 수 있습니다.',
+  'consult_view': '상담 관리 페이지에서 월별로 상담 내역을 조회할 수 있습니다.',
+  'consult_manage': '상담의 확정/미확정 상태와 메모를 수정할 수 있습니다.',
   'inventory_view': '재고 현황을 조회할 수 있습니다.',
   'inventory_manage': '재고를 추가/수정/삭제할 수 있습니다.',
   'staff_view': '직원 목록을 조회할 수 있습니다.',


### PR DESCRIPTION
## 누적 변경 통합 PR

develop 브랜치에 누적된 변경사항을 main으로 머지하는 통합 PR입니다.

### 최근 포함 작업
- **feat(consultations)**: 월별 상담 관리 메뉴 신설 (`/dashboard/consultations`)
  - 월(YYYY-MM) 선택 + URL 동기화
  - 확정/미확정/미결정 상태별 카운트 카드 + 필터
  - 환자명·상담내용 검색
  - 메모(remarks) 인라인 편집, 상태 인라인 토글
  - DB 스키마 변경 없음 (기존 `consult_logs.consult_status`/`remarks` 재사용)
  - `consult_view`/`consult_manage` 권한 신설 (NEW_FEATURE_PREFIXES 자동 보충)

### 머지 정책
- 새 커밋이 develop에 누적되면 이 PR에도 자동 누적됨
- 사람이 직접 main 머지 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)