### PR TITLE
fix(community/telegram): 모임장 즉시 진입 + 초대 링크 404

### DIFF
--- a/dental-clinic-manager/src/app/community/telegram/join/[code]/page.tsx
+++ b/dental-clinic-manager/src/app/community/telegram/join/[code]/page.tsx
@@ -1,0 +1,16 @@
+/**
+ * Legacy redirect — 이전 버전에서 복사한 초대 링크가
+ * 잘못된 경로(/community/telegram/join/...)로 만들어진 경우
+ * 정식 경로(/dashboard/community/telegram/join/...)로 자동 이동.
+ */
+
+import { redirect } from 'next/navigation'
+
+export default async function LegacyInviteRedirect({
+  params,
+}: {
+  params: Promise<{ code: string }>
+}) {
+  const { code } = await params
+  redirect(`/dashboard/community/telegram/join/${code}`)
+}

--- a/dental-clinic-manager/src/app/dashboard/community/telegram/[slug]/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/community/telegram/[slug]/page.tsx
@@ -33,9 +33,11 @@ export default function TelegramBoardPage() {
         }
         setGroup(groupData)
 
-        // 멤버십 확인
+        // 멤버십 확인 — 모임장(created_by) 본인이거나 master_admin 이면 멤버 테이블
+        // 등록 여부와 무관하게 멤버처럼 본문 접근 허용 (가입 신청 화면을 노출하지 않음).
         const { data: membershipData } = await telegramMemberService.checkMembership(groupData.id)
-        setIsMember(membershipData ?? false)
+        const ownerOrMaster = groupData.created_by === user.id || user.role === 'master_admin'
+        setIsMember(ownerOrMaster ? true : (membershipData ?? false))
         setLoading(false)
       }
       fetchGroup()

--- a/dental-clinic-manager/src/components/Telegram/AdminTelegramMembers.tsx
+++ b/dental-clinic-manager/src/components/Telegram/AdminTelegramMembers.tsx
@@ -55,7 +55,7 @@ export default function AdminTelegramMembers({ groupId }: AdminTelegramMembersPr
   }
 
   const handleCopyLink = async (link: TelegramInviteLink) => {
-    const url = `${window.location.origin}/community/telegram/join/${link.invite_code}`
+    const url = `${window.location.origin}/dashboard/community/telegram/join/${link.invite_code}`
     await navigator.clipboard.writeText(url)
     setCopiedLinkId(link.id)
     setTimeout(() => setCopiedLinkId(null), 2000)

--- a/dental-clinic-manager/src/components/Telegram/TelegramBoardMemberPanel.tsx
+++ b/dental-clinic-manager/src/components/Telegram/TelegramBoardMemberPanel.tsx
@@ -146,7 +146,7 @@ export default function TelegramBoardMemberPanel({
   }
 
   const handleCopyLink = async (link: TelegramInviteLink) => {
-    const url = `${window.location.origin}/community/telegram/join/${link.invite_code}`
+    const url = `${window.location.origin}/dashboard/community/telegram/join/${link.invite_code}`
     await navigator.clipboard.writeText(url)
     setCopiedLinkId(link.id)
     setTimeout(() => setCopiedLinkId(null), 2000)

--- a/dental-clinic-manager/supabase/migrations/20260511_telegram_group_auto_owner_member.sql
+++ b/dental-clinic-manager/supabase/migrations/20260511_telegram_group_auto_owner_member.sql
@@ -1,0 +1,40 @@
+-- ============================================
+-- 소모임 모임장 자동 멤버 등록 + 기존 데이터 backfill
+--
+-- 배경: telegram_group_members 에 모임장(created_by) 이 자동 등록되지 않아,
+-- 신규 그룹이나 owner 가 누락된 그룹에서 모임장이 자기 모임에 진입할 때
+-- 비멤버 화면(가입 신청 요구)으로 노출되는 문제 발생.
+--
+-- 조치 1) 신규 그룹 INSERT 시 owner 를 'admin' 멤버로 자동 upsert
+-- 조치 2) 기존 그룹 중 owner 가 멤버 테이블에 없는 케이스 일괄 backfill
+--
+-- Migration: 20260511_telegram_group_auto_owner_member.sql
+-- Created: 2026-05-11
+-- ============================================
+
+CREATE OR REPLACE FUNCTION auto_add_owner_as_member()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.created_by IS NOT NULL THEN
+    INSERT INTO telegram_group_members (telegram_group_id, user_id, role, joined_via)
+    VALUES (NEW.id, NEW.created_by, 'admin', 'admin')
+    ON CONFLICT (telegram_group_id, user_id) DO NOTHING;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS trg_auto_add_owner_member ON telegram_groups;
+CREATE TRIGGER trg_auto_add_owner_member
+  AFTER INSERT ON telegram_groups
+  FOR EACH ROW EXECUTE FUNCTION auto_add_owner_as_member();
+
+-- 기존 그룹들 backfill — owner 가 멤버에 없으면 admin 으로 등록
+INSERT INTO telegram_group_members (telegram_group_id, user_id, role, joined_via)
+SELECT g.id, g.created_by, 'admin', 'admin'
+FROM telegram_groups g
+WHERE g.created_by IS NOT NULL
+ON CONFLICT (telegram_group_id, user_id) DO NOTHING;
+
+COMMENT ON FUNCTION auto_add_owner_as_member IS
+  'telegram_groups INSERT 시 created_by(모임장)를 자동으로 telegram_group_members 에 admin 멤버로 등록';


### PR DESCRIPTION
## Summary
- 모임장/마스터가 자기 모임에 들어갈 때 가입 신청 화면이 보이던 문제 — \`isMember\` 판단에 \`created_by===user.id || role='master_admin'\` 분기 추가, DB 트리거 \`auto_add_owner_as_member\`로 신규 그룹부터는 owner 자동 멤버 등록, 기존 그룹 backfill
- 초대 링크 클릭 시 404 — TelegramBoardMemberPanel / AdminTelegramMembers 가 \`/community/telegram/join/<code>\` 로 URL 을 생성했음. 실제 라우트는 \`/dashboard/community/telegram/join/[code]\`. 두 컴포넌트 URL 교정 + 옛 잘못된 링크용 서버 리다이렉트 페이지 추가

## Test plan
- [x] \`npm run build\` 성공, DB 트리거/backfill 운영 적용 검증
- [ ] 모임장이 자기 모임("치과 경영 스터디 - 투자") 진입 시 가입 신청 화면 없이 본문 표시 확인
- [ ] 새로 복사한 초대 링크가 정상 동작, 옛 잘못된 링크도 자동 리다이렉트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)