### PR TITLE
feat(invite): 미가입자도 초대 링크 → 회원가입 → 공개 소모임 자동 진입

### DIFF
--- a/dental-clinic-manager/src/app/auth/callback/route.ts
+++ b/dental-clinic-manager/src/app/auth/callback/route.ts
@@ -77,8 +77,18 @@ export async function GET(request: NextRequest) {
         } else if (profile) {
           console.log('[Auth Callback] User profile:', { status: profile.status, email: profile.email })
 
+          // 공개 소모임 초대 링크로 가입한 사용자는 next 가 해당 경로면 승인 전이어도 그쪽으로 안내한다.
+          // (DashboardLayout 도 같은 경로에서는 pending/rejected 통과를 허용함)
+          const isPublicTelegramGroupRoute =
+            next.startsWith('/dashboard/community/telegram/') &&
+            next.replace('/dashboard/community/telegram/', '').length > 0
+
           // status에 따라 적절한 페이지로 리다이렉트
           if (profile.status === 'pending') {
+            if (isPublicTelegramGroupRoute) {
+              console.log('[Auth Callback] Pending user with public telegram group invite, redirecting to:', next)
+              return NextResponse.redirect(new URL(next, request.url))
+            }
             console.log('[Auth Callback] User is pending approval, redirecting to /pending-approval')
             return NextResponse.redirect(new URL('/pending-approval', request.url))
           } else if (profile.status === 'rejected') {

--- a/dental-clinic-manager/src/app/dashboard/community/telegram/[slug]/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/community/telegram/[slug]/page.tsx
@@ -83,25 +83,10 @@ export default function TelegramBoardPage() {
             </Button>
           </div>
         </div>
-      ) : isMember === false && group.visibility === 'public_list' ? (
-        /* 목록만 공개 - 게시글 열람 불가 */
-        <div className="text-center py-20">
-          <div className="w-16 h-16 bg-at-tag rounded-full flex items-center justify-center mx-auto mb-4">
-            <Globe className="w-8 h-8 text-at-accent" />
-          </div>
-          <h2 className="text-lg font-semibold text-at-text mb-2">{group.board_title}</h2>
-          {group.board_description && (
-            <p className="text-sm text-at-text-weak mb-2">{group.board_description}</p>
-          )}
-          <p className="text-sm text-at-text-weak mb-6">게시글을 열람하려면 모임에 가입해야 합니다.</p>
-          <JoinRequestButton groupId={group.id} onJoined={() => router.refresh()} />
-          <div className="mt-6">
-            <Button variant="outline" size="sm" onClick={() => router.push('/dashboard/community/telegram')}>
-              게시판 목록으로
-            </Button>
-          </div>
-        </div>
       ) : (
+        // 공개 모임(public_list / public_read / public_full)은 비멤버도 게시글 열람 허용.
+        // 글쓰기/댓글 권한은 본문 안내 배너 + 작성 UI 측에서 visibility 별로 제한.
+
         <>
           {/* 게시판 헤더 */}
           <div className="bg-gradient-to-r from-sky-500 to-blue-600 px-4 sm:px-6 py-3 sm:py-4 rounded-t-xl shadow-sm">

--- a/dental-clinic-manager/src/app/dashboard/layout.tsx
+++ b/dental-clinic-manager/src/app/dashboard/layout.tsx
@@ -51,6 +51,13 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     enabled: !!user?.clinic_id
   })
 
+  // 공개 소모임 상세 페이지(/dashboard/community/telegram/<slug>)는
+  // 가입 승인 전(pending/rejected)에도 초대 링크 진입자가 본문을 열람할 수 있도록 통과시킨다.
+  // 정책: 비공개 모임이면 페이지 자체에서 가입 안내 화면을 노출하므로 layout 분기는 경로 기반으로만 처리.
+  const isPublicTelegramGroupRoute =
+    pathname.startsWith('/dashboard/community/telegram/') &&
+    pathname.replace('/dashboard/community/telegram/', '').length > 0
+
   // 사용자 상태 체크 - 퇴사자, 승인대기, 거절된 사용자 리다이렉트
   // 미로그인 사용자는 홈(로그인 화면)으로 리다이렉트하며 원래 URL 을 redirect 파라미터로 전달
   // (그렇지 않으면 무한 로딩 스피너만 노출됨 — 소모임 초대 링크 같은 진입 경로 차단)
@@ -68,11 +75,15 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       return
     }
     if (user.status === 'pending' || user.status === 'rejected') {
+      if (isPublicTelegramGroupRoute) {
+        // 공개 모임 초대 링크 진입자는 가입 승인 전이어도 본문 열람 허용
+        return
+      }
       console.log('[DashboardLayout] User is pending/rejected, redirecting to /pending-approval')
       router.replace('/pending-approval')
       return
     }
