### PR TITLE
fix(community/telegram): 실장 등 일반 회원에게 공개 소모임 목록 노출

### DIFF
--- a/dental-clinic-manager/supabase/migrations/20260511_telegram_groups_public_visible.sql
+++ b/dental-clinic-manager/supabase/migrations/20260511_telegram_groups_public_visible.sql
@@ -1,0 +1,40 @@
+-- ============================================
+-- telegram_groups SELECT 정책 확장 — 공개 모임은 인증된 사용자라면 누구나 조회 가능
+--
+-- 기존(20260408): master_admin / 멤버 / 그룹 생성자만 조회 가능.
+-- → 실장(manager) 등 일반 가입 회원이 공개(visibility != 'private') 모임 목록조차
+--   가져오지 못해 "공개 소모임" 섹션이 비어 보이는 문제 발생.
+--
+-- 변경: visibility 가 public_list/public_read/public_full 이고 is_active=true,
+--      status='approved' 인 그룹은 인증된 사용자라면 누구나 SELECT 허용.
+--      비공개(visibility='private') 그룹은 기존과 동일하게 멤버/owner/master 만.
+--      공개 정도는 모임장이 visibility 로 결정하므로 정책은 visibility 만 신뢰.
+--
+-- Migration: 20260511_telegram_groups_public_visible.sql
+-- Created: 2026-05-11
+-- ============================================
+
+DROP POLICY IF EXISTS "telegram_groups_select" ON telegram_groups;
+
+CREATE POLICY "telegram_groups_select" ON telegram_groups
+  FOR SELECT TO authenticated
+  USING (
+    -- master_admin: 모든 그룹
+    auth.uid() IN (SELECT id FROM users WHERE role = 'master_admin')
+    OR
+    -- 그룹 멤버
+    id IN (
+      SELECT telegram_group_id FROM telegram_group_members
+      WHERE user_id = auth.uid()
+    )
+    OR
+    -- 모임장(생성자)
+    created_by = auth.uid()
+    OR
+    -- 공개 모임(목록/열람/열람+댓글)은 모든 인증 사용자가 조회 가능
+    (
+      is_active = true
+      AND status = 'approved'
+      AND visibility IN ('public_list', 'public_read', 'public_full')
+    )
+  );


### PR DESCRIPTION
## Summary
- 실장(manager) 등 일반 가입 회원에게 공개 소모임 목록이 안 보이던 문제 해결
- 원인: \`telegram_groups\` SELECT RLS 가 master_admin / 멤버 / 모임장 만 허용 → 비멤버 일반 사용자는 \`visibility=public_*\` 모임 row 자체를 받지 못함
- 수정: SELECT 정책에 \`is_active AND status='approved' AND visibility IN ('public_list','public_read','public_full')\` 분기 추가. 비공개 모임은 기존과 동일하게 멤버/owner/master 만

## Test plan
- [x] 운영 DB 적용 확인
- [ ] 실장 계정으로 진입 시 \`공개 소모임\` 섹션에 "치과 경영 스터디 - 투자" 등이 노출되는지 확인
- [ ] 비공개 모임은 비멤버에게 여전히 노출되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)