### PR TITLE
fix(cron): 텔레그램 일일요약 KST 10시로 이동 (Hobby cron 한도 우회)

### DIFF
--- a/dental-clinic-manager/src/app/api/cron/daily-tasks/route.ts
+++ b/dental-clinic-manager/src/app/api/cron/daily-tasks/route.ts
@@ -1,8 +1,11 @@
-// 일일 작업 크론 (뉴스 크롤링)
-// 텔레그램 요약은 다음날 KST 10시 발송 정책에 따라 /api/cron/telegram-summary 로 분리됨.
+// 일일 작업 크론 — KST 10시에 뉴스 크롤링 + 텔레그램 일일요약을 함께 실행.
+// (Vercel Hobby 플랜의 cron 갯수 한도 때문에 별도 cron 항목을 만들 수 없어
+//  요약 호출을 같은 라우트에 묶고, 스케줄을 KST 10시로 옮겨 "다음날 오전 10시 발송"
+//  요구사항을 충족.)
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { runNewsCrawl } from '@/lib/newsCrawlService'
+import { runTelegramSummary } from '@/lib/telegramSummaryCron'
 
 export const maxDuration = 60
 
@@ -21,18 +24,20 @@ export async function GET(request: Request) {
 
   const supabase = createClient(supabaseUrl, supabaseServiceKey)
 
-  try {
-    const news = await runNewsCrawl(supabase)
-    return NextResponse.json({
-      success: true,
-      news: { success: true, results: news },
-      timestamp: new Date().toISOString(),
-    })
-  } catch (error) {
-    return NextResponse.json({
-      success: false,
-      news: { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
-      timestamp: new Date().toISOString(),
-    }, { status: 500 })
-  }
+  // 뉴스 + 텔레그램 요약을 병렬 실행 (개별 실패가 다른 작업을 막지 않도록 allSettled)
+  const [newsResult, summaryResult] = await Promise.allSettled([
+    runNewsCrawl(supabase),
+    runTelegramSummary(supabase),
+  ])
+
+  return NextResponse.json({
+    success: true,
+    news: newsResult.status === 'fulfilled'
+      ? { success: true, results: newsResult.value }
+      : { success: false, error: newsResult.reason?.message ?? 'Unknown error' },
+    telegramSummary: summaryResult.status === 'fulfilled'
+      ? { success: true, results: summaryResult.value }
+      : { success: false, error: summaryResult.reason?.message ?? 'Unknown error' },
+    timestamp: new Date().toISOString(),
+  })
 }

--- a/dental-clinic-manager/vercel.json
+++ b/dental-clinic-manager/vercel.json
@@ -12,10 +12,6 @@
     },
     {
       "path": "/api/cron/daily-tasks",
-      "schedule": "30 15 * * *"
-    },
-    {
-      "path": "/api/cron/telegram-summary",
       "schedule": "0 1 * * *"
     },
     {


### PR DESCRIPTION
## Summary
- 사용자 보고: 텔레그램 모임방 일일 요약이 여전히 자정 즈음에 발송됨
- 원인 추정: 직전 PR #549의 vercel.json cron 추가가 Vercel Hobby 한도에 걸려 production deploy에서 거부 → production은 옛 daily-tasks(요약 포함, KST 00:30) 그대로 실행 중
- 수정: cron 갯수를 늘리지 않도록 \`daily-tasks\` 스케줄 자체를 KST 10시로 옮기고, 별도 \`telegram-summary\` cron 항목 제거. 라우트는 수동 트리거용으로 유지.

## Test plan
- [x] \`npm run build\` 성공
- [ ] Vercel 배포 성공 여부 + cron 대시보드에서 \`daily-tasks\` 가 \`0 1 * * *\` (UTC) 로 등록됐는지 확인
- [ ] 다음 KST 10:00 에 텔레그램 그룹에 어제분 요약이 1회 게시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)