### PR TITLE
feat(notify): 신규 대표원장 가입 시 마스터에게 승인 요청 SMS 발송

### DIFF
--- a/dental-clinic-manager/src/app/api/admin/notify-master-on-signup/route.ts
+++ b/dental-clinic-manager/src/app/api/admin/notify-master-on-signup/route.ts
@@ -1,0 +1,140 @@
+// 신규 회원가입 발생 시 마스터(master_admin)의 휴대폰으로 승인 요청 SMS 를 발송한다.
+// SignupForm 가입 성공 직후 fire-and-forget 으로 호출된다.
+//
+// 정책:
+// - 마스터의 핵심 책임은 신규 대표원장(owner) 가입 승인이므로 role='owner' 일 때만 발송.
+// - 비-owner 가입은 본인 clinic 의 owner 가 승인하는 흐름이라 마스터에게 알리지 않는다.
+// - 알리고 키는 마스터의 clinic 또는 시스템 첫 활성 설정을 사용 (별도 환경 변수 없이 동작).
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { aligoFetch } from '@/lib/aligoFetch'
+
+const ALIGO_API_URL = 'https://apis.aligo.in'
+
+function normalizePhone(raw: string | null | undefined): string {
+  if (!raw) return ''
+  return raw.replace(/[^0-9]/g, '')
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json().catch(() => ({}))) as { userId?: string }
+    const userId = body.userId
+    if (!userId) {
+      return NextResponse.json({ success: false, error: 'userId required' }, { status: 400 })
+    }
+
+    const supabase = getSupabaseAdmin()
+    if (!supabase) {
+      return NextResponse.json({ success: false, error: 'Database connection not available' }, { status: 500 })
+    }
+
+    // 1) 신규 가입자 정보 조회
+    const { data: newUser, error: newUserErr } = await supabase
+      .from('users')
+      .select('id, name, email, role, status, clinic_id, clinic:clinics(name)')
+      .eq('id', userId)
+      .single()
+    if (newUserErr || !newUser) {
+      return NextResponse.json({ success: false, error: '신규 가입자 조회 실패' }, { status: 404 })
+    }
+    if (newUser.status !== 'pending') {
+      return NextResponse.json({ success: true, skipped: 'not pending' })
+    }
+    // owner 가입에만 마스터에게 발송
+    if (newUser.role !== 'owner') {
+      return NextResponse.json({ success: true, skipped: 'not owner role' })
+    }
+
+    // 2) 마스터 사용자 + 전화번호 조회
+    const { data: masters } = await supabase
+      .from('users')
+      .select('id, name, phone, clinic_id')
+      .eq('role', 'master_admin')
+      .eq('status', 'active')
+
+    const targets = (masters ?? [])
+      .map((m) => ({ ...m, phone: normalizePhone(m.phone) }))
+      .filter((m) => m.phone.length >= 10)
+
+    if (targets.length === 0) {
+      return NextResponse.json({ success: false, error: '전화번호가 등록된 마스터 계정이 없습니다.' }, { status: 400 })
+    }
+
+    // 3) 발송용 알리고 설정: 마스터 본인의 clinic → 시스템 첫 활성 설정 순으로 폴백
+    let aligo: { api_key: string; user_id: string; sender_number: string } | null = null
+    for (const m of targets) {
+      if (!m.clinic_id) continue
+      const { data } = await supabase
+        .from('aligo_settings')
+        .select('api_key, user_id, sender_number')
+        .eq('clinic_id', m.clinic_id)
+        .maybeSingle()
+      if (data?.api_key && data?.user_id && data?.sender_number) {
+        aligo = data as any
+        break
+      }
+    }
+    if (!aligo) {
+      const { data } = await supabase
+        .from('aligo_settings')
+        .select('api_key, user_id, sender_number')
+        .not('api_key', 'is', null)
+        .not('user_id', 'is', null)
+        .not('sender_number', 'is', null)
+        .limit(1)
+        .maybeSingle()
+      if (data?.api_key && data?.user_id && data?.sender_number) aligo = data as any
+    }
+    if (!aligo) {
+      return NextResponse.json({ success: false, error: '알리고 발송 설정을 찾지 못했습니다.' }, { status: 400 })
+    }
+
+    // 4) 메시지 구성
+    const origin = process.env.NEXT_PUBLIC_SITE_URL || req.headers.get('origin') || req.nextUrl.origin
+    const dashboardUrl = `${origin}/master`
+    const clinicName = ((newUser as any).clinic?.name as string | undefined) ?? '신규 치과'
+    const message =
+      `[클리닉매니저] 신규 대표원장 가입 승인 요청\n` +
+      `· ${newUser.name} (${newUser.email})\n` +
+      `· ${clinicName}\n` +
+      `승인하기: ${dashboardUrl}`
+    const msgBytes = new Blob([message]).size
+    const actualType = msgBytes > 90 ? 'LMS' : 'SMS'
+    const title = '신규 가입 승인 요청'
+
+    // 5) 각 마스터에게 발송
+    const results: Array<{ userId: string; phone: string; ok: boolean; aligoCode?: string | number; message?: string }> = []
+    for (const m of targets) {
+      const params = new URLSearchParams()
+      params.append('key', aligo.api_key)
+      params.append('user_id', aligo.user_id)
+      params.append('sender', aligo.sender_number)
+      params.append('receiver', m.phone)
+      params.append('msg', message)
+      params.append('msg_type', actualType)
+      if (actualType !== 'SMS') params.append('title', title)
+      if (process.env.NODE_ENV === 'development') params.append('testmode_yn', 'Y')
+
+      try {
+        const res = await aligoFetch(`${ALIGO_API_URL}/send/`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
+        })
+        const json = (await res.json()) as { result_code: string | number; message: string; msg_id?: string | number }
+        const codeNum = Number(json.result_code)
+        const ok = Number.isFinite(codeNum) && codeNum >= 1
+        results.push({ userId: m.id, phone: m.phone, ok, aligoCode: json.result_code, message: json.message })
+      } catch (e) {
+        results.push({ userId: m.id, phone: m.phone, ok: false, message: e instanceof Error ? e.message : String(e) })
+      }
+    }
+
+    return NextResponse.json({ success: true, sent: results })
+  } catch (e) {
+    console.error('[notify-master-on-signup] error:', e)
+    return NextResponse.json({ success: false, error: e instanceof Error ? e.message : 'unknown error' }, { status: 500 })
+  }
+}

