### PR TITLE
feat(community/telegram): 가입 신청·승인 + 마스터 모임장 교체

### DIFF
--- a/dental-clinic-manager/src/app/api/telegram/groups/[id]/join-requests/[requestId]/route.ts
+++ b/dental-clinic-manager/src/app/api/telegram/groups/[id]/join-requests/[requestId]/route.ts
@@ -1,0 +1,162 @@
+/**
+ * Telegram Group Join Request — 개별 처리
+ *
+ *   PATCH /api/telegram/groups/[id]/join-requests/[requestId]
+ *     body: { action: 'approve' | 'reject' | 'cancel', reject_reason?: string }
+ *     - approve/reject: 모임장 또는 master_admin
+ *     - cancel: 본인
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ id: string; requestId: string }> },
+) {
+  const { id: groupId, requestId } = await context.params
+  const supabase = getSupabaseAdmin()
+  if (!supabase) return NextResponse.json({ data: null, error: 'DB error' }, { status: 500 })
+
+  const supabaseAuth = await createClient()
+  const { data: { user } } = await supabaseAuth.auth.getUser()
+  if (!user) return NextResponse.json({ data: null, error: '인증 필요' }, { status: 401 })
+
+  const body = await request.json().catch(() => ({}))
+  const action = body?.action as 'approve' | 'reject' | 'cancel'
+  const rejectReason: string | null = (body?.reject_reason ?? '').toString().trim().slice(0, 500) || null
+  if (!['approve', 'reject', 'cancel'].includes(action)) {
+    return NextResponse.json({ data: null, error: 'action 값이 잘못됨' }, { status: 400 })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: req } = await (supabase as any)
+    .from('telegram_group_join_requests')
+    .select('id, telegram_group_id, user_id, status')
+    .eq('id', requestId)
+    .maybeSingle()
+  if (!req || req.telegram_group_id !== groupId) {
+    return NextResponse.json({ data: null, error: '신청을 찾을 수 없습니다' }, { status: 404 })
+  }
+  if (req.status !== 'pending') {
+    return NextResponse.json({ data: null, error: `이미 처리된 신청입니다 (${req.status})` }, { status: 409 })
+  }
+
+  // 그룹/권한 확인
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: group } = await (supabase as any)
+    .from('telegram_groups')
+    .select('id, board_slug, board_title, created_by')
+    .eq('id', groupId)
+    .maybeSingle()
+  if (!group) return NextResponse.json({ data: null, error: '그룹을 찾을 수 없습니다' }, { status: 404 })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const userRow = await (supabase as any).from('users').select('role, clinic_id').eq('id', user.id).maybeSingle()
+  const role = userRow.data?.role
+  const callerClinicId = userRow.data?.clinic_id ?? null
+  const isMaster = role === 'master_admin'
+  const isCreator = group.created_by === user.id
+  const isApplicant = req.user_id === user.id
+
+  if (action === 'cancel' && !isApplicant) {
+    return NextResponse.json({ data: null, error: '본인 신청만 취소할 수 있습니다' }, { status: 403 })
+  }
+  if (action !== 'cancel' && !isMaster && !isCreator) {
+    return NextResponse.json({ data: null, error: '권한이 없습니다' }, { status: 403 })
+  }
+
+  if (action === 'cancel') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (supabase as any)
+      .from('telegram_group_join_requests')
+      .update({ status: 'cancelled', reviewed_at: new Date().toISOString(), reviewed_by: user.id })
+      .eq('id', requestId)
+      .select()
+      .single()
+    if (error) return NextResponse.json({ data: null, error: error.message }, { status: 500 })
+    return NextResponse.json({ data, error: null })
+  }
+
+  if (action === 'approve') {
+    // 멤버 추가 (UNIQUE 충돌 시 무시)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error: memberError } = await (supabase as any)
+      .from('telegram_group_members')
+      .upsert(
+        { telegram_group_id: groupId, user_id: req.user_id, joined_via: 'admin' },
+        { onConflict: 'telegram_group_id,user_id', ignoreDuplicates: true },
+      )
+    if (memberError) {
+      return NextResponse.json({ data: null, error: memberError.message }, { status: 500 })
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (supabase as any)
+      .from('telegram_group_join_requests')
+      .update({ status: 'approved', reviewed_at: new Date().toISOString(), reviewed_by: user.id })
+      .eq('id', requestId)
+      .select()
+      .single()
+    if (error) return NextResponse.json({ data: null, error: error.message }, { status: 500 })
+
+    // 신청자에게 알림 — 신청자 clinic_id 사용
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const applicant = await (supabase as any).from('users').select('clinic_id').eq('id', req.user_id).maybeSingle()
+    const applicantClinicId = applicant.data?.clinic_id ?? callerClinicId
+    if (applicantClinicId) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (supabase as any).from('user_notifications').insert({
+        clinic_id: applicantClinicId,
+        user_id: req.user_id,
+        type: 'group_join_approved',
+        title: '소모임 가입 승인',
+        content: `"${group.board_title}" 모임 가입이 승인되었습니다`,
+        link: `/dashboard/community/telegram/${group.board_slug}`,
+        reference_type: 'group_join_request',
+        reference_id: requestId,
+        created_by: user.id,
+      })
+    }
+
+    return NextResponse.json({ data, error: null })
+  }
+
+  // reject
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase as any)
+    .from('telegram_group_join_requests')
+    .update({
+      status: 'rejected',
+      reject_reason: rejectReason,
+      reviewed_at: new Date().toISOString(),
+      reviewed_by: user.id,
+    })
+    .eq('id', requestId)
+    .select()
+    .single()
+  if (error) return NextResponse.json({ data: null, error: error.message }, { status: 500 })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const applicant = await (supabase as any).from('users').select('clinic_id').eq('id', req.user_id).maybeSingle()
+  const applicantClinicId = applicant.data?.clinic_id ?? callerClinicId
+  if (applicantClinicId) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (supabase as any).from('user_notifications').insert({
+      clinic_id: applicantClinicId,
+      user_id: req.user_id,
+      type: 'group_join_rejected',
+      title: '소모임 가입 거절',
+      content: rejectReason
+        ? `"${group.board_title}" 모임 가입이 거절되었습니다. 사유: ${rejectReason}`
+        : `"${group.board_title}" 모임 가입이 거절되었습니다`,
+      link: `/dashboard/community/telegram`,
+      reference_type: 'group_join_request',
+      reference_id: requestId,
+      created_by: user.id,
+    })
+  }
+
+  return NextResponse.json({ data, error: null })
+}

--- a/dental-clinic-manager/src/app/api/telegram/groups/[id]/join-requests/route.ts
+++ b/dental-clinic-manager/src/app/api/telegram/groups/[id]/join-requests/route.ts
@@ -1,0 +1,174 @@
+/**
+ * Telegram Group Join Requests API
+ *
+ *   GET  /api/telegram/groups/[id]/join-requests           — 모임장/master: 신청 목록(기본 pending), staff: mine=1로 본인 신청만
+ *   POST /api/telegram/groups/[id]/join-requests           — 본인 가입 신청 생성
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+
+type GroupRow = { id: string; board_slug: string; board_title: string; created_by: string | null }
+
+async function isMaster(userId: string): Promise<boolean> {
+  const supabase = getSupabaseAdmin()
+  if (!supabase) return false
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data } = await (supabase as any).from('users').select('role').eq('id', userId).maybeSingle()
+  return data?.role === 'master_admin'
+}
+
+async function fetchGroup(groupId: string): Promise<GroupRow | null> {
+  const supabase = getSupabaseAdmin()
+  if (!supabase) return null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data } = await (supabase as any)
+    .from('telegram_groups')
+    .select('id, board_slug, board_title, created_by')
+    .eq('id', groupId)
+    .maybeSingle()
+  return data as GroupRow | null
+}
+
+async function getRequesterClinicId(userId: string): Promise<string | null> {
+  const supabase = getSupabaseAdmin()
+  if (!supabase) return null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data } = await (supabase as any).from('users').select('clinic_id').eq('id', userId).maybeSingle()
+  return data?.clinic_id ?? null
+}
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id: groupId } = await context.params
+  const supabase = getSupabaseAdmin()
+  if (!supabase) return NextResponse.json({ data: null, error: 'DB error' }, { status: 500 })
+
+  const supabaseAuth = await createClient()
+  const { data: { user } } = await supabaseAuth.auth.getUser()
+  if (!user) return NextResponse.json({ data: null, error: '인증 필요' }, { status: 401 })
+
+  const group = await fetchGroup(groupId)
+  if (!group) return NextResponse.json({ data: null, error: '그룹을 찾을 수 없습니다' }, { status: 404 })
+
+  const { searchParams } = new URL(request.url)
+  const mine = searchParams.get('mine') === '1'
+  const statusFilter = searchParams.get('status') || 'pending'
+
+  const master = await isMaster(user.id)
+  const isCreator = group.created_by === user.id
+
+  // 본인 신청만 조회는 누구나 가능
+  if (mine) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (supabase as any)
+      .from('telegram_group_join_requests')
+      .select('*')
+      .eq('telegram_group_id', groupId)
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false })
+      .limit(1)
+    if (error) return NextResponse.json({ data: null, error: error.message }, { status: 500 })
+    return NextResponse.json({ data: data?.[0] ?? null, error: null })
+  }
+
+  // 전체 조회는 모임장/master만
+  if (!master && !isCreator) {
+    return NextResponse.json({ data: null, error: '권한이 없습니다' }, { status: 403 })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let q = (supabase as any)
+    .from('telegram_group_join_requests')
+    .select('*, applicant:users!telegram_group_join_requests_user_id_fkey(id, name, email)')
+    .eq('telegram_group_id', groupId)
+    .order('created_at', { ascending: false })
+  if (statusFilter !== 'all') q = q.eq('status', statusFilter)
+  const { data, error } = await q
+  if (error) return NextResponse.json({ data: null, error: error.message }, { status: 500 })
+  return NextResponse.json({ data, error: null })
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id: groupId } = await context.params
+  const supabase = getSupabaseAdmin()
+  if (!supabase) return NextResponse.json({ data: null, error: 'DB error' }, { status: 500 })
+
+  const supabaseAuth = await createClient()
+  const { data: { user } } = await supabaseAuth.auth.getUser()
+  if (!user) return NextResponse.json({ data: null, error: '인증 필요' }, { status: 401 })
+
+  const body = await request.json().catch(() => ({}))
+  const message: string | null = (body?.message ?? '').toString().trim().slice(0, 500) || null
+
+  const group = await fetchGroup(groupId)
+  if (!group) return NextResponse.json({ data: null, error: '그룹을 찾을 수 없습니다' }, { status: 404 })
+
+  // 이미 멤버면 거부
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: existingMember } = await (supabase as any)
+    .from('telegram_group_members')
+    .select('id')
+    .eq('telegram_group_id', groupId)
+    .eq('user_id', user.id)
+    .maybeSingle()
+  if (existingMember) {
+    return NextResponse.json({ data: null, error: '이미 모임 멤버입니다' }, { status: 400 })
+  }
+
+  // pending 신청이 이미 있으면 거부
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: existingReq } = await (supabase as any)
+    .from('telegram_group_join_requests')
+    .select('id, status')
+    .eq('telegram_group_id', groupId)
+    .eq('user_id', user.id)
+    .eq('status', 'pending')
+    .maybeSingle()
+  if (existingReq) {
+    return NextResponse.json({ data: existingReq, error: '이미 신청이 접수되어 대기 중입니다' }, { status: 409 })
+  }
+
+  // 신규 신청 INSERT
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase as any)
+    .from('telegram_group_join_requests')
+    .insert({ telegram_group_id: groupId, user_id: user.id, message })
+    .select()
+    .single()
+  if (error) return NextResponse.json({ data: null, error: error.message }, { status: 500 })
+
+  // 모임장 + master_admin 에게 알림
+  if (group.created_by) {
+    const requesterClinicId = await getRequesterClinicId(user.id)
+    // 알림은 모임장 clinic 기준이 더 자연스러우나, 그룹은 글로벌이므로 신청자 clinic 사용
+    if (requesterClinicId) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const requesterUser = await (supabase as any).from('users').select('name, email').eq('id', user.id).maybeSingle()
+      const requesterName = requesterUser.data?.name || requesterUser.data?.email || '사용자'
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const ownerClinic = await (supabase as any).from('users').select('clinic_id').eq('id', group.created_by).maybeSingle()
+      const ownerClinicId = ownerClinic.data?.clinic_id ?? requesterClinicId
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (supabase as any).from('user_notifications').insert({
+        clinic_id: ownerClinicId,
+        user_id: group.created_by,
+        type: 'group_join_requested',
+        title: '소모임 가입 신청',
+        content: `${requesterName}님이 "${group.board_title}" 모임 가입을 신청했습니다`,
+        link: `/dashboard/community/telegram/${group.board_slug}?manage=requests`,
+        reference_type: 'group_join_request',
+        reference_id: data.id,
+        created_by: user.id,
+      })
+    }
+  }
+
+  return NextResponse.json({ data, error: null }, { status: 201 })
+}

--- a/dental-clinic-manager/src/app/dashboard/community/telegram/[slug]/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/community/telegram/[slug]/page.tsx
@@ -2,14 +2,14 @@
 
 import { useState, useEffect } from 'react'
 import { useRouter, useParams, useSearchParams } from 'next/navigation'
-import { Send, Loader2, ShieldAlert, ChevronLeft, Settings, Globe, UserPlus } from 'lucide-react'
+import { Send, Loader2, ShieldAlert, ChevronLeft, Settings, Globe } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
 import { Button } from '@/components/ui/Button'
 import TelegramBoardPostList from '@/components/Telegram/TelegramBoardPostList'
 import TelegramBoardMemberPanel from '@/components/Telegram/TelegramBoardMemberPanel'
+import JoinRequestButton from '@/components/Telegram/JoinRequestButton'
 import { telegramGroupService, telegramMemberService } from '@/lib/telegramService'
-import type { TelegramGroup, TelegramGroupVisibility } from '@/types/telegram'
-import { TELEGRAM_VISIBILITY_LABELS } from '@/types/telegram'
+import type { TelegramGroup } from '@/types/telegram'
 
 export default function TelegramBoardPage() {
   const router = useRouter()
@@ -69,11 +69,17 @@ export default function TelegramBoardPage() {
           <div className="w-16 h-16 bg-amber-100 rounded-full flex items-center justify-center mx-auto mb-4">
             <ShieldAlert className="w-8 h-8 text-amber-500" />
           </div>
-          <h2 className="text-lg font-semibold text-at-text mb-2">접근 권한이 없습니다</h2>
-          <p className="text-sm text-at-text-weak mb-6">이 게시판은 모임 멤버만 열람할 수 있습니다.<br />초대 링크를 통해 가입해 주세요.</p>
-          <Button variant="outline" onClick={() => router.push('/dashboard/community/telegram')}>
-            게시판 목록으로
-          </Button>
+          <h2 className="text-lg font-semibold text-at-text mb-2">{group.board_title}</h2>
+          {group.board_description && (
+            <p className="text-sm text-at-text-weak mb-2">{group.board_description}</p>
+          )}
+          <p className="text-sm text-at-text-weak mb-6">비공개 모임입니다. 가입 신청 후 모임장 승인을 받아야 열람할 수 있습니다.</p>
+          <JoinRequestButton groupId={group.id} onJoined={() => router.refresh()} />
+          <div className="mt-6">
+            <Button variant="outline" size="sm" onClick={() => router.push('/dashboard/community/telegram')}>
+              게시판 목록으로
+            </Button>
+          </div>
         </div>
       ) : isMember === false && group.visibility === 'public_list' ? (
         /* 목록만 공개 - 게시글 열람 불가 */
