### PR TITLE
feat(marketing-brand): 주/보조 브랜드 컬러 12종 프리셋 선택 UI

### DIFF
--- a/dental-clinic-manager/src/components/marketing/brand/BrandColorPresetPicker.tsx
+++ b/dental-clinic-manager/src/components/marketing/brand/BrandColorPresetPicker.tsx
@@ -1,0 +1,50 @@
+'use client';
+import { BRAND_COLOR_PRESETS, type BrandColorPreset } from '@/lib/marketing/brand/presets';
+
+interface Props {
+  primary: string;
+  secondary: string;
+  onSelect: (preset: BrandColorPreset) => void;
+}
+
+function normalize(c: string) {
+  return (c || '').trim().toLowerCase();
+}
+
+export function BrandColorPresetPicker({ primary, secondary, onSelect }: Props) {
+  const activeKey = BRAND_COLOR_PRESETS.find(
+    p => normalize(p.primary) === normalize(primary) && normalize(p.secondary) === normalize(secondary)
+  )?.key;
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2.5">
+      {BRAND_COLOR_PRESETS.map(p => {
+        const selected = activeKey === p.key;
+        return (
+          <button
+            key={p.key}
+            type="button"
+            onClick={() => onSelect(p)}
+            className={`relative rounded-xl border-2 overflow-hidden text-left transition-all ${
+              selected ? 'border-at-accent shadow-md' : 'border-at-border hover:border-at-text-weak'
+            }`}
+          >
+            <div className="flex h-12">
+              <div className="flex-1" style={{ background: p.primary }} />
+              <div className="w-1/3" style={{ background: p.secondary }} />
+            </div>
+            <div className="px-2 py-1.5 bg-white">
+              <p className="text-[11px] font-semibold text-at-text leading-tight">{p.label}</p>
+              <p className="text-[10px] text-at-text-weak leading-tight">{p.description}</p>
+            </div>
+            {selected && (
+              <span className="absolute top-1 right-1 inline-flex items-center justify-center w-4 h-4 rounded-full bg-at-accent text-white text-[10px] font-bold">
+                ✓
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/dental-clinic-manager/src/components/marketing/brand/BrandSettingsForm.tsx
+++ b/dental-clinic-manager/src/components/marketing/brand/BrandSettingsForm.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import type { BrandAssets, MedicalLawPresetKey } from '@/types/brand';
 import { MedicalLawPresetPicker } from './MedicalLawPresetPicker';
+import { BrandColorPresetPicker } from './BrandColorPresetPicker';
 
 export interface BrandFormState {
   name_ko: string;
@@ -101,6 +102,15 @@ export function BrandSettingsForm({ state, onChange, onSave, onLogoUpload, savin
               onChange={(e) => { const f = e.target.files?.[0]; if (f) handleLogo(f); }} />
           </label>
         </div>
+      </Field>
+
+      <Field label="브랜드 컬러 조합 프리셋">
+        <BrandColorPresetPicker
+          primary={state.primary_color}
+          secondary={state.secondary_color}
+          onSelect={(p) => onChange({ ...state, primary_color: p.primary, secondary_color: p.secondary })}
+        />
+        <p className="text-[11px] text-at-text-weak mt-2">프리셋을 선택하면 주/보조 컬러가 함께 설정됩니다. 아래에서 직접 조정도 가능합니다.</p>
       </Field>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/dental-clinic-manager/src/lib/marketing/brand/presets.ts
+++ b/dental-clinic-manager/src/lib/marketing/brand/presets.ts
@@ -1,5 +1,100 @@
 import type { MedicalLawPreset, MedicalLawPresetKey } from '@/types/brand';
 
+export interface BrandColorPreset {
+  key: string;
+  label: string;
+  description: string;
+  primary: string;
+  secondary: string;
+}
+
+export const BRAND_COLOR_PRESETS: BrandColorPreset[] = [
+  {
+    key: 'trust_blue',
+    label: '신뢰 블루',
+    description: '청결·전문성',
+    primary: '#0B5394',
+    secondary: '#4FC3F7',
+  },
+  {
+    key: 'fresh_mint',
+    label: '프레시 민트',
+    description: '청량·위생',
+    primary: '#00897B',
+    secondary: '#B2DFDB',
+  },
+  {
+    key: 'natural_green',
+    label: '내추럴 그린',
+    description: '자연·편안함',
+    primary: '#1B5E20',
+    secondary: '#C5E1A5',
+  },
+  {
+    key: 'warm_coral',
+    label: '웜 코랄',
+    description: '친근·따뜻함',
+    primary: '#E64A19',
+    secondary: '#FFCCBC',
+  },
+  {
+    key: 'soft_rose',
+    label: '소프트 로즈',
+    description: '부드러움·여성',
+    primary: '#C2185B',
+    secondary: '#F8BBD0',
+  },
+  {
+    key: 'premium_navy',
+    label: '프리미엄 네이비',
+    description: '고급·전문',
+    primary: '#1A237E',
+    secondary: '#FFC107',
+  },
+  {
+    key: 'modern_charcoal',
+    label: '모던 차콜',
+    description: '미니멀·세련',
+    primary: '#263238',
+    secondary: '#90A4AE',
+  },
+  {
+    key: 'wood_brown',
+    label: '우디 브라운',
+    description: '내추럴·차분',
+    primary: '#5D4037',
+    secondary: '#D7CCC8',
+  },
+  {
+    key: 'royal_purple',
+    label: '로얄 퍼플',
+    description: '고급·우아함',
+    primary: '#4527A0',
+    secondary: '#D1C4E9',
+  },
+  {
+    key: 'sunny_amber',
+    label: '서니 앰버',
+    description: '활기·밝음',
+    primary: '#F57C00',
+    secondary: '#FFE0B2',
+  },
+  {
+    key: 'sky_breeze',
+    label: '스카이 브리즈',
+    description: '시원·개방감',
+    primary: '#0277BD',
+    secondary: '#E1F5FE',
+  },
+  {
+    key: 'forest_sage',
+    label: '포레스트 세이지',
+    description: '안정·평온',
+    primary: '#2E5339',
+    secondary: '#DCE8D5',
+  },
+];
+
 export const MEDICAL_LAW_PRESETS: Record<MedicalLawPresetKey, MedicalLawPreset> = {
   yellow_black: {
     key: 'yellow_black',


### PR DESCRIPTION
## Summary
- 주 브랜드 컬러와 보조 브랜드 컬러를 한 번에 선택할 수 있는 12종 프리셋(신뢰 블루, 프레시 민트, 내추럴 그린, 웜 코랄, 소프트 로즈, 프리미엄 네이비, 모던 차콜, 우디 브라운, 로얄 퍼플, 서니 앰버, 스카이 브리즈, 포레스트 세이지)을 추가했습니다.
- 마케팅 자동화 → 설정 → 브랜드 이미지 탭의 컬러 입력란 위에 노출되며, 선택 시 primary/secondary 컬러가 동시에 채워지고 미리보기가 즉시 갱신됩니다.
- 현재 컬러 조합과 일치하는 프리셋에는 ✓ 표시가 붙고, 프리셋 선택 후에도 컬러 피커로 자유롭게 미세 조정이 가능합니다.

## Test plan
- [x] 빌드 통과 (`npm run build`)
- [x] 마케팅 → 설정 → 브랜드 이미지 진입 시 12개 프리셋 카드 정상 렌더
- [x] 프리미엄 네이비 선택 → primary `#1A237E`, secondary `#FFC107` 자동 적용
- [x] 모던 차콜 선택 → primary `#263238`, secondary `#90A4AE` 자동 적용 + ✓ 인디케이터 노출
- [x] 미리보기 이미지 URL의 타임스탬프 자동 갱신 확인
- [x] 콘솔 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)