### PR TITLE
feat(approve): 가입 승인 시 owner 안내 SMS + 마스터 알림 1회 발송 가드

### DIFF
--- a/dental-clinic-manager/src/app/api/admin/notify-master-on-signup/route.ts
+++ b/dental-clinic-manager/src/app/api/admin/notify-master-on-signup/route.ts
@@ -33,7 +33,7 @@ export async function POST(req: NextRequest) {
     // 1) 신규 가입자 정보 조회
     const { data: newUser, error: newUserErr } = await supabase
       .from('users')
-      .select('id, name, email, role, status, clinic_id, clinic:clinics(name)')
+      .select('id, name, email, role, status, clinic_id, created_at, master_notify_sent_at, clinic:clinics(name)')
       .eq('id', userId)
       .single()
     if (newUserErr || !newUser) {
@@ -45,6 +45,17 @@ export async function POST(req: NextRequest) {
     // owner 가입에만 마스터에게 발송
     if (newUser.role !== 'owner') {
       return NextResponse.json({ success: true, skipped: 'not owner role' })
+    }
+    // 스팸 방지: 이미 발송된 사용자 차단
+    if (newUser.master_notify_sent_at) {
+      return NextResponse.json({ success: true, skipped: 'already notified' })
+    }
+    // 스팸 방지: 가입 직후(30분) 진입자에 한해서만 발송
+    if (newUser.created_at) {
+      const ageMs = Date.now() - new Date(newUser.created_at).getTime()
+      if (ageMs > 30 * 60 * 1000 || ageMs < 0) {
+        return NextResponse.json({ success: true, skipped: 'out of grace window' })
+      }
     }
 
     // 2) 마스터 사용자 + 전화번호 조회
@@ -130,6 +141,15 @@ export async function POST(req: NextRequest) {
       } catch (e) {
         results.push({ userId: m.id, phone: m.phone, ok: false, message: e instanceof Error ? e.message : String(e) })
       }
+    }
+
+    // 6) 1회 발송 후 sent_at 기록 — 이후 같은 userId 로 호출 시 차단됨
+    const anySuccess = results.some((r) => r.ok)
+    if (anySuccess) {
+      await supabase
+        .from('users')
+        .update({ master_notify_sent_at: new Date().toISOString() })
+        .eq('id', userId)
     }
 
     return NextResponse.json({ success: true, sent: results })

--- a/dental-clinic-manager/src/app/api/staff/approve/route.ts
+++ b/dental-clinic-manager/src/app/api/staff/approve/route.ts
@@ -1,6 +1,8 @@
 // 원장용 직원 승인 API — 인원 상한 가드 포함
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { aligoFetch } from '@/lib/aligoFetch'
 import {
   countActiveEmployees,
   getSubscription,
@@ -9,6 +11,11 @@ import {
 import { findPlanByHeadcount, requiresUpgrade } from '@/lib/subscriptionPlans'
 
 const FREE_LIMIT = 4
+const ALIGO_API_URL = 'https://apis.aligo.in'
+
+function normalizePhone(raw: string | null | undefined): string {
+  return (raw ?? '').replace(/[^0-9]/g, '')
+}
 
 export async function POST(req: Request) {
   const body = await req.json().catch(() => ({}))
@@ -99,6 +106,93 @@ export async function POST(req: Request) {
 
   if (upErr) {
     return NextResponse.json({ error: upErr.message }, { status: 500 })
+  }
+
+  // 승인 안내 SMS — 승인된 owner 에게 가입 승인 완료를 알린다. 실패해도 승인 자체에는 영향 없음.
+  // (현재는 owner 한정. 마스터의 책임 영역이 owner 가입 승인이라 사용자 요청에 맞춰 한정.)
+  try {
+    const admin = getSupabaseAdmin()
+    if (admin) {
+      const { data: approvedUsers } = await admin
+        .from('users')
+        .select('id, name, phone, role, clinic_id, clinic:clinics(name)')
+        .in('id', ids)
+        .eq('status', 'active')
+
+      const targets = (approvedUsers ?? [])
+        .filter((u: any) => u.role === 'owner')
+        .map((u: any) => ({ ...u, phone: normalizePhone(u.phone) }))
+        .filter((u: any) => u.phone.length >= 10)
+
+      if (targets.length > 0) {
+        // 발송용 알리고 설정: 승인자(me) clinic → 시스템 첫 활성 폴백
+        let aligo: { api_key: string; user_id: string; sender_number: string } | null = null
+        if (me.clinic_id) {
+          const { data } = await admin
+            .from('aligo_settings')
+            .select('api_key, user_id, sender_number')
+            .eq('clinic_id', me.clinic_id)
+            .maybeSingle()
+          if (data?.api_key && data?.user_id && data?.sender_number) aligo = data as any
+        }
+        if (!aligo) {
+          const { data } = await admin
+            .from('aligo_settings')
+            .select('api_key, user_id, sender_number')
+            .not('api_key', 'is', null)
+            .not('user_id', 'is', null)
+            .not('sender_number', 'is', null)
+            .limit(1)
+            .maybeSingle()
+          if (data?.api_key && data?.user_id && data?.sender_number) aligo = data as any
+        }
+
+        if (aligo) {
+          const origin =
+            process.env.NEXT_PUBLIC_SITE_URL || req.headers.get('origin') || ''
+          const loginUrl = origin ? `${origin}/` : ''
+
+          await Promise.all(
+            targets.map(async (u: any) => {
+              const clinicName = (u.clinic?.name as string | undefined) ?? ''
+              const message =
+                `[클리닉매니저] 안녕하세요 ${u.name}님,\n` +
+                `${clinicName ? `${clinicName} ` : ''}대표원장 가입이 승인되었습니다.\n` +
+                `지금 로그인하여 서비스를 이용해주세요.` +
+                (loginUrl ? `\n${loginUrl}` : '')
+              const msgBytes = new Blob([message]).size
+              const actualType = msgBytes > 90 ? 'LMS' : 'SMS'
+
+              const params = new URLSearchParams()
+              params.append('key', aligo!.api_key)
+              params.append('user_id', aligo!.user_id)
+              params.append('sender', aligo!.sender_number)
+              params.append('receiver', u.phone)
+              params.append('msg', message)
+              params.append('msg_type', actualType)
+              if (actualType !== 'SMS') params.append('title', '가입 승인 안내')
+              if (process.env.NODE_ENV === 'development') params.append('testmode_yn', 'Y')
+
+              try {
+                const r = await aligoFetch(`${ALIGO_API_URL}/send/`, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                  body: params.toString(),
+                })
+                const j = (await r.json().catch(() => ({}))) as { result_code?: string | number; message?: string }
+                if (process.env.NODE_ENV !== 'production') {
+                  console.log('[approve sms]', u.id, j)
+                }
+              } catch (smsErr) {
+                console.warn('[approve] sms send failed (non-blocking):', smsErr)
+              }
+            }),
+          )
+        }
+      }
+    }
+  } catch (notifyErr) {
+    console.warn('[approve] approval-sms flow error (non-blocking):', notifyErr)
   }
 
   return NextResponse.json({ success: true, approvedCount: ids.length })

--- a/dental-clinic-manager/src/components/Protocol/ProtocolForm.tsx
+++ b/dental-clinic-manager/src/components/Protocol/ProtocolForm.tsx
@@ -2,11 +2,14 @@
 
 import { useState, useEffect, useMemo, useRef } from 'react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
+import { Save, RotateCcw, X as XIcon } from 'lucide-react'
 import ProtocolStepsEditor from './ProtocolStepsEditor'
 import SmartTagInput from './SmartTagInput'
 import ProtocolStepViewer from './ProtocolStepViewer'
 import { dataService } from '@/lib/dataService'
 import { tagSuggestionService } from '@/lib/tagSuggestionService'
+import { useProtocolDraftAutoSave } from '@/hooks/useProtocolDraftAutoSave'
+import { appConfirm } from '@/components/ui/AppDialog'
 import type { ProtocolCategory, ProtocolFormData, ProtocolStep } from '@/types'
 import {
   buildDefaultStep,
@@ -68,6 +71,35 @@ export default function ProtocolForm({
   const [clinicId, setClinicId] = useState<string>('')
   // 폼 초기화 여부 추적 (부모 리렌더로 인한 initialData 참조 변경 시 폼 리셋 방지)
   const formInitializedRef = useRef(false)
+
+  // 임시저장 자동 동기화 — 다른 페이지 갔다 와도 이어서 작성 가능
+  const draftKey = mode === 'create' ? 'new' : `edit-${initialData?.id ?? 'unknown'}`
+  const { lastSaved, restored, clearDraft, dismissRestoredNotice } = useProtocolDraftAutoSave({
+    draftKey,
+    formData,
+    setFormData,
+    enabled: !loading && !reviewLoading,
+  })
+
+  const handleDiscardDraft = async () => {
+    const ok = await appConfirm('임시저장된 내용을 폐기하고 처음부터 다시 작성하시겠습니까?')
+    if (!ok) return
+    clearDraft()
+    // 폼을 초기 상태로 복원
+    setFormData({
+      title: initialData?.title || '',
+      category_id: initialData?.category_id || '',
+      content: serializeStepsToHtml(resolvedInitialSteps),
+      status: initialData?.status || 'draft',
+      tags: initialData?.tags || [],
+      change_summary: initialData?.change_summary || '',
+      change_type: initialData?.change_type || 'minor',
+      steps:
+        initialData?.steps && initialData.steps.length > 0
+          ? initialData.steps
+          : resolvedInitialSteps,
+    })
+  }
 
   useEffect(() => {
     fetchInitialData()
@@ -177,6 +209,8 @@ export default function ProtocolForm({
         content: stepsHtml,
         steps: formData.steps
       })
+      // 제출 성공 시 임시저장 폐기
+      clearDraft()
       shouldClose = mode === 'create'
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : '저장 중 오류가 발생했습니다.'
@@ -195,10 +229,18 @@ export default function ProtocolForm({
       <div className="bg-white rounded-lg shadow-xl max-w-4xl w-full my-8">
         <form onSubmit={handleSubmit}>
           {/* Header */}
-          <div className="flex items-center justify-between p-6 border-b border-at-border">
-            <h2 className="text-2xl font-bold text-at-text">
-              {mode === 'create' ? '새 프로토콜 작성' : '프로토콜 수정'}
-            </h2>
+          <div className="flex items-center justify-between gap-3 p-6 border-b border-at-border">
+            <div className="flex items-center gap-3 flex-1 min-w-0">
+              <h2 className="text-2xl font-bold text-at-text">
+                {mode === 'create' ? '새 프로토콜 작성' : '프로토콜 수정'}
+              </h2>
+              {lastSaved && !restored && (
+                <span className="inline-flex items-center gap-1 text-xs text-at-text-weak whitespace-nowrap">
+                  <Save className="w-3 h-3" />
+                  임시저장됨 · {formatRelativeTime(lastSaved)}
+                </span>
+              )}
+            </div>
             <button
               type="button"
               onClick={onCancel}
@@ -210,6 +252,38 @@ export default function ProtocolForm({
 
           {/* Body */}
           <div className="p-6 space-y-6 max-h-[calc(100vh-250px)] overflow-y-auto">
+            {/* 임시저장 복원 안내 */}
+            {restored && lastSaved && (
+              <div className="flex items-start gap-2 p-3 bg-at-accent-light border border-at-accent/30 rounded-md text-sm">
+                <RotateCcw className="w-4 h-4 text-at-accent flex-shrink-0 mt-0.5" />
+                <div className="flex-1">
+                  <p className="text-at-text font-medium">
+                    이전 작성 내용을 불러왔습니다
+                  </p>
+                  <p className="text-at-text-secondary text-xs mt-0.5">
+                    {formatRelativeTime(lastSaved)}에 자동 저장된 임시 내용입니다. 이어서 작성하거나 새로 시작할 수 있습니다.
+                  </p>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={handleDiscardDraft}
+                    className="text-xs px-2 py-1 text-at-text-secondary border border-at-border rounded hover:bg-white"
+                  >
+                    새로 시작
+                  </button>
+                  <button
+                    type="button"
+                    onClick={dismissRestoredNotice}
+                    className="p-1 text-at-text-weak hover:text-at-text-secondary"
+                    title="알림 닫기"
+                  >
+                    <XIcon className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              </div>
+            )}
+
             {error && (
               <div className="bg-at-error-bg border border-red-200 text-at-error px-4 py-3 rounded-md text-sm">
                 {error}
@@ -384,6 +458,7 @@ export default function ProtocolForm({
                       content: stepsHtml,
                       steps: formData.steps
                     })
+                    clearDraft()
                   } catch (err) {
                     const errorMessage = err instanceof Error ? err.message : '저장 중 오류가 발생했습니다.'
                     setError(errorMessage)
@@ -402,4 +477,16 @@ export default function ProtocolForm({
       </div>
     </div>
   )
+}
+
+function formatRelativeTime(date: Date): string {
+  const diffMs = Date.now() - date.getTime()
+  const sec = Math.max(1, Math.floor(diffMs / 1000))
+  if (sec < 60) return `${sec}초 전`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}분 전`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}시간 전`
+  const day = Math.floor(hr / 24)
+  return `${day}일 전`
 }

--- a/dental-clinic-manager/src/hooks/useProtocolDraftAutoSave.ts
+++ b/dental-clinic-manager/src/hooks/useProtocolDraftAutoSave.ts
@@ -1,0 +1,143 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { ProtocolFormData } from '@/types'
+
+const DRAFT_KEY_PREFIX = 'protocol-draft:'
+const DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7일
+const SAVE_DEBOUNCE_MS = 800
+
+interface DraftPayload {
+  version: 1
+  data: ProtocolFormData
+  savedAt: string
+}
+
+/** HTML 문자열에서 텍스트만 추출하여 비어있는지 확인 (빈 단락, NBSP, 공백 무시) */
+function hasNonEmptyHtmlContent(html?: string): boolean {
+  if (!html) return false
+  const text = html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;| /g, '')
+    .trim()
+  return text.length > 0
+}
+
+interface UseProtocolDraftAutoSaveArgs {
+  /** 폼 인스턴스별 고유 키 (예: 'new' 또는 `edit-${id}`) */
+  draftKey: string
+  formData: ProtocolFormData
+  setFormData: (data: ProtocolFormData) => void
+  /** false면 복원/저장 모두 비활성 (저장 중·로딩 중일 때 등) */
+  enabled: boolean
+  /** 사용자가 복원을 명시적으로 거부했을 때 호출되는 콜백 */
+  onDiscard?: () => void
+}
+
+interface UseProtocolDraftAutoSaveResult {
+  /** 마지막 저장 시각 (없으면 null) */
+  lastSaved: Date | null
+  /** 마운트 시 draft가 복원되었는지 여부 — UI 알림에 활용 */
+  restored: boolean
+  /** 저장된 draft를 명시적으로 삭제 (제출 성공·사용자 폐기 등) */
+  clearDraft: () => void
+  /** 복원 알림 닫기 (사용자가 X 클릭) */
+  dismissRestoredNotice: () => void
+}
+
+export function useProtocolDraftAutoSave({
+  draftKey,
+  formData,
+  setFormData,
+  enabled,
+  onDiscard,
+}: UseProtocolDraftAutoSaveArgs): UseProtocolDraftAutoSaveResult {
+  const fullKey = DRAFT_KEY_PREFIX + draftKey
+  const [lastSaved, setLastSaved] = useState<Date | null>(null)
+  const [restored, setRestored] = useState(false)
+  const restoreAttemptedRef = useRef(false)
+
+  // 초기 복원: 마운트 시 1회만 시도
+  useEffect(() => {
+    if (restoreAttemptedRef.current) return
+    restoreAttemptedRef.current = true
+    if (!enabled) return
+    if (typeof window === 'undefined') return
+    try {
+      const raw = window.localStorage.getItem(fullKey)
+      if (!raw) return
+      const payload = JSON.parse(raw) as DraftPayload
+      if (!payload || payload.version !== 1 || !payload.data) {
+        window.localStorage.removeItem(fullKey)
+        return
+      }
+      const savedAt = new Date(payload.savedAt)
+      const age = Date.now() - savedAt.getTime()
+      if (age > DRAFT_TTL_MS) {
+        window.localStorage.removeItem(fullKey)
+        return
+      }
+      setFormData(payload.data)
+      setLastSaved(savedAt)
+      setRestored(true)
+    } catch (e) {
+      // 파싱 실패 등은 조용히 무시하고 키 정리
+      try {
+        window.localStorage.removeItem(fullKey)
+      } catch {
+        /* ignore */
+      }
+      console.warn('[useProtocolDraftAutoSave] restore failed:', e)
+    }
+  }, [enabled, fullKey, setFormData])
+
+  // 자동 저장: formData 변경 디바운스
+  useEffect(() => {
+    if (!enabled) return
+    if (typeof window === 'undefined') return
+    // 빈 폼은 저장하지 않음 (제목·내용·태그 모두 비어있으면 의미 없음)
+    // buildDefaultStep은 content를 '<p></p>'로 시작하므로 HTML 내부 텍스트로 판정
+    const isEmpty =
+      !formData.title?.trim() &&
+      !formData.change_summary?.trim() &&
+      (!formData.tags || formData.tags.length === 0) &&
+      (!formData.steps ||
+        formData.steps.every((s) => !s.title?.trim() && !hasNonEmptyHtmlContent(s.content)))
+    if (isEmpty) return
+
+    const timer = setTimeout(() => {
+      try {
+        const payload: DraftPayload = {
+          version: 1,
+          data: formData,
+          savedAt: new Date().toISOString(),
+        }
+        window.localStorage.setItem(fullKey, JSON.stringify(payload))
+        setLastSaved(new Date(payload.savedAt))
+      } catch (e) {
+        // QuotaExceededError 등은 조용히 무시 (사용자 흐름 차단 금지)
+        console.warn('[useProtocolDraftAutoSave] save failed:', e)
+      }
+    }, SAVE_DEBOUNCE_MS)
+
+    return () => clearTimeout(timer)
+  }, [enabled, fullKey, formData])
+
+  const clearDraft = useCallback(() => {
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage.removeItem(fullKey)
+      setLastSaved(null)
+      setRestored(false)
+    } catch {
+      /* ignore */
+    }
+  }, [fullKey])
+
+  const dismissRestoredNotice = useCallback(() => {
+    setRestored(false)
+    onDiscard?.()
+  }, [onDiscard])
+
+  return { lastSaved, restored, clearDraft, dismissRestoredNotice }
+}

--- a/dental-clinic-manager/supabase/migrations/20260511_users_master_notify_sent_at.sql
+++ b/dental-clinic-manager/supabase/migrations/20260511_users_master_notify_sent_at.sql
@@ -1,0 +1,16 @@
+-- ============================================
+-- 마스터 가입 승인 요청 SMS 1회 발송 추적용 컬럼 추가
+-- Migration: 20260511_users_master_notify_sent_at.sql
+-- Created: 2026-05-11
+--
+-- 배경: /api/admin/notify-master-on-signup 라우트가 누구나 호출 가능한 형태로 열려 있어
+-- 임의의 userId 를 시도해 마스터에게 스팸 SMS 를 보낼 가능성이 있었다.
+-- 1회 발송 후에는 같은 userId 로 호출해도 차단되도록 발송 시각을 기록한다.
+-- (시간 제한과 함께 동작하여 가입 직후 30분 이내에만 발송 허용)
+-- ============================================
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS master_notify_sent_at TIMESTAMPTZ DEFAULT NULL;
+
+COMMENT ON COLUMN users.master_notify_sent_at IS
+  '마스터에게 신규 가입 승인 요청 SMS 를 발송한 시각. 1회 발송 차단 및 스팸 방지용.';


### PR DESCRIPTION
## Summary
1. **승인 안내 SMS 신규 기능**: 마스터가 신규 대표원장 가입을 승인하면, 가입자(owner) 휴대폰으로 \"가입 승인 완료\" SMS 가 자동 발송됩니다.
2. **보안 보강**: 직전 PR #576 에서 추가된 \"마스터에게 가입 알림 SMS\" 라우트가 인증 없이 호출 가능했던 결함을 1회 발송 가드 + 시간 제한으로 차단합니다.

## 변경 파일
- 추가: \`supabase/migrations/20260511_users_master_notify_sent_at.sql\` — \`users.master_notify_sent_at\` 컬럼 추가
- 수정: \`src/app/api/admin/notify-master-on-signup/route.ts\` — 중복/시간 검증 + 발송 후 sent_at 기록
- 수정: \`src/app/api/staff/approve/route.ts\` — UPDATE 성공 후 승인된 owner 에게 SMS 발송

## 마이그레이션 적용 상태
✅ production DB 에 이미 적용 (DATABASE_URL pg 직접 실행)

## 동작
### 마스터 가입 알림 SMS
- \`master_notify_sent_at IS NULL\` 검증 → 이미 발송된 사용자면 skip
- \`created_at\` 으로부터 30분 이내인지 검증 → 그 외 모두 skip
- 발송 성공 시 sent_at 기록 → 1회만 발송

### 승인 안내 SMS
- \`pending → active\` UPDATE 성공 후 owner 만 추출 → 휴대폰 SMS
- 알리고 키 폴백: 승인자 clinic → 시스템 첫 활성
- 발송 실패해도 승인 응답은 정상

## Test plan
- [ ] 신규 owner 가입 → 마스터 SMS 1회만 도착, 재호출 시 skipped 응답
- [ ] 30분 후 재호출 시 \"out of grace window\" 차단
- [ ] 마스터가 승인 → owner 휴대폰에 \"가입 승인 완료\" SMS 도착
- [ ] 일반 owner 가 직원 승인 → 직원에게는 SMS 안 감 (owner role 한정)