### PR TITLE
fix(auth): 로그인 후 항상 대시보드로 — redirect 파라미터 운반 중단

### DIFF
--- a/dental-clinic-manager/src/app/dashboard/layout.tsx
+++ b/dental-clinic-manager/src/app/dashboard/layout.tsx
@@ -59,14 +59,13 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     pathname.replace('/dashboard/community/telegram/', '').length > 0
 
   // 사용자 상태 체크 - 퇴사자, 승인대기, 거절된 사용자 리다이렉트
-  // 미로그인 사용자는 홈(로그인 화면)으로 리다이렉트하며 원래 URL 을 redirect 파라미터로 전달
-  // (그렇지 않으면 무한 로딩 스피너만 노출됨 — 소모임 초대 링크 같은 진입 경로 차단)
+  // 미로그인 사용자는 홈(로그인 화면)으로 리다이렉트한다.
+  // 정책: redirect 파라미터를 운반하지 않는다 — 로그인 후 항상 대시보드로 이동시키기로 결정됐기 때문.
+  // (초대 링크의 신규 가입 후속 진입은 /auth/callback 의 next 파라미터로 별도 처리됨)
   useEffect(() => {
     if (loading) return
     if (!user) {
-      const qs = searchParams.toString()
-      const next = qs ? `${pathname}?${qs}` : pathname
-      router.replace(`/?show=login&redirect=${encodeURIComponent(next)}`)
+      router.replace('/?show=login')
       return
     }
     if (user.status === 'resigned') {

--- a/dental-clinic-manager/src/components/Landing/shared/AuthFlow.tsx
+++ b/dental-clinic-manager/src/components/Landing/shared/AuthFlow.tsx
@@ -52,10 +52,12 @@ export default function AuthFlow({ children }: AuthFlowProps) {
         router.push('/pending-approval')
         return
       }
-      const redirect = searchParams.get('redirect')
-      router.push(redirect || '/dashboard')
+      // 정책: 로그인 후에는 ?redirect= 파라미터가 있어도 무시하고 항상 대시보드로 이동.
+      // 사용자 요청 — 소모임 등 URL 이 redirect 로 박혀 있어 의도치 않게 그곳으로 가는 사례 차단.
+      // 신규 가입자의 초대 링크 후속 진입은 /auth/callback 의 next 파라미터로 별도 처리됨.
+      router.push('/dashboard')
     }
-  }, [isAuthenticated, user, router, searchParams])
+  }, [isAuthenticated, user, router])
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
로그인 직후 의도치 않게 소모임 등 다른 페이지로 이동하던 문제 수정.

## 원인
[DashboardLayout](src/app/dashboard/layout.tsx) 이 미로그인 dashboard 진입 시 \`/?show=login&redirect=원래URL\` 로 보내고, [AuthFlow](src/components/Landing/shared/AuthFlow.tsx) 가 로그인 성공 후 그 redirect 파라미터로 이동했다. 사용자가 이전에 클릭한 소모임 URL 이 사이드바 prefetch/뒤로가기 등으로 redirect 에 박히면 의도치 않게 그곳으로 이동.

## 수정
- AuthFlow: 로그인 후 \`?redirect=\` 무시, 항상 \`/dashboard\` 로 이동
- DashboardLayout: 미로그인 시 \`?redirect=\` 안 붙이고 \`/?show=login\` 만 사용

신규 가입자의 초대 링크 후속 진입(이메일 인증 → 공개 소모임 자동 진입) 흐름은 \`/auth/callback\` 의 \`next\` 파라미터로 별도 처리되므로 영향 없다.

## Test plan
- [ ] 기존 계정 로그인 → 무조건 대시보드 진입
- [ ] 미로그인 상태에서 dashboard 직접 진입 → 로그인 화면 → 로그인 → 대시보드 (원래 URL 로 안 감)
- [ ] 신규 가입자 인증 메일 클릭 → 공개 소모임 자동 진입은 그대로 동작 (auth callback 흐름)
- [ ] /pending-approval, /resigned 강제 이동 흐름은 회귀 없음