### PR TITLE
release: develop → main (스마트 머니 엔진 9개 결함 일괄 수정 외 누적)

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
@@ -62,6 +62,10 @@ export const dynamic = 'force-dynamic'
 // 기본 10초로는 KR 종목 분석 시 KIS 60 req 페이지네이션이 timeout
 export const maxDuration = 60
 
+// 뉴스 데이터 통합은 아직 미구현 — 통합 후 getNewsEventsForTicker(ticker, market, asOfDate) 반환값 사용
+// (현재는 빈 배열이라 newsContextEngine 은 항상 null 패턴 반환)
+const NEWS_EVENTS_PLACEHOLDER: never[] = []
+
 // ============================================
 // 내부 타입
 // ============================================
@@ -423,7 +427,7 @@ export async function POST(request: NextRequest) {
     newsContext = analyzeNewsContext({
       bars: newsBars,
       signalDetails: [],
-      newsEvents: [],
+      newsEvents: NEWS_EVENTS_PLACEHOLDER,
     })
 
     // ===== 외인/기관 (KR 일별 매매 동향) =====
@@ -543,7 +547,7 @@ export async function POST(request: NextRequest) {
       const dNewsContext = analyzeNewsContext({
         bars: dNewsBars,
         signalDetails: [],
-        newsEvents: [],
+        newsEvents: NEWS_EVENTS_PLACEHOLDER,
       })
 
       const dScore = computeSmartMoneyScore({
@@ -629,7 +633,7 @@ export async function POST(request: NextRequest) {
           const dSession = analyzeSession(dSessionBars, market)
 
           const dNewsBars: NewsBar[] = preBars.map((b) => ({ ...b }))
-          const dNewsContext = analyzeNewsContext({ bars: dNewsBars, signalDetails: [], newsEvents: [] })
+          const dNewsContext = analyzeNewsContext({ bars: dNewsBars, signalDetails: [], newsEvents: NEWS_EVENTS_PLACEHOLDER })
 
           const dScore = computeSmartMoneyScore({
             vwap: dVwap,

--- a/dental-clinic-manager/src/components/Layout/UserNotificationDropdown.tsx
+++ b/dental-clinic-manager/src/components/Layout/UserNotificationDropdown.tsx
@@ -189,9 +189,9 @@ export default function UserNotificationDropdown() {
         )}
       </button>
 
-      {/* 드롭다운 — 모바일에서는 viewport 폭을 넘지 않도록 너비를 viewport에 맞춤 */}
+      {/* 드롭다운 — 모바일에서는 viewport 기준으로 고정해 잘림을 방지하고, 데스크탑은 버튼 기준 정렬 유지 */}
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-[min(calc(100vw-1rem),24rem)] sm:w-96 max-h-[calc(100vh-5rem)] bg-at-surface rounded-xl shadow-at-card border border-at-border overflow-hidden z-50 flex flex-col">
+        <div className="fixed top-16 left-2 right-2 w-auto max-h-[calc(100dvh-5rem)] bg-at-surface rounded-xl shadow-at-card border border-at-border overflow-hidden z-50 flex flex-col sm:absolute sm:top-auto sm:left-auto sm:right-0 sm:mt-2 sm:w-96 sm:max-h-[calc(100dvh-5rem)]">
           {/* 헤더 */}
           <div className="flex items-center justify-between px-4 py-3 border-b border-at-border bg-at-surface-alt">
             <h3 className="font-semibold text-at-text">알림</h3>

--- a/dental-clinic-manager/src/lib/smartMoney/algoFootprintEngine.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/algoFootprintEngine.ts
@@ -1,13 +1,18 @@
 /**
  * 알고리즘 풋프린트 엔진 — TWAP / VWAP / Iceberg / Sniper / MOO / MOC
  *
- * - TWAP score   : 1분봉 거래량의 변동계수 역수 (균등할수록 높음)
- * - VWAP score   : 시간대별 거래량 분포와 U-shape 표준곡선 코사인 유사도
+ * - TWAP score   : 가운데 시간대 거래량의 robust CV(IQR/median) 역수
+ *                  iqrRatio ≤ 0.2 → 100점, iqrRatio ≥ 1.0 → 0점으로 임계 강화
+ *                  (자연 인트라데이도 0.5~0.8 범위라 종전 매핑은 변별력 낮았음)
+ * - VWAP score   : 5구간 거래량 분포(ratio-of-mean)와 U-shape 기준 Pearson 상관계수
+ *                  r ≤ 0.3 → 0점, r ≥ 0.9 → 100점 (cosine은 모든 양수 벡터에서
+ *                  항상 > 0 이라 변별력이 없었음 → 중심화한 Pearson으로 교체)
  * - Iceberg score: ±5% 가격대 클러스터에서 동일 크기 체결이 반복되는 횟수
  * - Sniper score : 상위 5% 거래량 봉 직후의 가격 변화율 / 평균 가격 변화율
  * - MOO score    : 첫 봉(시가 동시호가) 거래량이 일중 중앙값 대비 얼마나 큰가
  * - MOC score    : 마지막 봉(종가 동시호가) 거래량이 일중 중앙값 대비 얼마나 큰가
  *
+ * - dominantAlgo     : 최고 점수가 60점 이상일 때만 부여 (종전 40 → 60으로 상향)
  * - direction        : 양봉/음봉 비율(과 close-OHLC 위치)로 매집/분배 추정
  * - auctionDirection : MOO/MOC 발생 시 시·종가 봉의 양봉/음봉 방향
  */
@@ -46,14 +51,23 @@ function scoreTwap(bars: AlgoBar[]): number {
   const median = sorted[Math.floor(sorted.length * 0.5)]
   if (median <= 0) return 0
   const iqrRatio = (q3 - q1) / median // robust CV (1차 분산/중심)
-  // iqrRatio = 0 → 완전 균등 (TWAP 100점), iqrRatio = 2 → 자연 거래 (0점)
-  // 실제 TWAP 알고가 일부 시간대 매매하면 iqrRatio 0.3~0.8 정도로 줄어듦
-  return Math.max(0, Math.min(100, ((2 - iqrRatio) / 2) * 100))
+  // 자연 인트라데이도 iqrRatio 0.5~0.8 범위라 종전 (2→0) 매핑은 대부분의 날에서
+  // 60점 이상을 만들어 변별력이 없었음. 진짜 TWAP 알고리즘 시그니처는 매우 평탄한
+  // 분포(< 0.3)를 만들어야 하므로 임계를 다음과 같이 강화:
+  // iqrRatio ≤ 0.2 → 100점, iqrRatio ≥ 1.0 → 0점
+  if (iqrRatio <= 0.2) return 100
+  if (iqrRatio >= 1.0) return 0
+  return Math.round(((1.0 - iqrRatio) / 0.8) * 100)
 }
 
 // ============================================
-// VWAP — U-shape 표준곡선 코사인 유사도
+// VWAP — U-shape 표준곡선 Pearson 상관계수
 // (장 시작/종료 부근에 거래량 집중되는 자연스러운 패턴 ≈ VWAP 알고)
+//
+// 종전 코사인 유사도는 두 벡터 모두 양수이므로 항상 > 0 → 어떤 정상 거래일도
+// 80~95점이 나와 변별력이 없었음. 평균 중심화한 Pearson 상관계수로 교체하면
+// 형상(shape)만을 비교하여 진짜 U-shape에서만 높은 점수를 부여한다.
+// r ≤ 0.3 → 0점, r ≥ 0.9 → 100점 (그 사이 선형 보간).
 // ============================================
 function scoreVwap(bars: AlgoBar[]): number {
   if (bars.length < 5) return 0
@@ -65,20 +79,30 @@ function scoreVwap(bars: AlgoBar[]): number {
     const idx = Math.min(buckets - 1, Math.floor((i / n) * buckets))
     bucket[idx] += bars[i].volume
   }
+  const totalVol = bucket.reduce((s, v) => s + v, 0)
+  if (totalVol <= 0) return 0
+  // ratio-of-mean 정규화: 각 버킷 / 평균
+  const mean = totalVol / buckets
+  const normBucket = bucket.map(v => v / mean)
   // U-shape 표준 (양 끝 강 / 가운데 약)
   const uShape = [1.5, 0.7, 0.5, 0.7, 1.5]
-  // 코사인 유사도
-  let dot = 0
-  let normA = 0
-  let normB = 0
+  // Pearson 상관계수 (normBucket vs uShape)
+  const meanX = normBucket.reduce((s, v) => s + v, 0) / buckets
+  const meanY = uShape.reduce((s, v) => s + v, 0) / buckets
+  let num = 0, denX = 0, denY = 0
   for (let i = 0; i < buckets; i++) {
-    dot += bucket[i] * uShape[i]
-    normA += bucket[i] ** 2
-    normB += uShape[i] ** 2
+    const dx = normBucket[i] - meanX
+    const dy = uShape[i] - meanY
+    num += dx * dy
+    denX += dx * dx
+    denY += dy * dy
   }
-  if (normA === 0 || normB === 0) return 0
-  const cos = dot / (Math.sqrt(normA) * Math.sqrt(normB))
-  return Math.max(0, Math.min(100, cos * 100))
+  if (denX === 0 || denY === 0) return 0
+  const r = num / Math.sqrt(denX * denY)
+  // r ≤ 0.3 → 0점, r ≥ 0.9 → 100점
+  if (r <= 0.3) return 0
+  if (r >= 0.9) return 100
+  return Math.round(((r - 0.3) / 0.6) * 100)
 }
 
 // ============================================
@@ -375,7 +399,7 @@ export function analyzeAlgoFootprint(
     { algo: 'MOC', score: mocScore },
   ]
   scores.sort((a, b) => b.score - a.score)
-  const dominantAlgo = scores[0].score >= 40 ? scores[0].algo : null
+  const dominantAlgo = scores[0].score >= 60 ? scores[0].algo : null
 
   const direction = detectDirection(bars)
 

--- a/dental-clinic-manager/src/lib/smartMoney/liquidityEngine.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/liquidityEngine.ts
@@ -1,17 +1,18 @@
 /**
  * 유동성 풀 / 스윕 검출 (SMC) — Equal-Highs / Equal-Lows / PDH / PDL
  *
- * - 스윙 하이/로우는 5봉 프랙탈(±2 이웃 대비 국부극값)로 검출
- * - 0.2% 이내로 모이는 스윙 하이 클러스터 → equal-highs 풀 (level = 평균)
- * - 0.2% 이내로 모이는 스윙 로우 클러스터 → equal-lows 풀
+ * - 스윙 하이/로우는 3봉 프랙탈(±1 이웃 대비 국부극값)로 검출
+ * - 0.5% 이내로 모이는 스윙 하이 클러스터 → equal-highs 풀 (level = 평균)
+ * - 0.5% 이내로 모이는 스윙 로우 클러스터 → equal-lows 풀
  * - dailyBars ≥ 2 이면 second-to-last day 의 high/low → PDH/PDL 풀
  * - 단독 스윙은 swing-high / swing-low 풀
  *
  * - 스윕 검출(최근 20봉 스캔):
- *   bullish-sweep: bar.low < pool.level*0.999 AND bar.close > pool.level
- *                  AND lower-wick > 50% range AND volume > 1.3x avg(20)
- *   bearish-sweep: bar.high > pool.level*1.001 AND bar.close < pool.level
- *                  AND upper-wick > 50% range AND volume > 1.3x avg(20)
+ *   bullish-sweep: bar.low < pool.level*0.999 AND bar.close > pool.level*1.002
+ *                  AND lower-wick > 50% range AND volume > 1.15x avg(20)
+ *   bearish-sweep: bar.high > pool.level*1.001 AND bar.close < pool.level*0.998
+ *                  AND upper-wick > 50% range AND volume > 1.15x avg(20)
+ *   (recoveredInside 는 close 가 0.2% 마진을 두고 회복했는지 여부 — 약한 회복은 false)
  * - 풀이 한번 hit 되면 swept=true, recentSweeps 에 newest-first 로 누적 (max 5)
  *
  * - bars.length < 20 이면 안전 기본값 반환
@@ -44,7 +45,7 @@ interface SwingPoint {
 
 function findSwingHighs(bars: LiquidityBar[]): SwingPoint[] {
   const out: SwingPoint[] = []
-  // 3봉 프랙탈 (좌우 1봉씩): 좌 2봉 + 우 2봉(5봉)에서 완화 — 일봉 60일치에서 더 많은 swing 포착
+  // 3봉 프랙탈 (좌우 1봉씩) — 60일 일봉에서 swing 더 많이 포착하도록 완화
   for (let i = 1; i < bars.length - 1; i++) {
     const h = bars[i].high
     if (h > bars[i - 1].high && h > bars[i + 1].high) {
@@ -202,7 +203,7 @@ function detectSweeps(
         barIndex: i,
         wickRatio: lowerWick,
         volumeSpike: volSpike,
-        recoveredInside: b.close > pool.level,
+        recoveredInside: b.close > pool.level * 1.002,
         description: `Bullish sweep of ${pool.type} @ ${pool.level.toFixed(2)}`,
       })
     }
@@ -221,7 +222,7 @@ function detectSweeps(
         barIndex: i,
         wickRatio: upperWick,
         volumeSpike: volSpike,
-        recoveredInside: b.close < pool.level,
+        recoveredInside: b.close < pool.level * 0.998,
         description: `Bearish sweep of ${pool.type} @ ${pool.level.toFixed(2)}`,
       })
     }

--- a/dental-clinic-manager/src/lib/smartMoney/orderBlockFvgEngine.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/orderBlockFvgEngine.ts
@@ -5,12 +5,12 @@
  *
  * - Bullish Order Block (강세 OB):
  *     강한 상승 임펄스 직전의 마지막 음봉(close < open).
- *     "직후 1~3봉이 합쳐서 ≥ 1.0% 상승" + "직전 swing high 돌파" 조건을 만족하면 채택.
+ *     "직후 1~3봉이 합쳐서 ≥ 0.5% 상승" + "직전 swing high 돌파" 조건을 만족하면 채택.
  *     해당 음봉의 high/low 가 OB 존(zone)이 된다.
  *
  * - Bearish Order Block (약세 OB):
  *     강한 하락 임펄스 직전의 마지막 양봉(close > open).
- *     "직후 1~3봉이 합쳐서 ≥ 1.0% 하락" + "직전 swing low 이탈" 조건을 만족하면 채택.
+ *     "직후 1~3봉이 합쳐서 ≥ 0.5% 하락" + "직전 swing low 이탈" 조건을 만족하면 채택.
  *
  * - Mitigated 플래그:
  *     이후 봉이 OB 존에 재진입(Re-entry)했는지 여부.
@@ -19,7 +19,7 @@
  * - Fair Value Gap (3봉 불균형):
  *     · Bullish FVG: candle1.high < candle3.low → gap zone = [candle1.high, candle3.low]
  *     · Bearish FVG: candle1.low  > candle3.high → gap zone = [candle3.high, candle1.low]
- *     · filled: 이후 봉의 가격 범위가 gap을 일부라도 덮으면 true
+ *     · filled: 이후 봉의 가격 범위가 gap을 일부라도 덮으면 true (부분/완전 미구분)
  *
  * - 결과는 최신순으로 OB 10개 / FVG 10개까지만 유지.
  */

--- a/dental-clinic-manager/src/lib/smartMoney/sessionAnalyzer.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/sessionAnalyzer.ts
@@ -61,8 +61,10 @@ function parseDateTime(raw: string, market: 'KR' | 'US'): ParsedDateTime | null 
       Number.isFinite(hour) && Number.isFinite(min)
     ) {
       // 시장 로컬타임으로 가정. UTC epoch는 시장 오프셋 보정.
-      // KR=+9, US ET=-4 (DST 단순화: 4월~10월 EDT, 그 외 EST -5).
-      const offsetHr = market === 'KR' ? 9 : (mon >= 3 && mon <= 11 ? -4 : -5)
+      // KR=+9, US ET=정확한 DST 계산 (3월 둘째 일요일 ~ 11월 첫째 일요일 EDT -4, 그 외 EST -5).
+      // tentative 한 UTC date 를 만들어 isUsDst 로 정확한 offset 판정 — DST 전환 시각 ±1h 윈도우 외에는 정확.
+      const tentative = new Date(Date.UTC(year, mon - 1, day, hour, min))
+      const offsetHr = market === 'KR' ? 9 : (isUsDst(tentative) ? -4 : -5)
       const utcMs = Date.UTC(year, mon - 1, day, hour - offsetHr, min)
       return {
         epochMs: utcMs,
@@ -94,10 +96,29 @@ function toParsedFromDate(d: Date, market: 'KR' | 'US'): ParsedDateTime {
   }
 }
 
-/** 단순 미국 DST 추정: 3월~10월 EDT, 11월~2월 EST */
+/**
+ * 정확한 미국 DST 계산 — DST는 3월 둘째 일요일 02:00 ET ~ 11월 첫째 일요일 02:00 ET.
+ * Returns true if the given UTC date falls in EDT period.
+ */
 function isUsDst(d: Date): boolean {
-  const m = d.getUTCMonth() + 1
-  return m >= 3 && m <= 10
+  const year = d.getUTCFullYear()
+  // Second Sunday of March
+  const marStart = new Date(Date.UTC(year, 2, 1)) // March 1 UTC
+  const marDow = marStart.getUTCDay() // 0=Sun
+  // First Sunday: if March 1 is Sunday (dow=0) → first Sunday is March 1, second is March 8
+  // Else first Sunday is March (8 - marDow), second is March (15 - marDow)
+  const secondSunMar = marDow === 0 ? 8 : 15 - marDow
+  // 02:00 ET on that day → 07:00 UTC (still EST before transition)
+  const dstStart = Date.UTC(year, 2, secondSunMar, 7, 0, 0)
+
+  const novStart = new Date(Date.UTC(year, 10, 1)) // November 1 UTC
+  const novDow = novStart.getUTCDay()
+  const firstSunNov = novDow === 0 ? 1 : 8 - novDow
+  // 02:00 ET = 06:00 UTC (EDT before transition)
+  const dstEnd = Date.UTC(year, 10, firstSunNov, 6, 0, 0)
+
+  const t = d.getTime()
+  return t >= dstStart && t < dstEnd
 }
 
 // ============================================

--- a/dental-clinic-manager/src/lib/smartMoney/smartMoneyScorer.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/smartMoneyScorer.ts
@@ -5,6 +5,9 @@
  *   investorFlow 25 / wyckoffPhase 20 / marketStructure 15 / liquidity 10
  *   VSA 10 / algoFootprint 10 / 단일봉 Wyckoff 5 / VWAP 5
  *
+ * ※ investorFlow 가중치는 미국 종목 / KR KIS 미연결 시 자동으로 나머지 7개 컴포넌트에
+ *   비례 재분배되어 ±100 범위 유지.
+ *
  * 트랩 모디파이어:
  *   bull-trap + score>0 → score *= 0.7
  *   bear-trap + score<0 → score *= 0.7
@@ -419,6 +422,9 @@ export function computeSmartMoneyScore(input: ScorerInput): ScorerOutput {
     }
   }
 
+  // NOTE: newsContext 기반 signalDetail 은 현재 동작하지 않는다 —
+  // route.ts 에서 newsEvents: [] 로 호출하므로 analyzeNewsContext 가 항상 null pattern을 반환.
+  // 뉴스 데이터 통합(getNewsEventsForTicker) 구현 후 활성화 예정. 로직은 그대로 유지.
   if (newsContext && newsContext.pattern) {
     signalDetails.push({
       type: newsContext.pattern,
@@ -453,15 +459,22 @@ export function computeSmartMoneyScore(input: ScorerInput): ScorerOutput {
   // ============================================
   // 종합 점수
   // ============================================
-  let rawScore =
-    flowComponent
-    + wyckoffPhaseComponent
+  const otherComponents =
+    wyckoffPhaseComponent
     + structureComponent
     + liquidityComponent
     + vsaComponent
     + algoComponent
     + wyckoffComponent
     + vwapComponent
+
+  // investorFlow가 null(미국 종목/KR limited-mode)이면 나머지 75 가중치를 100으로 정규화 — 만점 범위 동일하게 유지
+  const FLOW_WEIGHT = 25
+  const TOTAL_WEIGHT = 100
+  const rebalanceFactor = investorFlow === null
+    ? TOTAL_WEIGHT / (TOTAL_WEIGHT - FLOW_WEIGHT)
+    : 1
+  let rawScore = (flowComponent + otherComponents) * rebalanceFactor
 
   // 트랩 모디파이어
   if (traps?.bullTrapDetected && rawScore > 0) {
@@ -486,6 +499,7 @@ export function computeSmartMoneyScore(input: ScorerInput): ScorerOutput {
   let manipRisk = 0
   if (traps?.bullTrapDetected) manipRisk += 40
   if (traps?.bearTrapDetected) manipRisk += 40
+  // TODO: 활성화는 뉴스 데이터 통합(getNewsEventsForTicker) 구현 후 — 현재 newsEvents 가 빈 배열이라 항상 null pattern.
   if (newsContext?.pattern === 'news-fade') manipRisk += 30
   if (newsContext?.pattern === 'sell-the-news') manipRisk += 20
   if (vsa?.signals.some((s) => s.type === 'buying-climax' || s.type === 'selling-climax')) manipRisk += 20

--- a/dental-clinic-manager/src/lib/smartMoney/trapEngine.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/trapEngine.ts
@@ -1,13 +1,13 @@
 /**
  * 트랩 엔진 — Bull Trap / Bear Trap (실패한 돌파)
  *
- * - 저항선/지지선: 최근 5봉 윈도우를 제외한 직전 30봉의 최고가/최저가
- * - Bull Trap : 최근 5봉 내에서 저항선을 +0.1% 초과 돌파했으나
- *               이후 ≤3봉 안에 종가가 저항선 아래로 회귀
- *               + (돌파 봉 거래량이 평균 대비 1.2배 이하 OR 돌파 폭만큼 추가 하락)
- * - Bear Trap : 최근 5봉 내에서 지지선을 -0.1% 초과 이탈했으나
- *               이후 ≤3봉 안에 종가가 지지선 위로 회귀
- *               + (이탈 봉 거래량이 평균 대비 1.2배 이하 OR V자 반등)
+ * - 저항선/지지선: 최근 10봉 윈도우를 제외한 직전 30봉의 최고가/최저가
+ * - Bull Trap : 최근 10봉 내에서 저항선을 +0.1% 초과 돌파했으나
+ *               이후 ≤5봉 안에 종가가 저항선 아래로 회귀
+ *               + (돌파 봉 거래량이 평균 대비 1.5배 이하 OR 돌파 폭만큼 추가 하락)
+ * - Bear Trap : 최근 10봉 내에서 지지선을 -0.1% 초과 이탈했으나
+ *               이후 ≤5봉 안에 종가가 지지선 위로 회귀
+ *               + (이탈 봉 거래량이 평균 대비 1.5배 이하 OR V자 반등)
  * - volumeDivergence : 돌파/이탈 봉의 거래량이 평균 미만이면 true
  */
 
@@ -80,7 +80,7 @@ export function detectTraps(bars: Bar[]): TrapResult {
 
   const details: TrapDetail[] = []
 
-  // 최근 5봉을 순회하며 트랩 후보 검사
+  // 최근 10봉을 순회하며 트랩 후보 검사
   for (let i = recentStart; i <= lastIdx; i++) {
     const breakBar = bars[i]
     const avgVol = avgVolumeBefore(bars, i)

--- a/dental-clinic-manager/src/lib/smartMoney/vsaEngine.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/vsaEngine.ts
@@ -7,15 +7,19 @@
  *   - closePosition : (close - low) / spread (0=하단, 1=상단)
  *   - volRatio      : volume / avg(직전 20봉)
  *
- * 시그널 (최근 5봉만 actionable):
- *   - No Demand       : 양봉 / 좁은 spread / volRatio < 0.7
- *   - No Supply       : 음봉 / 좁은 spread / volRatio < 0.7
- *   - Buying Climax   : volRatio > 2.5 / wide spread / closePosition < 0.5 / 직전 추세 상승
- *   - Selling Climax  : volRatio > 2.5 / wide spread / closePosition > 0.5 / 직전 추세 하락
- *   - Stopping Volume : 음봉 / 매우 큰 거래량 / closePosition > 0.66 / 작은 body
+ * 시그널 (최근 10봉만 actionable):
+ *   - No Demand       : 양봉 / 좁은 spread(<0.85x avg10) / volRatio < 0.85 / 직전 추세 상승
+ *   - No Supply       : 음봉 / 좁은 spread(<0.85x avg10) / volRatio < 0.85 / 직전 추세 하락
+ *   - Buying Climax   : volRatio > 1.8 / wide spread(>1.3x avg10) / closePosition < 0.34 / 직전 추세 상승
+ *   - Selling Climax  : volRatio > 1.8 / wide spread(>1.3x avg10) / closePosition > 0.66 / 직전 추세 하락
+ *   - Stopping Volume : 음봉 / volRatio > 1.8 / closePosition > 0.66 / 작은 body(<0.4x spread)
+ *
+ * 주의:
+ *   - No-demand/No-supply 는 정통 VSA 정의대로 trend 컨텍스트(uptrend/downtrend)가 있어야만 발화
+ *   - Climax close-position 은 상/하 1/3 영역(0.66/0.34)으로 강화됨 (기존 0.5 → 너무 관대)
  *
  * effortVsResult:
- *   - bullish : Selling Climax / Stopping Volume / No Supply 중 하나라도 최근 5봉 내 발견
+ *   - bullish : Selling Climax / Stopping Volume / No Supply 중 하나라도 최근 10봉 내 발견
  *   - bearish : Buying Climax / No Demand 발견
  *   - neutral : 그 외
  */
@@ -38,6 +42,8 @@ const NARROW_SPREAD_MULT = 0.85 // 0.7→0.85 완화 (No Demand/Supply 더 잘 �
 const WIDE_SPREAD_MULT = 1.3    // 1.5→1.3 완화 (Climax wide-spread 인정 범위 넓힘)
 const LOW_VOL_RATIO = 0.85      // 0.7→0.85 완화 (No Demand/Supply 검출)
 const CLIMAX_VOL_RATIO = 1.8    // 2.5→1.8 완화 (climax 검출)
+const CLIMAX_CLOSE_POS_UPPER = 0.66   // 상단 1/3 (selling climax: 강한 lower-wick → close 상단)
+const CLIMAX_CLOSE_POS_LOWER = 0.34   // 하단 1/3 (buying climax: 강한 upper-wick → close 하단)
 const STOPPING_CLOSE_POS = 0.66
 const STOPPING_BODY_TO_SPREAD = 0.4   // 작은 body 기준
 const MAX_SIGNALS = 10
@@ -165,31 +171,41 @@ export function analyzeVSA(bars: Bar[]): VSAResult {
     const isWide = m.spread > avgSpread * WIDE_SPREAD_MULT
     const trend = priorTrend(bars, i)
 
-    // No Demand
-    if (m.bodyDirection === 'up' && isNarrow && m.volRatio < LOW_VOL_RATIO) {
+    // No Demand — 상승 추세 중 약한 양봉 (정통 VSA: uptrend 컨텍스트 필수)
+    if (
+      m.bodyDirection === 'up' &&
+      isNarrow &&
+      m.volRatio < LOW_VOL_RATIO &&
+      trend === 'up'
+    ) {
       signals.push(buildSignal('no-demand', i, m, '수요 부재 — 상승 동력 소진'))
     }
 
-    // No Supply
-    if (m.bodyDirection === 'down' && isNarrow && m.volRatio < LOW_VOL_RATIO) {
+    // No Supply — 하락 추세 중 약한 음봉 (정통 VSA: downtrend 컨텍스트 필수)
+    if (
+      m.bodyDirection === 'down' &&
+      isNarrow &&
+      m.volRatio < LOW_VOL_RATIO &&
+      trend === 'down'
+    ) {
       signals.push(buildSignal('no-supply', i, m, '공급 부재 — 매도 압력 고갈'))
     }
 
-    // Buying Climax
+    // Buying Climax — close 가 하단 1/3 (강한 upper-wick = 매수 소진)
     if (
       m.volRatio > CLIMAX_VOL_RATIO &&
       isWide &&
-      m.closePosition < 0.5 &&
+      m.closePosition < CLIMAX_CLOSE_POS_LOWER &&
       trend === 'up'
     ) {
       signals.push(buildSignal('buying-climax', i, m, '매수 클라이맥스 — 분배 가능성'))
     }
 
-    // Selling Climax
+    // Selling Climax — close 가 상단 1/3 (강한 lower-wick = 매도 흡수)
     if (
       m.volRatio > CLIMAX_VOL_RATIO &&
       isWide &&
-      m.closePosition > 0.5 &&
+      m.closePosition > CLIMAX_CLOSE_POS_UPPER &&
       trend === 'down'
     ) {
       signals.push(buildSignal('selling-climax', i, m, '매도 클라이맥스 — 매집 흡수 가능성'))

--- a/dental-clinic-manager/src/lib/smartMoney/wyckoffPhaseEngine.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/wyckoffPhaseEngine.ts
@@ -6,7 +6,7 @@
  *
  * 매집(Accumulation) 이벤트:
  *   - PS    : 거래량이 평균 1.5배 이상으로 처음 증가하나 가격은 소폭 하락
- *   - SC    : 거래량 2.5배 + 음봉 + 하단 wick > 50% + 구간 저점 부근
+ *   - SC    : 거래량 1.8배 + 음봉 + 하단 wick > 35% + 구간 저점 부근
  *   - AR    : SC 이후 10봉 내 최고가 (자동 반등)
  *   - ST    : SC 저점을 1% 이내로 재테스트 + SC 대비 거래량 감소
  *   - Spring: SC/ST 저점을 0.3~2% 침범 후 회복 마감 + 거래량 1.5배
@@ -15,19 +15,19 @@
  *
  * 분배(Distribution) 이벤트:
  *   - PSY  : 거래량 증가하는 양봉 (예비 공급)
- *   - BC   : 거래량 2.5배 + 양봉 + 상단 wick > 50% + 구간 고점 부근
+ *   - BC   : 거래량 1.8배 + 양봉 + 상단 wick > 35% + 구간 고점 부근
  *   - AR   : BC 이후 10봉 내 최저가
  *   - ST   : BC 고점 1% 이내 재테스트 + BC 대비 거래량 감소
  *   - UTAD : BC/ST 고점 0.3~2% 돌파 후 종가가 다시 아래로 마감 + 거래량 증가
  *   - SOW  : AR 저점 하향 돌파 음봉 + 거래량 증가
  *   - LPSY : SOW 이후 직전 지지대 아래서 반등 실패
  *
- * 페이즈 결정:
- *   - A : SC+AR+ST (또는 PSY+BC+AR) 모두 탐지
- *   - B : A + ST가 2개 이상 (장기 횡보)
- *   - C : A/B + Spring (또는 UTAD)
- *   - D : C + SOS (또는 SOW)
- *   - E : D + LPS (또는 LPSY)
+ * 페이즈 결정 (prerequisite 시퀀스 강제):
+ *   - A : SC+AR (또는 PSY+BC+AR) 탐지
+ *   - B : A + ST가 1개 이상 (장기 횡보)
+ *   - C : A 충족 후 Spring 발견 시 (또는 UTAD)
+ *   - D : B 또는 C 후 SOS 발견 시 (또는 SOW)
+ *   - E : D 후 LPS 발견 시 (또는 LPSY)
  *
  * - cycle  : accumulation/distribution 이벤트 카운트 비교 (≥2개 우세 쪽)
  * - confidence : clamp(eventsCount * 15 + (phase ? 25 : 0), 0, 100)
@@ -506,26 +506,26 @@ export function detectWyckoffPhase(
     events = accEvents.length >= distEvents.length ? accEvents : distEvents
   }
 
-  // phase 결정 — 핵심 마커가 발견되면 더 관대하게 인정
-  // (이전: hasA가 SC+AR+ST 모두, hasC가 hasA && spring 필수 → 너무 빡빡)
+  // phase 결정 — prerequisite 시퀀스 강제 (Spring/SOS/LPS 단독 발견만으로는
+  // 후기 단계 인정 안 함). 이전 markers 가 없으면 false-positive 후기 phase 가 나옴.
   let phase: WyckoffPhaseResult['phase'] = null
   if (cycle === 'accumulation') {
-    const hasA = !!(acc.sc && acc.ar)              // SC + AR 만 있으면 A
-    const hasB = hasA && acc.sts.length >= 1       // ST 1개 이상 → B
-    const hasC = !!acc.spring                       // Spring 단독으로도 Phase C 인정
-    const hasD = !!acc.sos                          // SOS 단독으로도 Phase D 인정
-    const hasE = !!acc.lps                          // LPS 단독으로도 Phase E 인정
+    const hasA = !!(acc.sc && acc.ar)
+    const hasB = hasA && acc.sts.length >= 1
+    const hasC = hasA && !!acc.spring                    // Spring은 A 이후라야 의미
+    const hasD = (hasB || hasC) && !!acc.sos             // SOS는 B 또는 C 이후
+    const hasE = hasD && !!acc.lps                       // LPS는 D 이후
     if (hasE) phase = 'E'
     else if (hasD) phase = 'D'
     else if (hasC) phase = 'C'
     else if (hasB) phase = 'B'
     else if (hasA) phase = 'A'
   } else if (cycle === 'distribution') {
-    const hasA = !!(dist.bc && dist.ar)            // BC + AR 만 있으면 A (PSY 필수 제거)
+    const hasA = !!(dist.bc && dist.ar)
     const hasB = hasA && dist.sts.length >= 1
-    const hasC = !!dist.utad
-    const hasD = !!dist.sow
-    const hasE = !!dist.lpsy
+    const hasC = hasA && !!dist.utad
+    const hasD = (hasB || hasC) && !!dist.sow
+    const hasE = hasD && !!dist.lpsy
     if (hasE) phase = 'E'
     else if (hasD) phase = 'D'
     else if (hasC) phase = 'C'


### PR DESCRIPTION
## Summary
- 스마트 머니 분석 14개 엔진 전수 검증 후 발견된 9개 결함 일괄 수정
  - 명백한 버그 2건: liquidityEngine.recoveredInside 항상 true / scorer 의 US 종목 ±75 만점 한계
  - 로직 강화 4건: VSA 추세 컨텍스트, 클라이맥스 closePosition 임계, Wyckoff Phase 순차 prerequisite, sessionAnalyzer DST 정확화
  - 변별력 개선 3건: algoFootprint VWAP Pearson 매핑, TWAP 임계 강화, dominantAlgo 임계 40→60
  - 주석/상수 일치화 5건: trap/liquidity/orderBlock/vsa/wyckoffPhase 헤더 doc 코드와 동기화
  - newsContext 미통합 명시화 (TODO + Placeholder)
- 직전 누적: 심리 분석 LLM 응답 스키마 검증 안정화, 차트 공포·탐욕 지수 오버레이, 백테스트 calculateBuyHold/round4/Sharpe 버그 수정, 전략 비교 시장 혼합, 히스토리 light=1 단순화

## Test plan
- [x] npm run build 통과
- [ ] /investment/smart-money 페이지에서 KR(KIS 연결) / KR(limited) / US 종목 분석 시
  - 점수 ±100 범위 정상 산출 (특히 US 종목)
  - liquidity sweep recoveredInside 약한/강한 회복 구분 동작
  - VSA no-demand/no-supply false positive 감소 확인
  - Wyckoff Phase C/D/E 가 prerequisite 없으면 미확정으로 표시
- [ ] dominantAlgo 가 평범한 거래일에 항상 잡히지 않는지 확인