-  }, [user, loading, router, pathname, searchParams])
+  }, [user, loading, router, pathname, searchParams, isPublicTelegramGroupRoute])
 
   // 페이지 변경 시 모바일 메뉴 닫기 및 activeTab 동기화
   useEffect(() => {
@@ -128,7 +139,15 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     )
   }
 
-  if (!user || user.status === 'resigned' || user.status === 'pending' || user.status === 'rejected') {
+  if (!user || user.status === 'resigned') {
+    return (
+      <div className="min-h-screen bg-at-surface-alt flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-at-accent"></div>
+      </div>
+    )
+  }
+  // pending/rejected 사용자는 공개 모임 상세 페이지에 한해 본문 렌더 허용
+  if ((user.status === 'pending' || user.status === 'rejected') && !isPublicTelegramGroupRoute) {
     return (
       <div className="min-h-screen bg-at-surface-alt flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-at-accent"></div>

--- a/dental-clinic-manager/src/components/Auth/SignupForm.tsx
+++ b/dental-clinic-manager/src/components/Auth/SignupForm.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
 import Image from 'next/image'
 import { EyeIcon, EyeSlashIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 import { dataService } from '@/lib/dataService'
@@ -26,6 +27,11 @@ export default function SignupForm({
   onSignupSuccess,
   onSearchClinics,
 }: SignupFormProps) {
+  // 초대 링크 등을 통해 진입한 경우 ?redirect=... 로 원래 가려던 경로가 운반된다.
+  // 회원가입 → 이메일 인증 → 자동 진입 흐름에서 next 파라미터로 끝까지 보존하기 위해 읽어둔다.
+  const searchParams = useSearchParams()
+  const redirectAfterAuth = searchParams.get('redirect') || ''
+
   const [formData, setFormData] = useState({
     userId: '',
     name: '', // 사용자 이름 필드 추가
@@ -255,11 +261,17 @@ export default function SignupForm({
 
       // 1. 인증 사용자 생성
       console.log('[Signup] Creating auth user...');
+      // 초대 링크 등으로 진입한 경우, 인증 메일의 콜백 URL에 next 파라미터를 운반해
+      // 인증 후 원래 가려던 페이지로 곧장 안내한다.
+      const callbackUrl = new URL(`${window.location.origin}/auth/callback`);
+      if (redirectAfterAuth) {
+        callbackUrl.searchParams.set('next', redirectAfterAuth);
+      }
       const { data: authData, error: authError} = await supabase.auth.signUp({
         email: formData.userId,
         password: formData.password,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback`,
+          emailRedirectTo: callbackUrl.toString(),
         }
       });
 


### PR DESCRIPTION
## Summary
- 초대 링크(`/dashboard/community/telegram/<slug>`)를 회원가입 미경험자가 클릭해도 회원가입 → 이메일 인증 → 해당 공개 소모임으로 자연스럽게 안내
- `?redirect=` 파라미터를 회원가입 폼 → 인증 메일 콜백(`?next=`) → 대시보드 layout 까지 전 구간 보존
- `pending`/`rejected` 사용자도 **공개 소모임 상세 경로에 한해** 본문 열람 허용 (다른 대시보드 기능은 기존대로 승인 전 차단)
- `visibility='public_list'` 모임도 비멤버에게 차단 화면을 띄우지 않고 본문 열람 허용 (PR #569 RLS 확장과 짝을 이루는 UI 변경)

## 변경 파일
- `src/components/Auth/SignupForm.tsx` — `emailRedirectTo` 에 `next` 파라미터 운반
- `src/app/auth/callback/route.ts` — 공개 소모임 경로면 pending 사용자도 그쪽으로 안내
- `src/app/dashboard/layout.tsx` — pending/rejected 사용자 공개 모임 경로 예외 처리
- `src/app/dashboard/community/telegram/[slug]/page.tsx` — public_list 차단 화면 제거

## 정책
- 병원 관계자 가입 모델(직책/소속 병원 입력)은 그대로 유지
- 공개 모임 열람은 가입 승인 전에도 가능, 글쓰기/댓글은 visibility 별 권한 그대로

## Test plan
- [ ] 로그아웃 상태에서 공개 모임 초대 링크 클릭 → 로그인 화면 → 회원가입 클릭
- [ ] 회원가입 완료 → 인증 메일에 `?next=<원래경로>` 포함 확인
- [ ] 인증 메일 클릭 → 공개 소모임 상세 페이지로 바로 진입(승인 전이어도)
- [ ] 동일 사용자가 `/dashboard/financial` 등 다른 경로 접근 시 `/pending-approval` 로 리다이렉트되는지 확인
- [ ] 기존 회원이 초대 링크 클릭 시 흐름 회귀 없음 확인