### PR TITLE
fix(seo): 경쟁글 분석 1·2위 누락 + 이미지 과집계 수정

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/package.json
+++ b/dental-clinic-manager/marketing-worker/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hayan-marketing-worker",
-  "version": "1.1.102",
+  "version": "1.1.103",
   "description": "하얀치과 마케팅 워커 - Electron 데스크탑 앱",
   "productName": "클리닉 매니저 워커",
   "private": true,

--- a/dental-clinic-manager/marketing-worker/electron/src/seo-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/seo-bridge.ts
@@ -189,6 +189,25 @@ async function processKeywordAnalysis(job: SeoJob, page: any): Promise<void> {
       }
     };
 
+    const normalizePostUrl = (href: string): string => {
+      try {
+        const u = new URL(href);
+        if (u.pathname.includes('PostView.naver')) {
+          const blogId = u.searchParams.get('blogId');
+          const logNo = u.searchParams.get('logNo');
+          if (blogId && logNo) {
+            return `https://blog.naver.com/${blogId}/${logNo}`;
+          }
+        }
+        if (u.hostname === 'm.blog.naver.com') {
+          u.hostname = 'blog.naver.com';
+        }
+        return u.toString();
+      } catch {
+        return href;
+      }
+    };
+
     const candidates = [
       '.title_area a',
       '.api_txt_lines.total_tit',
@@ -205,8 +224,10 @@ async function processKeywordAnalysis(job: SeoJob, page: any): Promise<void> {
       const items = document.querySelectorAll(sel);
       let hit = 0;
       items.forEach((el: Element) => {
-        const href = (el as HTMLAnchorElement).href;
-        if (!href || !href.includes('blog.naver.com') || seen.has(href) || urls.length >= 5) return;
+        const rawHref = (el as HTMLAnchorElement).href;
+        if (!rawHref || !rawHref.includes('blog.naver.com') || urls.length >= 5) return;
+        const href = normalizePostUrl(rawHref);
+        if (seen.has(href)) return;
         if (!isValidPostUrl(href)) {
           rejected++;
           return;
@@ -294,18 +315,72 @@ async function processCompetitorCompare(job: SeoJob, page: any): Promise<void> {
   if (!myPostUrl) throw new Error('myPostUrl이 필요합니다');
 
   // 1. 경쟁 글 분석
-  const searchUrl = `https://search.naver.com/search.naver?ssc=tab.blog.all&query=${encodeURIComponent(keyword)}`;
+  const searchUrl = `https://search.naver.com/search.naver?ssc=tab.blog.all&where=blog&query=${encodeURIComponent(keyword)}`;
   await page.goto(searchUrl, { waitUntil: 'domcontentloaded', timeout: 30000 });
   await page.waitForTimeout(2000);
 
   const postUrls: string[] = await page.evaluate(() => {
-    const links: string[] = [];
-    document.querySelectorAll('.title_area a, .api_txt_lines.total_tit').forEach((el: Element) => {
-      const href = (el as HTMLAnchorElement).href;
-      if (href && href.includes('blog.naver.com') && links.length < 5) {
-        links.push(href);
+    const isValidPostUrl = (href: string): boolean => {
+      try {
+        const u = new URL(href);
+        if (!u.hostname.endsWith('blog.naver.com')) return false;
+        if (u.hostname === 'section.blog.naver.com') return false;
+        if (u.pathname.includes('PostView.naver')) {
+          return !!(u.searchParams.get('blogId') && u.searchParams.get('logNo'));
+        }
+        const seg = u.pathname.split('/').filter(Boolean);
+        if (seg.length < 2) return false;
+        const [blogId, postId] = seg;
+        if (!blogId || blogId.endsWith('.naver')) return false;
+        return /^\d+$/.test(postId);
+      } catch {
+        return false;
       }
-    });
+    };
+
+    const normalizePostUrl = (href: string): string => {
+      try {
+        const u = new URL(href);
+        if (u.pathname.includes('PostView.naver')) {
+          const blogId = u.searchParams.get('blogId');
+          const logNo = u.searchParams.get('logNo');
+          if (blogId && logNo) {
+            return `https://blog.naver.com/${blogId}/${logNo}`;
+          }
+        }
+        if (u.hostname === 'm.blog.naver.com') {
+          u.hostname = 'blog.naver.com';
+        }
+        return u.toString();
+      } catch {
+        return href;
+      }
+    };
+
+    const selectors = [
+      '.title_area a',
+      '.api_txt_lines.total_tit',
+      'a.title_link',
+      '.bx .title_area a',
+      '.lst_total a[href*="blog.naver.com"]',
+      'a[href*="blog.naver.com"]',
+    ];
+    const seen = new Set<string>();
+    const links: string[] = [];
+
+    for (const sel of selectors) {
+      const items = document.querySelectorAll(sel);
+      items.forEach((el: Element) => {
+        const rawHref = (el as HTMLAnchorElement).href;
+        if (!rawHref || !rawHref.includes('blog.naver.com') || links.length >= 5) return;
+        const href = normalizePostUrl(rawHref);
+        if (seen.has(href) || !isValidPostUrl(href)) return;
+        seen.add(href);
+        links.push(href);
+      });
+      if (links.length >= 5) break;
+    }
+
     return links;
   });
 
@@ -371,7 +446,57 @@ async function scrapeAndAnalyzePost(page: any, url: string, keyword: string, ran
       clone.querySelectorAll('script, style, noscript').forEach((n) => n.remove());
       bodyText = (clone.textContent || '').replace(/\s+/g, ' ').trim();
     }
-    const images = document.querySelectorAll('.se-image-resource, img[id^="img"]');
+    const collectContentImageSources = (): string[] => {
+      const bodyEl = document.querySelector('.se-main-container, #postViewArea');
+      if (!bodyEl) return [];
+
+      const candidates = bodyEl.querySelectorAll('img');
+      const sources = new Set<string>();
+
+      candidates.forEach((img) => {
+        const src =
+          img.getAttribute('data-lazy-src') ||
+          img.getAttribute('data-src') ||
+          img.getAttribute('src') ||
+          '';
+        const normalizedSrc = src.trim();
+        if (!normalizedSrc || normalizedSrc.startsWith('data:')) return;
+
+        const widthAttr = Number(img.getAttribute('width') || '0');
+        const heightAttr = Number(img.getAttribute('height') || '0');
+        const naturalWidth = (img as HTMLImageElement).naturalWidth || 0;
+        const naturalHeight = (img as HTMLImageElement).naturalHeight || 0;
+        const width = naturalWidth || widthAttr;
+        const height = naturalHeight || heightAttr;
+        if ((width > 0 && width < 80) || (height > 0 && height < 80)) return;
+
+        const className = (img.getAttribute('class') || '').toLowerCase();
+        const alt = (img.getAttribute('alt') || '').toLowerCase();
+        if (
+          className.includes('emoji') ||
+          className.includes('icon') ||
+          className.includes('sticker') ||
+          alt.includes('emoji') ||
+          alt.includes('icon')
+        ) {
+          return;
+        }
+
+        if (
+          /\/(profile|thumbnail|thumb|icon|emoji|sticker|map|marker)\b/i.test(normalizedSrc) ||
+          normalizedSrc.includes('staticmap') ||
+          normalizedSrc.includes('/MapService/')
+        ) {
+          return;
+        }
+
+        sources.add(normalizedSrc);
+      });
+
+      return [...sources];
+    };
+
+    const images = collectContentImageSources();
     const videos = document.querySelectorAll('iframe[src*="youtube"], iframe[src*="tv.naver"], .se-video');
     const headings = document.querySelectorAll('.se-text-paragraph-align- .se-text-paragraph span[style*="font-size: 2"], h2, h3, h4');
     const paragraphs = document.querySelectorAll('.se-text-paragraph, p');

--- a/dental-clinic-manager/seo-worker/src/analyzer/naverScraper.ts
+++ b/dental-clinic-manager/seo-worker/src/analyzer/naverScraper.ts
@@ -49,59 +49,106 @@ export async function searchNaverBlog(keyword: string): Promise<ScrapedPost[]> {
       const results: { title: string; postUrl: string; blogUrl: string; blogName: string }[] = [];
       const seenUrls = new Set<string>();
 
-      // 모든 blog.naver.com 링크 중 글 URL 패턴(blogid/postnum)인 것을 찾기
-      const allLinks = document.querySelectorAll('a[href*="blog.naver.com"]');
-
-      allLinks.forEach((a) => {
-        const href = a.getAttribute('href') || '';
-        const text = (a.textContent || '').trim();
-
-        // 글 URL 패턴 확인 (blog.naver.com/blogid/숫자)
-        const postMatch = href.match(/blog\.naver\.com\/([^/?#]+)\/(\d+)/);
-        if (!postMatch) return;
-
-        // 제목 텍스트가 충분히 긴 링크만 (5자 이상, 미리보기 텍스트는 보통 더 김)
-        if (text.length < 5 || text.length > 200) return;
-
-        // 이미 수집된 URL 건너뜀
-        if (seenUrls.has(href)) return;
-
-        // 미리보기/본문 스니펫 링크 제외 - 제목 링크만 선택
-        // 제목 링크는 보통 상위 컨테이너에서 첫 번째로 등장하는 짧은 텍스트
-        const parentText = (a.parentElement?.textContent || '').trim();
-        // 본문 미리보기 링크는 텍스트가 매우 길다 (60자 이상)
-        if (text.length > 60) return;
-
-        seenUrls.add(href);
-
-        const blogId = postMatch[1];
-        const blogUrl = `https://blog.naver.com/${blogId}`;
-
-        // 블로그명 찾기 - 상위 요소에서 blogid 링크 중 글이 아닌 것
-        let blogName = blogId;
-        let container = a.parentElement;
-        for (let i = 0; i < 15 && container; i++) {
-          container = container.parentElement;
+      const isValidPostUrl = (href: string): boolean => {
+        try {
+          const u = new URL(href);
+          if (!u.hostname.endsWith('blog.naver.com')) return false;
+          if (u.hostname === 'section.blog.naver.com') return false;
+          if (u.pathname.includes('PostView.naver')) {
+            return !!(u.searchParams.get('blogId') && u.searchParams.get('logNo'));
+          }
+          const seg = u.pathname.split('/').filter(Boolean);
+          if (seg.length < 2) return false;
+          const [blogId, postId] = seg;
+          if (!blogId || blogId.endsWith('.naver')) return false;
+          return /^\d+$/.test(postId);
+        } catch {
+          return false;
         }
-        if (container) {
-          const nameLinks = container.querySelectorAll(`a[href*="blog.naver.com/${blogId}"]`);
-          nameLinks.forEach((nl) => {
-            const nlHref = nl.getAttribute('href') || '';
-            const nlText = (nl.textContent || '').trim();
-            // 글 URL이 아닌 블로그 홈 URL이고 텍스트가 있으면 블로그명
-            if (!nlHref.match(/\/\d+$/) && nlText.length > 0 && nlText.length < 50) {
-              blogName = nlText;
+      };
+
+      const normalizePostUrl = (href: string): string => {
+        try {
+          const u = new URL(href);
+          if (u.pathname.includes('PostView.naver')) {
+            const blogId = u.searchParams.get('blogId');
+            const logNo = u.searchParams.get('logNo');
+            if (blogId && logNo) {
+              return `https://blog.naver.com/${blogId}/${logNo}`;
             }
+          }
+          if (u.hostname === 'm.blog.naver.com') {
+            u.hostname = 'blog.naver.com';
+          }
+          return u.toString();
+        } catch {
+          return href;
+        }
+      };
+
+      const getBlogId = (href: string): string | null => {
+        try {
+          const u = new URL(href);
+          if (u.pathname.includes('PostView.naver')) return u.searchParams.get('blogId');
+          const seg = u.pathname.split('/').filter(Boolean);
+          return seg[0] || null;
+        } catch {
+          return null;
+        }
+      };
+
+      const selectors = [
+        '.title_area a',
+        '.api_txt_lines.total_tit',
+        'a.title_link',
+        '.bx .title_area a',
+        '.lst_total a[href*="blog.naver.com"]',
+        'a[href*="blog.naver.com"]',
+      ];
+
+      for (const selector of selectors) {
+        const links = document.querySelectorAll(selector);
+        for (const link of links) {
+          const rawHref = (link as HTMLAnchorElement).href || '';
+          const text = (link.textContent || '').trim().replace(/\s+/g, ' ');
+          if (!rawHref || !rawHref.includes('blog.naver.com')) continue;
+          if (results.length >= 5) break;
+
+          const postUrl = normalizePostUrl(rawHref);
+          if (seenUrls.has(postUrl) || !isValidPostUrl(postUrl)) continue;
+          if (text.length < 3 || text.length > 200) continue;
+
+          seenUrls.add(postUrl);
+
+          const blogId = getBlogId(postUrl);
+          const blogUrl = blogId ? `https://blog.naver.com/${blogId}` : '';
+          let blogName = blogId || '';
+
+          const resultRoot =
+            link.closest('[class*="bx"], [class*="fds-"], [class*="view_wrap"], li') ||
+            link.parentElement;
+          if (resultRoot && blogId) {
+            const nameCandidates = resultRoot.querySelectorAll('a[href*="blog.naver.com"]');
+            for (const nameLink of nameCandidates) {
+              const nameHref = (nameLink as HTMLAnchorElement).href || '';
+              const nameText = (nameLink.textContent || '').trim();
+              if (!nameText || nameText === text || nameText.length > 50) continue;
+              if (!nameHref.includes(`blog.naver.com/${blogId}`)) continue;
+              if (isValidPostUrl(normalizePostUrl(nameHref))) continue;
+              blogName = nameText;
+              break;
+            }
+          }
+
+          results.push({
+            title: text,
+            postUrl,
+            blogUrl,
+            blogName: blogName || blogId || '',
           });
         }
-
-        results.push({
-          title: text,
-          postUrl: href,
-          blogUrl,
-          blogName,
-        });
-      });
+        if (results.length >= 5) break;
+      }
 
       return results;
     });
@@ -177,11 +224,7 @@ export async function scrapePostDetail(postUrl: string): Promise<PostDetail> {
     ]);
 
     // 이미지 수 (콘텐츠 이미지만 카운트 — 지도 타일, UI 아이콘 제외)
-    const imageCount = await countElements(contentPage, [
-      '.se-main-container img.se-image-resource',
-      '.se-module-image img',
-      '#postViewArea img[src*="postfiles"], #postViewArea img[src*="blogfiles"]',
-    ]);
+    const imageCount = await countContentImages(contentPage);
 
     // 동영상 수
     const videoCount = await countElements(contentPage, [
@@ -346,6 +389,62 @@ async function countElements(page: Page, selectors: string[]): Promise<number> {
     }
   }
   return maxCount;
+}
+
+async function countContentImages(page: Page): Promise<number> {
+  try {
+    return await page.evaluate(() => {
+      const bodyEl = document.querySelector('.se-main-container, #postViewArea, .post-view');
+      if (!bodyEl) return 0;
+
+      const images = bodyEl.querySelectorAll('img');
+      const sources = new Set<string>();
+
+      images.forEach((img) => {
+        const src =
+          img.getAttribute('data-lazy-src') ||
+          img.getAttribute('data-src') ||
+          img.getAttribute('src') ||
+          '';
+        const normalizedSrc = src.trim();
+        if (!normalizedSrc || normalizedSrc.startsWith('data:')) return;
+
+        const widthAttr = Number(img.getAttribute('width') || '0');
+        const heightAttr = Number(img.getAttribute('height') || '0');
+        const naturalWidth = (img as HTMLImageElement).naturalWidth || 0;
+        const naturalHeight = (img as HTMLImageElement).naturalHeight || 0;
+        const width = naturalWidth || widthAttr;
+        const height = naturalHeight || heightAttr;
+        if ((width > 0 && width < 80) || (height > 0 && height < 80)) return;
+
+        const className = (img.getAttribute('class') || '').toLowerCase();
+        const alt = (img.getAttribute('alt') || '').toLowerCase();
+        if (
+          className.includes('emoji') ||
+          className.includes('icon') ||
+          className.includes('sticker') ||
+          alt.includes('emoji') ||
+          alt.includes('icon')
+        ) {
+          return;
+        }
+
+        if (
+          /\/(profile|thumbnail|thumb|icon|emoji|sticker|map|marker)\b/i.test(normalizedSrc) ||
+          normalizedSrc.includes('staticmap') ||
+          normalizedSrc.includes('/MapService/')
+        ) {
+          return;
+        }
+
+        sources.add(normalizedSrc);
+      });
+
+      return sources.size;
+    });
+  } catch {
+    return 0;
+  }
 }
 
 async function countParagraphs(page: Page): Promise<number> {


### PR DESCRIPTION
## Summary
사용자 보고: "1, 2위 글들 분석 자체가 진행 안 되고, 이미지 갯수가 실제보다 과하게 나옴" — Codex 가 두 원인을 동시에 수정.

### 1) 1·2위 누락 (URL 정규화 누락)
- 네이버 검색 결과에서 `PostView.naver?blogId&logNo`, `m.blog.naver.com/{blogId}/{logNo}` 형태가 표준 본문 URL로 정규화되지 않아 일부 상위 결과가 탈락하던 문제
- `normalizePostUrl` 추가: PostView.naver → /{blogId}/{logNo} 변환, m.blog.naver.com → blog.naver.com 통일

### 2) 이미지 과집계
- 본문 컨테이너 내 모든 `<img>` 를 셈하면서 아이콘/이모지/스티커/지도 마커/프로필 썸네일/중복 src 까지 포함되어 실제 본문 이미지보다 훨씬 많이 잡힘
- `collectContentImageSources` 추가:
  - `data:` URI 제외
  - 80px 미만 작은 이미지 제외
  - class/alt 의 emoji/icon/sticker 제외
  - src 경로의 profile/thumbnail/icon/emoji/sticker/map/marker/staticmap/MapService 제외
  - Set 으로 중복 src 제거

### 적용 범위
- `marketing-worker/electron/src/seo-bridge.ts`
- `seo-worker/src/analyzer/naverScraper.ts`
- 워커 버전 `1.1.102 → 1.1.103`

## Test plan
- [x] 메인 앱 빌드 통과
- [x] 워커 tsc 통과 (dist/seo-bridge.js 에 `collectContentImageSources` / `normalizePostUrl` 컴파일 확인)
- [ ] 사용자 워커 업데이트 후 키워드 재분석 → 1·2위 본문 정상 추출 + 이미지 개수 정확 확인

🤖 Generated with [Codex](https://github.com/openai/codex) + [Claude Code](https://claude.com/claude-code)