### PR TITLE
fix(community/telegram): users 임베디드 join 제거 (schema cache 오류)

### DIFF
--- a/dental-clinic-manager/src/app/api/telegram/groups/[id]/join-requests/route.ts
+++ b/dental-clinic-manager/src/app/api/telegram/groups/[id]/join-requests/route.ts
@@ -80,16 +80,35 @@ export async function GET(
     return NextResponse.json({ data: null, error: '권한이 없습니다' }, { status: 403 })
   }
 
+  // telegram_group_join_requests.user_id 가 auth.users(id) 를 참조하므로 PostgREST
+  // 임베디드 join 은 schema cache 에서 관계를 못 찾는다. 별도 쿼리로 사용자 정보를 merge.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let q = (supabase as any)
     .from('telegram_group_join_requests')
-    .select('*, applicant:users!telegram_group_join_requests_user_id_fkey(id, name, email)')
+    .select('*')
     .eq('telegram_group_id', groupId)
     .order('created_at', { ascending: false })
   if (statusFilter !== 'all') q = q.eq('status', statusFilter)
-  const { data, error } = await q
+  const { data: rows, error } = await q
   if (error) return NextResponse.json({ data: null, error: error.message }, { status: 500 })
-  return NextResponse.json({ data, error: null })
+
+  const userIds = Array.from(new Set((rows ?? []).map((r: { user_id: string }) => r.user_id)))
+  const userMap = new Map<string, { id: string; name: string | null; email: string | null }>()
+  if (userIds.length > 0) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: users } = await (supabase as any)
+      .from('users')
+      .select('id, name, email')
+      .in('id', userIds)
+    for (const u of (users ?? []) as Array<{ id: string; name: string | null; email: string | null }>) {
+      userMap.set(u.id, u)
+    }
+  }
+  const merged = (rows ?? []).map((r: { user_id: string }) => ({
+    ...r,
+    applicant: userMap.get(r.user_id) ?? null,
+  }))
+  return NextResponse.json({ data: merged, error: null })
 }
 
 export async function POST(

--- a/dental-clinic-manager/src/lib/telegramService.ts
+++ b/dental-clinic-manager/src/lib/telegramService.ts
@@ -161,7 +161,10 @@ export const telegramGroupService = {
   },
 
   /**
-   * 마스터 전용 — 모든 소모임 조회 (status/visibility 필터 없음, 모임장/멤버수 join)
+   * 마스터 전용 — 모든 소모임 조회 (status/visibility 필터 없음, 모임장/멤버수 정보 포함)
+   * telegram_groups.created_by 는 auth.users(id) 를 참조하므로 PostgREST 의 임베디드
+   * resource(users join)가 schema cache 에서 관계를 찾지 못해 오류가 난다.
+   * → 그룹 / 멤버 / 모임장 사용자 3개를 각각 단순 쿼리한 뒤 클라이언트에서 merge.
    * RLS 가 master_admin 을 허용해야 정상 동작. 권한 부족 시 빈 결과로 폴백.
    */
   async getAllGroupsForMaster(): Promise<{ data: TelegramGroup[] | null; error: string | null }> {
@@ -169,16 +172,19 @@ export const telegramGroupService = {
       const supabase = await ensureConnection()
       if (!supabase) throw new Error('Database connection failed')
 
-      // 1) 그룹 + 모임장 join
+      // 1) 그룹 본문 (조인 없음)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data, error } = await (supabase as any)
+      const { data: rawGroups, error } = await (supabase as any)
         .from('telegram_groups')
-        .select('*, creator:users!telegram_groups_created_by_fkey(id, name, email)')
+        .select('*')
         .order('created_at', { ascending: false })
       if (error) throw error
 
-      // 2) 멤버 수 별도 집계 (그룹 수가 많지 않으므로 단순 N+1 회피용 단일 쿼리)
-      const groupIds = (data ?? []).map((g: { id: string }) => g.id)
+      const groups = (rawGroups ?? []) as TelegramGroup[]
+      const groupIds = groups.map(g => g.id)
+      const creatorIds = Array.from(new Set(groups.map(g => g.created_by).filter((v): v is string => !!v)))
+
+      // 2) 멤버 수 집계
       const memberCounts = new Map<string, number>()
       if (groupIds.length > 0) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -191,8 +197,22 @@ export const telegramGroupService = {
         }
       }
 
-      const enriched = (data ?? []).map((g: TelegramGroup) => ({
+      // 3) 모임장 사용자 정보 (별도 쿼리)
+      const creatorMap = new Map<string, { id: string; name: string | null; email: string | null }>()
+      if (creatorIds.length > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data: users } = await (supabase as any)
+          .from('users')
+          .select('id, name, email')
+          .in('id', creatorIds)
+        for (const u of (users ?? []) as Array<{ id: string; name: string | null; email: string | null }>) {
+          creatorMap.set(u.id, u)
+        }
+      }
+
+      const enriched = groups.map(g => ({
         ...g,
+        creator: g.created_by ? (creatorMap.get(g.created_by) ?? null) : null,
         member_count: memberCounts.get(g.id) ?? 0,
       }))
       return { data: enriched, error: null }


### PR DESCRIPTION
## Summary
- 마스터 계정에서 텔레그램 관리 진입 시 \"Could not find a relationship between 'telegram_groups' and 'users' in the schema cache\" 오류
- 원인: \`telegram_groups.created_by\` 와 \`telegram_group_join_requests.user_id\` 가 \`auth.users(id)\` 를 참조하지만 PostgREST 는 public.users 와의 FK 만 인식 → 임베디드 join 실패
- 수정: \`getAllGroupsForMaster\` 와 join-requests GET 에서 임베디드 join 제거, 그룹/멤버/사용자를 각각 단순 쿼리한 뒤 클라이언트에서 merge

## Test plan
- [x] \`npm run build\` 성공
- [ ] master_admin 으로 텔레그램 관리 페이지 진입 시 오류 없이 그룹 목록 + 모임장/멤버 수 표시
- [ ] 모임장 권한자가 가입 신청 관리 패널 진입 시 신청자 이름/이메일 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)