### PR TITLE
fix(sms): 알리고 multipart→urlencoded 전환 (Fixie 프록시 호환)

### DIFF
--- a/dental-clinic-manager/src/app/api/cron/referral-thanks/route.ts
+++ b/dental-clinic-manager/src/app/api/cron/referral-thanks/route.ts
@@ -114,17 +114,22 @@ export async function GET(request: NextRequest) {
       }
       const msgType = byteSize > 90 ? 'LMS' : 'SMS'
 
-      const fd = new FormData()
-      fd.append('key', aligo.api_key)
-      fd.append('user_id', aligo.user_id)
-      fd.append('sender', aligo.sender_number)
-      fd.append('receiver', r.referrer.phone_number)
-      fd.append('msg', message)
-      fd.append('msg_type', msgType)
-      if (msgType === 'LMS') fd.append('title', '소개 감사 인사')
+      // urlencoded 사용 — Fixie/ProxyAgent 환경에서 multipart 가 깨지는 문제 회피
+      const params = new URLSearchParams()
+      params.append('key', aligo.api_key)
+      params.append('user_id', aligo.user_id)
+      params.append('sender', aligo.sender_number)
+      params.append('receiver', r.referrer.phone_number)
+      params.append('msg', message)
+      params.append('msg_type', msgType)
+      if (msgType === 'LMS') params.append('title', '소개 감사 인사')
 
       try {
-        const res = await aligoFetch(`${ALIGO_API_URL}/send/`, { method: 'POST', body: fd })
+        const res = await aligoFetch(`${ALIGO_API_URL}/send/`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
+        })
         const json = await res.json()
         // Aligo 스펙: result_code 는 Integer, >= 1 이면 성공.
         const codeNum = Number(json.result_code)

--- a/dental-clinic-manager/src/app/api/recall/sms/route.ts
+++ b/dental-clinic-manager/src/app/api/recall/sms/route.ts
@@ -88,13 +88,15 @@ export async function POST(request: NextRequest) {
     }
 
     // 알리고 API 요청 데이터 준비
-    const formData = new FormData()
-    formData.append('key', aligoSettings.api_key)
-    formData.append('user_id', aligoSettings.user_id)
-    formData.append('sender', aligoSettings.sender_number)
-    formData.append('receiver', receiverList.join(','))
-    formData.append('msg', message)
-    formData.append('msg_type', actualMsgType)
+    // multipart/form-data 대신 application/x-www-form-urlencoded 사용 — undici ProxyAgent + Fixie
+    // 터널링 환경에서 multipart boundary 가 깨져 알리고가 파라미터를 못 읽는 문제 회피.
+    const params = new URLSearchParams()
+    params.append('key', aligoSettings.api_key)
+    params.append('user_id', aligoSettings.user_id)
+    params.append('sender', aligoSettings.sender_number)
+    params.append('receiver', receiverList.join(','))
+    params.append('msg', message)
+    params.append('msg_type', actualMsgType)
     if (title && actualMsgType !== 'SMS') {
       const titleBytes = new Blob([title]).size
       if (titleBytes > 44) {
@@ -103,17 +105,18 @@ export async function POST(request: NextRequest) {
           { status: 400 }
         )
       }
-      formData.append('title', title)
+      params.append('title', title)
     }
     // 테스트 모드 (개발 환경에서만)
     if (process.env.NODE_ENV === 'development') {
-      formData.append('testmode_yn', 'Y')
+      params.append('testmode_yn', 'Y')
     }
 
     // 알리고 API 호출
     const aligoResponse = await aligoFetch(`${ALIGO_API_URL}/send/`, {
       method: 'POST',
-      body: formData
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString()
     })
 
     const aligoResult: AligoResponse = await aligoResponse.json()
