### PR TITLE
fix(dashboard): 위젯 탭 위치 정렬 통일 (내 업무 / 병원 일정)

### DIFF
--- a/dental-clinic-manager/src/components/Dashboard/MyTasksSection.tsx
+++ b/dental-clinic-manager/src/components/Dashboard/MyTasksSection.tsx
@@ -242,71 +242,63 @@ export default function MyTasksSection() {
 
   return (
     <div>
-      {/* 헤더 */}
-      <div className="flex items-center justify-between mb-3">
+      {/* 헤더 + 탭 (ScheduleWidget 과 동일한 인라인 구조) */}
+      <div className="flex items-center justify-between mb-3 gap-2">
         <h3 className="text-sm font-semibold text-at-text tracking-[0.08px] flex items-center gap-2">
           <ClipboardList className="w-4 h-4 text-at-accent" />
           내 업무
-          {!loading && (
+          {!loading && !isAdmin && (
             <span className="text-xs text-at-text-weak font-normal ml-0.5">
-              {isAdmin
-                ? `담당 ${assignedToMe.length} · 지시 ${assignedByMe.length}`
-                : `${assignedToMe.length}건`}
+              {assignedToMe.length}건
             </span>
           )}
         </h3>
-        <button
-          type="button"
-          onClick={() => load(false)}
-          disabled={refreshing || loading}
-          className="inline-flex items-center gap-1 px-2 py-1 text-xs text-at-text-secondary hover:text-at-text bg-at-surface-alt hover:bg-at-surface-hover border border-at-border rounded-lg transition-colors disabled:opacity-50"
-          title="새로고침"
-        >
-          <RefreshCw className={`w-3.5 h-3.5 ${refreshing ? 'animate-spin' : ''}`} />
-        </button>
-      </div>
-
-      {/* 관리자 탭 */}
-      {isAdmin && (
-        <div className="flex items-center gap-1 mb-2">
+        <div className="flex items-center gap-2">
+          {isAdmin && (
+            <div
+              role="tablist"
+              aria-label="업무 구분"
+              className="flex items-center gap-0.5 bg-white rounded-xl p-0.5 border border-at-border"
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={tab === 'toMe'}
+                onClick={() => setTab('toMe')}
+                className={`px-2.5 py-1 rounded-lg text-xs font-medium transition-colors tracking-[0.07px] ${
+                  tab === 'toMe'
+                    ? 'bg-at-accent text-white'
+                    : 'text-at-text-secondary hover:bg-at-surface-hover'
+                }`}
+              >
+                담당 {assignedToMe.length}
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={tab === 'byMe'}
+                onClick={() => setTab('byMe')}
+                className={`px-2.5 py-1 rounded-lg text-xs font-medium transition-colors tracking-[0.07px] ${
+                  tab === 'byMe'
+                    ? 'bg-at-accent text-white'
+                    : 'text-at-text-secondary hover:bg-at-surface-hover'
+                }`}
+              >
+                지시 {assignedByMe.length}
+              </button>
+            </div>
+          )}
           <button
             type="button"
-            onClick={() => setTab('toMe')}
-            className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-xl border transition-colors ${
-              tab === 'toMe'
-                ? 'bg-at-accent text-white border-at-accent'
-                : 'bg-white text-at-text-secondary border-at-border hover:bg-at-surface-alt'
-            }`}
+            onClick={() => load(false)}
+            disabled={refreshing || loading}
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs text-at-text-secondary hover:text-at-text bg-at-surface-alt hover:bg-at-surface-hover border border-at-border rounded-lg transition-colors disabled:opacity-50"
+            title="새로고침"
           >
-            내 업무
-            <span
-              className={`text-[10px] px-1.5 py-0.5 rounded-full ${
-                tab === 'toMe' ? 'bg-white/20 text-white' : 'bg-at-surface-alt text-at-text-weak'
-              }`}
-            >
-              {assignedToMe.length}
-            </span>
-          </button>
-          <button
-            type="button"
-            onClick={() => setTab('byMe')}
-            className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-xl border transition-colors ${
-              tab === 'byMe'
-                ? 'bg-at-accent text-white border-at-accent'
-                : 'bg-white text-at-text-secondary border-at-border hover:bg-at-surface-alt'
-            }`}
-          >
-            내가 지시한 업무
-            <span
-              className={`text-[10px] px-1.5 py-0.5 rounded-full ${
-                tab === 'byMe' ? 'bg-white/20 text-white' : 'bg-at-surface-alt text-at-text-weak'
-              }`}
-            >
-              {assignedByMe.length}
-            </span>
+            <RefreshCw className={`w-3.5 h-3.5 ${refreshing ? 'animate-spin' : ''}`} />
           </button>
         </div>
-      )}
+      </div>
 
       {/* 본문 */}
       {loading ? (


### PR DESCRIPTION
## Summary
대시보드 그리드에서 나란히 표시되는 **내 업무**(MyTasksSection)와 **병원 일정**(ScheduleWidget) 두 위젯의 탭 위치가 달라 박스가 정렬되어 보이지 않는 문제 수정.

### 원인
- **병원 일정**: 탭이 헤더 h3와 **같은 행** (inline)
- **내 업무**: 탭이 헤더 **아래 별도 row** (관리자 전용 `mb-2` 행)
→ 그리드 안에서 수직 위치가 어긋남.

### 결정 (UX 비교)
| 방식 | 트레이드오프 |
|------|------|
| A. 인라인 (병원 일정 패턴) | 세로 공간 절약, 컴팩트, **그리드 정렬 안정** ← 선택 |
| B. 별도 행 (내 업무 기존) | 탭 클릭 영역 큼, 대신 정렬 어긋남 (지금 문제) |

A안 채택 — 대시보드에서는 세로 공간 절약과 정렬 일관성이 우선, 탭 개수도 2-3개라 인라인이 충분.

### 변경 사항 (MyTasksSection.tsx)
- 별도 탭 row 제거, 헤더 우측에 인라인 배치
- 탭 스타일을 ScheduleWidget과 동일하게: `px-2.5 py-1 rounded-lg text-xs` 컴팩트 pill
- 헤더 카운트 표기 중복 제거 — 관리자는 탭 안 "담당 N / 지시 M", 일반은 헤더 "N건" 유지
- 새로고침 버튼은 탭 우측에 그룹화

## Test plan
- [x] `npm run build` 성공
- [ ] Vercel preview에서 두 위젯의 탭이 같은 수직 위치에 정렬되는지 확인
- [ ] 관리자/일반 두 시나리오 모두 정렬 확인
- [ ] 모바일 화면에서도 정렬 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)