### PR TITLE
release: develop → main (전략 랭킹 최적화 + 심리분석/백테스트 안정화 외)

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/backtest/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/backtest/route.ts
@@ -251,6 +251,14 @@ export async function POST(request: NextRequest) {
       }, { status: 400 })
     }
 
+    // 초고가 종목(BRK.A ~$700k 등) 사전 검증 — 1주 매수도 불가능하면 backtest 가 빈 결과로 끝나 사용자가 원인을 알기 어려움.
+    const firstPrice = prices[0].open
+    if (firstPrice > 0 && firstPrice > capital) {
+      return NextResponse.json({
+        error: `${ticker} 1주 가격(${firstPrice.toLocaleString(undefined, { maximumFractionDigits: 2 })}) 이 초기 자본(${capital.toLocaleString()}) 보다 큽니다. 자본을 ${Math.ceil(firstPrice * 1.2).toLocaleString()} 이상으로 설정하거나 다른 종목을 선택해 주세요.`
+      }, { status: 400 })
+    }
+
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), 55_000)
 

--- a/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
@@ -37,7 +37,7 @@ import { calculateVWAP, type VWAPInputBar } from '@/lib/smartMoney/vwapEngine'
 import { detectWyckoff, type WyckoffBar } from '@/lib/smartMoney/wyckoffEngine'
 import { analyzeAlgoFootprint, type AlgoBar } from '@/lib/smartMoney/algoFootprintEngine'
 import { analyzeInvestorFlow } from '@/lib/smartMoney/investorFlowAnalyzer'
-import { computeSmartMoneyScore } from '@/lib/smartMoney/smartMoneyScorer'
+import { computeSmartMoneyScore, NEWS_INTEGRATION_ACTIVE } from '@/lib/smartMoney/smartMoneyScorer'
 import { generateLLMComment } from '@/lib/smartMoney/llmAnalyzer'
 // ===== 정교화 엔진 =====
 import { detectWyckoffPhase, type PhaseBar } from '@/lib/smartMoney/wyckoffPhaseEngine'
@@ -98,6 +98,8 @@ interface AnalysisResponse extends SmartMoneyAnalysis {
    * UI 가 이 플래그를 보고 안내 배너를 노출한다.
    */
   limitedDataMode?: boolean
+  /** 'inactive' = 뉴스 데이터 통합 전 (news-fade/sell-the-news 가중치 미적용). UI 디버그/안내용. */
+  newsSignalIntegration?: 'active' | 'inactive'
 }
 
 // ============================================
@@ -814,6 +816,7 @@ export async function POST(request: NextRequest) {
     ...analysis,
     triggeredAlerts: triggeredAlerts && triggeredAlerts.length > 0 ? triggeredAlerts : undefined,
     limitedDataMode: isKRLimitedMode ? true : undefined,
+    newsSignalIntegration: NEWS_INTEGRATION_ACTIVE ? 'active' : 'inactive',
   }
 
   return NextResponse.json({ data: response })

--- a/dental-clinic-manager/src/app/api/investment/strategies/rankings/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/strategies/rankings/route.ts
@@ -8,8 +8,9 @@
  *   avgWinRate, avgSharpe, profitFactor, avgMDD (낮은 순),
  *   totalTrades (안정성 — 거래 많은 순), cloneCount (인기)
  *
- * 통계 출처: backtest_runs (status=completed) — 원본 작성자의 모든 백테스트 기록 집계.
- *           최소 3회 이상 백테스트 기록이 있는 전략만 노출 (의미있는 통계 확보).
+ * 통계 출처: strategy_ranking_stats — backtest_runs 변경 시 trigger 로 사전 집계된 테이블.
+ *           backtest_runs 70k+ rows 를 매 요청마다 JS 로 aggregate 하던 종전 방식 대비
+ *           수 초 → 100ms 미만으로 단축. 최소 3회 이상 백테스트 기록만 노출.
  */
 
 import { NextRequest, NextResponse } from 'next/server'