@@ -134,19 +137,13 @@ export async function POST(request: NextRequest) {
         }
       })
     } else {
-      // IP 인증 오류 체크 (스펙: -101 = 인증오류). 알리고 IP 보안 정책의 정확한 메뉴 명칭은 공식 문서에 없어
-      // 고객센터 문의로 안내. 본 서비스는 Vercel 서버리스라 호출마다 IP가 달라질 수 있다는 사실은 고지.
-      let errorMessage = aligoResult.message || '문자 발송에 실패했습니다.'
-      if (
-        resultCodeNum === -101 ||
-        errorMessage.includes('ip') ||
-        errorMessage.includes('IP') ||
-        errorMessage.includes('인증오류')
-      ) {
-        errorMessage =
-          'IP 인증 오류로 보입니다. 알리고 고객센터(1661-1565 또는 smartsms.aligo.in 문의하기)에 IP 인증 해제 또는 IP 등록 절차를 문의해주세요. ' +
-          '본 서비스는 Vercel 서버리스로 동작하여 호출마다 발송 IP가 달라질 수 있어 특정 IP 등록 방식은 안정적이지 않습니다.'
-      }
+      // 알리고가 반환한 원본 메시지를 그대로 보여줌. IP 인증 오류처럼 보여도 실제로는 다른 원인(파라미터 누락 등)일 수 있어 휴리스틱 변환은 위험.
+      // 알리고 원본 message 가 "-IP" 등 IP 관련 단서를 포함할 때만 부가 안내 덧붙임.
+      const aligoMessage = aligoResult.message || '문자 발송에 실패했습니다.'
+      const isIpAuthError = /-IP\b/i.test(aligoMessage) || aligoMessage.includes('등록되지 않은 IP') || aligoMessage.includes('등록되지 않은 ip')
+      const errorMessage = isIpAuthError
+        ? `${aligoMessage}\n\n발신 IP 가 알리고에 등록되지 않은 것 같습니다. Fixie 고정 IP(52.5.155.132, 52.87.82.133) 가 알리고 IP 인증 화이트리스트에 모두 등록되어 있는지 확인해주세요.`
+        : aligoMessage
 
       return NextResponse.json({
         success: false,
@@ -214,14 +211,15 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    // 알리고 잔여 문자 조회 API 호출
-    const formData = new FormData()
-    formData.append('key', aligoSettings.api_key)
-    formData.append('user_id', aligoSettings.user_id)
+    // 알리고 잔여 문자 조회 API 호출 (urlencoded — multipart/프록시 호환성 이슈 회피)
+    const params = new URLSearchParams()
+    params.append('key', aligoSettings.api_key)
+    params.append('user_id', aligoSettings.user_id)
 
     const aligoResponse = await aligoFetch(`${ALIGO_API_URL}/remain/`, {
       method: 'POST',
-      body: formData
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString()
     })
 
     const aligoResult = await aligoResponse.json()

--- a/dental-clinic-manager/src/app/api/referrals/sms/route.ts
+++ b/dental-clinic-manager/src/app/api/referrals/sms/route.ts
@@ -45,23 +45,28 @@ export async function POST(req: NextRequest) {
     }
     const actualType = msgBytes > 90 && msg_type === 'SMS' ? 'LMS' : msg_type
 
-    const formData = new FormData()
-    formData.append('key', aligo.api_key)
-    formData.append('user_id', aligo.user_id)
-    formData.append('sender', aligo.sender_number)
-    formData.append('receiver', phone_number)
-    formData.append('msg', message)
-    formData.append('msg_type', actualType)
+    // urlencoded 사용 — undici ProxyAgent + Fixie 터널링에서 multipart boundary 손상되는 문제 회피
+    const params = new URLSearchParams()
+    params.append('key', aligo.api_key)
+    params.append('user_id', aligo.user_id)
+    params.append('sender', aligo.sender_number)
+    params.append('receiver', phone_number)
+    params.append('msg', message)
+    params.append('msg_type', actualType)
     if (title && actualType !== 'SMS') {
       const titleBytes = new Blob([title]).size
       if (titleBytes > 44) {
         return NextResponse.json({ success: false, error: '문자 제목은 44바이트 이하여야 합니다.' }, { status: 400 })
       }
-      formData.append('title', title)
+      params.append('title', title)
     }
-    if (process.env.NODE_ENV === 'development') formData.append('testmode_yn', 'Y')
+    if (process.env.NODE_ENV === 'development') params.append('testmode_yn', 'Y')
 
-    const aligoRes = await aligoFetch(`${ALIGO_API_URL}/send/`, { method: 'POST', body: formData })
+    const aligoRes = await aligoFetch(`${ALIGO_API_URL}/send/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    })
     const aligoJson = (await aligoRes.json()) as { result_code: string | number; message: string; msg_id?: string | number }
 
     if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
## Summary
- **근본 원인 해결**: undici ProxyAgent + multipart/form-data 조합이 Fixie HTTP 터널링 환경에서 boundary 가 손상되어 알리고가 \`key\` 등 파라미터를 못 읽고 \`-101 API 키가 입력되지 않았습니다\` 반환하던 문제
- 알리고 호출 3곳 모두 \`URLSearchParams\` + \`application/x-www-form-urlencoded\` 로 전환 (boundary 없음 → 프록시 100% 호환)
- 클라이언트에 표시되는 IP 오류 휴리스틱이 너무 광범위해 진짜 알리고 메시지를 가리던 문제도 함께 정정

## Test plan
- [x] \`npm run build\` 통과
- [x] Production endpoint 직접 POST 호출로 \`-101 API 키 누락\` 응답 확인 (변경 전)
- [ ] 머지 후 Production endpoint 직접 POST 호출로 정상 응답 확인 (변경 후)
- [ ] 사용자분 본인 휴대폰 SMS 발송 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)