### PR TITLE
fix(marketing-worker): SEO 경쟁글 body_length 부풀려짐 수정

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/package.json
+++ b/dental-clinic-manager/marketing-worker/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hayan-marketing-worker",
-  "version": "1.1.99",
+  "version": "1.1.101",
   "description": "하얀치과 마케팅 워커 - Electron 데스크탑 앱",
   "productName": "클리닉 매니저 워커",
   "private": true,

--- a/dental-clinic-manager/marketing-worker/electron/src/seo-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/seo-bridge.ts
@@ -319,9 +319,19 @@ async function scrapeAndAnalyzePost(page: any, url: string, keyword: string, ran
 
   // 정량 데이터 추출
   const quantitative = await contentFrame.evaluate((kw: string) => {
-    const title = document.querySelector('.se-title-text, .pcol1')?.textContent?.trim() || '';
+    const title = (document.querySelector('.se-title-text, .pcol1')?.textContent || '')
+      .replace(/\s+/g, ' ')
+      .trim();
     const bodyEl = document.querySelector('.se-main-container, #postViewArea');
-    const bodyText = bodyEl?.textContent?.trim() || '';
+    // body_length 부풀려짐 방지:
+    //  1) script/style/noscript 자식 제거 (실제 본문이 아님)
+    //  2) 모든 공백/줄바꿈을 단일 공백으로 정규화 (textContent 가 그대로 보존하던 줄바꿈/연속 공백 제거)
+    let bodyText = '';
+    if (bodyEl) {
+      const clone = bodyEl.cloneNode(true) as HTMLElement;
+      clone.querySelectorAll('script, style, noscript').forEach((n) => n.remove());
+      bodyText = (clone.textContent || '').replace(/\s+/g, ' ').trim();
+    }
     const images = document.querySelectorAll('.se-image-resource, img[id^="img"]');
     const videos = document.querySelectorAll('iframe[src*="youtube"], iframe[src*="tv.naver"], .se-video');
     const headings = document.querySelectorAll('.se-text-paragraph-align- .se-text-paragraph span[style*="font-size: 2"], h2, h3, h4');


### PR DESCRIPTION
## Summary
- 경쟁글 분석 미리보기에서 "글자수가 실제보다 너무 많이 카운팅" 되는 문제 수정.
- 원인: 워커가 `bodyEl.textContent` 로 본문을 추출하면서 줄바꿈·연속 공백을 그대로 보존해 시각적 글자수보다 훨씬 큰 값이 저장됨 (예: 3,000자 글 → 9,966자).
- 수정: `scrapeAndAnalyzePost` 에서 본문 컨테이너를 cloneNode 후 script/style/noscript 자식 제거, `\\s+ → ' '` 정규화 후 `body_length` / `body_text` / `keyword_count` 모두 정규화된 텍스트 기준으로 재계산.
- 워커 버전 `1.1.99 → 1.1.101` bump.

## Test plan
- [x] 빌드 통과 (`tsc` — dist/seo-bridge.js 에 cloneNode + replace(/\\s+/g, ' ') 정상 포함)
- [x] 기존 코드 동작 확인: posts/new + 마케팅 AI 글쓰기 탭의 미리보기에서 referencedPosts 표시
- [ ] 사용자: 워커 업데이트 후 "다시 분석" → body_length 가 시각적 글자수와 일치하는지 확인

## 사용자 안내
- 기존 24h 캐시는 부풀려진 값을 그대로 보여줄 수 있습니다. "다시 분석" 버튼을 누르면 새 워커가 정확한 값으로 덮어씁니다.
- 사용자가 사용하는 워커는 1.1.101 로 업데이트가 필요합니다 (자동 업데이트가 활성화돼 있다면 다음 실행 시 갱신).

🤖 Generated with [Claude Code](https://claude.com/claude-code)