### PR TITLE
fix(protocols): 승인 즉시 활성 반영 + 같은 페이지 알림 바로가기 재동작

### DIFF
--- a/dental-clinic-manager/src/components/Management/ProtocolManagement.tsx
+++ b/dental-clinic-manager/src/components/Management/ProtocolManagement.tsx
@@ -84,7 +84,10 @@ interface ProtocolManagementProps {
 export default function ProtocolManagement({ currentUser, hideHeader = false }: ProtocolManagementProps) {
   const searchParams = useSearchParams()
   const { hasPermission } = usePermissions()
-  const autoOpenedRef = useRef(false)
+  // 알림 바로가기를 같은 페이지에서 다시 눌렀을 때도 동작하도록, 마지막으로 자동
+  // 오픈한 protocolId 를 기억하고 다른 id 일 때만 다시 오픈한다(단일 boolean 가드는
+  // 페이지 첫 진입 이후 모든 후속 변경을 막아 같은 페이지에서의 알림 클릭이 무시됨).
+  const lastAutoOpenedIdRef = useRef<string | null>(null)
   const [activeSubTab, setActiveSubTab] = useState<'list' | 'categories' | 'permissions'>('list')
   const [initialLoadDone, setInitialLoadDone] = useState(false)
   const [protocols, setProtocols] = useState<Protocol[]>([])
@@ -203,18 +206,20 @@ export default function ProtocolManagement({ currentUser, hideHeader = false }: 
     }
   }, [])
 
-  // URL의 review/view 파라미터로 해당 프로토콜 상세 자동 오픈
+  // URL의 review/view 파라미터로 해당 프로토콜 상세 자동 오픈.
+  // 같은 페이지에 머문 채로 알림 바로가기를 눌러도 (id 가 다르면) 다시 오픈하도록
+  // lastAutoOpenedIdRef 와 비교한다.
   useEffect(() => {
     const protocolId = searchParams.get('review') || searchParams.get('view')
-    if (protocolId && initialLoadDone && !autoOpenedRef.current) {
-      autoOpenedRef.current = true
-      dataService.getProtocolById(protocolId).then((result) => {
-        if (result.data) {
-          setSelectedProtocol(result.data as Protocol)
-          setShowDetail(true)
-        }
-      })
-    }
+    if (!protocolId || !initialLoadDone) return
+    if (lastAutoOpenedIdRef.current === protocolId) return
+    lastAutoOpenedIdRef.current = protocolId
+    dataService.getProtocolById(protocolId).then((result) => {
+      if (result.data) {
+        setSelectedProtocol(result.data as Protocol)
+        setShowDetail(true)
+      }
+    })
   }, [searchParams, initialLoadDone])
 
   const fetchProtocols = async () => {
@@ -1185,6 +1190,11 @@ export default function ProtocolManagement({ currentUser, hideHeader = false }: 
                 onEdit={handleEditProtocol}
                 onDelete={handleDeleteProtocol}
                 onSplit={canEdit ? handleSplitProtocol : undefined}
+                // 승인/반려/검토 요청 등으로 protocol 이 갱신되면 즉시 목록 반영
+                onProtocolChanged={(updated) => {
+                  setProtocols(prev => prev.map(p => p.id === updated.id ? { ...p, ...updated } : p))
+                  setSelectedProtocol(prev => prev && prev.id === updated.id ? { ...prev, ...updated } : prev)
+                }}
               />
             )}
 

--- a/dental-clinic-manager/src/components/Protocol/ProtocolDetail.tsx
+++ b/dental-clinic-manager/src/components/Protocol/ProtocolDetail.tsx
@@ -49,6 +49,8 @@ interface ProtocolDetailProps {
   onEdit: (protocol: Protocol) => void
   onDelete: (protocolId: string) => void
   onSplit?: (protocol: Protocol) => void
+  /** 본문 변경(승인/반려/검토요청 등)으로 protocol 이 갱신되면 부모에 즉시 알림 */
+  onProtocolChanged?: (protocol: Protocol) => void
 }
 
 export default function ProtocolDetail({
@@ -56,7 +58,8 @@ export default function ProtocolDetail({
   onClose,
   onEdit,
   onDelete,
-  onSplit
+  onSplit,
+  onProtocolChanged,
 }: ProtocolDetailProps) {
   const { hasPermission } = usePermissions()
   const { user } = useAuth()
@@ -97,7 +100,9 @@ export default function ProtocolDetail({
         setError(result.error)
         setProtocol(null)
       } else {
-        setProtocol((result.data as Protocol | null) ?? null)
+        const fresh = (result.data as Protocol | null) ?? null
+        setProtocol(fresh)
+        if (fresh) onProtocolChanged?.(fresh)
 
         // 개별 권한 확인 (대표원장이 아닌 경우에만)
         if (user && user.role !== 'owner') {


### PR DESCRIPTION
## Summary
- 프로토콜 승인 후 목록의 상태가 \"활성\"으로 즉시 반영되도록 \`ProtocolDetail.onProtocolChanged\` 콜백 추가 → \`ProtocolManagement\` 가 \`protocols\` / \`selectedProtocol\` 의 해당 항목을 즉시 교체
- 같은 프로토콜 페이지에 머문 채로 알림 바로가기를 눌러도 다른 프로토콜로 이동 가능하도록 \`autoOpenedRef\` (boolean) → \`lastAutoOpenedIdRef\` (마지막 id) 로 가드 방식 변경

## Test plan
- [x] \`npm run build\` 성공
- [ ] 검토 요청된 프로토콜을 모달에서 승인 → 모달과 목록 모두 \"활성\" 배지 즉시 표시
- [ ] 프로토콜 페이지에 있는 상태에서 다른 프로토콜 알림 클릭 → 새 프로토콜 상세 모달이 열리는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)