### PR TITLE
fix(protocols): 반려 사유가 요청자에게 보이지 않던 문제 해결

### DIFF
--- a/dental-clinic-manager/src/components/Protocol/ProtocolDetail.tsx
+++ b/dental-clinic-manager/src/components/Protocol/ProtocolDetail.tsx
@@ -72,6 +72,8 @@ export default function ProtocolDetail({
   const [hasEditPermission, setHasEditPermission] = useState(false)
   const [hasDeletePermission, setHasDeletePermission] = useState(false)
   const [pendingReview, setPendingReview] = useState<ProtocolReview | null>(null)
+  // 가장 최근에 반려된 검토 — 부원장 등 요청자가 사유를 본문에서 확인할 수 있도록 별도 보관
+  const [latestRejectedReview, setLatestRejectedReview] = useState<ProtocolReview | null>(null)
   const [showReviewRequestModal, setShowReviewRequestModal] = useState(false)
   const [reviewRequestMessage, setReviewRequestMessage] = useState('')
   const [showRejectModal, setShowRejectModal] = useState(false)
@@ -134,8 +136,18 @@ export default function ProtocolDetail({
   const fetchPendingReview = useCallback(async () => {
     const result = await dataService.getProtocolReviews(protocolId)
     if (!result.error && result.data) {
-      const pending = result.data.find((r: ProtocolReview) => r.status === 'pending')
-      setPendingReview(pending || null)
+      const reviews = result.data as ProtocolReview[]
+      const pending = reviews.find(r => r.status === 'pending') || null
+      setPendingReview(pending)
+      // pending 이 없을 때만 최근 반려 사유를 노출 (재요청 진행 중이면 pending 정보가 우선)
+      if (!pending) {
+        const rejected = [...reviews]
+          .filter(r => r.status === 'rejected')
+          .sort((a, b) => new Date(b.reviewed_at || b.updated_at).getTime() - new Date(a.reviewed_at || a.updated_at).getTime())[0] || null
+        setLatestRejectedReview(rejected)
+      } else {
+        setLatestRejectedReview(null)
+      }
     }
   }, [protocolId])
 
@@ -534,6 +546,33 @@ export default function ProtocolDetail({
                 </p>
                 <p className="text-xs text-amber-500 mt-1">
                   {new Date(pendingReview.created_at).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* 최근 반려 사유 — 부원장 등 요청자가 본문에서 확인할 수 있도록
+            pending 이 없고(=재요청 전), 가장 최근 검토가 rejected 인 경우 노출 */}
+        {!pendingReview && latestRejectedReview && (
+          <div className="mx-6 mt-4 p-3 bg-at-error-bg border border-red-200 rounded-lg">
+            <div className="flex items-start gap-2">
+              <XCircleIcon className="h-5 w-5 text-red-500 mt-0.5 flex-shrink-0" />
+              <div className="flex-1">
+                <p className="text-sm font-medium text-red-800">검토 반려됨</p>
+                <p className="text-sm text-red-700 mt-0.5">
+                  {latestRejectedReview.reviewer_user?.name || '대표원장'}님이 검토를 반려했습니다.
+                  {latestRejectedReview.review_message ? (
+                    <span className="block mt-1 whitespace-pre-wrap">사유: {latestRejectedReview.review_message}</span>
+                  ) : (
+                    <span className="block mt-1 text-red-500">(별도 사유가 입력되지 않았습니다)</span>
+                  )}
+                  {latestRejectedReview.request_message && (
+                    <span className="block mt-1 text-red-500 text-xs">원 요청 메시지: {latestRejectedReview.request_message}</span>
+                  )}
+                </p>
+                <p className="text-xs text-red-500 mt-1">
+                  {new Date(latestRejectedReview.reviewed_at || latestRejectedReview.updated_at).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- 반려된 검토의 \`review_message\`(사유)가 요청자(부원장 등) 화면에 표시되지 않던 문제 해결
- \`fetchPendingReview\` 가 pending 만 가져와 rejected 정보가 사라지던 구조 → 최근 반려 리뷰를 별도 state 로 보관
- pending 이 없을 때 본문 상단에 빨간 배너로 반려자/사유/원 요청 메시지/일시 표시

## Test plan
- [x] \`npm run build\` 성공
- [ ] 대표원장이 사유를 입력해 반려 → 부원장 알림 + 부원장이 해당 프로토콜 상세 진입 시 본문 상단에 사유 배너 노출 확인
- [ ] 부원장이 재검토 요청 시 사유 배너가 사라지고 pending 안내로 전환되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)