### PR TITLE
release: develop → main (누적 변경 통합)

### DIFF
--- a/dental-clinic-manager/src/app/globals.css
+++ b/dental-clinic-manager/src/app/globals.css
@@ -304,6 +304,13 @@ body {
   white-space: pre-wrap;
 }
 
+/* 빈 단락(엔터 2번으로 생성된 <p></p>)을 빈 줄로 표시
+   — 에디터와 뷰어 모두 일관되게 빈 줄을 보이게 함 */
+.protocol-editor-content p:empty::before,
+.prose p:empty::before {
+  content: '\00a0'; /* non-breaking space — line-height 확보 */
+}
+
 /* Protocol Images */
 .protocol-image {
   max-width: 100%;

--- a/dental-clinic-manager/src/components/Contract/ContractDetail.tsx
+++ b/dental-clinic-manager/src/components/Contract/ContractDetail.tsx
@@ -587,7 +587,13 @@ export default function ContractDetail({ contractId, currentUser }: ContractDeta
 
           {/* Article 4 - 계약기간 월급여액 */}
           <section className="border-b pb-4">
-            <h2 className="text-lg font-bold mb-3">제4조 (계약기간 월급여액) ({data.salary_base_type === 'net' ? '세후' : '세전'})</h2>
+            {/*
+              주의(불변성): 2026-04-14 a1703141 이전에 서명·완료된 계약서는
+              salary_base_type 필드가 contract_data에 저장되지 않아 NULL 이다.
+              당시 본문 표기는 하드코딩 "(세후)" 였으므로 NULL 은 '세후'로 폴백해야
+              과거 PDF/원본과 동일한 표시를 보장한다. 명시적으로 'gross' 일 때만 '세전'.
+            */}
+            <h2 className="text-lg font-bold mb-3">제4조 (계약기간 월급여액) ({data.salary_base_type === 'gross' ? '세전' : '세후'})</h2>
             <p className="font-bold">월급여액: {formatSalary(data.salary_base)}</p>
           </section>
 

--- a/dental-clinic-manager/src/components/Contract/ContractForm.tsx
+++ b/dental-clinic-manager/src/components/Contract/ContractForm.tsx
@@ -16,7 +16,7 @@ import type { UserProfile } from '@/contexts/AuthContext'
 import { formatResidentNumber, autoFormatResidentNumber, validateResidentNumberWithMessage } from '@/utils/residentNumberUtils'
 import { decryptResidentNumber } from '@/utils/encryptionUtils'
 import type { DaySchedule, WorkSchedule, DayName } from '@/types/workSchedule'
-import { appAlert } from '@/components/ui/AppDialog'
+import { appAlert, appConfirm } from '@/components/ui/AppDialog'
 import { TimePicker } from '@/components/ui/TimePicker'
 
 interface ContractFormProps {
@@ -218,6 +218,14 @@ export default function ContractForm({ currentUser, employees, onSuccess, onCanc
       await appAlert('계약 기간(종료일)을 설정해주세요.')
       return
     }
+
+    // 서명 이후엔 본문 변경이 불가능하므로(계약서 불변성), 세전/세후 선택을 명시적으로 재확인.
+    // 과거 누락으로 잘못 표시된 사고(세전↔세후 표기 변경)를 방지하기 위함.
+    const salaryLabel = salaryType === 'net' ? '세후 (실수령액)' : '세전 (세금 포함)'
+    const ok = await appConfirm(
+      `다음 조건으로 계약서를 생성합니다.\n\n• 급여 기준: ${salaryLabel}\n• 월급여액: ${(formData.salary_base ?? 0).toLocaleString()}원\n\n서명 완료 후에는 본문을 수정할 수 없습니다. 진행하시겠습니까?`,
+    )
+    if (!ok) return
 
     setLoading(true)
 

--- a/dental-clinic-manager/src/lib/contractService.ts
+++ b/dental-clinic-manager/src/lib/contractService.ts
@@ -433,6 +433,11 @@ class ContractService {
 
   /**
    * Update contract data
+   *
+   * 불변성: 서명 단계 이후의 계약서는 본문(contract_data) 변경을 거부한다.
+   * 동일 보호가 DB BEFORE UPDATE 트리거(enforce_contract_immutability)로도 걸려 있으나,
+   * 서비스 레이어에서 더 명확한 에러 메시지를 주기 위해 사전 가드 한다.
+   * status 자체 전이는 updateContractStatus 를 사용한다.
    */
   async updateContract(
     contractId: string,
@@ -444,6 +449,26 @@ class ContractService {
     }
 
     try {
+      // 현재 상태 조회
+      const { data: existing, error: fetchError } = await supabase
+        .from('employment_contracts')
+        .select('status')
+        .eq('id', contractId)
+        .single()
+      if (fetchError) {
+        return { success: false, error: fetchError.message }
+      }
+
+      const locked = ['pending_employee_signature', 'pending_employer_signature', 'completed']
+        .includes((existing as { status: string }).status)
+      const tryingToChangeBody = Object.prototype.hasOwnProperty.call(updates, 'contract_data')
+      if (locked && tryingToChangeBody) {
+        return {
+          success: false,
+          error: '서명 단계 이후의 계약서 본문은 변경할 수 없습니다.',
+        }
+      }
+
       const { data, error } = await supabase
         .from('employment_contracts')
         .update({

--- a/dental-clinic-manager/supabase/migrations/20260511_contract_immutability_after_sign.sql
+++ b/dental-clinic-manager/supabase/migrations/20260511_contract_immutability_after_sign.sql
@@ -1,0 +1,44 @@
+-- ============================================
+-- 근로계약서 — 서명 단계 이후 contract_data 변경 차단 (불변성)
+-- 사용자 보고: a1703141 커밋(2026-04-14)에서 표시 로직만 바뀌었음에도
+-- 서명 완료된 계약서의 본문 표기가 "세후 → 세전"으로 보이는 사실상의 문구 변경 발생.
+-- 향후 동일/유사한 사고를 막기 위해, status 가 서명 단계 이후이면
+-- contract_data JSONB 자체의 변경을 DB 레벨에서 거부한다.
+--
+-- 허용:
+--   - status 자체 전이 (예: pending_*_signature → completed, → cancelled)
+--   - status='draft' 인 동안의 자유로운 편집
+--
+-- 차단:
+--   - status IN ('pending_employee_signature','pending_employer_signature','completed')
+--     인 row에서 contract_data 의 내용이 달라지면 EXCEPTION
+--
+-- Migration: 20260511_contract_immutability_after_sign.sql
+-- Created: 2026-05-11
+-- ============================================
+
+CREATE OR REPLACE FUNCTION enforce_contract_immutability()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- 이전 상태(OLD)가 서명 단계 이후일 때만 검사
+  IF OLD.status IN ('pending_employee_signature', 'pending_employer_signature', 'completed') THEN
+    -- contract_data 가 실제로 바뀌면 차단
+    IF (OLD.contract_data IS DISTINCT FROM NEW.contract_data) THEN
+      RAISE EXCEPTION
+        '서명 단계 이후의 계약서 본문(contract_data)은 변경할 수 없습니다. (contract_id=%, status=%)',
+        OLD.id, OLD.status
+        USING ERRCODE = 'check_violation';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS enforce_contract_immutability_trg ON employment_contracts;
+CREATE TRIGGER enforce_contract_immutability_trg
+  BEFORE UPDATE ON employment_contracts
+  FOR EACH ROW
+  EXECUTE FUNCTION enforce_contract_immutability();
+
+COMMENT ON FUNCTION enforce_contract_immutability IS
+  '근로계약서 본문(contract_data) 불변성 강제 — 서명 단계 이후에는 status 외 변경을 거부';


### PR DESCRIPTION
## Summary
- 김지성 부원장 계약서가 "세후 300만원"으로 발급됐는데 화면에는 "세전 300만원"으로 보이던 문제 해결
- 원인: 2026-04-14 a1703141 커밋에서 \`ContractDetail\` 제4조 헤더의 하드코딩 \`(세후)\` 가 \`data.salary_base_type === 'net' ? '세후' : '세전'\` 조건식으로 바뀌면서, 이전에 작성·서명된 계약서들의 NULL 값이 '세전'으로 폴백됨. 영향 3건(이진희/김혜린/김지성). 데이터 자체가 바뀐 흔적은 없음.
- 보강:
  1. 표시 폴백을 명시적 'gross'에서만 '세전', 그 외(NULL/'net')는 '세후' — 서명 시점 PDF와 일치
  2. DB BEFORE UPDATE 트리거 \`enforce_contract_immutability\` — 서명 단계/완료 후 \`contract_data\` 변경 시 RAISE EXCEPTION
  3. \`contractService.updateContract\` 서비스 가드 — 잠금 상태에서 본문 변경 요청 거부
  4. ContractForm 제출 전 확인 다이얼로그 — 세전/세후·금액 명시, "서명 후 수정 불가" 안내

## Test plan
- [x] \`npm run build\` 성공
- [x] DB 트리거 동작 검증: 완료 계약서 \`contract_data\` 수정 시도 → 차단됨 / status no-op → 통과
- [ ] 영향 3건(이진희/김혜린/김지성)의 화면 표시가 "세후"로 복원되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)