### PR TITLE
fix(auth): 신규 가입자도 인증 후 대시보드 흐름으로 통일

### DIFF
--- a/dental-clinic-manager/src/app/auth/callback/route.ts
+++ b/dental-clinic-manager/src/app/auth/callback/route.ts
@@ -77,18 +77,11 @@ export async function GET(request: NextRequest) {
         } else if (profile) {
           console.log('[Auth Callback] User profile:', { status: profile.status, email: profile.email })
 
-          // 공개 소모임 초대 링크로 가입한 사용자는 next 가 해당 경로면 승인 전이어도 그쪽으로 안내한다.
-          // (DashboardLayout 도 같은 경로에서는 pending/rejected 통과를 허용함)
-          const isPublicTelegramGroupRoute =
-            next.startsWith('/dashboard/community/telegram/') &&
-            next.replace('/dashboard/community/telegram/', '').length > 0
+          // 정책: 신규 가입자도 인증 후 next 무시하고 대시보드 흐름으로 통일.
+          // 승인 대기/거절/정지 사용자만 /pending-approval 로 분기.
 
           // status에 따라 적절한 페이지로 리다이렉트
           if (profile.status === 'pending') {
-            if (isPublicTelegramGroupRoute) {
-              console.log('[Auth Callback] Pending user with public telegram group invite, redirecting to:', next)
-              return NextResponse.redirect(new URL(next, request.url))
-            }
             console.log('[Auth Callback] User is pending approval, redirecting to /pending-approval')
             return NextResponse.redirect(new URL('/pending-approval', request.url))
           } else if (profile.status === 'rejected') {

--- a/dental-clinic-manager/src/components/Auth/SignupForm.tsx
+++ b/dental-clinic-manager/src/components/Auth/SignupForm.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { useSearchParams } from 'next/navigation'
 import Image from 'next/image'
 import { EyeIcon, EyeSlashIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 import { dataService } from '@/lib/dataService'
@@ -27,11 +26,6 @@ export default function SignupForm({
   onSignupSuccess,
   onSearchClinics,
 }: SignupFormProps) {
-  // 초대 링크 등을 통해 진입한 경우 ?redirect=... 로 원래 가려던 경로가 운반된다.
-  // 회원가입 → 이메일 인증 → 자동 진입 흐름에서 next 파라미터로 끝까지 보존하기 위해 읽어둔다.
-  const searchParams = useSearchParams()
-  const redirectAfterAuth = searchParams.get('redirect') || ''
-
   const [formData, setFormData] = useState({
     userId: '',
     name: '', // 사용자 이름 필드 추가
@@ -260,18 +254,13 @@ export default function SignupForm({
       }
 
       // 1. 인증 사용자 생성
+      // 정책: 신규 가입자도 인증 후 항상 대시보드 흐름으로 통일. next 파라미터 운반하지 않는다.
       console.log('[Signup] Creating auth user...');
-      // 초대 링크 등으로 진입한 경우, 인증 메일의 콜백 URL에 next 파라미터를 운반해
-      // 인증 후 원래 가려던 페이지로 곧장 안내한다.
-      const callbackUrl = new URL(`${window.location.origin}/auth/callback`);
-      if (redirectAfterAuth) {
-        callbackUrl.searchParams.set('next', redirectAfterAuth);
-      }
       const { data: authData, error: authError} = await supabase.auth.signUp({
         email: formData.userId,
         password: formData.password,
         options: {
-          emailRedirectTo: callbackUrl.toString(),
+          emailRedirectTo: `${window.location.origin}/auth/callback`,
         }
       });
 


### PR DESCRIPTION
## Summary
신규 가입자의 인증 메일 콜백 후속 흐름을 일반 대시보드 흐름으로 통일.

## 변경
- [SignupForm.tsx](src/components/Auth/SignupForm.tsx): \`emailRedirectTo\` 의 \`?next=\` 운반 제거 (PR #572 흐름 정리)
- [/auth/callback/route.ts](src/app/auth/callback/route.ts): pending 사용자가 공개 소모임 경로면 그쪽으로 안내하던 분기 제거

## 동작
- pending 사용자: 인증 후 \`/pending-approval\` (그대로)
- active 사용자: 인증 후 next(=기본 \`/\`) → AuthFlow → \`/dashboard\` (PR #586 결합)
- rejected/suspended: 인증 후 \`/pending-approval\` (그대로)

[DashboardLayout](src/app/dashboard/layout.tsx) 의 pending/rejected 가 공개 소모임 경로 통과시키는 분기는 그대로 — 사용자가 직접 URL 을 입력했을 때의 안전망으로 유지. 인증 콜백이 그쪽으로 자동 안내하는 흐름만 끊는다.

## Test plan
- [ ] 신규 회원가입 → 인증 메일 클릭 → /pending-approval (pending) 또는 /dashboard (active) 진입
- [ ] 어떤 케이스에서도 공개 소모임 페이지로 자동 진입 안 함
- [ ] 비밀번호 재설정(type=recovery) 흐름은 회귀 없음 (/update-password 로 이동)