### PR TITLE
fix(investment): 계좌 미연결도 대시보드 정상 표시 + 안내 멘트 수정

### DIFF
--- a/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
@@ -376,29 +376,6 @@ function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergenc
       }
     } catch { alert('네트워크 오류') } finally { setTogglingId(null) }
   }
-  if (!hasCredential) {
-    return (
-      <div className="max-w-lg mx-auto mt-8">
-        <div className="bg-white rounded-3xl shadow-sm border border-at-border p-8 text-center">
-          <div className="w-16 h-16 rounded-2xl bg-at-accent-light flex items-center justify-center mx-auto mb-4">
-            <Link2 className="w-8 h-8 text-at-accent" />
-          </div>
-          <h2 className="text-xl font-bold text-at-text mb-2">증권 계좌를 연결하세요</h2>
-          <p className="text-sm text-at-text-secondary mb-6">
-            한국투자증권(KIS) 계좌를 연결하면 자동매매, 백테스트, 포트폴리오 분석 기능을 사용할 수 있습니다.
-          </p>
-          <button
-            onClick={() => onNavigate('connect')}
-            className="inline-flex items-center gap-2 px-6 py-3 bg-at-accent text-white rounded-xl font-medium hover:bg-at-accent-hover transition-colors"
-          >
-            계좌 연결하기 <ArrowRight className="w-4 h-4" />
-          </button>
-          <p className="mt-4 text-xs text-at-text-weak">모의투자 계좌로 먼저 시작할 수 있습니다</p>
-        </div>
-      </div>
-    )
-  }
-
   const formatCurrency = (n: number) => {
     if (!Number.isFinite(n)) return '--'
     return Math.round(n).toLocaleString('ko-KR')
@@ -412,7 +389,9 @@ function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergenc
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-xl font-bold text-at-text">투자 대시보드</h2>
-          <p className="text-sm text-at-text-secondary mt-1">포트폴리오 현황과 활성 전략을 확인하세요</p>
+          <p className="text-sm text-at-text-secondary mt-1">
+            전략 작성·백테스트·분석은 계좌 연결 없이 바로 이용할 수 있습니다. 계좌 연결은 실주문(자동매매) 실행 시에만 필요합니다.
+          </p>
         </div>
         {hasCredential && (
           <button
@@ -426,6 +405,25 @@ function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergenc
           </button>
         )}
       </div>
+
+      {/* 계좌 미연결 안내 — 차단이 아닌 안내. 다른 기능은 그대로 사용 가능. */}
+      {hasCredential === false && (
+        <div className="flex items-start gap-3 p-4 rounded-xl bg-at-accent-light border border-at-border">
+          <Link2 className="w-5 h-5 text-at-accent flex-shrink-0 mt-0.5" />
+          <div className="flex-1">
+            <p className="text-sm text-at-text font-medium">증권 계좌 미연결 상태</p>
+            <p className="text-xs text-at-text-secondary mt-1">
+              자동매매(실주문)는 KIS 증권 계좌 연결 후 실행됩니다. 전략 관리·백테스트·전략 비교·심리 분석 등은 그대로 이용 가능합니다.
+            </p>
+            <button
+              onClick={() => onNavigate('connect')}
+              className="mt-2 inline-flex items-center gap-1 text-sm text-at-accent font-medium hover:underline"
+            >
+              계좌 연결하러 가기 <ArrowRight className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        </div>
+      )}
 
       {balanceError && (
         <div className="flex items-center gap-2 p-3 rounded-xl bg-red-50 border border-red-200 text-red-700 text-sm">
@@ -469,7 +467,7 @@ function DashboardSubTab({ hasCredential, strategies, activeStrategies, emergenc
               <span className="flex-shrink-0 w-6 h-6 rounded-full bg-at-accent-light text-at-accent text-xs font-bold flex items-center justify-center">1</span>
               <div>
                 <button onClick={() => onNavigate('connect')} className="text-at-accent font-medium hover:underline">계좌 연결</button>
-                <span className="text-at-text-secondary"> - KIS 증권 계좌를 연결 (모의투자부터 권장)</span>
+                <span className="text-at-text-secondary"> - 자동매매(실주문) 실행 시에만 필요 · KIS 증권 (모의투자부터 권장)</span>
               </div>
             </li>
             <li className="flex gap-3">


### PR DESCRIPTION
## Summary
자동 주식 매매 대시보드에서 계좌 미연결 시 화면 전체가 "계좌 연결하세요" 안내 카드로 차단되던 것을 풀고, 다른 기능(전략 작성·백테스트·분석 등)을 그대로 사용할 수 있도록 합니다.

## 정책 반영
계좌 연결은 **자동매매(실주문) 실행 시에만** 필요합니다. 그 외 기능은 계좌 연결 없이 그대로 사용 가능합니다.

## 변경
[InvestmentTab.tsx](src/components/Investment/InvestmentTab.tsx) DashboardSubTab:
- \`!hasCredential\` early return 제거
- 대신 상단에 작은 안내 배너 노출 (계좌 미연결 시): "자동매매(실주문)는 계좌 연결 후 실행됩니다. 전략 관리·백테스트·전략 비교·심리 분석 등은 그대로 이용 가능합니다."
- 헤더 부제 문구를 정책에 맞게 수정
- 자동매매 시작 가이드의 1단계(계좌 연결) 문구에 "자동매매 실행 시에만 필요" 보충

잔고 카드는 미연결 시 기존대로 \`--\` 표시되고, 잔고 새로고침 버튼은 hasCredential 일 때만 노출되는 동작은 그대로 유지.

## Test plan
- [ ] 계좌 연결 안 된 owner: 대시보드 진입 → 요약 카드/긴급 정지 미노출/가이드 모두 정상 표시, 상단에 안내 배너
- [ ] 안내 배너 "계좌 연결하러 가기" 클릭 → connect 탭으로 이동
- [ ] 다른 탭(전략 관리, 전략 비교, 백테스트 등) 계좌 연결 없이 정상 사용
- [ ] 계좌 연결 후 다시 대시보드 → 안내 배너 사라지고 잔고 표시