@@ -86,9 +92,12 @@ export default function TelegramBoardPage() {
             <p className="text-sm text-at-text-weak mb-2">{group.board_description}</p>
           )}
           <p className="text-sm text-at-text-weak mb-6">게시글을 열람하려면 모임에 가입해야 합니다.</p>
-          <Button variant="outline" onClick={() => router.push('/dashboard/community/telegram')}>
-            게시판 목록으로
-          </Button>
+          <JoinRequestButton groupId={group.id} onJoined={() => router.refresh()} />
+          <div className="mt-6">
+            <Button variant="outline" size="sm" onClick={() => router.push('/dashboard/community/telegram')}>
+              게시판 목록으로
+            </Button>
+          </div>
         </div>
       ) : (
         <>

--- a/dental-clinic-manager/src/components/Layout/UserNotificationDropdown.tsx
+++ b/dental-clinic-manager/src/components/Layout/UserNotificationDropdown.tsx
@@ -19,6 +19,7 @@ import {
   ClipboardDocumentListIcon,
   ClipboardDocumentCheckIcon,
   ChevronRightIcon,
+  UserPlusIcon,
 } from '@heroicons/react/24/outline'
 import { BellIcon as BellSolidIcon } from '@heroicons/react/24/solid'
 import type { UserNotification, UserNotificationType } from '@/types/notification'
@@ -52,6 +53,9 @@ const NotificationTypeIcons: Record<UserNotificationType, React.ComponentType<{ 
   subscription_upgrade_required: ExclamationCircleIcon,
   subscription_payment_succeeded: CheckCircleIcon,
   monthly_report_ready: DocumentTextIcon,
+  group_join_requested: UserPlusIcon,
+  group_join_approved: CheckCircleIcon,
+  group_join_rejected: XCircleIcon,
 }
 
 // 알림 타입별 기본 링크 매핑 (link가 없는 경우 fallback)

--- a/dental-clinic-manager/src/components/Telegram/AdminTelegramManager.tsx
+++ b/dental-clinic-manager/src/components/Telegram/AdminTelegramManager.tsx
@@ -1,15 +1,27 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Plus, Send, ChevronDown, ChevronUp, Power, PowerOff, Loader2, AlertCircle, Sparkles } from 'lucide-react'
+import { Plus, Send, ChevronDown, ChevronUp, Power, PowerOff, Loader2, AlertCircle, Sparkles, UserCog } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
-import { telegramGroupService } from '@/lib/telegramService'
+import { telegramGroupService, telegramMemberService } from '@/lib/telegramService'
 import { useAuth } from '@/contexts/AuthContext'
 import AdminTelegramGroupSetupGuide from './AdminTelegramGroupSetupGuide'
 import AdminTelegramMembers from './AdminTelegramMembers'
 import AdminTelegramSyncStatus from './AdminTelegramSyncStatus'
 import AdminTelegramApplications from './AdminTelegramApplications'
