### PR TITLE
feat(marketing-seo): 경쟁글 분석 미리보기 — 참고한 글 표시 가독성 개선

### DIFF
--- a/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
@@ -43,6 +43,21 @@ import { useFormDraft, clearFormDraft } from '@/hooks/useFormDraft'
 
 const DRAFT_KEY = 'marketing-new-post-draft-v1'
 
+function extractNaverBlogId(url: string): string {
+  if (!url) return ''
+  try {
+    const u = new URL(url)
+    if (u.hostname.includes('blog.naver.com')) {
+      const seg = u.pathname.split('/').filter(Boolean)
+      const id = seg[0] || ''
+      if (id && !id.endsWith('.naver')) return `@${id}`
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return ''
+}
+
 const ContentEditor = dynamic(() => import('@/components/marketing/ContentEditor'), { ssr: false })
 import { TimePicker } from '@/components/ui/TimePicker'
 
@@ -485,32 +500,58 @@ export default function NewMarketingPostPage() {
                 {seoResult.referencedPosts && seoResult.referencedPosts.length > 0 && (
                   <div>
                     <p className="text-[11px] font-medium text-at-text-secondary mb-1.5">
-                      분석에 참고한 글 ({seoResult.referencedPosts.length}개)
+                      분석에 참고한 글 ({seoResult.referencedPosts.length}개) — 네이버 상위 노출 결과
                     </p>
-                    <ul className="space-y-1">
-                      {seoResult.referencedPosts.map((p) => (
-                        <li key={`${p.rank}-${p.postUrl}`} className="text-[11px] leading-relaxed">
-                          <span className="inline-block w-6 text-at-text-weak font-medium">{p.rank}위</span>
-                          <span className="text-at-text-weak">
-                            글자수 {p.bodyLength.toLocaleString()}자 · 이미지 {p.imageCount}장 · 소제목 {p.headingCount}개 —{' '}
-                          </span>
-                          {p.postUrl ? (
-                            <a
-                              href={p.postUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-indigo-700 hover:underline break-all"
-                            >
-                              {p.title || p.postUrl}
-                            </a>
-                          ) : (
-                            <span className="text-at-text">{p.title}</span>
-                          )}
-                          {p.blogName && (
-                            <span className="text-at-text-weak"> ({p.blogName})</span>
-                          )}
-                        </li>
-                      ))}
+                    <ul className="space-y-1.5">
+                      {seoResult.referencedPosts.map((p) => {
+                        const isAnalyzed = p.bodyLength > 0
+                        const fallbackBlogId = extractNaverBlogId(p.postUrl)
+                        const displayTitle = p.title?.trim() || (isAnalyzed ? p.postUrl : '(제목 없음 — 본문 추출 실패)')
+                        const displayBlog = p.blogName || fallbackBlogId
+                        return (
+                          <li
+                            key={`${p.rank}-${p.postUrl}`}
+                            className={`rounded-lg border px-2.5 py-2 text-[11px] ${
+                              isAnalyzed ? 'bg-white border-at-border' : 'bg-at-surface-alt border-dashed border-at-border'
+                            }`}
+                          >
+                            <div className="flex items-start gap-2">
+                              <span className="inline-flex items-center justify-center min-w-[28px] h-5 px-1.5 rounded-md bg-indigo-50 text-indigo-700 text-[10px] font-bold">
+                                {p.rank}위
+                              </span>
+                              <div className="flex-1 min-w-0">
+                                <div className="flex items-center gap-1.5 flex-wrap">
+                                  {p.postUrl ? (
+                                    <a
+                                      href={p.postUrl}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className={`font-medium hover:underline break-all ${isAnalyzed ? 'text-indigo-700' : 'text-at-text-weak'}`}
+                                    >
+                                      {displayTitle}
+                                    </a>
+                                  ) : (
+                                    <span className="font-medium text-at-text-weak">{displayTitle}</span>
+                                  )}
+                                  {!isAnalyzed && (
+                                    <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-200 text-[10px] font-medium">
+                                      분석 제외
+                                    </span>
+                                  )}
+                                </div>
+                                {displayBlog && (
+                                  <p className="mt-0.5 text-[10.5px] text-at-text-weak">📝 {displayBlog}</p>
+                                )}
+                                {isAnalyzed && (
+                                  <p className="mt-0.5 text-[10.5px] text-at-text-weak">
+                                    글자수 {p.bodyLength.toLocaleString()}자 · 이미지 {p.imageCount}장 · 소제목 {p.headingCount}개
+                                  </p>
+                                )}
+                              </div>
+                            </div>
+                          </li>
+                        )
+                      })}
                     </ul>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- 경쟁글 분석 미리보기에서 "분석에 참고한 글"을 카드 형태로 표시해 어떤 글이 분석에 사용됐는지 한눈에 확인할 수 있도록 가독성을 개선했습니다.
- 본문 추출에 실패해 분석에서 빠진 항목은 회색 톤 + "분석 제외" 배지로 명확히 구분합니다.
- 제목·블로그명이 비어있을 때도 URL에서 네이버 블로그 ID(`@blogId`)를 자동 추출하여 항상 출처를 식별할 수 있게 했습니다.

## Test plan
- [x] 빌드 통과 (`npm run build`)
- [x] 캐시된 키워드(`천호역 치과 실손24`) 분석 결과 미리보기 정상 표시
- [x] 1·2위: 본문 추출 실패 → "(제목 없음)" + 분석 제외 배지 + 회색 카드
- [x] 3·4위: 제목 + @whitedc0902(URL 자동 추출) + 메트릭(글자수/이미지/소제목)
- [x] 5위: 제목 + @ajuaju123 + 메트릭
- [x] 콘솔 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)