@@ -56,6 +57,23 @@ interface RankingItem {
 
 const MIN_RUNS_FOR_RANKING = 3
 
+interface StatRow {
+  entry_type: 'shared' | 'preset'
+  entry_id: string
+  market: 'KR' | 'US'
+  runs: number
+  ticker_count: number
+  avg_return: number | null
+  best_return: number | null
+  worst_return: number | null
+  avg_win_rate: number | null
+  avg_sharpe: number | null
+  avg_mdd: number | null
+  avg_pf: number | null
+  total_trades: number
+  last_run_at: string | null
+}
+
 export async function GET(req: NextRequest) {
   const auth = await requireAuth()
   if (auth.error || !auth.user) {
@@ -75,148 +93,59 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Server error' }, { status: 500 })
   }
 
-  // 1. 공유된 전략 + 작성자 정보 조회
-  let q = supabase
-    .from('investment_strategies')
-    .select('id, user_id, name, description, target_market, indicators, shared_at, share_alias, clone_count')
-    .eq('is_shared', true)
+  // 1. 사전 집계 테이블에서 stats 조회 — runs >= 3 인 행만
+  let statsQ = supabase
+    .from('strategy_ranking_stats')
+    .select('entry_type, entry_id, market, runs, ticker_count, avg_return, best_return, worst_return, avg_win_rate, avg_sharpe, avg_mdd, avg_pf, total_trades, last_run_at')
+    .gte('runs', MIN_RUNS_FOR_RANKING)
   if (market === 'KR' || market === 'US') {
-    q = q.eq('target_market', market)
+    statsQ = statsQ.eq('market', market)
   }
-  const { data: sharedRaw, error: shareErr } = await q.limit(500)
-  if (shareErr) {
-    return NextResponse.json({ error: shareErr.message }, { status: 500 })
+  const { data: statsRaw, error: statsErr } = await statsQ.limit(500)
+  if (statsErr) {
+    return NextResponse.json({ error: statsErr.message }, { status: 500 })
   }
-  const shared = (sharedRaw ?? []) as Array<{
+  const stats = (statsRaw ?? []) as StatRow[]
+
+  // 2. shared 항목용 메타 (investment_strategies + users) 일괄 조회
+  const sharedIds = Array.from(new Set(
+    stats.filter(s => s.entry_type === 'shared').map(s => s.entry_id),
+  ))
+  type StratRow = {
     id: string
     user_id: string
     name: string
     description: string | null
     target_market: 'KR' | 'US'
-    indicators: unknown
     shared_at: string | null
     share_alias: string | null
     clone_count: number | null
-  }>
-
-  // 2. 작성자 이름 매핑 (users.name)
-  const userIds = Array.from(new Set(shared.map(s => s.user_id)))
-  const { data: usersRaw } = await supabase
-    .from('users')
-    .select('id, name, hospital_name')
-    .in('id', userIds)
-  const userMap = new Map<string, { name: string | null; hospital_name: string | null }>()
-  for (const u of (usersRaw ?? []) as Array<{ id: string; name: string | null; hospital_name: string | null }>) {
-    userMap.set(u.id, { name: u.name, hospital_name: u.hospital_name })
+    is_shared: boolean
   }
-
-  // 3. 백테스트 통계 집계 — strategy_id 가 공유 전략 ID 인 모든 run
-  const strategyIds = shared.map(s => s.id)
-  type RunRow = {
-    strategy_id: string | null
-    preset_id?: string | null
-    market?: string | null
-    ticker: string
-    total_return: number | null
-    win_rate: number | null
-    max_drawdown: number | null
-    sharpe_ratio: number | null
-    profit_factor: number | null
-    total_trades: number | null
-    executed_at: string | null
+  let sharedStrats: StratRow[] = []
+  if (sharedIds.length > 0) {
+    const { data: stratsRaw } = await supabase
+      .from('investment_strategies')
+      .select('id, user_id, name, description, target_market, shared_at, share_alias, clone_count, is_shared')
+      .in('id', sharedIds)
+      .eq('is_shared', true)
+    sharedStrats = (stratsRaw ?? []) as StratRow[]
   }
+  const stratMap = new Map(sharedStrats.map(s => [s.id, s]))
 
-  const runs: RunRow[] = []
-  if (strategyIds.length > 0) {
-    const { data: sharedRunsRaw } = await supabase
-      .from('backtest_runs')
-      .select('strategy_id, ticker, total_return, win_rate, max_drawdown, sharpe_ratio, profit_factor, total_trades, executed_at')
-      .in('strategy_id', strategyIds)
-      .eq('status', 'completed')
-      .limit(20000)
-    for (const r of (sharedRunsRaw ?? []) as RunRow[]) runs.push(r)
+  const userIds = Array.from(new Set(sharedStrats.map(s => s.user_id)))
+  type UserRow = { id: string; name: string | null; hospital_name: string | null }
+  let userRows: UserRow[] = []
+  if (userIds.length > 0) {
+    const { data: usersRaw } = await supabase
+      .from('users')
+      .select('id, name, hospital_name')
+      .in('id', userIds)
+    userRows = (usersRaw ?? []) as UserRow[]
   }
+  const userMap = new Map(userRows.map(u => [u.id, u]))
 
-  const byStrategy = new Map<string, RunRow[]>()
-  for (const r of runs) {
-    if (!r.strategy_id) continue
-    const arr = byStrategy.get(r.strategy_id) ?? []
-    arr.push(r)
-    byStrategy.set(r.strategy_id, arr)
-  }
-
-  // 4. 랭킹 항목 빌드 — 우선 공유 user 전략
-  const items: RankingItem[] = []
-  for (const s of shared) {
-    const sRuns = byStrategy.get(s.id) ?? []
-    if (sRuns.length < MIN_RUNS_FOR_RANKING) continue
-
-    const returns = sRuns.map(r => Number(r.total_return ?? 0))
-    const winRates = sRuns.map(r => Number(r.win_rate ?? 0))
-    const sharpes = sRuns.map(r => Number(r.sharpe_ratio ?? 0))
-    const mdds = sRuns.map(r => Number(r.max_drawdown ?? 0))
-    const pfs = sRuns.map(r => Number(r.profit_factor ?? 0)).filter(v => isFinite(v) && v > 0)
-    const trades = sRuns.reduce((sum, r) => sum + Number(r.total_trades ?? 0), 0)
-    const tickers = new Set(sRuns.map(r => r.ticker))
-    const lastRunAt = sRuns
-      .map(r => r.executed_at)
-      .filter((x): x is string => Boolean(x))
-      .sort()
-      .pop() ?? null
-
-    const userInfo = userMap.get(s.user_id)
-    const authorAlias = anonymize(s.share_alias, userInfo?.name, userInfo?.hospital_name)
-
-    items.push({
-      type: 'shared',
-      strategyId: s.id,
-      name: s.name,
-      description: s.description,
-      targetMarket: s.target_market,
-      authorAlias,
-      sharedAt: s.shared_at,
-      cloneCount: Number(s.clone_count ?? 0),
-      isMine: s.user_id === auth.user.id,
-      runs: sRuns.length,
-      tickerCount: tickers.size,
-      avgReturn: avg(returns),
-      bestReturn: returns.length > 0 ? Math.max(...returns) : 0,
-      worstReturn: returns.length > 0 ? Math.min(...returns) : 0,
-      avgWinRate: avg(winRates),
-      avgSharpe: avg(sharpes),
-      avgMDD: avg(mdds),
-      avgPF: avg(pfs),
-      totalTrades: trades,
-      lastRunAt,
-    })
-  }
-
-  // 4b. 프리셋 전략 백테스트 집계 (시스템 프리셋, 모든 사용자 공통)
-  // backtest_runs.preset_id 로 식별. (preset_id, market) 별로 별도 항목 (시장에 따라 성과 다름).
-  const presetIdSet = new Set(PRESET_STRATEGIES.map(p => p.id))
-  let presetRunsQuery = supabase
-    .from('backtest_runs')
-    .select('preset_id, market, ticker, total_return, win_rate, max_drawdown, sharpe_ratio, profit_factor, total_trades, executed_at')
-    .not('preset_id', 'is', null)
-    .eq('status', 'completed')
-  if (market === 'KR' || market === 'US') {
-    presetRunsQuery = presetRunsQuery.eq('market', market)
-  }
-  const { data: presetRunsRaw } = await presetRunsQuery.limit(50000)
-
-  // (preset_id, market) → runs
-  const byPresetMarket = new Map<string, RunRow[]>()
-  for (const r of (presetRunsRaw ?? []) as RunRow[]) {
-    if (!r.preset_id || !presetIdSet.has(r.preset_id)) continue
-    const m = (r.market === 'KR' || r.market === 'US') ? r.market : null
-    if (!m) continue
-    const key = `${r.preset_id}|${m}`
-    const arr = byPresetMarket.get(key) ?? []
-    arr.push(r)
-    byPresetMarket.set(key, arr)
-  }
-
-  // 프리셋 클론 횟수 (user strategies 중 source_preset_id 카운트)
+  // 3. preset clone count 일괄 조회
   const { data: clonesRaw } = await supabase
     .from('investment_strategies')
     .select('source_preset_id')
@@ -227,47 +156,54 @@ export async function GET(req: NextRequest) {
     cloneCountByPreset.set(c.source_preset_id, (cloneCountByPreset.get(c.source_preset_id) ?? 0) + 1)
   }
 
-  for (const [key, pRuns] of byPresetMarket) {
-    if (pRuns.length < MIN_RUNS_FOR_RANKING) continue
-    const [presetId, mk] = key.split('|')
-    const preset = PRESET_STRATEGIES.find(p => p.id === presetId)
-    if (!preset) continue
-
-    const returns = pRuns.map(r => Number(r.total_return ?? 0))
-    const winRates = pRuns.map(r => Number(r.win_rate ?? 0))
-    const sharpes = pRuns.map(r => Number(r.sharpe_ratio ?? 0))
-    const mdds = pRuns.map(r => Number(r.max_drawdown ?? 0))
-    const pfs = pRuns.map(r => Number(r.profit_factor ?? 0)).filter(v => isFinite(v) && v > 0)
-    const trades = pRuns.reduce((sum, r) => sum + Number(r.total_trades ?? 0), 0)
-    const tickers = new Set(pRuns.map(r => r.ticker))
-    const lastRunAt = pRuns
-      .map(r => r.executed_at)
-      .filter((x): x is string => Boolean(x))
-      .sort()
-      .pop() ?? null
-
-    items.push({
-      type: 'preset',
-      presetId,
-      name: preset.name,
-      description: preset.description,
-      targetMarket: mk as 'KR' | 'US',
-      authorAlias: '공식 프리셋',
-      sharedAt: null,
-      cloneCount: cloneCountByPreset.get(presetId) ?? 0,
-      isMine: false,
-      runs: pRuns.length,
-      tickerCount: tickers.size,
-      avgReturn: avg(returns),
-      bestReturn: returns.length > 0 ? Math.max(...returns) : 0,
-      worstReturn: returns.length > 0 ? Math.min(...returns) : 0,
-      avgWinRate: avg(winRates),
-      avgSharpe: avg(sharpes),
-      avgMDD: avg(mdds),
-      avgPF: avg(pfs),
-      totalTrades: trades,
-      lastRunAt,
-    })
+  // 4. stats + 메타 머지 → RankingItem
+  const items: RankingItem[] = []
+  for (const s of stats) {
+    const base = {
+      runs: s.runs,
+      tickerCount: s.ticker_count,
+      avgReturn: numOr0(s.avg_return),
+      bestReturn: numOr0(s.best_return),
+      worstReturn: numOr0(s.worst_return),
+      avgWinRate: numOr0(s.avg_win_rate),
+      avgSharpe: numOr0(s.avg_sharpe),
+      avgMDD: numOr0(s.avg_mdd),
+      avgPF: numOr0(s.avg_pf),
+      totalTrades: s.total_trades,
+      lastRunAt: s.last_run_at,
+    }
+    if (s.entry_type === 'shared') {
+      const strat = stratMap.get(s.entry_id)
+      if (!strat) continue   // 공유 해제됐거나 삭제된 전략
+      const user = userMap.get(strat.user_id)
+      items.push({
+        type: 'shared',
+        strategyId: strat.id,
+        name: strat.name,
+        description: strat.description,
+        targetMarket: strat.target_market,
+        authorAlias: anonymize(strat.share_alias, user?.name, user?.hospital_name),
+        sharedAt: strat.shared_at,
+        cloneCount: Number(strat.clone_count ?? 0),
+        isMine: strat.user_id === auth.user.id,
+        ...base,
+      })
+    } else {
+      const preset = PRESET_STRATEGIES.find(p => p.id === s.entry_id)
+      if (!preset) continue
+      items.push({
+        type: 'preset',
+        presetId: preset.id,
+        name: preset.name,
+        description: preset.description,
+        targetMarket: s.market,
+        authorAlias: '공식 프리셋',
+        sharedAt: null,
+        cloneCount: cloneCountByPreset.get(preset.id) ?? 0,
+        isMine: false,
+        ...base,
+      })
+    }
   }
 
   // 5. 정렬 (sortBy 기준 내림차순. avgMDD 만 오름차순(낮을수록 좋음))
@@ -283,7 +219,7 @@ export async function GET(req: NextRequest) {
 
   return NextResponse.json({
     data: items.slice(0, limit),
-    totalShared: shared.length,
+    totalShared: sharedStrats.length,
     totalPresets: PRESET_STRATEGIES.length,
     rankedCount: items.length,
     sharedItemsCount,
@@ -295,9 +231,10 @@ export async function GET(req: NextRequest) {
 // 유틸
 // ============================================
 
-function avg(nums: number[]): number {
-  if (nums.length === 0) return 0
-  return nums.reduce((s, v) => s + v, 0) / nums.length
+function numOr0(v: number | null | undefined): number {
+  if (v === null || v === undefined) return 0
+  const n = Number(v)
+  return Number.isFinite(n) ? n : 0
 }
 
 /** 작성자 이름 익명화. share_alias 우선, 없으면 users.name → 마스킹, 없으면 hospital_name → 마스킹, 없으면 '익명'. */

--- a/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
@@ -628,23 +628,30 @@ export default function NewMarketingPostPage() {
                 <span className="ml-2 text-[11px] text-at-text-weak">(경쟁 평균 {seoResult.avgImageCount.toFixed(1)}장)</span>
               )}
             </label>
-            <div className="flex items-center gap-2 flex-wrap">
-              {[0, 1, 2, 3, 4, 5].map((n) => (
-                <button
-                  key={n}
-                  type="button"
-                  onClick={() => setImageCount(n)}
-                  className={`w-9 h-9 rounded-lg text-sm font-semibold transition-colors ${
-                    imageCount === n
-                      ? 'bg-at-accent text-white'
-                      : 'bg-at-surface-alt text-at-text-secondary border border-at-border hover:bg-at-border'
-                  }`}
-                >
-                  {n}
-                </button>
-              ))}
-              <span className="text-xs text-at-text-weak ml-1">
-                {imageCount === 0 ? '이미지 없이 글만 생성' : `최대 ${imageCount}개`}
+            <div className="flex items-center gap-3 flex-wrap">
+              <input
+                type="number"
+                min={0}
+                max={20}
+                value={imageCount}
+                onChange={(e) => {
+                  const v = Number(e.target.value)
+                  if (Number.isNaN(v)) return setImageCount(0)
+                  setImageCount(Math.min(20, Math.max(0, Math.floor(v))))
+                }}
+                className="w-20 h-9 px-2 rounded-lg border border-at-border bg-white text-sm font-semibold text-at-text text-center focus:outline-none focus:ring-2 focus:ring-at-accent"
+              />
+              <input
+                type="range"
+                min={0}
+                max={20}
+                step={1}
+                value={imageCount}
+                onChange={(e) => setImageCount(Number(e.target.value))}
+                className="flex-1 min-w-[160px] max-w-[320px] accent-at-accent cursor-pointer"
+              />
+              <span className="text-xs text-at-text-weak">
+                {imageCount === 0 ? '이미지 없이 글만 생성' : `${imageCount}개 생성 (0~20)`}
               </span>
             </div>
           </div>

--- a/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
+++ b/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
@@ -809,14 +809,31 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
                   </span>
                 )}
               </label>
-              <div className="flex items-center gap-2 flex-wrap">
-                {[0, 1, 2, 3, 4, 5].map((n) => (
-                  <button key={n} type="button" onClick={() => setImageCount(n)}
-                    className={`w-9 h-9 rounded-lg text-sm font-semibold transition-colors ${imageCount === n ? 'bg-at-accent text-white' : 'bg-at-surface-alt text-at-text-secondary border border-at-border hover:bg-at-border'}`}>
-                    {n}
-                  </button>
-                ))}
-                <span className="text-xs text-at-text-weak ml-1">{imageCount === 0 ? '이미지 없이 글만 생성' : `최대 ${imageCount}개`}</span>
+              <div className="flex items-center gap-3 flex-wrap">
+                <input
+                  type="number"
+                  min={0}
+                  max={20}
+                  value={imageCount}
+                  onChange={(e) => {
+                    const v = Number(e.target.value)
+                    if (Number.isNaN(v)) return setImageCount(0)
+                    setImageCount(Math.min(20, Math.max(0, Math.floor(v))))
+                  }}
+                  className="w-20 h-9 px-2 rounded-lg border border-at-border bg-white text-sm font-semibold text-at-text text-center focus:outline-none focus:ring-2 focus:ring-at-accent"
+                />
+                <input
+                  type="range"
+                  min={0}
+                  max={20}
+                  step={1}
+                  value={imageCount}
+                  onChange={(e) => setImageCount(Number(e.target.value))}
+                  className="flex-1 min-w-[160px] max-w-[320px] accent-at-accent cursor-pointer"
+                />
+                <span className="text-xs text-at-text-weak">
+                  {imageCount === 0 ? '이미지 없이 글만 생성' : `${imageCount}개 생성 (0~20)`}
+                </span>
               </div>
             </div>
 

--- a/dental-clinic-manager/src/lib/marketing/image-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/image-generator.ts
@@ -60,6 +60,86 @@ function getVisualStyleInstruction(visualStyle?: ImageVisualStyle): string {
   }
 }
 
+// ─── 클리닉 브랜드 가이드라인 + 디자인 패턴 prefix 생성 ───
+
+interface BrandPromptCtx {
+  name_ko?: string | null;
+  name_en?: string | null;
+  primary_color?: string | null;
+  secondary_color?: string | null;
+  slogan?: string | null;
+}
+
+async function loadBrandPromptContext(clinicId: string): Promise<BrandPromptCtx | null> {
+  const admin = getSupabaseAdmin();
+  if (!admin) return null;
+  const { data } = await (admin as any)
+    .from('clinic_brand_assets')
+    .select('name_ko, name_en, primary_color, secondary_color, slogan')
+    .eq('clinic_id', clinicId)
+    .maybeSingle();
+  return (data as BrandPromptCtx) || null;
+}
+
+/**
+ * 인포그래픽 스타일 카드 이미지의 디자인 패턴(참조: 서울안아프게치과 블로그)을
+ * 클리닉 브랜드 컬러/명칭으로 치환해 프롬프트 prefix 로 생성.
+ * - 정사각형(1:1) 카드 레이아웃
+ * - 상단: 영문 클리닉명을 자간 넓은 작은 헤더로
+ * - 메인: 질문형 굵은 타이틀 + 키워드는 주 브랜드 컬러로 강조
+ * - 중간: 주제 관련 일러스트/사진 영역
+ * - 하단: 주 브랜드 컬러 박스 + 체크리스트(✓) 핵심 포인트
+ * - 푸터: 한글 클리닉명 + 영문 브랜드 자간 텍스트
+ */
+function buildBrandDesignPrefix(ctx: BrandPromptCtx | null, imageStyle?: ImageStyleOption): string {
+  if (!ctx) return '';
+  const nameKo = (ctx.name_ko || '').trim();
+  const nameEn = (ctx.name_en || '').trim();
+  const primary = (ctx.primary_color || '').trim();
+  const secondary = (ctx.secondary_color || '').trim();
+  const slogan = (ctx.slogan || '').trim();
+  if (!nameKo && !nameEn && !primary && !secondary) return '';
+
+  const isInfographic = imageStyle === 'infographic_only';
+
+  const lines: string[] = [];
+  lines.push('## 클리닉 브랜드 가이드라인 (반드시 반영)');
+  if (nameKo) lines.push(`- 클리닉명(한글): ${nameKo}`);
+  if (nameEn) lines.push(`- 클리닉명(영문): ${nameEn}`);
+  if (primary) lines.push(`- 주 브랜드 컬러(메인 강조): ${primary}`);
+  if (secondary) lines.push(`- 보조 브랜드 컬러(보조 강조): ${secondary}`);
+  if (slogan) lines.push(`- 슬로건: ${slogan}`);
+  lines.push('- 모든 색상/타이포는 위 브랜드 톤에 맞춰 일관되게 표현');
+
+  if (isInfographic) {
+    lines.push('');
+    lines.push('## 카드 인포그래픽 디자인 패턴 (네이버 블로그 노출용 정사각형 카드)');
+    lines.push('정사각형(1:1) 카드 한 장. 다음 4단 레이아웃을 따르세요:');
+    if (nameEn) {
+      lines.push(`1) 최상단: 영문 클리닉명 "${nameEn}" 을 작은 글자·넓은 자간(letter-spacing)으로 가로 중앙 정렬`);
+    } else {
+      lines.push('1) 최상단: 작은 글자의 영문 헤더 (자간 넓게)');
+    }
+    lines.push('2) 메인 타이틀: 환자가 궁금해할 질문형 카피 1~2줄. 굵은 산세리프, 키워드는 주 브랜드 컬러로 강조. 보조 부제 1줄.');
+    lines.push('3) 중간: 주제와 관련된 치과 일러스트/도식/모형 이미지 (사람 얼굴 생성 금지, 깔끔한 의료용 비주얼).');
+    if (primary) {
+      lines.push(`4) 하단: 주 브랜드 컬러(${primary}) 배경 박스 안에 화이트 체크마크(✓) + 핵심 포인트 2~3줄 (불릿 리스트).`);
+    } else {
+      lines.push('4) 하단: 진한 브랜드 컬러 박스 + 체크마크(✓) 핵심 포인트 2~3줄.');
+    }
+    if (nameKo) {
+      lines.push(`5) 최하단 푸터: "${nameKo}" 한글 클리닉명 (작은 글씨, 가운데 정렬). 로고가 있으면 함께 배치.`);
+    }
+    lines.push('');
+    lines.push('## 텍스트 렌더링 주의');
+    lines.push('- 한국어 텍스트는 정확한 한글 폰트(고딕 계열)로 렌더링하고, 자모 깨짐/잘못된 글자 절대 금지.');
+    lines.push('- 이미지 안 텍스트는 짧고 명확하게 — 의미 없는 외국어/가짜 글자 사용 금지.');
+  } else {
+    lines.push('- 사용 색상의 주조: 위 브랜드 컬러를 포인트로 사용 (전체 도배는 피하고 자연스러운 색감).');
+  }
+  return lines.join('\n') + '\n\n';
+}
+
 // ─── 마스터가 설정한 이미지 프롬프트 로딩 (전역 적용) ───
 
 async function loadImagePromptTemplate(clinicId: string, promptKey: string = 'image.blog'): Promise<string | null> {
@@ -132,6 +212,10 @@ export async function generateBlogImage(
   // clinicId 우선순위: 기존 파라미터 > 새 파라미터
   const resolvedClinicId = clinicId || generationClinicId;
 
+  // 클리닉 브랜드 가이드 prefix (주/보조 컬러, 클리닉명, 카드 디자인 패턴)
+  const brandCtx = resolvedClinicId ? await loadBrandPromptContext(resolvedClinicId) : null;
+  const brandPrefix = buildBrandDesignPrefix(brandCtx, imageStyle);
+
   // 마스터 이미지 프롬프트 템플릿 적용
   let fullPrompt: string;
 
@@ -149,6 +233,9 @@ export async function generateBlogImage(
   } else {
     fullPrompt = buildDefaultImagePrompt(prompt);
   }
+
+  // 브랜드 가이드라인은 항상 최상단에 prepend (마스터 템플릿/폴백 둘 다 적용)
+  if (brandPrefix) fullPrompt = brandPrefix + fullPrompt;
 
   // 이미지 스타일 지침 추가
   fullPrompt += getImageStyleInstruction(imageStyle);
@@ -209,6 +296,10 @@ export async function generatePlatformImage(
   const styleInstruction = getImageStyleInstruction(imageStyle);
   const visualInstruction = getVisualStyleInstruction(imageVisualStyle);
 
+  // 클리닉 브랜드 가이드 prefix
+  const brandCtx = generationClinicId ? await loadBrandPromptContext(generationClinicId) : null;
+  const brandPrefix = buildBrandDesignPrefix(brandCtx, imageStyle);
+
   // 마스터 프롬프트 템플릿 적용 (플랫폼 이미지에도 마스터 스타일 가이드 반영)
   let fullPrompt: string;
   if (generationClinicId) {
@@ -222,6 +313,7 @@ export async function generatePlatformImage(
   } else {
     fullPrompt = `${platformStyle}\n\n치과 블로그 주제: ${prompt}`;
   }
+  if (brandPrefix) fullPrompt = brandPrefix + fullPrompt;
   fullPrompt += styleInstruction + visualInstruction;
 
   const provider = await getImageProvider();

--- a/dental-clinic-manager/src/lib/psychology/llmClient.ts
+++ b/dental-clinic-manager/src/lib/psychology/llmClient.ts
@@ -177,6 +177,13 @@ function computeFearGreedSeries(snapshot: PsychologyInputSnapshot): number[] {
   }
 }
 
+/** 큰 거래량(US 대형주는 분당 수백만)을 K/M 단위로 압축해 프롬프트 토큰을 절약 */
+function fmtVolume(v: number): string {
+  if (!Number.isFinite(v) || v < 1000) return String(v)
+  if (v < 1_000_000) return `${Math.round(v / 100) / 10}K`
+  return `${Math.round(v / 100_000) / 10}M`
+}
+
 function buildUserPrompt(args: AnalyzeArgs, fearGreed: number[]): string {
   const { ticker, market, triggerKind, triggerDetail, snapshot, asOf } = args
   // 모든 ts 를 KST 로 통일해 LLM 에 전달 — 본문에서도 KST 시각을 사용하게 됨.
@@ -185,7 +192,7 @@ function buildUserPrompt(args: AnalyzeArgs, fearGreed: number[]): string {
     const tsStr = kst?.iso ?? c.ts
     const fg = fearGreed[i]
     const fgStr = (typeof fg === 'number' && !Number.isNaN(fg)) ? ` F=${Math.round(fg)}` : ''
-    return `[${i}] ${tsStr} O=${c.open} H=${c.high} L=${c.low} C=${c.close} V=${c.volume}${fgStr}`
+    return `[${i}] ${tsStr} O=${c.open} H=${c.high} L=${c.low} C=${c.close} V=${fmtVolume(c.volume)}${fgStr}`
   }).join('\n')
   const orderbookSummary = snapshot.orderbook
     ? `호가 (10단계): 매수총잔량=${snapshot.orderbook.totalBidQty}, 매도총잔량=${snapshot.orderbook.totalAskQty}\n` +
@@ -222,12 +229,14 @@ export async function analyzePsychology(args: AnalyzeArgs): Promise<AnalyzeResul
 
   const fearGreedSeries = computeFearGreedSeries(args.snapshot)
   const userPrompt = buildUserPrompt(args, fearGreedSeries)
+  // US 종목은 분당 거래량 수백만으로 candleLines 가 길어 narrative 출력 토큰이 부족할 수 있음 → 한도 상향
+  const maxTokens = args.market === 'US' ? 1800 : 1200
   const start = Date.now()
 
   for (let attempt = 0; attempt < 2; attempt++) {
     const res = await client.messages.create({
       model: MODEL_ID,
-      max_tokens: 1200,
+      max_tokens: maxTokens,
       temperature: 0.3,
       system: SYSTEM_PROMPT,
       tools: [TOOL_DEFINITION],
@@ -263,7 +272,21 @@ export async function analyzePsychology(args: AnalyzeArgs): Promise<AnalyzeResul
     const validLabel: ScoreLabel = (VALID_SCORE_LABELS as readonly string[]).includes(parsed.data.score_label)
       ? parsed.data.score_label as ScoreLabel
       : deriveScoreLabel(parsed.data.psychology_score)
-    const baseNarrative = parsed.data.narrative.trim() ||
+    // narrative 비면 진단용 경고 + 점수 기반 기본 문장. attempt=0 일 땐 재시도로 회복 시도.
+    const narrativeTrim = parsed.data.narrative.trim()
+    if (!narrativeTrim && attempt === 0) {
+      console.warn('[psychology llm] empty narrative on first attempt, retrying', {
+        ticker: args.ticker, market: args.market,
+        score: parsed.data.psychology_score, markers: cleanMarkers.length,
+      })
+      continue
+    }
+    if (!narrativeTrim) {
+      console.warn('[psychology llm] empty narrative on final attempt — using fallback', {
+        ticker: args.ticker, market: args.market, score: parsed.data.psychology_score,
+      })
+    }
+    const baseNarrative = narrativeTrim ||
       `심리 점수 ${parsed.data.psychology_score} (${validLabel}). 모델이 상세 해설을 생성하지 못해 기본 정보만 표시합니다.`
 
     // 안전망 (2단):

--- a/dental-clinic-manager/src/lib/smartMoney/sessionAnalyzer.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/sessionAnalyzer.ts
@@ -62,9 +62,19 @@ function parseDateTime(raw: string, market: 'KR' | 'US'): ParsedDateTime | null 
     ) {
       // 시장 로컬타임으로 가정. UTC epoch는 시장 오프셋 보정.
       // KR=+9, US ET=정확한 DST 계산 (3월 둘째 일요일 ~ 11월 첫째 일요일 EDT -4, 그 외 EST -5).
-      // tentative 한 UTC date 를 만들어 isUsDst 로 정확한 offset 판정 — DST 전환 시각 ±1h 윈도우 외에는 정확.
-      const tentative = new Date(Date.UTC(year, mon - 1, day, hour, min))
-      const offsetHr = market === 'KR' ? 9 : (isUsDst(tentative) ? -4 : -5)
+      //
+      // DST 경계 보정: ET wall-clock 를 무작정 UTC 로 간주해 isUsDst() 에 넣으면
+      // DST 시작일 03:00~07:59 ET (= UTC 같은 숫자) 가 dstStart(07:00 UTC) 미만이라
+      // EST 로 잘못 판정됨. EDT/EST 두 후보 UTC 를 각각 만들어 어느 쪽이 자기 일관성을 갖는지로 결정.
+      let offsetHr: number
+      if (market === 'KR') {
+        offsetHr = 9
+      } else {
+        // EDT 가정 — local hour + 4 가 UTC 시각
+        const utcIfEdt = Date.UTC(year, mon - 1, day, hour + 4, min)
+        // 그 UTC 시각이 실제로 DST 기간 안인지 확인 (자기 일관성)
+        offsetHr = isUsDst(new Date(utcIfEdt)) ? -4 : -5
+      }
       const utcMs = Date.UTC(year, mon - 1, day, hour - offsetHr, min)
       return {
         epochMs: utcMs,

--- a/dental-clinic-manager/src/lib/smartMoney/smartMoneyScorer.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/smartMoneyScorer.ts
@@ -5,15 +5,17 @@
  *   investorFlow 25 / wyckoffPhase 20 / marketStructure 15 / liquidity 10
  *   VSA 10 / algoFootprint 10 / 단일봉 Wyckoff 5 / VWAP 5
  *
- * ※ investorFlow 가중치는 미국 종목 / KR KIS 미연결 시 자동으로 나머지 7개 컴포넌트에
- *   비례 재분배되어 ±100 범위 유지.
+ * ※ investorFlow 가중치는 미국 종목 / KR KIS 미연결 시 0 으로 잡혀 사실상 ±75 만점.
+ *   시장 간 라벨(strong/mild) 임계값을 일관되게 유지하기 위해 의도된 한계 — UI 가
+ *   investorFlow=null 일 때 "수급 데이터 없음 (±25 가중)" 안내를 노출해야 함.
  *
  * 트랩 모디파이어:
  *   bull-trap + score>0 → score *= 0.7
  *   bear-trap + score<0 → score *= 0.7
  *
  * manipulationRiskScore (0~100):
- *   trap 감지 +40, news pattern +30, climax 신호 +20, no-demand/supply +10 (clamp)
+ *   trap 감지 +40, climax 신호 +20, no-demand/supply +10 (clamp)
+ *   ※ news pattern (+30/+20) 은 NEWS_INTEGRATION_ACTIVE=false 동안 비활성화.
  */
 
 import type {
@@ -58,6 +60,13 @@ export interface ScorerOutput {
   /** 0~100 — 시장 조작 위험도 (UI 노출용) */
   manipulationRiskScore: number
 }
+
+/**
+ * 뉴스 데이터 통합(getNewsEventsForTicker) 활성화 플래그.
+ * 현재는 false 라 news pattern 가중치/시그널이 모두 비활성화. 통합 후 true 로 켜면
+ * 기존 로직이 그대로 활성화되고 응답 메타에 newsSignalIntegration='active' 노출.
+ */
+export const NEWS_INTEGRATION_ACTIVE = false
 
 const WEIGHTS = {
   investorFlow: 25,
@@ -422,10 +431,9 @@ export function computeSmartMoneyScore(input: ScorerInput): ScorerOutput {
     }
   }
 
-  // NOTE: newsContext 기반 signalDetail 은 현재 동작하지 않는다 —
-  // route.ts 에서 newsEvents: [] 로 호출하므로 analyzeNewsContext 가 항상 null pattern을 반환.
-  // 뉴스 데이터 통합(getNewsEventsForTicker) 구현 후 활성화 예정. 로직은 그대로 유지.
-  if (newsContext && newsContext.pattern) {
+  // newsContext signalDetail 은 NEWS_INTEGRATION_ACTIVE=false 면 push 자체를 차단.
+  // 향후 뉴스 통합 시 플래그만 켜면 활성화되도록 로직은 그대로 유지.
+  if (NEWS_INTEGRATION_ACTIVE && newsContext && newsContext.pattern) {
     signalDetails.push({
       type: newsContext.pattern,
       confidence: 70,
@@ -459,22 +467,19 @@ export function computeSmartMoneyScore(input: ScorerInput): ScorerOutput {
   // ============================================
   // 종합 점수
   // ============================================
-  const otherComponents =
-    wyckoffPhaseComponent
+  // investorFlow=null (US 종목/KR limited-mode) 시 flowComponent=0 이라 ±75 만점이 된다.
+  // 종전엔 rebalanceFactor=100/75 로 ±100 까지 스케일업했으나, 그렇게 하면 trap modifier(0.7)
+  // 와 interpretation threshold(±30/±60) 가 시장 간 비대칭으로 작동해 같은 라벨이
+  // 다른 기준으로 부여되는 문제가 있었음. → Codex review 권고에 따라 동등 라벨 기준 우선.
+  let rawScore =
+    flowComponent
+    + wyckoffPhaseComponent
     + structureComponent
     + liquidityComponent
     + vsaComponent
     + algoComponent
     + wyckoffComponent
     + vwapComponent
-
-  // investorFlow가 null(미국 종목/KR limited-mode)이면 나머지 75 가중치를 100으로 정규화 — 만점 범위 동일하게 유지
-  const FLOW_WEIGHT = 25
-  const TOTAL_WEIGHT = 100
-  const rebalanceFactor = investorFlow === null
-    ? TOTAL_WEIGHT / (TOTAL_WEIGHT - FLOW_WEIGHT)
-    : 1
-  let rawScore = (flowComponent + otherComponents) * rebalanceFactor
 
   // 트랩 모디파이어
   if (traps?.bullTrapDetected && rawScore > 0) {
@@ -496,12 +501,12 @@ export function computeSmartMoneyScore(input: ScorerInput): ScorerOutput {
   // ============================================
   // 조작 위험도 점수 (manipulationRiskScore)
   // ============================================
+  // 뉴스 데이터 통합 전까지 news pattern 가중치 비활성화 (모듈 레벨 NEWS_INTEGRATION_ACTIVE 참조).
   let manipRisk = 0
   if (traps?.bullTrapDetected) manipRisk += 40
   if (traps?.bearTrapDetected) manipRisk += 40
-  // TODO: 활성화는 뉴스 데이터 통합(getNewsEventsForTicker) 구현 후 — 현재 newsEvents 가 빈 배열이라 항상 null pattern.
-  if (newsContext?.pattern === 'news-fade') manipRisk += 30
-  if (newsContext?.pattern === 'sell-the-news') manipRisk += 20
+  if (NEWS_INTEGRATION_ACTIVE && newsContext?.pattern === 'news-fade') manipRisk += 30
+  if (NEWS_INTEGRATION_ACTIVE && newsContext?.pattern === 'sell-the-news') manipRisk += 20
   if (vsa?.signals.some((s) => s.type === 'buying-climax' || s.type === 'selling-climax')) manipRisk += 20
   if (vsa?.signals.some((s) => s.type === 'no-demand' || s.type === 'no-supply')) manipRisk += 10
   if (session?.judasSwingDetected) manipRisk += 15

--- a/dental-clinic-manager/supabase/migrations/20260514_strategy_ranking_stats.sql
+++ b/dental-clinic-manager/supabase/migrations/20260514_strategy_ranking_stats.sql
@@ -1,0 +1,202 @@
+-- ============================================
+-- 전략 랭킹 사전 집계 테이블 + 트리거
+--
+-- 목적: 랭킹 API 가 매 호출마다 70k+ rows fetch + JS 집계로 수 초 소요되던 문제 해결.
+-- 백테스트가 완료될 때마다 (entry_type, entry_id, market) 별 통계를 trigger 로
+-- 즉시 재계산해 저장. 랭킹 API 는 이 테이블만 SELECT 하면 됨.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS strategy_ranking_stats (
+  entry_type TEXT NOT NULL CHECK (entry_type IN ('shared', 'preset')),
+  entry_id TEXT NOT NULL,
+  market TEXT NOT NULL CHECK (market IN ('KR', 'US')),
+  runs INTEGER NOT NULL DEFAULT 0,
+  ticker_count INTEGER NOT NULL DEFAULT 0,
+  avg_return NUMERIC,
+  best_return NUMERIC,
+  worst_return NUMERIC,
+  avg_win_rate NUMERIC,
+  avg_sharpe NUMERIC,
+  avg_mdd NUMERIC,
+  avg_pf NUMERIC,
+  total_trades INTEGER NOT NULL DEFAULT 0,
+  last_run_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (entry_type, entry_id, market)
+);
+
+CREATE INDEX IF NOT EXISTS idx_srs_market_avg_return ON strategy_ranking_stats(market, avg_return DESC);
+CREATE INDEX IF NOT EXISTS idx_srs_runs ON strategy_ranking_stats(runs);
+CREATE INDEX IF NOT EXISTS idx_srs_updated ON strategy_ranking_stats(updated_at DESC);
+
+ALTER TABLE strategy_ranking_stats ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "anyone_can_read_ranking_stats" ON strategy_ranking_stats;
+CREATE POLICY "anyone_can_read_ranking_stats" ON strategy_ranking_stats
+  FOR SELECT USING (true);
+
+-- ============================================
+-- backtest_runs INSERT/UPDATE → stats 행 재계산
+-- ============================================
+CREATE OR REPLACE FUNCTION refresh_strategy_ranking_stats() RETURNS TRIGGER AS $$
+DECLARE
+  v_entry_type TEXT;
+  v_entry_id TEXT;
+BEGIN
+  IF NEW.status IS DISTINCT FROM 'completed' THEN
+    RETURN NEW;
+  END IF;
+  IF NEW.market NOT IN ('KR', 'US') THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.strategy_id IS NOT NULL THEN
+    v_entry_type := 'shared';
+    v_entry_id := NEW.strategy_id::TEXT;
+  ELSIF NEW.preset_id IS NOT NULL AND NEW.preset_id NOT IN ('custom', '') THEN
+    v_entry_type := 'preset';
+    v_entry_id := NEW.preset_id;
+  ELSE
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO strategy_ranking_stats (
+    entry_type, entry_id, market,
+    runs, ticker_count,
+    avg_return, best_return, worst_return,
+    avg_win_rate, avg_sharpe, avg_mdd, avg_pf,
+    total_trades, last_run_at, updated_at
+  )
+  SELECT
+    v_entry_type, v_entry_id, NEW.market,
+    COUNT(*),
+    COUNT(DISTINCT ticker),
+    AVG(total_return),
+    MAX(total_return),
+    MIN(total_return),
+    AVG(win_rate),
+    AVG(sharpe_ratio),
+    AVG(max_drawdown),
+    AVG(profit_factor) FILTER (WHERE profit_factor IS NOT NULL AND profit_factor > 0 AND profit_factor < 1e6),
+    COALESCE(SUM(total_trades), 0),
+    MAX(executed_at),
+    NOW()
+  FROM backtest_runs
+  WHERE status = 'completed'
+    AND market = NEW.market
+    AND CASE
+      WHEN v_entry_type = 'shared' THEN strategy_id::TEXT = v_entry_id
+      ELSE preset_id = v_entry_id
+    END
+  ON CONFLICT (entry_type, entry_id, market) DO UPDATE SET
+    runs = EXCLUDED.runs,
+    ticker_count = EXCLUDED.ticker_count,
+    avg_return = EXCLUDED.avg_return,
+    best_return = EXCLUDED.best_return,
+    worst_return = EXCLUDED.worst_return,
+    avg_win_rate = EXCLUDED.avg_win_rate,
+    avg_sharpe = EXCLUDED.avg_sharpe,
+    avg_mdd = EXCLUDED.avg_mdd,
+    avg_pf = EXCLUDED.avg_pf,
+    total_trades = EXCLUDED.total_trades,
+    last_run_at = EXCLUDED.last_run_at,
+    updated_at = NOW();
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_backtest_runs_refresh_ranking_stats ON backtest_runs;
+CREATE TRIGGER trg_backtest_runs_refresh_ranking_stats
+  AFTER INSERT OR UPDATE OF status, total_return, win_rate, sharpe_ratio, max_drawdown, profit_factor, total_trades
+  ON backtest_runs
+  FOR EACH ROW
+  EXECUTE FUNCTION refresh_strategy_ranking_stats();
+
+-- ============================================
+-- 초기 백필 (기존 backtest_runs 일괄 집계)
+-- ============================================
+INSERT INTO strategy_ranking_stats (
+  entry_type, entry_id, market,
+  runs, ticker_count,
+  avg_return, best_return, worst_return,
+  avg_win_rate, avg_sharpe, avg_mdd, avg_pf,
+  total_trades, last_run_at, updated_at
+)
+SELECT
+  'shared',
+  strategy_id::TEXT,
+  market,
+  COUNT(*),
+  COUNT(DISTINCT ticker),
+  AVG(total_return),
+  MAX(total_return),
+  MIN(total_return),
+  AVG(win_rate),
+  AVG(sharpe_ratio),
+  AVG(max_drawdown),
+  AVG(profit_factor) FILTER (WHERE profit_factor IS NOT NULL AND profit_factor > 0 AND profit_factor < 1e6),
+  COALESCE(SUM(total_trades), 0),
+  MAX(executed_at),
+  NOW()
+FROM backtest_runs
+WHERE status = 'completed'
+  AND strategy_id IS NOT NULL
+  AND market IN ('KR', 'US')
+GROUP BY strategy_id, market
+ON CONFLICT (entry_type, entry_id, market) DO UPDATE SET
+  runs = EXCLUDED.runs,
+  ticker_count = EXCLUDED.ticker_count,
+  avg_return = EXCLUDED.avg_return,
+  best_return = EXCLUDED.best_return,
+  worst_return = EXCLUDED.worst_return,
+  avg_win_rate = EXCLUDED.avg_win_rate,
+  avg_sharpe = EXCLUDED.avg_sharpe,
+  avg_mdd = EXCLUDED.avg_mdd,
+  avg_pf = EXCLUDED.avg_pf,
+  total_trades = EXCLUDED.total_trades,
+  last_run_at = EXCLUDED.last_run_at,
+  updated_at = NOW();
+
+INSERT INTO strategy_ranking_stats (
+  entry_type, entry_id, market,
+  runs, ticker_count,
+  avg_return, best_return, worst_return,
+  avg_win_rate, avg_sharpe, avg_mdd, avg_pf,
+  total_trades, last_run_at, updated_at
+)
+SELECT
+  'preset',
+  preset_id,
+  market,
+  COUNT(*),
+  COUNT(DISTINCT ticker),
+  AVG(total_return),
+  MAX(total_return),
+  MIN(total_return),
+  AVG(win_rate),
+  AVG(sharpe_ratio),
+  AVG(max_drawdown),
+  AVG(profit_factor) FILTER (WHERE profit_factor IS NOT NULL AND profit_factor > 0 AND profit_factor < 1e6),
+  COALESCE(SUM(total_trades), 0),
+  MAX(executed_at),
+  NOW()
+FROM backtest_runs
+WHERE status = 'completed'
+  AND preset_id IS NOT NULL
+  AND preset_id NOT IN ('custom', '')
+  AND market IN ('KR', 'US')
+GROUP BY preset_id, market
+ON CONFLICT (entry_type, entry_id, market) DO UPDATE SET
+  runs = EXCLUDED.runs,
+  ticker_count = EXCLUDED.ticker_count,
+  avg_return = EXCLUDED.avg_return,
+  best_return = EXCLUDED.best_return,
+  worst_return = EXCLUDED.worst_return,
+  avg_win_rate = EXCLUDED.avg_win_rate,
+  avg_sharpe = EXCLUDED.avg_sharpe,
+  avg_mdd = EXCLUDED.avg_mdd,
+  avg_pf = EXCLUDED.avg_pf,
+  total_trades = EXCLUDED.total_trades,
+  last_run_at = EXCLUDED.last_run_at,
+  updated_at = NOW();


### PR DESCRIPTION
## Summary
- 전략 랭킹 사전 집계 테이블 + trigger 도입으로 로딩 시간 단축
  (백테스트 시마다 strategy_ranking_stats 행 재계산 → API 는 단일 SELECT)
- TSLA 심리분석 narrative 누락 수정: candle volume K/M 압축, US 종목 max_tokens 1800, empty narrative 재시도 + 경고 로그
- BRK.A 같은 초고가 종목 사전 검증: 1주 가격 > 초기자본 시 명시적 에러
- 직전 누적: 스마트 머니 9개 엔진 결함 일괄 수정, 심리분석 LLM 응답 스키마 안정화

## Test plan
- [ ] /investment/strategies/rankings 페이지 로딩 시간 < 1초 확인
- [ ] 신규 백테스트 실행 후 ranking 페이지에 즉시 반영 확인
- [ ] TSLA 심리분석 narrative 생성 정상 동작
- [ ] BRK.A 백테스트 시 친절한 자본 부족 에러 노출