### PR TITLE
fix(auth): 미로그인 /dashboard/* 진입 시 로그인 화면으로 리다이렉트

### DIFF
--- a/dental-clinic-manager/src/app/dashboard/layout.tsx
+++ b/dental-clinic-manager/src/app/dashboard/layout.tsx
@@ -52,20 +52,27 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   })
 
   // 사용자 상태 체크 - 퇴사자, 승인대기, 거절된 사용자 리다이렉트
+  // 미로그인 사용자는 홈(로그인 화면)으로 리다이렉트하며 원래 URL 을 redirect 파라미터로 전달
+  // (그렇지 않으면 무한 로딩 스피너만 노출됨 — 소모임 초대 링크 같은 진입 경로 차단)
   useEffect(() => {
-    if (!loading && user) {
-      if (user.status === 'resigned') {
-        console.log('[DashboardLayout] User is resigned, redirecting to /resigned')
-        router.replace('/resigned')
-        return
-      }
-      if (user.status === 'pending' || user.status === 'rejected') {
-        console.log('[DashboardLayout] User is pending/rejected, redirecting to /pending-approval')
-        router.replace('/pending-approval')
-        return
-      }
+    if (loading) return
+    if (!user) {
+      const qs = searchParams.toString()
+      const next = qs ? `${pathname}?${qs}` : pathname
+      router.replace(`/?show=login&redirect=${encodeURIComponent(next)}`)
+      return
     }
-  }, [user, loading, router])
+    if (user.status === 'resigned') {
+      console.log('[DashboardLayout] User is resigned, redirecting to /resigned')
+      router.replace('/resigned')
+      return
+    }
+    if (user.status === 'pending' || user.status === 'rejected') {
+      console.log('[DashboardLayout] User is pending/rejected, redirecting to /pending-approval')
+      router.replace('/pending-approval')
+      return
+    }
+  }, [user, loading, router, pathname, searchParams])
 
   // 페이지 변경 시 모바일 메뉴 닫기 및 activeTab 동기화
   useEffect(() => {


### PR DESCRIPTION
## Summary
- 미로그인 상태에서 \`/dashboard/community/telegram/join/<code>\` 같은 보호 경로 진입 시 무한 로딩만 보이던 문제 해결
- \`DashboardLayout\` 에 user 가 없을 때 \`/?show=login&redirect=<원래 경로>\` 로 리다이렉트
- AuthFlow 는 이미 \`?redirect=\` 처리되어 있어 로그인 후 초대 가입 흐름이 끊김 없이 이어짐

## Test plan
- [x] \`npm run build\` 성공
- [ ] 로그아웃 상태에서 초대 링크 클릭 → 로그인 화면 노출 + 로그인 후 자동으로 초대 가입 페이지로 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)