--- a/dental-clinic-manager/src/components/Auth/SignupForm.tsx
+++ b/dental-clinic-manager/src/components/Auth/SignupForm.tsx
@@ -358,6 +358,17 @@ export default function SignupForm({
         }
       }
 
+      // 마스터에게 가입 승인 요청 SMS — fire-and-forget (실패해도 가입 자체에는 영향 없음).
+      // 정책: owner 가입에만 발송. 비-owner 가입은 본인 clinic 의 owner 가 승인하는 흐름.
+      if (formData.role === 'owner') {
+        fetch('/api/admin/notify-master-on-signup', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId: newUserId }),
+        })
+          .catch((err) => console.warn('[Signup] notify-master failed (non-blocking):', err));
+      }
+
       // 약관 동의 내역 저장 (SECURITY DEFINER RPC 사용)
       console.log('[Signup] Saving consent records...');
       const consentRecords = (Object.entries(consents) as [ConsentType, boolean][]).map(([type, agreed]) => ({


### PR DESCRIPTION
## Summary
신규 대표원장(owner) 가입이 발생하면 master_admin 계정의 휴대폰으로 승인 요청 SMS 와 `/master` 바로가기 링크를 자동 발송합니다.

## 변경 파일
- 추가: `src/app/api/admin/notify-master-on-signup/route.ts`
- 수정: `src/components/Auth/SignupForm.tsx` — RPC 성공 직후 fire-and-forget 호출

## 동작
1. SignupForm 에서 `role='owner'` 회원가입 → `create_clinic_with_owner` RPC 성공
2. 즉시 `/api/admin/notify-master-on-signup` 비차단 호출 (실패해도 가입 자체에 영향 없음)
3. 라우트 내부:
   - service_role 로 신규 가입자 정보 조회
   - master_admin(active) + 전화번호 등록자 추출 → 모두에게 발송
   - 알리고 키는 마스터 본인 clinic → 시스템 첫 활성 설정 순으로 폴백
   - 메시지 길이에 따라 SMS/LMS 자동 분기

## 메시지 예시
```
[클리닉매니저] 신규 대표원장 가입 승인 요청
· 홍길동 (hong@example.com)
· 강남클리닉치과
승인하기: https://hyclinic-manager.vercel.app/master
```

## 정책 결정 사항
- 마스터의 핵심 책임은 **신규 대표원장 승인**이므로 `role='owner'` 가입에만 발송
- 비-owner 가입(부원장/실장/팀원)은 본인 clinic 의 owner 가 승인하는 흐름이라 마스터에게 알리지 않음

## Test plan
- [ ] 새 대표원장 회원가입 → 마스터 계정 전화번호로 SMS 수신 확인
- [ ] 메시지에 가입자 이름/이메일/치과명 + 바로가기 링크 포함 확인
- [ ] 링크 클릭 → `/master` 진입 → 승인 대기 탭에 새 owner 표시 확인
- [ ] 비-owner 가입(실장 등) → 마스터에게 SMS 안 가는지 확인
- [ ] SMS 발송이 실패해도 가입 자체는 정상 완료되는지 확인 (fire-and-forget)
- [ ] 마스터의 clinic_id 가 NULL 일 때도 시스템 첫 활성 알리고 설정 폴백 동작 확인

## 추후 개선 후보
- master_admin 외 owner 직원 가입 알림 흐름 (현재는 자기 clinic owner 가 직접 확인하는 구조)
- 알림 채널 다양화 (in-app notification, 이메일 등)