### PR TITLE
fix(investment): 대표원장에게는 투자 메뉴 항상 노출

### DIFF
--- a/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
+++ b/dental-clinic-manager/src/components/Layout/TabNavigation.tsx
@@ -316,8 +316,11 @@ export default function TabNavigation({ activeTab, onTabChange, onItemClick, ski
   const { user } = useAuth()
   const isOwner = user?.role === 'owner'
   const isMasterAdmin = user?.role === 'master_admin'
+  // 대표원장(owner)은 본인 clinic 화이트리스트 여부와 무관하게 항상 노출.
+  // 잠금 상태(미구독)는 메뉴 자체는 보이되 클릭 시 구독 안내가 뜨도록 premiumFeature 흐름이 별도로 처리.
   const canSeeInvestment =
     isMasterAdmin ||
+    isOwner ||
     (!!user?.clinic_id && (INVESTMENT_ALLOWED_CLINIC_IDS as readonly string[]).includes(user.clinic_id))
   const { hasPremiumFeature } = usePremiumFeatures()
 


### PR DESCRIPTION
## Summary
다른 clinic 의 대표원장(owner) 들이 투자 메뉴를 볼 수 없던 문제 수정.

## 원인
[TabNavigation.tsx:319-321](src/components/Layout/TabNavigation.tsx#L319-L321) 의 \`canSeeInvestment\` 가:
- master_admin 이거나
- 본인 clinic_id 가 \`INVESTMENT_ALLOWED_CLINIC_IDS\` 화이트리스트(현재 '하얀치과' 1개) 에 있을 때만 통과

→ 다른 clinic owner 는 권한(\`investment_view\`/\`investment_manage\`)이 있어도 메뉴 자체가 안 보였다.

## 수정
\`isOwner\` 분기 추가. owner 는 화이트리스트 무관 노출.

미구독 상태는 \`menuConfig\` 의 \`premiumFeature\` 플래그 + \`usePremiumFeatures\` 잠금 UI 가 처리하므로 메뉴는 회색으로 노출되고 클릭 시 구독 안내가 뜨는 흐름은 그대로 유지된다.

## Test plan
- [ ] master_admin: 기존대로 노출
- [ ] 화이트리스트 clinic(하얀치과) owner: 기존대로 노출
- [ ] 그 외 clinic 의 owner: 메뉴 노출 (구독 미체결이면 잠금 상태로)
- [ ] 부원장/실장/팀원 등 비-owner: 기존대로 비노출 (ownerOnly + 권한 없음)