### PR TITLE
fix(task): 업무 일괄 액션바를 리스트 하단으로 이동

### DIFF
--- a/dental-clinic-manager/src/components/Bulletin/TaskList.tsx
+++ b/dental-clinic-manager/src/components/Bulletin/TaskList.tsx
@@ -410,47 +410,6 @@ export default function TaskList({ canCreate = false, showMyTasksOnly = false }:
         </div>
       </div>
 
-      {/* 선택된 업무가 있을 때만 액션바 노출 */}
-      {canBulkReassign && activeTab !== 'recurring' && selectedIds.size > 0 && (
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-3 bg-at-accent-light border border-at-accent rounded-xl">
-          <div className="flex items-center gap-3">
-            <span className="text-sm font-semibold text-at-accent">
-              {selectedIds.size}건 선택됨
-            </span>
-            <button
-              type="button"
-              onClick={toggleSelectAll}
-              className="text-sm font-medium text-at-accent hover:underline"
-            >
-              {selectedIds.size === displayedTasks.length && displayedTasks.length > 0
-                ? '전체 해제'
-                : '현재 보이는 업무 전체 선택'}
-            </button>
-          </div>
-          <div className="flex items-center gap-2 flex-wrap">
-            <Button
-              onClick={() => setShowBulkAssigneeModal(true)}
-              className="flex items-center gap-2"
-            >
-              <Users className="w-4 h-4" />
-              담당자 일괄 변경
-            </Button>
-            <Button
-              variant="outline"
-              onClick={handleBulkDelete}
-              className="flex items-center gap-2 text-at-error hover:text-at-error hover:bg-at-error-bg border-red-200"
-            >
-              <Trash2 className="w-4 h-4" />
-              일괄 삭제
-            </Button>
-            <Button variant="outline" onClick={clearSelection} className="flex items-center gap-2">
-              <X className="w-4 h-4" />
-              선택 해제
-            </Button>
-          </div>
-        </div>
-      )}
-
       {/* 통계 (클릭하면 해당 상태 필터링) */}
       {stats && (
         <div className="grid grid-cols-3 sm:grid-cols-6 gap-3">
@@ -745,6 +704,47 @@ export default function TaskList({ canCreate = false, showMyTasksOnly = false }:
           onToggleSelect={toggleSelect}
         />
       ))}
+
+      {/* 선택된 업무가 있을 때만 액션바 노출 — 리스트 하단에 위치 */}
+      {canBulkReassign && activeTab !== 'recurring' && selectedIds.size > 0 && (
+        <div className="sticky bottom-2 sm:bottom-4 z-20 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-3 bg-at-accent-light border border-at-accent rounded-xl shadow-at-card">
+          <div className="flex items-center gap-3">
+            <span className="text-sm font-semibold text-at-accent">
+              {selectedIds.size}건 선택됨
+            </span>
+            <button
+              type="button"
+              onClick={toggleSelectAll}
+              className="text-sm font-medium text-at-accent hover:underline"
+            >
+              {selectedIds.size === displayedTasks.length && displayedTasks.length > 0
+                ? '전체 해제'
+                : '현재 보이는 업무 전체 선택'}
+            </button>
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <Button
+              onClick={() => setShowBulkAssigneeModal(true)}
+              className="flex items-center gap-2"
+            >
+              <Users className="w-4 h-4" />
+              담당자 일괄 변경
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handleBulkDelete}
+              className="flex items-center gap-2 text-at-error hover:text-at-error hover:bg-at-error-bg border-red-200"
+            >
+              <Trash2 className="w-4 h-4" />
+              일괄 삭제
+            </Button>
+            <Button variant="outline" onClick={clearSelection} className="flex items-center gap-2">
+              <X className="w-4 h-4" />
+              선택 해제
+            </Button>
+          </div>
+        </div>
+      )}
 
       {/* 담당자 일괄 변경 모달 */}
       {showBulkAssigneeModal && (


### PR DESCRIPTION
## Summary
업무 지시 페이지에서 다중 선택 시 표시되는 일괄 액션바(담당자 일괄 변경 / 일괄 삭제 / 선택 해제)를 **리스트 상단에서 리스트 하단으로 이동**.

### 변경
[TaskList.tsx:413-452](src/components/Bulletin/TaskList.tsx#L413) 영역 → TaskCardView 아래로 이동.

### UX 보강 — sticky bottom 적용
단순히 list 하단에 두면 리스트가 길어졌을 때 스크롤 끝까지 가야 액션 버튼이 보이는 UX 문제가 생깁니다.
이를 방지하기 위해 액션바에 `sticky bottom-2 sm:bottom-4 z-20 shadow-at-card`를 추가했습니다.

| 상황 | 동작 |
|------|------|
| 선택 없음 | 액션바 미노출 (기존 동일) |
| 선택 있고 리스트 짧음 | 액션바가 리스트 바로 아래 표시 |
| 선택 있고 리스트 길어서 스크롤 중 | 액션바가 viewport 하단에 sticky 고정 |

### 영향 없음
- 액션 버튼 구성·핸들러 동일 (담당자 일괄 변경 / 일괄 삭제 / 선택 해제)
- 조건 동일 (`canBulkReassign && activeTab !== 'recurring' && selectedIds.size > 0`)
- BulkAssigneeChangeModal 등 모달 구성 무변경

## Test plan
- [x] `npm run build` 성공
- [ ] 업무 여러 개 선택 시 액션바가 리스트 하단에 표시되는지
- [ ] 리스트가 길어 스크롤 중일 때도 액션바가 viewport 하단에 고정되어 보이는지
- [ ] 모바일/데스크탑 모두 정상 표시되는지
- [ ] 일괄 변경·삭제·선택 해제 기능이 기존대로 동작하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)