### PR TITLE
release: develop → main (심리분석 워치리스트 한국 종목명 표시)

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/psychology/watchlist/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/psychology/watchlist/route.ts
@@ -2,8 +2,29 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireAuth } from '@/lib/auth/requireAuth'
 import { requireInvestmentSubscription } from '@/lib/userSubscription'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { KR_TICKER_DICT } from '@/lib/krTickerDict'
 
 const WATCHLIST_LIMIT = 10
+
+/** ticker → 종목명 lookup (한국 종목용). 못 찾으면 null. */
+const krNameByTicker: Map<string, string> = new Map(
+  KR_TICKER_DICT.map((e) => [e.ticker, e.name] as const),
+)
+function resolveKrName(ticker: string): string | null {
+  return krNameByTicker.get(ticker) ?? null
+}
+
+interface RawWatchlistRow {
+  id: string
+  user_id: string
+  ticker: string
+  name: string | null
+  market: 'KR' | 'US'
+  monitoring_enabled: boolean
+  trigger_price_change_pct: number | null
+  trigger_volume_multiplier: number | null
+  created_at: string
+}
 
 export async function GET() {
   const auth = await requireAuth()
@@ -18,7 +39,23 @@ export async function GET() {
     .eq('user_id', auth.user.id)
     .order('created_at', { ascending: false })
 
-  const tickers = (items ?? []).map(i => (i as { ticker: string }).ticker)
+  const rows = (items ?? []) as RawWatchlistRow[]
+
+  // 기존 데이터 백필: name이 비어있는 한국 종목은 사전(dictionary)으로 채워서 DB도 업데이트.
+  // (US 종목명은 사전 lookup 정확도가 낮아 fallback 없이 ticker 표시)
+  const backfillTargets = rows.filter((r) => !r.name && r.market === 'KR')
+  if (backfillTargets.length > 0) {
+    await Promise.all(
+      backfillTargets.map(async (r) => {
+        const resolved = resolveKrName(r.ticker)
+        if (!resolved) return
+        r.name = resolved
+        await admin.from('psychology_watchlist').update({ name: resolved }).eq('id', r.id)
+      }),
+    )
+  }
+
+  const tickers = rows.map((r) => r.ticker)
   const { data: latestAnalyses } = tickers.length
     ? await admin
         .from('psychology_analyses')
@@ -34,10 +71,10 @@ export async function GET() {
     if (!latestMap.has(key)) latestMap.set(key, a)
   }
 
-  const out = (items ?? []).map((it) => {
-    const item = it as { ticker: string; market: string }
-    return { ...item, latest_analysis: latestMap.get(`${item.ticker}:${item.market}`) ?? null }
-  })
+  const out = rows.map((r) => ({
+    ...r,
+    latest_analysis: latestMap.get(`${r.ticker}:${r.market}`) ?? null,
+  }))
   return NextResponse.json(out)
 }
 
@@ -47,10 +84,14 @@ export async function POST(req: NextRequest) {
   const gate = await requireInvestmentSubscription(auth.user.id)
   if (gate instanceof NextResponse) return gate
 
-  const body = await req.json().catch(() => null) as { ticker?: string; market?: string } | null
+  const body = await req.json().catch(() => null) as { ticker?: string; name?: string; market?: string } | null
   const ticker = body?.ticker?.trim().toUpperCase()
   const market = body?.market === 'KR' || body?.market === 'US' ? body.market : null
   if (!ticker || !market) return NextResponse.json({ error: 'ticker, market 필수' }, { status: 400 })
+
+  // name: 클라이언트가 전달한 값 우선 → 없으면 KR 사전 lookup → 그래도 없으면 NULL.
+  const providedName = body?.name?.trim()
+  const resolvedName = providedName || (market === 'KR' ? resolveKrName(ticker) : null)
 
   const admin = getSupabaseAdmin()!
   const { count } = await admin
@@ -63,7 +104,7 @@ export async function POST(req: NextRequest) {
 
   const { data, error } = await admin
     .from('psychology_watchlist')
-    .insert({ user_id: auth.user.id, ticker, market })
+    .insert({ user_id: auth.user.id, ticker, market, name: resolvedName })
     .select('*')
     .single()
   if (error) return NextResponse.json({ error: error.message }, { status: 400 })

--- a/dental-clinic-manager/src/components/Investment/Psychology/AddTickerModal.tsx
+++ b/dental-clinic-manager/src/components/Investment/Psychology/AddTickerModal.tsx
@@ -49,7 +49,7 @@ export default function AddTickerModal({ onClose, onAdded }: {
         const res = await fetch('/api/investment/psychology/watchlist', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ticker: it.ticker, market: it.market }),
+          body: JSON.stringify({ ticker: it.ticker, name: it.name, market: it.market }),
         })
         const data = await res.json().catch(() => ({}))
         if (res.ok) {

--- a/dental-clinic-manager/src/components/Investment/Psychology/Watchlist.tsx
+++ b/dental-clinic-manager/src/components/Investment/Psychology/Watchlist.tsx
@@ -35,9 +35,16 @@ export default function Watchlist({
             }`}
             onClick={() => onSelect(it)}>
             <div className="flex items-center justify-between gap-2">
-              <span className={`font-semibold text-sm truncate ${isActive ? 'text-at-accent' : 'text-at-text'}`}>
-                {it.ticker}
-              </span>
+              <div className="min-w-0 flex-1">
+                <div className={`font-semibold text-sm truncate ${isActive ? 'text-at-accent' : 'text-at-text'}`}>
+                  {it.name || it.ticker}
+                </div>
+                {it.name && it.name !== it.ticker && (
+                  <div className="text-[11px] font-mono text-at-text-weak truncate">
+                    {it.ticker} · {it.market === 'KR' ? '한국' : '미국'}
+                  </div>
+                )}
+              </div>
               <div className="flex items-center gap-0.5 flex-shrink-0">
                 <button onClick={e => { e.stopPropagation(); onToggleMonitoring(it) }}
                   className={`p-1 rounded-lg transition-colors ${

--- a/dental-clinic-manager/src/types/psychology.ts
+++ b/dental-clinic-manager/src/types/psychology.ts
@@ -43,6 +43,8 @@ export interface PsychologyWatchlistItem {
   id: string
   user_id: string
   ticker: string
+  /** 종목명 — 한국 종목은 ticker가 숫자라 사용자 식별을 위해 필수 */
+  name: string | null
   market: Market
   monitoring_enabled: boolean
   trigger_price_change_pct: number | null

--- a/dental-clinic-manager/supabase/migrations/20260512_psychology_watchlist_add_name.sql
+++ b/dental-clinic-manager/supabase/migrations/20260512_psychology_watchlist_add_name.sql
@@ -1,0 +1,5 @@
+-- psychology_watchlist 에 종목명(name) 컬럼 추가
+-- 기존 한국 종목은 ticker(6자리 숫자)만 저장되어 사용자가 어떤 종목인지 알아보기 어려움.
+-- 신규 등록 시 클라이언트에서 name 전달, 기존 데이터는 GET API 에서 KR_TICKER_DICT lazy backfill.
+ALTER TABLE psychology_watchlist
+  ADD COLUMN IF NOT EXISTS name TEXT NULL;


### PR DESCRIPTION
## Summary
- psychology_watchlist 에 name 컬럼 추가
- KR 종목 ticker → name 자동 백필 (KR_TICKER_DICT)
- 워치리스트 UI 에 종목명 표시