### PR TITLE
fix(notification): 모바일 헤더 알림 드롭다운 잘림 수정

### DIFF
--- a/dental-clinic-manager/src/components/Layout/UserNotificationDropdown.tsx
+++ b/dental-clinic-manager/src/components/Layout/UserNotificationDropdown.tsx
@@ -189,9 +189,9 @@ export default function UserNotificationDropdown() {
         )}
       </button>
 
-      {/* 드롭다운 */}
+      {/* 드롭다운 — 모바일에서는 viewport 폭을 넘지 않도록 너비를 viewport에 맞춤 */}
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-80 sm:w-96 bg-at-surface rounded-xl shadow-at-card border border-at-border overflow-hidden z-50">
+        <div className="absolute right-0 mt-2 w-[min(calc(100vw-1rem),24rem)] sm:w-96 max-h-[calc(100vh-5rem)] bg-at-surface rounded-xl shadow-at-card border border-at-border overflow-hidden z-50 flex flex-col">
           {/* 헤더 */}
           <div className="flex items-center justify-between px-4 py-3 border-b border-at-border bg-at-surface-alt">
             <h3 className="font-semibold text-at-text">알림</h3>
@@ -206,8 +206,8 @@ export default function UserNotificationDropdown() {
             )}
           </div>
 
-          {/* 알림 목록 */}
-          <div className="max-h-[400px] overflow-y-auto">
+          {/* 알림 목록 — 부모(max-h-[calc(100vh-5rem)]) 안에서 남은 공간을 채움 */}
+          <div className="flex-1 min-h-0 overflow-y-auto sm:max-h-[400px]">
             {loading ? (
               <div className="flex items-center justify-center py-8">
                 <div className="w-6 h-6 border-2 border-at-accent border-t-transparent rounded-full animate-spin" />


### PR DESCRIPTION
## Summary
모바일에서 헤더 우측 종 모양 알림 드롭다운이 화면 좌측을 넘어 잘리는 현상 수정.

### 원인
[UserNotificationDropdown.tsx:194](src/components/Layout/UserNotificationDropdown.tsx#L194)
- 드롭다운 너비 `w-80`(320px) **고정**
- `absolute right-0` — 종 버튼 우측 가장자리 기준
- 종 버튼 옆에 프로필 버튼이 있어 기준점이 viewport 우측 끝이 아닌 안쪽
- 좁은 화면(iPhone SE 375px 등)에서 박스 좌측이 viewport 좌측을 넘어 **잘림**

### 수정
| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| 박스 너비 (모바일) | `w-80` (320px 고정) | `w-[min(calc(100vw-1rem),24rem)]` — viewport-16px, 최대 384px |
| 박스 너비 (sm+) | `w-96` | 동일 (`sm:w-96`) |
| 최대 높이 | 없음 (목록만 `max-h-[400px]`) | `max-h-[calc(100vh-5rem)]` — 헤더+여백 제외한 viewport |
| 목록 영역 | `max-h-[400px]` 고정 | 모바일: `flex-1 min-h-0` (부모 max-h에 적응) / sm+: `sm:max-h-[400px]` 유지 |
| 컨테이너 | `overflow-hidden` | `overflow-hidden flex flex-col` |

## Test plan
- [x] `npm run build` 성공
- [ ] 모바일 (iPhone SE 375px) 화면에서 종 아이콘 클릭 시 박스가 viewport 안에 완전히 들어오는지
- [ ] 알림 항목이 많을 때 목록만 스크롤되고 헤더는 고정되는지
- [ ] sm 이상 화면에서 기존 384px 너비/400px 상한이 유지되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)