### PR TITLE
fix(approve): 마스터가 신규 owner 가입을 승인할 수 있도록 결함 수정

### DIFF
--- a/dental-clinic-manager/src/app/api/staff/approve/route.ts
+++ b/dental-clinic-manager/src/app/api/staff/approve/route.ts
@@ -34,40 +34,51 @@ export async function POST(req: Request) {
     .select('id, clinic_id, role')
     .eq('id', user.id)
     .single()
-  if (meErr || !me?.clinic_id) {
-    return NextResponse.json({ error: 'NO_CLINIC' }, { status: 403 })
+  if (meErr || !me) {
+    return NextResponse.json({ error: 'NO_USER' }, { status: 403 })
   }
   if (!['owner', 'master_admin'].includes(me.role as string)) {
     return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 })
   }
 
-  // 인원 상한 가드
-  const [activeCount, subscription] = await Promise.all([
-    countActiveEmployees(me.clinic_id),
-    getSubscription(me.clinic_id),
-  ])
-  const currentPlan = subscription?.plan_id ? await getPlanById(subscription.plan_id) : null
-  const currentLimit = currentPlan?.max_users ?? FREE_LIMIT
+  const isMaster = me.role === 'master_admin'
+  // 일반 owner 는 본인 clinic 의 직원만 승인 가능하므로 clinic_id 필수.
+  // master_admin 은 전체 서비스의 신규 가입(특히 다른 clinic 의 owner)을 승인하는 권한이므로 clinic_id 없어도 통과.
+  if (!isMaster && !me.clinic_id) {
+    return NextResponse.json({ error: 'NO_CLINIC' }, { status: 403 })
+  }
 
-  if (
-    requiresUpgrade({
-      currentActive: activeCount,
-      pendingToApprove: ids.length,
-      currentLimit,
-    })
-  ) {
-    const projected = activeCount + ids.length
-    return NextResponse.json(
-      {
-        error: 'UPGRADE_REQUIRED',
-        currentPlan: currentPlan?.name ?? 'free',
-        currentLimit,
+  // 인원 상한 가드: owner 가 자기 직원을 승인하는 경우에만 본인 clinic 한도로 검사한다.
+  // master_admin 은 다른 clinic 의 owner 를 승인하는 행위라 본인 clinic 한도 검사가 의미 없음.
+  // (승인 대상 clinic 별 한도는 그 clinic 의 owner 가 자기 직원을 승인할 때 다시 검사됨)
+  if (!isMaster) {
+    const [activeCount, subscription] = await Promise.all([
+      countActiveEmployees(me.clinic_id as string),
+      getSubscription(me.clinic_id as string),
+    ])
+    const currentPlan = subscription?.plan_id ? await getPlanById(subscription.plan_id) : null
+    const currentLimit = currentPlan?.max_users ?? FREE_LIMIT
+
+    if (
+      requiresUpgrade({
         currentActive: activeCount,
         pendingToApprove: ids.length,
-        recommendedPlan: findPlanByHeadcount(projected),
-      },
-      { status: 403 },
-    )
+        currentLimit,
+      })
+    ) {
+      const projected = activeCount + ids.length
+      return NextResponse.json(
+        {
+          error: 'UPGRADE_REQUIRED',
+          currentPlan: currentPlan?.name ?? 'free',
+          currentLimit,
+          currentActive: activeCount,
+          pendingToApprove: ids.length,
+          recommendedPlan: findPlanByHeadcount(projected),
+        },
+        { status: 403 },
+      )
+    }
   }
 
   // 승인 실행 (pending → active)
@@ -79,11 +90,12 @@ export async function POST(req: Request) {
     updatePayload.permissions = permissions
   }
 
-  const { error: upErr } = await supabase
-    .from('users')
-    .update(updatePayload)
-    .in('id', ids)
-    .eq('clinic_id', me.clinic_id)
+  // master_admin 은 어떤 clinic 의 사용자든 승인 가능, owner 는 본인 clinic 의 사용자만.
+  let q = supabase.from('users').update(updatePayload).in('id', ids)
+  if (!isMaster) {
+    q = q.eq('clinic_id', me.clinic_id as string)
+  }
+  const { error: upErr } = await q
 
   if (upErr) {
     return NextResponse.json({ error: upErr.message }, { status: 500 })


### PR DESCRIPTION
## Summary
`/api/staff/approve` 가 본인 `clinic_id` 와 동일한 사용자만 UPDATE 하도록 되어 있어, master_admin 이 신규 owner 가입자를 승인하면 **항상 실패**하던 결함을 수정합니다.

## 결함 분석
- RPC `create_clinic_with_owner` 는 신규 owner 를 `status='pending'` 으로 INSERT
- 마스터 페이지(`/master`)에 \"승인 대기\" UI 가 있고 owner 도 거기 표시됨
- 그러나 승인 버튼이 호출하는 [/api/staff/approve](src/app/api/staff/approve/route.ts) 는:
  - `!me.clinic_id` 이면 403 NO_CLINIC (마스터는 보통 clinic_id=NULL)
  - UPDATE 시 `.eq('clinic_id', me.clinic_id)` 필터 — 마스터의 clinic_id 와 새 owner 의 새 clinic_id 가 일치하지 않아 0 rows 업데이트

→ 결과: 마스터가 owner 승인을 시도해도 사실상 동작 안 함. \"마스터의 승인이 있어야 owner 가 active 된다\"는 정책이 실제로 불가능했던 상태.

## 수정 내용 ([src/app/api/staff/approve/route.ts](src/app/api/staff/approve/route.ts))
master_admin 분기 추가:
- clinic_id 필수 체크 우회 (소속 clinic 없어도 통과)
- 인원 상한 가드 우회 (본인 clinic 한도와 무관)
- UPDATE 시 `.eq('clinic_id', ...)` 필터 우회 (모든 clinic 의 사용자 승인 가능)

일반 owner 가 본인 직원을 승인하는 흐름은 변경 없음.

## Test plan
- [ ] 새 대표원장(owner) 회원가입 → `users.status='pending'` 확인
- [ ] 마스터(sani81@gmail.com) 로그인 → `/master` → 승인 대기 탭 → 새 owner 표시 확인
- [ ] 승인 버튼 클릭 → \"사용자가 승인되었습니다\" 알림 + 목록에서 제거 확인
- [ ] 승인된 owner 가 다시 로그인 → 자기 clinic 대시보드 진입 확인
- [ ] 일반 owner 가 자기 직원 승인 시: 본인 clinic 직원만 승인 가능한지 회귀 확인 (다른 clinic 직원 ID 를 넣어도 0 rows)