### PR TITLE
fix(community/telegram): 사진/파일 404 + BOT_TOKEN 노출 정리

### DIFF
--- a/dental-clinic-manager/src/app/api/telegram/files/[messageId]/route.ts
+++ b/dental-clinic-manager/src/app/api/telegram/files/[messageId]/route.ts
@@ -1,0 +1,117 @@
+/**
+ * 텔레그램 첨부파일 서버 프록시
+ *
+ *   GET /api/telegram/files/[messageId]
+ *
+ * 동기:
+ *  - 텔레그램 봇 파일은 file_id → getFile → file_path 흐름이며, file_path 는
+ *    1시간 후 만료된다. 기존 코드(supabase webhook)는 만료 후에도 죽은 URL 을
+ *    DB 에 보관해 클릭 시 Telegram 이 `{"ok":false,"error_code":404}` 응답을
+ *    그대로 사용자에게 노출하고 있었다.
+ *  - 또한 그 URL 에는 BOT_TOKEN 이 포함되어 DB / 브라우저에 노출되는 보안 사고
+ *    도 동반되어 있어, 토큰은 서버에만 두고 사용자에게는 우리 라우트만 보이도록 한다.
+ *
+ * 동작:
+ *  - messageId(telegram_messages.id)로 file_id 조회
+ *  - 사용자 권한 확인: 해당 그룹의 멤버 / owner / master_admin / 또는 그룹
+ *    visibility 가 public_read 이상이어야 다운로드 허용 (private + 비멤버 거부)
+ *  - getFile 호출 → file_path 수신 → telegram CDN 에서 파일을 fetch → 그대로 stream
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ messageId: string }> },
+) {
+  const { messageId } = await context.params
+  const supabase = getSupabaseAdmin()
+  if (!supabase) return NextResponse.json({ error: 'DB error' }, { status: 500 })
+
+  // 1) 메시지 + 그룹 정보 조회
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: msg } = await (supabase as any)
+    .from('telegram_messages')
+    .select('id, telegram_group_id, file_id, file_name, file_mime_type, file_size')
+    .eq('id', messageId)
+    .maybeSingle()
+  if (!msg || !msg.file_id) {
+    return NextResponse.json({ error: '파일을 찾을 수 없습니다' }, { status: 404 })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: group } = await (supabase as any)
+    .from('telegram_groups')
+    .select('id, visibility, created_by')
+    .eq('id', msg.telegram_group_id)
+    .maybeSingle()
+  if (!group) {
+    return NextResponse.json({ error: '그룹을 찾을 수 없습니다' }, { status: 404 })
+  }
+
+  // 2) 권한 확인
+  const supabaseAuth = await createClient()
+  const { data: { user } } = await supabaseAuth.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: '인증 필요' }, { status: 401 })
+  }
+  let allowed = false
+  // master_admin
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: u } = await (supabase as any).from('users').select('role').eq('id', user.id).maybeSingle()
+  if (u?.role === 'master_admin') allowed = true
+  // owner
+  if (!allowed && group.created_by === user.id) allowed = true
+  // 멤버
+  if (!allowed) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: m } = await (supabase as any)
+      .from('telegram_group_members')
+      .select('id')
+      .eq('telegram_group_id', group.id)
+      .eq('user_id', user.id)
+      .maybeSingle()
+    if (m) allowed = true
+  }
+  // public_read 이상이면 비멤버도 허용
+  if (!allowed && (group.visibility === 'public_read' || group.visibility === 'public_full')) {
+    allowed = true
+  }
+  if (!allowed) {
+    return NextResponse.json({ error: '권한이 없습니다' }, { status: 403 })
+  }
+
+  // 3) Telegram getFile → file_path
+  const botToken = process.env.TELEGRAM_BOT_TOKEN
+  if (!botToken) {
+    return NextResponse.json({ error: 'TELEGRAM_BOT_TOKEN 미설정' }, { status: 500 })
+  }
+  const getFileRes = await fetch(`https://api.telegram.org/bot${botToken}/getFile?file_id=${encodeURIComponent(msg.file_id)}`)
+  const getFileJson = await getFileRes.json() as { ok: boolean; result?: { file_path: string }; description?: string }
+  if (!getFileJson.ok || !getFileJson.result?.file_path) {
+    console.error('[telegram-files] getFile failed:', getFileJson)
+    return NextResponse.json({ error: 'Telegram getFile 실패' }, { status: 502 })
+  }
+
+  // 4) 실제 파일 stream
+  const fileRes = await fetch(`https://api.telegram.org/file/bot${botToken}/${getFileJson.result.file_path}`)
+  if (!fileRes.ok || !fileRes.body) {
+    return NextResponse.json({ error: 'Telegram 파일 다운로드 실패' }, { status: 502 })
+  }
+
+  const headers = new Headers()
+  const contentType = fileRes.headers.get('content-type') || msg.file_mime_type || 'application/octet-stream'
+  headers.set('Content-Type', contentType)
+  const contentLength = fileRes.headers.get('content-length') || (msg.file_size ? String(msg.file_size) : '')
+  if (contentLength) headers.set('Content-Length', contentLength)
+  if (msg.file_name) {
+    const safe = encodeURIComponent(msg.file_name)
+    headers.set('Content-Disposition', `inline; filename*=UTF-8''${safe}`)
+  }
+  // 캐싱 정책 — 1시간 (file_path 와 동일 한도)
+  headers.set('Cache-Control', 'private, max-age=3600')
+
+  return new Response(fileRes.body, { status: 200, headers })
+}

--- a/dental-clinic-manager/src/components/Telegram/TelegramBoardPostCard.tsx
+++ b/dental-clinic-manager/src/components/Telegram/TelegramBoardPostCard.tsx
@@ -40,6 +40,20 @@ export default function TelegramBoardPostCard({ post, onClick, selectMode = fals
 
   const showCheckbox = selectMode || alwaysShowCheckbox
 
+  // 첫 첨부 파일이 이미지면 카드에 작은 썸네일 표시 (서버 프록시 경유)
+  const firstImage = (() => {
+    const files = post.file_urls ?? []
+    const ids = post.source_message_ids ?? []
+    if (!files.length) return null
+    const f = files[0]
+    const name = f.name ?? ''
+    const mime = f.type ?? ''
+    const isImage = mime.startsWith('image/') || /\.(png|jpe?g|gif|webp|bmp|heic|heif|avif)$/i.test(name)
+    if (!isImage) return null
+    const messageId = ids[0]
+    return messageId ? `/api/telegram/files/${messageId}` : null
+  })()
+
   const handleClick = () => {
     if (selectMode && selectable && onToggleSelect) {
       onToggleSelect(post.id)
@@ -89,6 +103,15 @@ export default function TelegramBoardPostCard({ post, onClick, selectMode = fals
       </div>
       {/* 제목 */}
       <div className="flex-1 min-w-0 flex items-center gap-1.5">