-import type { TelegramGroup } from '@/types/telegram'
+import GroupOwnerEditor from './GroupOwnerEditor'
+import type { TelegramGroup, TelegramGroupVisibility } from '@/types/telegram'
+import { TELEGRAM_VISIBILITY_LABELS, TELEGRAM_GROUP_STATUS_LABELS } from '@/types/telegram'
+
+function formatKstDate(iso: string | null): string {
+  if (!iso) return '-'
+  try {
+    return new Date(iso).toLocaleDateString('ko-KR', {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      timeZone: 'Asia/Seoul',
+    })
+  } catch { return '-' }
+}
 
 export default function AdminTelegramManager() {
   const { user } = useAuth()
@@ -26,7 +38,8 @@ export default function AdminTelegramManager() {
 
   const fetchGroups = async () => {
     setLoading(true)
-    const { data, error: fetchError } = await telegramGroupService.getGroups()
+    // 마스터 관리자 페이지에서는 전체 그룹 + 모임장/멤버수까지 함께 받아 화면에 표기
+    const { data, error: fetchError } = await telegramGroupService.getAllGroupsForMaster()
     if (fetchError) {
       setError(fetchError)
     } else {
@@ -195,9 +208,63 @@ export default function AdminTelegramManager() {
                 )}
               </div>
 
-              {/* 확장된 상세 (멤버 관리) */}
+              {/* 확장된 상세 (메타 + 모임장 + 멤버 관리) */}
               {expandedGroupId === group.id && (
-                <div className="border-t border-at-border p-4 bg-at-surface-alt">
+                <div className="border-t border-at-border p-4 bg-at-surface-alt space-y-4">
+                  {/* 그룹 메타 정보 */}
+                  <div className="bg-white rounded-lg p-3 space-y-2 border border-at-border">
+                    <div className="flex items-center gap-1.5 flex-wrap text-[11px]">
+                      <span className="px-1.5 py-0.5 rounded bg-at-surface-alt text-at-text-secondary">
+                        {TELEGRAM_VISIBILITY_LABELS[(group.visibility ?? 'private') as TelegramGroupVisibility]}
+                      </span>
+                      <span className={`px-1.5 py-0.5 rounded ${
+                        group.status === 'approved' ? 'bg-at-success-bg text-at-success'
+                        : group.status === 'pending' ? 'bg-at-warning-bg text-amber-700'
+                        : 'bg-at-error-bg text-at-error'
+                      }`}>
+                        {TELEGRAM_GROUP_STATUS_LABELS[group.status]}
+                      </span>
+                      <span className="px-1.5 py-0.5 rounded bg-sky-50 text-sky-700">
+                        멤버 {group.member_count ?? 0}명
+                      </span>
+                    </div>
+                    <dl className="grid grid-cols-2 gap-x-3 gap-y-1 text-[11px] text-at-text-secondary">
+                      <div className="flex items-center gap-1">
+                        <span className="text-at-text-weak shrink-0">신청일</span>
+                        <span>{formatKstDate(group.created_at)}</span>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <span className="text-at-text-weak shrink-0">개설일</span>
+                        <span>{formatKstDate(group.reviewed_at)}</span>
+                      </div>
+                      <div className="col-span-2 flex items-center gap-1 truncate">
+                        <span className="text-at-text-weak shrink-0">slug</span>
+                        <code className="text-at-text font-mono truncate">{group.board_slug}</code>
+                      </div>
+                      {group.board_description && (
+                        <div className="col-span-2 flex items-center gap-1 truncate">
+                          <span className="text-at-text-weak shrink-0">설명</span>
+                          <span className="text-at-text truncate">{group.board_description}</span>
+                        </div>
+                      )}
+                      {group.application_reason && (
+                        <div className="col-span-2 line-clamp-2">
+                          <span className="text-at-text-weak">신청 사유: </span>
+                          <span>{group.application_reason}</span>
+                        </div>
+                      )}
+                    </dl>
+
+                    {/* 모임장 지정/교체 (마스터 전용) */}
+                    <div className="pt-2 border-t border-at-border">
+                      <GroupOwnerEditor
+                        groupId={group.id}
+                        currentOwner={group.creator ?? null}
+                        onChanged={(owner) => setGroups(prev => prev.map(g => g.id === group.id ? { ...g, creator: owner, created_by: owner.id } : g))}
+                      />
+                    </div>
+                  </div>
+
                   <AdminTelegramMembers groupId={group.id} />
                 </div>
               )}

--- a/dental-clinic-manager/src/components/Telegram/GroupOwnerEditor.tsx
+++ b/dental-clinic-manager/src/components/Telegram/GroupOwnerEditor.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+/**
+ * 마스터 전용 — 소모임의 모임장(created_by) 지정/교체.
+ * 사용자 검색 → 선택 → PATCH /api/telegram/groups/[id].
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { Loader2, UserCog, Search, X, CheckCircle2 } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import { telegramMemberService } from '@/lib/telegramService'
+import { useAuth } from '@/contexts/AuthContext'
+
+interface Props {
+  groupId: string
+  currentOwner?: { id: string; name: string | null; email: string | null } | null
+  /** 변경 성공 시 부모에 새 owner 정보 전달 */
+  onChanged?: (owner: { id: string; name: string | null; email: string | null }) => void
+}
+
+export default function GroupOwnerEditor({ groupId, currentOwner, onChanged }: Props) {
+  const { user } = useAuth()
+  const [editing, setEditing] = useState(!currentOwner)
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<{ id: string; name: string; email: string }[]>([])
+  const [searching, setSearching] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!editing) return
+    if (timerRef.current) clearTimeout(timerRef.current)
+    if (query.trim().length < 2) {
+      setResults([])
+      return
+    }
+    timerRef.current = setTimeout(async () => {
+      setSearching(true)
+      const { data } = await telegramMemberService.searchUsersForInvite(query.trim(), groupId)
+      setResults(data ?? [])
+      setSearching(false)
+    }, 250)
+    return () => { if (timerRef.current) clearTimeout(timerRef.current) }
+  }, [query, editing, groupId])
+
+  const assign = async (target: { id: string; name: string; email: string }) => {
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/telegram/groups/${groupId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: user?.id, created_by: target.id }),
+      })
+      const j = await res.json()
+      if (!res.ok) {
+        setError(j?.error ?? '모임장 변경에 실패했습니다')
+      } else {
+        // 새 owner 를 멤버로도 자동 등록(이미 있으면 무시)
+        await telegramMemberService.addMember(groupId, target.id, 'admin').catch(() => {})
+        const newOwner = { id: target.id, name: target.name, email: target.email }
+        onChanged?.(newOwner)
+        setSuccess(`${target.name || target.email} 님으로 변경되었습니다`)
+        setEditing(false)
+        setQuery('')
+        setResults([])
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '오류')
+    } finally { setSubmitting(false) }
+  }
+
+  if (!editing) {
+    return (
+      <div className="flex items-center gap-2 text-xs">
+        <span className="text-at-text-weak">모임장</span>
+        <span className="font-medium text-at-text">
+          {currentOwner?.name || '(미지정)'}
+        </span>
+        {currentOwner?.email && (
+          <span className="text-at-text-weak">· {currentOwner.email}</span>
+        )}
+        <button
+          onClick={() => { setEditing(true); setError(null); setSuccess(null) }}
+          className="ml-auto inline-flex items-center gap-1 text-at-accent hover:underline"
+        >
+          <UserCog className="w-3 h-3" />{currentOwner ? '교체' : '지정'}
+        </button>
+        {success && <span className="text-at-success">{success}</span>}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2 p-3 bg-at-surface-alt rounded-lg border border-at-border">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium text-at-text-secondary inline-flex items-center gap-1">
+          <UserCog className="w-3.5 h-3.5" />모임장 {currentOwner ? '교체' : '지정'}
+        </p>
+        <button onClick={() => { setEditing(false); setQuery(''); setResults([]); setError(null) }}
+          className="text-at-text-weak hover:text-at-text">
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+      <div className="relative">
+        <Search className="w-3.5 h-3.5 absolute left-2 top-1/2 -translate-y-1/2 text-at-text-weak" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="이름 또는 이메일로 검색"
+          className="w-full pl-7 pr-3 py-1.5 text-xs border border-at-border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-at-accent"
+        />
+        {searching && (
+          <Loader2 className="w-3.5 h-3.5 animate-spin absolute right-2 top-1/2 -translate-y-1/2 text-at-text-weak" />
+        )}
+      </div>
+      {error && <p className="text-xs text-at-error">{error}</p>}
+      {results.length > 0 && (
+        <div className="max-h-48 overflow-y-auto space-y-1">
+          {results.map(u => (
+            <button
+              key={u.id}
+              onClick={() => assign(u)}
+              disabled={submitting}
+              className="w-full text-left p-2 rounded-lg hover:bg-white border border-transparent hover:border-at-border text-xs"
+            >
+              <div className="font-medium text-at-text">{u.name}</div>
+              <div className="text-at-text-weak">{u.email}</div>
+            </button>
+          ))}
+        </div>
+      )}
+      {query.trim().length >= 2 && !searching && results.length === 0 && (
+        <p className="text-[11px] text-at-text-weak text-center py-2">검색 결과 없음</p>
+      )}
+      {submitting && (
+        <div className="flex items-center justify-center py-2">
+          <Loader2 className="w-4 h-4 animate-spin text-at-accent" />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Telegram/JoinRequestButton.tsx
+++ b/dental-clinic-manager/src/components/Telegram/JoinRequestButton.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Loader2, UserPlus, CheckCircle2, XCircle, Clock } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+
+type Status = 'pending' | 'approved' | 'rejected' | 'cancelled'
+interface JoinRequest {
+  id: string
+  status: Status
+  message: string | null
+  reject_reason: string | null
+  created_at: string
+  reviewed_at: string | null
+}
+
+interface Props {
+  groupId: string
+  /** 멤버 가입 후 새로고침 콜백 (옵션) */
+  onJoined?: () => void
+  /** 카드 상단/하단 어느 위치에 두어도 어울리도록 자체 padding 없음 */
+  className?: string
+}
+
+export default function JoinRequestButton({ groupId, onJoined, className }: Props) {
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [my, setMy] = useState<JoinRequest | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchMine = useCallback(async () => {
+    setLoading(true)
+    try {
+      const r = await fetch(`/api/telegram/groups/${groupId}/join-requests?mine=1`, { cache: 'no-store' })
+      const j = await r.json()
+      setMy(j?.data ?? null)
+    } catch { /* noop */ }
+    finally { setLoading(false) }
+  }, [groupId])
+
+  useEffect(() => { fetchMine() }, [fetchMine])
+
+  const submit = async () => {
+    setSubmitting(true)
+    setError(null)
+    try {
+      const r = await fetch(`/api/telegram/groups/${groupId}/join-requests`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: message.trim() || null }),
+      })
+      const j = await r.json()
+      if (!r.ok) {
+        setError(j?.error ?? '신청에 실패했습니다')
+      } else {
+        setShowForm(false)
+        setMessage('')
+        await fetchMine()
+        onJoined?.()
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '신청 중 오류')
+    } finally { setSubmitting(false) }
+  }
+
+  const cancel = async () => {
+    if (!my) return
+    setSubmitting(true)
+    try {
+      await fetch(`/api/telegram/groups/${groupId}/join-requests/${my.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'cancel' }),
+      })
+      await fetchMine()
+    } finally { setSubmitting(false) }
+  }
+
+  if (loading) {
+    return (
+      <div className={`flex items-center justify-center py-2 ${className ?? ''}`}>
+        <Loader2 className="w-4 h-4 animate-spin text-at-text-weak" />
+      </div>
+    )
+  }
+
+  // pending 상태
+  if (my && my.status === 'pending') {
+    return (
+      <div className={`flex flex-col items-center gap-2 ${className ?? ''}`}>
+        <div className="inline-flex items-center gap-1.5 text-sm text-amber-700 bg-at-warning-bg px-3 py-1.5 rounded-lg border border-amber-200">
+          <Clock className="w-4 h-4" />
+          가입 신청 접수됨 — 모임장 승인 대기 중
+        </div>
+        <button
+          onClick={cancel}
+          disabled={submitting}
+          className="text-xs text-at-text-weak hover:text-at-error underline underline-offset-2 disabled:opacity-50"
+        >
+          신청 취소
+        </button>
+      </div>
+    )
+  }
+
+  // 거절됨 — 재신청 가능
+  if (my && my.status === 'rejected') {
+    return (
+      <div className={`flex flex-col items-center gap-2 ${className ?? ''}`}>
+        <div className="inline-flex items-center gap-1.5 text-sm text-at-error bg-at-error-bg px-3 py-1.5 rounded-lg border border-red-200">
+          <XCircle className="w-4 h-4" />
+          이전 신청이 거절되었습니다
+          {my.reject_reason && <span className="text-at-text-secondary">· {my.reject_reason}</span>}
+        </div>
+        <Button onClick={() => setShowForm(true)} size="sm" variant="outline">
+          <UserPlus className="w-4 h-4 mr-1" />다시 신청
+        </Button>
+        {showForm && (
+          <FormBlock
+            message={message}
+            setMessage={setMessage}
+            submitting={submitting}
+            error={error}
+            onCancel={() => { setShowForm(false); setError(null) }}
+            onSubmit={submit}
+          />
+        )}
+      </div>
+    )
+  }
+
+  // approved (혹시 화면이 갱신되기 전 잠깐 보이는 경우)
+  if (my && my.status === 'approved') {
+    return (
+      <div className={`inline-flex items-center gap-1.5 text-sm text-at-success bg-at-success-bg px-3 py-1.5 rounded-lg border border-green-200 ${className ?? ''}`}>
+        <CheckCircle2 className="w-4 h-4" />
+        가입이 승인되었습니다 — 잠시 후 멤버 권한이 반영됩니다
+      </div>
+    )
+  }
+
+  // 신청 이력 없음 또는 cancelled — 신청 가능
+  return (
+    <div className={`flex flex-col items-center gap-2 ${className ?? ''}`}>
+      {!showForm ? (
+        <Button onClick={() => setShowForm(true)} variant="outline">
+          <UserPlus className="w-4 h-4 mr-1.5" />가입 신청
+        </Button>
+      ) : (
+        <FormBlock
+          message={message}
+          setMessage={setMessage}
+          submitting={submitting}
+          error={error}
+          onCancel={() => { setShowForm(false); setError(null) }}
+          onSubmit={submit}
+        />
+      )}
+    </div>
+  )
+}
+
+function FormBlock(props: {
+  message: string
+  setMessage: (s: string) => void
+  submitting: boolean
+  error: string | null
+  onCancel: () => void
+  onSubmit: () => void
+}) {
+  return (
+    <div className="w-full max-w-md bg-white border border-at-border rounded-xl p-4 space-y-3">
+      <label className="block">
+        <span className="text-xs font-medium text-at-text-secondary">가입 신청 메시지 (선택)</span>
+        <textarea
+          rows={3}
+          maxLength={500}
+          value={props.message}
+          onChange={(e) => props.setMessage(e.target.value)}
+          placeholder="모임장에게 전달할 짧은 인사·소개를 적어주세요"
+          className="mt-1 w-full px-3 py-2 text-sm border border-at-border rounded-lg focus:outline-none focus:ring-2 focus:ring-at-accent"
+        />
+        <span className="text-[11px] text-at-text-weak">{props.message.length}/500</span>
+      </label>
+      {props.error && (
+        <p className="text-xs text-at-error bg-at-error-bg px-2 py-1.5 rounded">{props.error}</p>
+      )}
+      <div className="flex items-center justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={props.onCancel} disabled={props.submitting}>
+          취소
+        </Button>
+        <Button size="sm" onClick={props.onSubmit} disabled={props.submitting}>
+          {props.submitting ? <Loader2 className="w-4 h-4 animate-spin" /> : '신청 보내기'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Telegram/JoinRequestManager.tsx
+++ b/dental-clinic-manager/src/components/Telegram/JoinRequestManager.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+/**
+ * 모임장/마스터가 가입 신청 목록을 확인하고 승인·거부하는 패널.
+ * 멤버 관리 모달 내부에 mount 한다.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import { Loader2, CheckCircle2, XCircle, Inbox, Clock } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+
+interface JoinRequestRow {
+  id: string
+  telegram_group_id: string
+  user_id: string
+  message: string | null
+  status: 'pending' | 'approved' | 'rejected' | 'cancelled'
+  reject_reason: string | null
+  reviewed_at: string | null
+  created_at: string
+  applicant?: { id: string; name: string | null; email: string | null } | null
+}
+
+function formatKstDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' })
+  } catch { return iso }
+}
+
+export default function JoinRequestManager({ groupId }: { groupId: string }) {
+  const [rows, setRows] = useState<JoinRequestRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [processingId, setProcessingId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [rejectModalId, setRejectModalId] = useState<string | null>(null)
+  const [rejectReason, setRejectReason] = useState('')
+
+  const fetchRows = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const r = await fetch(`/api/telegram/groups/${groupId}/join-requests?status=pending`, { cache: 'no-store' })
+      const j = await r.json()
+      if (!r.ok) setError(j?.error ?? '조회 실패')
+      else setRows(j?.data ?? [])
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '조회 실패')
+    } finally { setLoading(false) }
+  }, [groupId])
+
+  useEffect(() => { fetchRows() }, [fetchRows])
+
+  const approve = async (row: JoinRequestRow) => {
+    setProcessingId(row.id)
+    try {
+      const r = await fetch(`/api/telegram/groups/${groupId}/join-requests/${row.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'approve' }),
+      })
+      const j = await r.json()
+      if (!r.ok) setError(j?.error ?? '승인 실패')
+      await fetchRows()
+    } finally { setProcessingId(null) }
+  }
+
+  const reject = async () => {
+    if (!rejectModalId) return
+    setProcessingId(rejectModalId)
+    try {
+      const r = await fetch(`/api/telegram/groups/${groupId}/join-requests/${rejectModalId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'reject', reject_reason: rejectReason.trim() || null }),
+      })
+      const j = await r.json()
+      if (!r.ok) setError(j?.error ?? '거부 실패')
+      setRejectModalId(null)
+      setRejectReason('')
+      await fetchRows()
+    } finally { setProcessingId(null) }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-semibold text-at-text flex items-center gap-1.5">
+          <Clock className="w-4 h-4 text-amber-500" />
+          가입 신청 대기 ({rows.length})
+        </h4>
+        <button onClick={fetchRows} className="text-xs text-at-text-weak hover:text-at-text">
+          새로고침
+        </button>
+      </div>
+
+      {error && (
+        <p className="text-xs text-at-error bg-at-error-bg px-2 py-1.5 rounded">{error}</p>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-6">
+          <Loader2 className="w-5 h-5 animate-spin text-at-text-weak" />
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="text-center py-6 text-at-text-weak">
+          <Inbox className="w-8 h-8 mx-auto mb-2 opacity-30" />
+          <p className="text-xs">대기 중인 가입 신청이 없습니다</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {rows.map(row => (
+            <div key={row.id} className="p-3 bg-white border border-at-border rounded-lg space-y-2">
+              <div className="flex items-center justify-between">
+                <div className="text-sm font-medium text-at-text">
+                  {row.applicant?.name || row.applicant?.email || '사용자'}
+                </div>
+                <div className="text-[11px] text-at-text-weak">
+                  {formatKstDate(row.created_at)}
+                </div>
+              </div>
+              {row.applicant?.email && (
+                <p className="text-[11px] text-at-text-weak">{row.applicant.email}</p>
+              )}
+              {row.message && (
+                <p className="text-xs text-at-text-secondary bg-at-surface-alt px-2 py-1.5 rounded">
+                  {row.message}
+                </p>
+              )}
+              <div className="flex items-center justify-end gap-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => { setRejectModalId(row.id); setRejectReason('') }}
+                  disabled={processingId === row.id}
+                  className="text-at-error"
+                >
+                  <XCircle className="w-4 h-4 mr-1" />거절
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() => approve(row)}
+                  disabled={processingId === row.id}
+                >
+                  {processingId === row.id ? <Loader2 className="w-4 h-4 animate-spin" /> : (
+                    <><CheckCircle2 className="w-4 h-4 mr-1" />승인</>
+                  )}
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* 거절 사유 입력 */}
+      {rejectModalId && (
+        <div className="fixed inset-0 z-[60] bg-black/40 flex items-center justify-center p-4">
+          <div className="bg-white rounded-xl p-4 max-w-sm w-full space-y-3 border border-at-border">
+            <h5 className="text-sm font-semibold text-at-text">거절 사유 (선택)</h5>
+            <textarea
+              rows={3}
+              maxLength={500}
+              value={rejectReason}
+              onChange={(e) => setRejectReason(e.target.value)}
+              placeholder="신청자에게 전달할 거절 사유"
+              className="w-full px-3 py-2 text-sm border border-at-border rounded-lg focus:outline-none focus:ring-2 focus:ring-at-accent"
+            />
+            <div className="flex items-center justify-end gap-2">
+              <Button variant="ghost" size="sm" onClick={() => { setRejectModalId(null); setRejectReason('') }}>
+                취소
+              </Button>
+              <Button size="sm" onClick={reject} disabled={processingId === rejectModalId}>
+                {processingId === rejectModalId ? <Loader2 className="w-4 h-4 animate-spin" /> : '거절 처리'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Telegram/TelegramBoardMemberPanel.tsx
+++ b/dental-clinic-manager/src/components/Telegram/TelegramBoardMemberPanel.tsx
@@ -11,6 +11,7 @@ import { telegramMemberService, telegramInviteLinkService, telegramGroupService 
 import type { TelegramGroupMember, TelegramInviteLink, TelegramGroupVisibility } from '@/types/telegram'
 import { TELEGRAM_VISIBILITY_LABELS, TELEGRAM_VISIBILITY_DESCRIPTIONS } from '@/types/telegram'
 import { appConfirm } from '@/components/ui/AppDialog'
+import JoinRequestManager from './JoinRequestManager'
 
 interface TelegramBoardMemberPanelProps {
   groupId: string
@@ -260,6 +261,11 @@ export default function TelegramBoardMemberPanel({
                     </button>
                   ))}
                 </div>
+              </div>
+
+              {/* 가입 신청 대기 섹션 */}
+              <div className="pt-2 border-t border-at-border">
+                <JoinRequestManager groupId={groupId} />
               </div>
 
               {/* 초대 링크 섹션 */}

--- a/dental-clinic-manager/src/types/notification.ts
+++ b/dental-clinic-manager/src/types/notification.ts
@@ -316,6 +316,9 @@ export type UserNotificationType =
   | 'subscription_upgrade_required'  // 구독 업그레이드 필요 (원장에게)
   | 'subscription_payment_succeeded' // 결제 성공 후 대기자 승인 안내 (원장에게)
   | 'monthly_report_ready'           // 월간 성과 보고서 생성 완료 (대표원장/실장에게)
+  | 'group_join_requested'           // 소모임 가입 신청 (모임장에게)
+  | 'group_join_approved'            // 소모임 가입 승인 (신청자에게)
+  | 'group_join_rejected'            // 소모임 가입 거절 (신청자에게)
 
 // 사용자 알림 타입 라벨
 export const USER_NOTIFICATION_TYPE_LABELS: Record<UserNotificationType, string> = {
@@ -343,7 +346,10 @@ export const USER_NOTIFICATION_TYPE_LABELS: Record<UserNotificationType, string>
   system: '시스템 알림',
   subscription_upgrade_required: '구독 업그레이드 필요',
   subscription_payment_succeeded: '결제 완료 · 승인 대기',
-  monthly_report_ready: '월간 성과 보고서'
+  monthly_report_ready: '월간 성과 보고서',
+  group_join_requested: '소모임 가입 신청',
+  group_join_approved: '소모임 가입 승인',
+  group_join_rejected: '소모임 가입 거절'
 }
 
 // 사용자 알림 아이콘 매핑
@@ -372,7 +378,10 @@ export const USER_NOTIFICATION_TYPE_ICONS: Record<UserNotificationType, string> 
   system: 'bell',
   subscription_upgrade_required: 'alert-circle',
   subscription_payment_succeeded: 'credit-card',
-  monthly_report_ready: 'file-bar-chart-2'
+  monthly_report_ready: 'file-bar-chart-2',
+  group_join_requested: 'user-plus',
+  group_join_approved: 'check-circle',
+  group_join_rejected: 'x-circle'
 }
 
 // 사용자 알림 색상 매핑
@@ -401,7 +410,10 @@ export const USER_NOTIFICATION_TYPE_COLORS: Record<UserNotificationType, { icon:
   system: { icon: 'text-blue-500', bg: 'bg-blue-50', text: 'text-blue-700' },
   subscription_upgrade_required: { icon: 'text-amber-500', bg: 'bg-amber-50', text: 'text-amber-700' },
   subscription_payment_succeeded: { icon: 'text-emerald-500', bg: 'bg-emerald-50', text: 'text-emerald-700' },
-  monthly_report_ready: { icon: 'text-indigo-500', bg: 'bg-indigo-50', text: 'text-indigo-700' }
+  monthly_report_ready: { icon: 'text-indigo-500', bg: 'bg-indigo-50', text: 'text-indigo-700' },
+  group_join_requested: { icon: 'text-sky-500', bg: 'bg-sky-50', text: 'text-sky-700' },
+  group_join_approved: { icon: 'text-green-500', bg: 'bg-green-50', text: 'text-green-700' },
+  group_join_rejected: { icon: 'text-red-500', bg: 'bg-red-50', text: 'text-red-700' }
 }
 
 // 사용자 알림 인터페이스

--- a/dental-clinic-manager/supabase/migrations/20260511_add_group_join_notification_types.sql
+++ b/dental-clinic-manager/supabase/migrations/20260511_add_group_join_notification_types.sql
@@ -1,0 +1,35 @@
+-- user_notifications.type CHECK 에 소모임 가입 신청 관련 3종 추가
+-- Migration: 20260511_add_group_join_notification_types.sql
+ALTER TABLE user_notifications DROP CONSTRAINT IF EXISTS user_notifications_type_check;
+
+ALTER TABLE user_notifications ADD CONSTRAINT user_notifications_type_check
+CHECK (type = ANY (ARRAY[
+  'leave_approval_pending'::text,
+  'leave_approved'::text,
+  'leave_rejected'::text,
+  'leave_forwarded'::text,
+  'contract_signature_required'::text,
+  'contract_signed'::text,
+  'contract_completed'::text,
+  'contract_cancelled'::text,
+  'document_resignation'::text,
+  'document_approved'::text,
+  'document_rejected'::text,
+  'document'::text,
+  'telegram_board_approved'::text,
+  'telegram_board_rejected'::text,
+  'telegram_board_pending'::text,
+  'task_assigned'::text,
+  'task_completed'::text,
+  'protocol_review_requested'::text,
+  'protocol_review_approved'::text,
+  'protocol_review_rejected'::text,
+  'subscription_upgrade_required'::text,
+  'subscription_payment_succeeded'::text,
+  'important'::text,
+  'system'::text,
+  'monthly_report_ready'::text,
+  'group_join_requested'::text,
+  'group_join_approved'::text,
+  'group_join_rejected'::text
+]));

--- a/dental-clinic-manager/supabase/migrations/20260511_telegram_group_join_requests.sql
+++ b/dental-clinic-manager/supabase/migrations/20260511_telegram_group_join_requests.sql
@@ -1,0 +1,87 @@
+-- ============================================
+-- 소모임 가입 신청/승인 워크플로우
+--
+-- 공개 소모임이라도 글쓰기 권한을 위해서는 모임장의 승인이 필요한 경우가 많아,
+-- 비멤버가 "가입 신청 → 모임장 승인/거부 → 자동 멤버 등록" 흐름을 위한 테이블.
+--
+-- Migration: 20260511_telegram_group_join_requests.sql
+-- Created: 2026-05-11
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS telegram_group_join_requests (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  telegram_group_id UUID NOT NULL REFERENCES telegram_groups(id) ON DELETE CASCADE,
+  user_id           UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  message           TEXT,
+  status            VARCHAR(20) NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending', 'approved', 'rejected', 'cancelled')),
+  reject_reason     TEXT,
+  reviewed_by       UUID REFERENCES auth.users(id),
+  reviewed_at       TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- 동일 사용자의 pending 신청은 그룹당 1건만
+CREATE UNIQUE INDEX IF NOT EXISTS idx_join_requests_unique_pending
+  ON telegram_group_join_requests (telegram_group_id, user_id)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_join_requests_group_status
+  ON telegram_group_join_requests (telegram_group_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_join_requests_user
+  ON telegram_group_join_requests (user_id, created_at DESC);
+
+ALTER TABLE telegram_group_join_requests ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: 본인 신청 + 모임장(created_by) + master_admin
+DROP POLICY IF EXISTS "join_requests_select" ON telegram_group_join_requests;
+CREATE POLICY "join_requests_select" ON telegram_group_join_requests
+  FOR SELECT TO authenticated
+  USING (
+    user_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM telegram_groups g
+      WHERE g.id = telegram_group_join_requests.telegram_group_id
+        AND g.created_by = auth.uid()
+    )
+    OR EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'master_admin')
+  );
+
+-- INSERT: 본인만 자기 신청 가능
+DROP POLICY IF EXISTS "join_requests_insert_self" ON telegram_group_join_requests;
+CREATE POLICY "join_requests_insert_self" ON telegram_group_join_requests
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+-- UPDATE: 본인(취소) + 모임장(승인/거부) + master_admin
+DROP POLICY IF EXISTS "join_requests_update" ON telegram_group_join_requests;
+CREATE POLICY "join_requests_update" ON telegram_group_join_requests
+  FOR UPDATE TO authenticated
+  USING (
+    user_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM telegram_groups g
+      WHERE g.id = telegram_group_join_requests.telegram_group_id
+        AND g.created_by = auth.uid()
+    )
+    OR EXISTS (SELECT 1 FROM users WHERE id = auth.uid() AND role = 'master_admin')
+  );
+
+-- DELETE 없이 운영(취소는 status='cancelled')
+
+-- updated_at 자동 갱신 트리거
+CREATE OR REPLACE FUNCTION update_join_requests_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_join_requests_updated_at ON telegram_group_join_requests;
+CREATE TRIGGER trg_join_requests_updated_at
+  BEFORE UPDATE ON telegram_group_join_requests
+  FOR EACH ROW EXECUTE FUNCTION update_join_requests_updated_at();
+
+COMMENT ON TABLE telegram_group_join_requests IS '소모임 가입 신청 — pending/approved/rejected/cancelled 상태로 운영';


### PR DESCRIPTION
## Summary
- 공개 소모임 비멤버 화면에 가입 신청 버튼 + 메시지 입력 + 상태(대기/거절/승인) 표시
- 모임장/마스터의 가입 신청 관리 패널 (TelegramBoardMemberPanel 내부)
- 알림 3종 추가: \`group_join_requested\` / \`group_join_approved\` / \`group_join_rejected\`
- 커뮤니티 관리 텔레그램 페이지의 펼침 상세에 모임장·신청일·개설일·멤버 수·공개범위·상태 등 메타 정보 추가
- 마스터 전용 모임장 지정/교체 UI (orphan 그룹 즉시 owner 부여 가능)

## Test plan
- [x] \`npm run build\` 성공, DB 마이그레이션(테이블·정책·CHECK) 운영 적용 완료
- [ ] 비멤버 사용자가 공개 소모임 진입 → "가입 신청" 버튼 → 신청 완료 후 "대기 중" 표시
- [ ] 모임장/master가 멤버 관리 패널에서 신청 보이고 승인/거절 가능, 승인 시 즉시 멤버로 등록
- [ ] 마스터가 \`/dashboard/community/telegram-admin\` (또는 통합 페이지)에서 펼침 → 모임장·신청일·개설일·멤버수 표시 확인
- [ ] 마스터가 orphan 그룹("미지정") 펼침에서 모임장 지정, 기존 그룹에서 교체 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)