### PR TITLE
feat(protocol): 검토 반려 후 "수정 후 재검토 요청" 흐름

### DIFF
--- a/dental-clinic-manager/src/components/Protocol/ProtocolDetail.tsx
+++ b/dental-clinic-manager/src/components/Protocol/ProtocolDetail.tsx
@@ -182,11 +182,16 @@ export default function ProtocolDetail({
           }))
         )
       }
+      const wasRejection = !!latestRejectedReview
       setShowReviewRequestModal(false)
       setReviewRequestMessage('')
       await fetchProtocol()
       await fetchPendingReview()
-      await appAlert('검토 요청이 전송되었습니다.')
+      await appAlert(
+        wasRejection
+          ? '수정 내용이 저장되고 재검토 요청이 대표원장에게 전송되었습니다.'
+          : '검토 요청이 전송되었습니다.'
+      )
     } catch (err) {
       setError(err instanceof Error ? err.message : '검토 요청 중 오류가 발생했습니다.')
     } finally {
@@ -574,6 +579,27 @@ export default function ProtocolDetail({
                 <p className="text-xs text-red-500 mt-1">
                   {new Date(latestRejectedReview.reviewed_at || latestRejectedReview.updated_at).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                 </p>
+                {/* 후속 액션: 본문을 수정하거나 곧바로 재검토 요청 (요청 시 대표원장에게 알림 자동 발송) */}
+                {canEdit && !isOwner && (
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <button
+                      onClick={() => onEdit(protocol)}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-at-text-secondary bg-white hover:bg-at-surface-alt rounded-xl border border-at-border transition-colors"
+                      title="본문 수정"
+                    >
+                      <PencilIcon className="h-4 w-4" />
+                      수정하기
+                    </button>
+                    <button
+                      onClick={() => setShowReviewRequestModal(true)}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-xl transition-colors"
+                      title="수정한 내용으로 재검토 요청 (대표원장에게 알림 전송)"
+                    >
+                      <PaperAirplaneIcon className="h-4 w-4" />
+                      수정 후 재검토 요청
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           </div>
@@ -645,25 +671,30 @@ export default function ProtocolDetail({
         />
       )}
 
-      {/* 검토 요청 모달 */}
+      {/* 검토 요청 모달 — 반려 이력이 있으면 "재검토 요청" 컨텍스트로 안내 */}
       {showReviewRequestModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[60] p-4">
           <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
-            <h3 className="text-lg font-bold text-at-text mb-4">프로토콜 검토 요청</h3>
+            <h3 className="text-lg font-bold text-at-text mb-4">
+              {latestRejectedReview ? '프로토콜 재검토 요청' : '프로토콜 검토 요청'}
+            </h3>
             <p className="text-sm text-at-text-secondary mb-4">
-              대표원장에게 &quot;{protocol.title}&quot; 프로토콜의 검토를 요청합니다.
-              승인되면 프로토콜이 활성화됩니다.
+              {latestRejectedReview
+                ? <>수정한 &quot;{protocol.title}&quot; 프로토콜을 대표원장에게 재검토 요청합니다. 요청과 함께 즉시 저장되며, 대표원장에게 알림이 발송됩니다.</>
+                : <>대표원장에게 &quot;{protocol.title}&quot; 프로토콜의 검토를 요청합니다. 승인되면 프로토콜이 활성화됩니다.</>}
             </p>
             <div className="mb-4">
               <label className="block text-sm font-medium text-at-text-secondary mb-1">
-                요청 메시지 (선택)
+                {latestRejectedReview ? '수정 사항 메시지 (선택)' : '요청 메시지 (선택)'}
               </label>
               <textarea
                 value={reviewRequestMessage}
                 onChange={(e) => setReviewRequestMessage(e.target.value)}
                 className="w-full px-3 py-2 border border-at-border rounded-xl text-sm focus:ring-2 focus:ring-at-accent focus:border-at-accent"
                 rows={3}
-                placeholder="검토 시 참고할 내용을 작성해주세요..."
+                placeholder={latestRejectedReview
+                  ? '반려 사유에 따라 어떤 부분을 수정했는지 적어주세요...'
+                  : '검토 시 참고할 내용을 작성해주세요...'}
               />
             </div>
             <div className="flex justify-end gap-3">
@@ -683,7 +714,7 @@ export default function ProtocolDetail({
                 ) : (
                   <PaperAirplaneIcon className="h-4 w-4" />
                 )}
-                검토 요청
+                {latestRejectedReview ? '재검토 요청' : '검토 요청'}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
프로토콜 검토 반려 후 후속 프로세스가 명확하지 않던 문제 해결.
반려 배너 안에 "수정하기" + "수정 후 재검토 요청" 버튼을 추가하고, 재검토 요청 시 대표원장에게 알림이 자동 발송되도록 함.

### 변경
[src/components/Protocol/ProtocolDetail.tsx](src/components/Protocol/ProtocolDetail.tsx)

1. **반려 배너에 후속 액션 버튼 추가** (`canEdit && !isOwner` 조건)
   - **수정하기** — `onEdit(protocol)` 호출 → 기존 편집 화면 진입
   - **수정 후 재검토 요청** — 기존 검토 요청 모달 재사용, 컨텍스트별 안내 분기
2. **모달 안내·버튼 라벨 컨텍스트 분기**
   - 일반 검토 요청 시: "프로토콜 검토 요청"
   - 재검토 요청 시(`latestRejectedReview` 존재): "프로토콜 재검토 요청", "요청과 함께 즉시 저장되며 대표원장에게 알림이 발송됩니다"
3. **성공 메시지 분기** — "수정 내용이 저장되고 재검토 요청이 대표원장에게 전송되었습니다"

### 기존 인프라 재사용 (DB·알림)
- `handleRequestReview()` → `createProtocolReview()` 한 트랜잭션:
  - protocol_reviews 새 행 (status=pending)
  - 이전 pending 자동 반려
  - protocol.status = pending_review
  - current_version_id = 사용자가 수정 후 저장한 가장 최근 버전
- 알림: `getClinicOwnerIds()` → `protocol_review_requested` 알림을 모든 대표원장에게 발송 (`/api/user-notifications`)

### 사용자 흐름
1. 부원장이 검토 요청 → 대표원장 반려 → protocol status 가 draft 로 복귀
2. 부원장이 다시 프로토콜 상세에 들어가면 **반려 사유 배너 + [수정하기] [수정 후 재검토 요청] 버튼** 노출
3. 수정하기 → 편집 → 저장 (current_version 갱신) → 상세로 돌아옴
4. **수정 후 재검토 요청** 클릭 → 모달 → 수정 사항 메시지 입력 → 확인
5. 한 액션으로 (a) 새 protocol_review 저장 (b) status=pending_review (c) 대표원장 알림 발송 완료

## Test plan
- [x] `npm run build` 성공
- [ ] 부원장 계정으로 검토 요청 → 대표원장 계정에서 반려
- [ ] 부원장이 다시 프로토콜 상세 진입 시 반려 배너 + 두 액션 버튼 보이는지
- [ ] 수정하기 클릭 → 편집 후 저장 → 상세 복귀 정상
- [ ] 수정 후 재검토 요청 클릭 → 모달 안내가 "재검토" 컨텍스트로 보이는지
- [ ] 확인 시 protocol status = pending_review, 대표원장에게 알림 도착하는지
- [ ] 대표원장 헤더 종 아이콘에서 알림 클릭 시 해당 프로토콜로 이동하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)