+        {firstImage && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={firstImage}
+            alt=""
+            loading="lazy"
+            className="w-7 h-7 rounded object-cover flex-shrink-0 bg-at-surface-alt border border-at-border"
+          />
+        )}
         <span className={`sm:hidden text-xs px-1.5 py-0.5 rounded flex-shrink-0 ${catColorClasses.bg} ${catColorClasses.text}`}>
           {categoryName}
         </span>

--- a/dental-clinic-manager/src/components/Telegram/TelegramBoardPostDetail.tsx
+++ b/dental-clinic-manager/src/components/Telegram/TelegramBoardPostDetail.tsx
@@ -40,6 +40,20 @@ export default function TelegramBoardPostDetail({
   const [likeCount, setLikeCount] = useState(post.like_count ?? 0)
   const [scrapCount, setScrapCount] = useState(post.scrap_count ?? 0)
 
+  // 텔레그램 첨부파일: 만료된 직링크(`api.telegram.org/file/bot.../...`) 대신
+  // 우리 서버 프록시(/api/telegram/files/[messageId])로 다운로드.
+  const files = useMemo(() => {
+    const ids = post.source_message_ids ?? []
+    return (post.file_urls ?? []).map((f, i) => {
+      const messageId = ids[i] ?? ids[0]
+      const proxyUrl = messageId ? `/api/telegram/files/${messageId}` : f.url
+      const name = f.name ?? ''
+      const mime = f.type ?? ''
+      const isImage = mime.startsWith('image/') || /\.(png|jpe?g|gif|webp|bmp|heic|heif|avif)$/i.test(name)
+      return { ...f, proxyUrl, isImage }
+    })
+  }, [post.file_urls, post.source_message_ids])
+
   const handleToggleLike = async () => {
     if (!currentUserId) return
     const { data } = await telegramBoardPostService.toggleLike(currentUserId, post.id)
@@ -178,29 +192,45 @@ export default function TelegramBoardPostDetail({
             )}
           </div>
 
-          {/* 파일 목록 */}
-          {(post.file_urls?.length ?? 0) > 0 && (
+          {/* 첨부 파일 (이미지 인라인 + 그 외 다운로드) */}
+          {files.length > 0 && (
             <div className="mb-4 p-3 bg-at-accent-light rounded-xl">
               <h4 className="text-sm font-medium text-at-accent mb-2 flex items-center gap-1">
                 <FileText className="w-4 h-4" />첨부 파일
               </h4>
-              <div className="space-y-2">
-                {post.file_urls.map((file, i) => (
-                  <a
-                    key={i}
-                    href={file.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-2 text-sm text-at-accent hover:text-at-accent hover:underline"
-                  >
-                    <Download className="w-3.5 h-3.5 flex-shrink-0" />
-                    <span className="truncate">{file.name || `파일 ${i + 1}`}</span>
-                    {file.size && (
-                      <span className="text-xs text-at-text-weak flex-shrink-0">
-                        ({formatFileSize(file.size)})
-                      </span>
+              <div className="space-y-3">
+                {files.map((file, i) => (
+                  <div key={i}>
+                    {file.isImage ? (
+                      <a href={file.proxyUrl} target="_blank" rel="noopener noreferrer" className="block">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={file.proxyUrl}
+                          alt={file.name || `이미지 ${i + 1}`}
+                          loading="lazy"
+                          className="max-h-[420px] w-auto rounded-lg border border-at-border bg-white object-contain"
+                        />
+                        {file.name && (
+                          <p className="text-xs text-at-text-weak mt-1 truncate">{file.name}</p>
+                        )}
+                      </a>
+                    ) : (
+                      <a
+                        href={file.proxyUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-2 text-sm text-at-accent hover:text-at-accent hover:underline"
+                      >
+                        <Download className="w-3.5 h-3.5 flex-shrink-0" />
+                        <span className="truncate">{file.name || `파일 ${i + 1}`}</span>
+                        {file.size && (
+                          <span className="text-xs text-at-text-weak flex-shrink-0">
+                            ({formatFileSize(file.size)})
+                          </span>
+                        )}
+                      </a>
                     )}
-                  </a>
+                  </div>
                 ))}
               </div>
             </div>

--- a/dental-clinic-manager/supabase/functions/telegram-webhook/index.ts
+++ b/dental-clinic-manager/supabase/functions/telegram-webhook/index.ts
@@ -248,24 +248,12 @@ Deno.serve(async (req) => {
 
     console.log("[telegram-webhook] Message type:", messageType, "hasFile:", hasFile, "hasLink:", hasLink, "sender:", senderName)
 
-    // 파일 URL 해석 (file_id -> file_path -> URL)
-    let fileUrl: string | null = null
-    if (hasFile && fileId && botToken) {
-      try {
-        const getFileRes = await fetch(
-          `https://api.telegram.org/bot${botToken}/getFile?file_id=${fileId}`
-        )
-        const getFileData = await getFileRes.json()
-        if (getFileData.ok && getFileData.result?.file_path) {
-          fileUrl = `https://api.telegram.org/file/bot${botToken}/${getFileData.result.file_path}`
-          console.log("[telegram-webhook] Resolved file URL for file_id:", fileId)
-        } else {
-          console.error("[telegram-webhook] getFile failed:", getFileData)
-        }
-      } catch (fileErr) {
-        console.error("[telegram-webhook] Error resolving file URL:", fileErr)
-      }
-    }
+    // 파일 URL은 우리 서버 프록시(/api/telegram/files/[messageId])로 통일.
+    // Telegram file_path 는 1시간 후 만료되며, 직링크에 BOT_TOKEN 이 포함되면
+    // DB / 사용자 브라우저에 토큰이 노출되는 보안 사고가 발생한다. 따라서 여기서는
+    // file_url 을 DB 에 채우지 않고, 다운로드 시점에 메시지 id 로 프록시가 처리.
+    // (getFile 호출은 webhook 단계에서 굳이 필요 없고, file_id 만 보관해도 충분)
+    const fileUrl: string | null = null
 
     // extracted_links: { url: string; title?: string }[] 형식
     const extractedLinks = allUrls.length > 0
@@ -321,12 +309,12 @@ Deno.serve(async (req) => {
       if (hasFile) {
         postTitle = `[파일] ${fileName || messageType} - ${senderName}`
         postType = 'file'
-        postFileUrls = fileUrl ? [{ url: fileUrl, name: fileName || undefined, type: fileMimeType || undefined, size: fileSize || undefined }] : []
+        // 다운로드 URL 은 우리 서버 프록시 경유 — 만료/토큰 노출 문제 해소
+        const proxyUrl = `/api/telegram/files/${savedMessage.id}`
+        postFileUrls = [{ url: proxyUrl, name: fileName || undefined, type: fileMimeType || undefined, size: fileSize || undefined }]
 
         contentHtml = `<p>${text ? text.replace(/\n/g, '<br>') : ''}</p>`
-        if (fileUrl) {
-          contentHtml += `<p><strong>파일:</strong> <a href="${fileUrl}" target="_blank">${fileName || messageType}</a></p>`
-        }
+        contentHtml += `<p><strong>파일:</strong> <a href="${proxyUrl}" target="_blank">${fileName || messageType}</a></p>`
         if (fileSize) {
           contentHtml += `<p><strong>크기:</strong> ${Math.round(fileSize / 1024)}KB</p>`
         }

--- a/dental-clinic-manager/supabase/migrations/20260511_telegram_board_posts_strip_bot_token_urls.sql
+++ b/dental-clinic-manager/supabase/migrations/20260511_telegram_board_posts_strip_bot_token_urls.sql
@@ -1,0 +1,55 @@
+-- ============================================
+-- 보안 보정 — telegram_board_posts.file_urls / content 에 박혀 있던
+-- BOT_TOKEN 포함 URL(`https://api.telegram.org/file/bot<TOKEN>/...`)을
+-- 서버 프록시(`/api/telegram/files/[messageId]`) URL 로 일괄 치환.
+--
+-- 원인: supabase webhook 함수가 file_id → file_path → 직링크를 만들어 그대로
+-- DB 에 저장했으나 (1) Telegram file_path 는 1시간 만료, (2) URL 에 BOT_TOKEN
+-- 이 포함되어 클라이언트 / DB 에 노출되는 보안 사고가 동반되었음.
+--
+-- 처리:
+--  1) file_urls[*].url 을 source_message_ids[0] 기준의 우리 프록시 URL 로 치환
+--     (배열 인덱스가 1대1 매핑되도록 webhook 함수가 항상 단일 메시지/단일 파일을
+--      넣고 있어, 첫 source_message_id 만 사용해도 충분)
+--  2) content HTML 안의 토큰 노출 URL 도 모두 동일 프록시로 치환
+--
+-- Migration: 20260511_telegram_board_posts_strip_bot_token_urls.sql
+-- Created: 2026-05-11
+-- ============================================
+
+UPDATE telegram_board_posts AS p
+SET
+  file_urls = (
+    SELECT jsonb_agg(
+      CASE
+        WHEN (f->>'url') LIKE 'https://api.telegram.org/file/bot%' AND p.source_message_ids IS NOT NULL AND array_length(p.source_message_ids, 1) >= 1
+          THEN jsonb_set(f, '{url}', to_jsonb('/api/telegram/files/' || (p.source_message_ids[1])::text), true)
+        ELSE f
+      END
+    )
+    FROM jsonb_array_elements(COALESCE(p.file_urls, '[]'::jsonb)) AS f
+  ),
+  content = CASE
+    WHEN p.content ~ 'https://api\.telegram\.org/file/bot[^/"]+/'
+      AND p.source_message_ids IS NOT NULL
+      AND array_length(p.source_message_ids, 1) >= 1
+    THEN regexp_replace(
+      p.content,
+      'https://api\.telegram\.org/file/bot[^"<\s]+',
+      '/api/telegram/files/' || (p.source_message_ids[1])::text,
+      'g'
+    )
+    ELSE p.content
+  END
+WHERE (
+  EXISTS (
+    SELECT 1 FROM jsonb_array_elements(COALESCE(p.file_urls, '[]'::jsonb)) AS f
+    WHERE (f->>'url') LIKE 'https://api.telegram.org/file/bot%'
+  )
+  OR p.content ~ 'https://api\.telegram\.org/file/bot[^/"]+/'
+);
+
+-- telegram_messages 에도 동일 토큰 URL 이 file_url 컬럼에 저장되어 있을 수 있음
+UPDATE telegram_messages
+SET file_url = NULL
+WHERE file_url LIKE 'https://api.telegram.org/file/bot%';


### PR DESCRIPTION
## Summary
- 게시판 사진/파일 클릭 시 \`{"ok":false,"error_code":404}\` 응답이 그대로 보이던 문제 해결
- supabase webhook 이 BOT_TOKEN 이 포함된 직링크를 DB 에 저장하던 보안 사고를 함께 정리
- 사진은 게시판 카드 썸네일 + 상세 본문에 인라인 \`<img>\` 로 표시

## Test plan
- [x] 신규 \`/api/telegram/files/[messageId]\` 라우트로 권한 체크 + getFile + stream 동작 확인 (\`npm run build\` 성공)
- [x] DB 보정: token URL 0건 (file_urls 11건 + telegram_messages.file_url 16건 모두 정리)
- [ ] 게시판에서 이미지 게시글 진입 시 사진이 인라인으로 표시, 클릭 시 새 탭에서 정상 다운로드
- [ ] 비이미지 첨부는 다운로드 버튼으로 정상 동작
- [ ] Edge Function 재배포(\`supabase functions deploy telegram-webhook\`) 후 신규 메시지는 토큰 노출 없는 프록시 URL 로 저장되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)