### PR TITLE
feat(investment): KIS 미연결도 KR 심리/스마트머니 분석 사용 (yahoo 폴백)

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
@@ -86,6 +86,14 @@ interface NormalizedBar {
 
 interface AnalysisResponse extends SmartMoneyAnalysis {
   triggeredAlerts?: Pick<SmartMoneyAlert, 'id' | 'ticker' | 'market' | 'signal_types'>[]
+  /**
+   * KR 종목인데 KIS 계좌 미연결이라 yahoo-finance2 폴백으로 동작한 경우 true.
+   * - 시세 15분 지연
+   * - 호가 분석 미제공
+   * - 외인기관 매매 동향 제외
+   * UI 가 이 플래그를 보고 안내 배너를 노출한다.
+   */
+  limitedDataMode?: boolean
 }
 
 // ============================================
@@ -134,12 +142,9 @@ export async function POST(request: NextRequest) {
     console.error('[smart-money/analyze] credential 조회 실패:', err)
   }
 
-  if (market === 'KR' && !kisCredential) {
-    return NextResponse.json(
-      { error: 'KIS 계좌 연결이 필요합니다', code: 'KIS_REQUIRED' },
-      { status: 401 }
-    )
-  }
+  // KR + KIS 미연결: yahoo-finance2 폴백으로 동작 — 15분 지연 분봉 + 호가/외인기관 미제공.
+  // 분석 결과에 limitedDataMode=true 를 표기하여 UI 가 안내할 수 있도록 한다.
+  const isKRLimitedMode = market === 'KR' && !kisCredential
 
   // 4. 시장별 데이터 수집
   let bars: NormalizedBar[] = []
@@ -246,19 +251,20 @@ export async function POST(request: NextRequest) {
         investorHistory = []
       }
     } else {
-      // US: yahoo-finance2 사용
-      const quote = await fetchCurrentQuote(ticker, 'US')
+      // US 또는 KR(KIS 미연결): yahoo-finance2 사용
+      const yMarket: 'KR' | 'US' = market === 'KR' ? 'KR' : 'US'
+      const quote = await fetchCurrentQuote(ticker, yMarket)
       currentPrice = quote.price ?? 0
 
       // 1분봉 — yahoo가 주는 6일치 데이터를 모두 사용 (캐시 우회로 fresh 데이터 보장)
-      const usBars: OHLCV[] = await fetchIntradayPrices({
+      // KR 은 yahoo 분봉이 비어있는 종목이 있어 빈 배열일 수 있음 → intraday 분석 비활성으로 처리됨.
+      const intradayBars: OHLCV[] = await fetchIntradayPrices({
         ticker,
-        market: 'US',
+        market: yMarket,
         timeframe: '1m',
         forceRefresh: true,
       })
-      const recent = usBars
-      bars = recent.map((b) => ({
+      bars = intradayBars.map((b) => ({
         datetime: b.date,
         open: b.open,
         high: b.high,
@@ -266,14 +272,18 @@ export async function POST(request: NextRequest) {
         close: b.close,
         volume: b.volume,
       }))
-      // US daily bars (60일치) — fetchPrices(yahoo-finance2)로 실제 일봉 페치
+      if (bars.length === 0 && isKRLimitedMode) {
+        intradayUnavailableReason = 'yahoo-finance2 에서 한국 종목 1분봉 데이터를 받지 못했습니다 (지연 또는 미지원).'
+      }
+
+      // 일봉 (90일치) — fetchPrices(yahoo-finance2) 로 실제 일봉 페치
       try {
-        const todayUS = new Date()
-        const pastUS = new Date()
-        pastUS.setDate(pastUS.getDate() - 90)
-        const usDaily = await fetchPrices(ticker, 'US', toDateString(pastUS), toDateString(todayUS))
-        if (usDaily && usDaily.length > 0) {
-          dailyBars = usDaily.map((b) => ({
+        const todayD = new Date()
+        const pastD = new Date()
+        pastD.setDate(pastD.getDate() - 90)
+        const daily = await fetchPrices(ticker, yMarket, toDateString(pastD), toDateString(todayD))
+        if (daily && daily.length > 0) {
+          dailyBars = daily.map((b) => ({
             datetime: b.date,
             open: b.open,
             high: b.high,
@@ -281,19 +291,25 @@ export async function POST(request: NextRequest) {
             close: b.close,
             volume: b.volume,
           }))
+          const ctx = computeRecentHighLow(daily, 20)
+          recent20DayHigh = ctx.high
+          recent20DayLow = ctx.low
         } else {
           // fallback: 분봉 압축
           dailyBars = aggregateBarsToDaily(bars)
+          const ctx = inferHighLowFromBars(bars)
+          recent20DayHigh = ctx.high
+          recent20DayLow = ctx.low
         }
       } catch (err) {
-        console.warn('[smart-money/analyze] US 일봉 페치 실패, 분봉 압축으로 fallback:', err)
+        console.warn('[smart-money/analyze] 일봉 페치 실패, 분봉 압축으로 fallback:', err)
         dailyBars = aggregateBarsToDaily(bars)
+        const ctx = inferHighLowFromBars(bars)
+        recent20DayHigh = ctx.high
+        recent20DayLow = ctx.low
       }
 
-      // 분봉으로 고저 추정 (US는 일봉 별도 호출 안함)
-      const ctx = inferHighLowFromBars(bars)
-      recent20DayHigh = ctx.high
-      recent20DayLow = ctx.low
+      // KR limited mode: 외인기관 매매 동향은 KIS only 라 빈 배열 (분석 흐름은 진행)
       investorHistory = []
     }
   } catch (err) {
@@ -793,6 +809,7 @@ export async function POST(request: NextRequest) {
   const response: AnalysisResponse = {
     ...analysis,
     triggeredAlerts: triggeredAlerts && triggeredAlerts.length > 0 ? triggeredAlerts : undefined,
+    limitedDataMode: isKRLimitedMode ? true : undefined,
   }
 
   return NextResponse.json({ data: response })

--- a/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
@@ -557,6 +557,25 @@ export function SmartMoneyContent() {
             </div>
           </div>
         )}
+
+        {/* KR 종목인데 KIS 미연결로 yahoo 폴백 동작 중일 때 안내 */}
+        {analysis?.limitedDataMode && (
+          <div className="mt-3 p-3 rounded-xl bg-amber-50 border border-amber-200 text-amber-900 text-sm">
+            <div className="flex items-start gap-2">
+              <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+              <div className="flex-1">
+                <p className="font-semibold">제한 모드 — 일반 시세 데이터 기반 분석</p>
+                <p className="text-xs mt-1 leading-relaxed">
+                  KIS 계좌 미연결 상태입니다. 한국 종목은 일반 시세(약 15분 지연)로 분봉을 받아 분석하며,
+                  호가 10단계와 외국인·기관 매매 동향은 제외됩니다.
+                  실시간/심층 분석은{' '}
+                  <a href="/investment/connect" className="font-semibold underline">KIS 계좌 연결</a>{' '}
+                  후 자동 활성화됩니다.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
       </section>
 
       {/* 분석 결과 */}

--- a/dental-clinic-manager/src/lib/psychology/marketDataFetcher.ts
+++ b/dental-clinic-manager/src/lib/psychology/marketDataFetcher.ts
@@ -1,7 +1,8 @@
 // src/lib/psychology/marketDataFetcher.ts
 //
 // 군중심리 분석용 통합 마켓 데이터 수집 헬퍼
-//   - KR: KIS API (분봉 + 호가 10단계)
+//   - KR (KIS 연결): KIS API (실시간 분봉 + 호가 10단계)
+//   - KR (KIS 미연결): yahoo-finance2 폴백 (15분 지연 분봉, 호가 미제공)
 //   - US: yahoo-finance2 (분봉만, 호가 미지원)
 
 import YahooFinance from 'yahoo-finance2'
@@ -59,7 +60,11 @@ async function fetchKRSnapshot(
   asOf?: Date
 ): Promise<PsychologyInputSnapshot> {
   const cred = await getUserKisCredential(userId)
-  if (!cred) throw new Error('KIS 계좌 연결이 필요합니다')
+
+  // KIS 미연결: yahoo-finance2 폴백 (15분 지연 분봉, 호가 미제공)
+  if (!cred) {
+    return fetchKRYahooFallback(ticker, count, asOf)
+  }
 
   // 모의계좌는 당일 데이터만 조회 가능 — 과거 일자 분석 차단
   if (asOf && cred.isPaperTrading) {
@@ -117,6 +122,61 @@ async function fetchKRSnapshot(
   }
 
   return { candles, orderbook }
+}
+
+/**
+ * KR 1분봉 yahoo-finance2 폴백
+ * - .KS(코스피) → 실패 시 .KQ(코스닥) 순으로 시도
+ * - 호가는 yahoo에서 제공 불가 → orderbook=null
+ * - 시세 15분 지연 — 가장 최근 분봉이 누락될 수 있음 (UI 에서 안내 필요)
+ */
+async function fetchKRYahooFallback(
+  ticker: string,
+  count = 60,
+  asOf?: Date
+): Promise<PsychologyInputSnapshot> {
+  const period2 = asOf ?? new Date()
+  // 정규장 외 시간/휴장일 영향 감안하여 24시간 buffer 추가
+  const period1 = new Date(period2.getTime() - Math.max(count, 60) * 60 * 1000 - 24 * 3600 * 1000)
+
+  type YahooQuote = {
+    date?: Date | string
+    open?: number | null
+    high?: number | null
+    low?: number | null
+    close?: number | null
+    volume?: number | null
+  }
+  type YahooChartResult = { quotes?: YahooQuote[] }
+
+  let result = (await yahooFinance.chart(`${ticker}.KS`, {
+    period1,
+    period2,
+    interval: '1m',
+  })) as YahooChartResult
+
+  if (!result?.quotes?.length) {
+    result = (await yahooFinance.chart(`${ticker}.KQ`, {
+      period1,
+      period2,
+      interval: '1m',
+    })) as YahooChartResult
+  }
+
+  const quotes = result?.quotes ?? []
+  const candles: MinuteCandle[] = quotes
+    .filter((q) => q.open != null && q.close != null && q.high != null && q.low != null)
+    .slice(-count)
+    .map((q) => ({
+      ts: new Date(q.date as Date | string).toISOString(),
+      open: Number(q.open),
+      high: Number(q.high),
+      low: Number(q.low),
+      close: Number(q.close),
+      volume: Number(q.volume ?? 0),
+    }))
+
+  return { candles, orderbook: null }
 }
 
 async function fetchUSSnapshot(

--- a/dental-clinic-manager/src/types/smartMoney.ts
+++ b/dental-clinic-manager/src/types/smartMoney.ts
@@ -296,6 +296,11 @@ export interface SmartMoneyAnalysis {
   generatedAt: string
   /** 최근 N일치 일자별 분석 (오래된 → 최신 순). 가장 최근 일자(마지막 항목)는 본 객체와 동일. */
   byDay?: DailyAnalysis[]
+  /**
+   * KR 종목인데 KIS 계좌 미연결이라 yahoo-finance2 폴백으로 수집된 데이터 기반 분석.
+   * - 시세 15분 지연 / 호가 분석 없음 / 외인기관 매매 동향 제외
+   */
+  limitedDataMode?: boolean
 }
 
 export interface PerCardComments {


### PR DESCRIPTION
## Summary
KIS 계좌 미연결 사용자도 한국 종목 심리분석·스마트머니 분석을 사용할 수 있도록 yahoo-finance2 폴백을 추가합니다(약 15분 지연 + 호가·외인기관 제외 모드).

## 변경
### 심리분석
- [marketDataFetcher.ts](src/lib/psychology/marketDataFetcher.ts) \`fetchKRSnapshot\`:
  KIS credential 없으면 신규 \`fetchKRYahooFallback\`(1분봉 .KS → .KQ) 호출
- 호가는 \`orderbook=null\` 로 진행 — LLM 프롬프트는 이미 null 안전 수용

### 스마트머니 분석
- [route.ts](src/app/api/investment/smart-money/analyze/route.ts):
  - KR + KIS 미연결의 401 \`KIS_REQUIRED\` 차단 제거
  - yahoo 폴백 분기 추가 (현재가/1분봉/일봉 모두 yahoo)
  - 외인기관 매매·호가는 제외 (KIS only)
  - 응답에 \`limitedDataMode=true\` flag 추가
- [smartMoney.ts](src/types/smartMoney.ts): \`SmartMoneyAnalysis.limitedDataMode\` 옵션 필드 추가

### UI
- [SmartMoneyContent.tsx](src/components/Investment/SmartMoney/SmartMoneyContent.tsx):
  \`limitedDataMode\` 일 때 amber 배너 노출 — "15분 지연 + 호가/외인기관 제외 모드. KIS 연결 시 자동 활성화"

## Trade-off
| 항목 | KIS 연결 | yahoo 폴백 |
|---|---|---|
| 시세 | 실시간 | 약 15분 지연 |
| 호가 10단계 | ✓ | ❌ |
| 외인기관 매매 | ✓ | ❌ (빈 배열) |
| 일봉 | KIS | yahoo .KS/.KQ |
| 분봉 | 1200개 | yahoo (일부 종목 미제공 가능) |

## Test plan
- [ ] KIS 미연결 owner 가 KR 종목으로 심리분석 → 정상 동작, 호가 분석만 빠짐
- [ ] KIS 미연결 owner 가 KR 종목으로 스마트머니 분석 → amber 배너 노출 + 분석 결과 정상
- [ ] yahoo 분봉이 빈 종목 → \`intradayUnavailableReason\` 으로 우아하게 안내
- [ ] KIS 연결된 owner → 기존대로 풀 데이터 분석 (limitedDataMode 미표시)
- [ ] US 종목 분석 → 영향 없음