### PR TITLE
feat(marketing): AI 글쓰기 기본값/초기화/키워드 mismatch/스타일 자동 sync + 단체 문자 스키마

### DIFF
--- a/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
@@ -98,22 +98,27 @@ export default function NewMarketingPostPage() {
   const [topic, setTopic] = useState('')
   const [keyword, setKeyword] = useState('')
   const [postType, setPostType] = useState<PostType>('informational')
-  const [tone, setTone] = useState<ToneType>('friendly')
-  const [useResearch, setUseResearch] = useState(false)
-  const [factCheck, setFactCheck] = useState(false)
+  const [tone, setTone] = useState<ToneType>('polite')
+  const [useResearch, setUseResearch] = useState(true)
+  const [factCheck, setFactCheck] = useState(true)
   const [platforms, setPlatforms] = useState<PlatformOptions>(DEFAULT_PLATFORM_PRESETS.informational)
   const [imageStyle, setImageStyle] = useState<ImageStyleOption>('infographic_only')
   const [imageVisualStyle, setImageVisualStyle] = useState<ImageVisualStyle>('realistic')
   const [imageCount, setImageCount] = useState(3)
   const [targetWordCount, setTargetWordCount] = useState<number>(1500)
-  const [useSeoAnalysis, setUseSeoAnalysis] = useState(false)
+  const [useSeoAnalysis, setUseSeoAnalysis] = useState(true)
   const [brandImageOptions, setBrandImageOptions] = useState<BrandImageOptions>({
     medicalLaw: { enabled: true, positions: ['top'] },
     title:      { enabled: true, positions: ['middle'], copy: '' },
     photo:      { enabled: true, positions: ['bottom'], mode: 'random' },
   })
   const seoPreview = useSeoPreview()
-  const seoResult = seoPreview.result
+  // 키워드 mismatch 가드: 입력 키워드와 분석된 키워드가 일치할 때만 결과 표시 (이전 분석 잔존 방지)
+  const seoResult = (
+    seoPreview.appliedKeyword &&
+    seoPreview.appliedKeyword === keyword.trim() &&
+    seoPreview.status === 'completed'
+  ) ? seoPreview.result : null
   const [referenceImageBase64, setReferenceImageBase64] = useState<string>('')
   const [referenceImagePreview, setReferenceImagePreview] = useState<string>('')
 
@@ -223,6 +228,30 @@ export default function NewMarketingPostPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [seoPreview.appliedKeyword, seoResult])
 
+  // 글 생성이 끝나면 입력 필드를 기본값으로 초기화 (결과 카드는 유지)
+  const resetInputsToDefaults = useCallback(() => {
+    setTopic('')
+    setKeyword('')
+    setPostType('informational')
+    setTone('polite')
+    setUseResearch(true)
+    setFactCheck(true)
+    setUseSeoAnalysis(true)
+    setPlatforms(DEFAULT_PLATFORM_PRESETS.informational)
+    setImageStyle('infographic_only')
+    setImageVisualStyle('realistic')
+    setImageCount(3)
+    setTargetWordCount(1500)
+    setBrandImageOptions({
+      medicalLaw: { enabled: true, positions: ['top'] },
+      title: { enabled: true, positions: ['middle'], copy: '' },
+      photo: { enabled: true, positions: ['bottom'], mode: 'random' },
+    })
+    setReferenceImageBase64('')
+    setReferenceImagePreview('')
+    clearFormDraft(DRAFT_KEY)
+  }, [])
+
   const handleResult = useCallback(async (result: GeneratedResultType) => {
     setGeneratedResult(result)
     setEditedTitle(result.title)
@@ -251,8 +280,10 @@ export default function NewMarketingPostPage() {
     } catch (saveErr) {
       console.error('자동 저장 실패:', saveErr)
     }
+    // 입력 필드 초기화 (결과 카드는 유지 — 사용자가 결과 확인 후 다음 글 입력 가능)
+    resetInputsToDefaults()
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [savedItemId, topic, keyword, postType, tone, useResearch, factCheck, platforms])
+  }, [savedItemId, topic, keyword, postType, tone, useResearch, factCheck, platforms, resetInputsToDefaults])
 
   useEffect(() => {
     aiGen.onResultCallback.current = handleResult
@@ -702,6 +733,8 @@ export default function NewMarketingPostPage() {
                         onChange={() => {
                           setImageStyle(value)
                           if (value !== 'use_own_image') { setReferenceImageBase64(''); setReferenceImagePreview('') }
+                          // 인포그래픽 선택 시 시각 스타일을 사실적 사진으로 자동 동기화
+                          if (value === 'infographic_only') setImageVisualStyle('realistic')
                         }}
                         className="mt-0.5 w-4 h-4 text-at-accent border-at-border focus:ring-at-accent"
                       />

--- a/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
+++ b/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
@@ -38,7 +38,7 @@ import ClinicalForm, { type ClinicalFormData } from '@/components/marketing/clin
 import ClinicalPhotoEditor from '@/components/marketing/clinical/ClinicalPhotoEditor'
 import { useAIGeneration, type GeneratedResultType } from '@/contexts/AIGenerationContext'
 import { useSeoPreview } from '@/hooks/useSeoPreview'
-import { useFormDraft } from '@/hooks/useFormDraft'
+import { useFormDraft, clearFormDraft } from '@/hooks/useFormDraft'
 import { BrandImageSection } from '@/components/marketing/brand/BrandImageSection'
 import type { BrandImageOptions } from '@/types/brand'
 
@@ -100,10 +100,10 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
   const [topic, setTopic] = useState('')
   const [keyword, setKeyword] = useState('')
   const [postType, setPostType] = useState<PostType>('informational')
-  const [tone, setTone] = useState<ToneType>('friendly')
-  const [useResearch, setUseResearch] = useState(false)
-  const [factCheck, setFactCheck] = useState(false)
-  const [useSeoAnalysis, setUseSeoAnalysis] = useState(false)
+  const [tone, setTone] = useState<ToneType>('polite')
+  const [useResearch, setUseResearch] = useState(true)
+  const [factCheck, setFactCheck] = useState(true)
+  const [useSeoAnalysis, setUseSeoAnalysis] = useState(true)
   const [platforms, setPlatforms] = useState<PlatformOptions>(DEFAULT_PLATFORM_PRESETS.informational)
   const [imageStyle, setImageStyle] = useState<ImageStyleOption>('infographic_only')
   const [imageVisualStyle, setImageVisualStyle] = useState<ImageVisualStyle>('realistic')
@@ -111,7 +111,12 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
   const [targetWordCount, setTargetWordCount] = useState<number>(1500)
   // ── SEO 분석 미리보기 ──
   const seoPreview = useSeoPreview()
-  const seoResult = seoPreview.result
+  // 키워드 mismatch 가드: 입력 키워드와 분석된 키워드가 일치할 때만 결과 표시 (이전 분석 잔존 방지)
+  const seoResult = (
+    seoPreview.appliedKeyword &&
+    seoPreview.appliedKeyword === keyword.trim() &&
+    seoPreview.status === 'completed'
+  ) ? seoPreview.result : null
   const [referenceImageBase64, setReferenceImageBase64] = useState<string>('')
   const [referenceImagePreview, setReferenceImagePreview] = useState<string>('')
   const [clinicalData, setClinicalData] = useState<ClinicalFormData | null>(null)
@@ -239,6 +244,30 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [seoPreview.appliedKeyword, seoResult])
 
+  // 글 생성이 끝나면 입력 필드를 기본값으로 초기화 (결과 카드는 유지)
+  const resetInputsToDefaults = useCallback(() => {
+    setTopic('')
+    setKeyword('')
+    setPostType('informational')
+    setTone('polite')
+    setUseResearch(true)
+    setFactCheck(true)
+    setUseSeoAnalysis(true)
+    setPlatforms(DEFAULT_PLATFORM_PRESETS.informational)
+    setImageStyle('infographic_only')
+    setImageVisualStyle('realistic')
+    setImageCount(3)
+    setTargetWordCount(1500)
+    setBrandImageOptions({
+      medicalLaw: { enabled: true, positions: ['top'] },
+      title: { enabled: true, positions: ['middle'], copy: '' },
+      photo: { enabled: true, positions: ['bottom'], mode: 'random' },
+    })
+    setReferenceImageBase64('')
+    setReferenceImagePreview('')
+    clearFormDraft(DRAFT_KEY)
+  }, [])
+
   // 컨텍스트에서 결과가 오면 로컬 상태에 반영
   const handleResult = useCallback((result: GeneratedResultType) => {
     setGeneratedResult(result)
@@ -249,7 +278,9 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
       setSavedItemId(result.savedItemId)
     }
     setSaveMessage({ type: 'success', text: '자동 저장되었습니다.' })
-  }, [])
+    // 입력 필드 초기화 (결과 카드는 유지)
+    resetInputsToDefaults()
+  }, [resetInputsToDefaults])
 
   // 결과 콜백 등록
   useEffect(() => {
@@ -876,7 +907,12 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
                     ([value, { label, description }]) => (
                       <label key={value} className="flex items-start gap-3 cursor-pointer">
                         <input type="radio" name="imageStyle" value={value} checked={imageStyle === value}
-                          onChange={() => { setImageStyle(value); if (value !== 'use_own_image') { setReferenceImageBase64(''); setReferenceImagePreview('') } }}
+                          onChange={() => {
+                            setImageStyle(value)
+                            if (value !== 'use_own_image') { setReferenceImageBase64(''); setReferenceImagePreview('') }
+                            // 인포그래픽 선택 시 시각 스타일을 사실적 사진으로 자동 동기화
+                            if (value === 'infographic_only') setImageVisualStyle('realistic')
+                          }}
                           className="mt-0.5 w-4 h-4 text-at-accent border-at-border focus:ring-at-accent" />
                         <div>
                           <span className="text-sm font-medium text-at-text">{label}</span>

--- a/dental-clinic-manager/src/types/bulkSms.ts
+++ b/dental-clinic-manager/src/types/bulkSms.ts
@@ -1,0 +1,88 @@
+export type BulkSmsCampaignStatus =
+  | 'draft' | 'scheduled' | 'sending' | 'sent' | 'failed' | 'cancelled'
+
+export type BulkSmsMsgType = 'SMS' | 'LMS'
+
+export type BulkSmsRecipientStatus = 'pending' | 'success' | 'failed'
+
+export interface BulkSmsCampaign {
+  id: string
+  clinic_id: string
+  created_by: string
+  title: string | null
+  message: string
+  msg_type: BulkSmsMsgType
+  total_count: number
+  success_count: number
+  fail_count: number
+  status: BulkSmsCampaignStatus
+  scheduled_at: string | null
+  sent_at: string | null
+  completed_at: string | null
+  filter_snapshot: BulkSmsFilter | null
+  exclude_recall_excluded: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface BulkSmsRecipient {
+  id: string
+  campaign_id: string
+  clinic_id: string
+  dentweb_patient_id: string | null
+  patient_name: string | null
+  phone_number: string
+  personalized_message: string
+  status: BulkSmsRecipientStatus
+  aligo_msg_id: string | null
+  error_message: string | null
+  sent_at: string | null
+  created_at: string
+}
+
+export interface BulkSmsTemplate {
+  id: string
+  clinic_id: string
+  name: string
+  content: string
+  is_default: boolean
+  created_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+// 필터
+export type Gender = 'male' | 'female' | 'all'
+
+export interface BulkSmsFilter {
+  gender?: Gender                    // 'all' 또는 미지정 = 전체
+  ageMin?: number | null
+  ageMax?: number | null
+  lastVisitFrom?: string | null      // ISO date 'YYYY-MM-DD'
+  lastVisitTo?: string | null
+  lastTreatmentTypes?: string[]      // 다중 선택
+  hasNextAppointment?: boolean | null  // null=전체, true=있음, false=없음
+  birthMonths?: number[]             // 1..12
+  searchKeyword?: string             // 이름/차트번호
+  activeOnly?: boolean               // 기본 true
+}
+
+// API 응답
+export interface BulkSmsEligiblePatient {
+  dentweb_patient_id: string
+  patient_name: string
+  phone_number: string
+  chart_number: string | null
+  birth_date: string | null
+  gender: string | null
+  last_visit_date: string | null
+  last_treatment_type: string | null
+  next_appointment_date: string | null
+}
+
+export interface BulkSmsEligibleResponse {
+  patients: BulkSmsEligiblePatient[]
+  total: number
+  excluded_count: number             // 리콜 제외로 빠진 환자 수
+  no_phone_count: number             // 전화번호 없어 자동 제외된 수
+}

--- a/dental-clinic-manager/src/types/marketing.ts
+++ b/dental-clinic-manager/src/types/marketing.ts
@@ -235,6 +235,10 @@ export interface ContentGenerateOptions {
   useSeoAnalysis?: boolean;
   platforms: PlatformOptions;
   imageStyle?: ImageStyleOption;
+  /** 스타일별 이미지 개수 분배. 사용자가 multi-select 로 스타일을 고르고 각 스타일별 카운트를 지정.
+   *  이 필드가 있으면 imageStyle/imageCount 보다 우선 적용 (스타일 합계 = 총 이미지 개수).
+   *  생략 시 기존 imageStyle/imageCount 단일 스타일 로직으로 동작 (하위 호환). */
+  imageStyleAllocation?: Partial<Record<ImageStyleOption, number>>;
   imageVisualStyle?: ImageVisualStyle;
   imageCount?: number;
   /** 사용자가 SEO 분석 결과를 보고 직접 정한 목표 본문 길이(자). 미지정 시 기본 1500자. */

--- a/dental-clinic-manager/supabase/migrations/20260514_create_bulk_sms.sql
+++ b/dental-clinic-manager/supabase/migrations/20260514_create_bulk_sms.sql
@@ -1,0 +1,109 @@
+-- ============================================
+-- 단체 문자 발송 기능 테이블 생성
+-- Migration: 20260514_create_bulk_sms.sql
+-- ============================================
+
+-- 1) 캠페인
+CREATE TABLE IF NOT EXISTS bulk_sms_campaigns (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  created_by UUID NOT NULL REFERENCES users(id),
+  title TEXT,
+  message TEXT NOT NULL,
+  msg_type TEXT NOT NULL DEFAULT 'SMS'
+    CHECK (msg_type IN ('SMS','LMS')),
+  total_count INTEGER NOT NULL DEFAULT 0,
+  success_count INTEGER NOT NULL DEFAULT 0,
+  fail_count INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft','scheduled','sending','sent','failed','cancelled')),
+  scheduled_at TIMESTAMPTZ,
+  sent_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  filter_snapshot JSONB,
+  exclude_recall_excluded BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bulk_sms_campaigns_clinic_status
+  ON bulk_sms_campaigns(clinic_id, status, scheduled_at);
+CREATE INDEX IF NOT EXISTS idx_bulk_sms_campaigns_clinic_created
+  ON bulk_sms_campaigns(clinic_id, created_at DESC);
+
+-- 2) 수신자별 발송 결과
+CREATE TABLE IF NOT EXISTS bulk_sms_recipients (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id UUID NOT NULL REFERENCES bulk_sms_campaigns(id) ON DELETE CASCADE,
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  dentweb_patient_id UUID REFERENCES dentweb_patients(id) ON DELETE SET NULL,
+  patient_name TEXT,
+  phone_number TEXT NOT NULL,
+  personalized_message TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','success','failed')),
+  aligo_msg_id TEXT,
+  error_message TEXT,
+  sent_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bulk_sms_recipients_campaign
+  ON bulk_sms_recipients(campaign_id);
+CREATE INDEX IF NOT EXISTS idx_bulk_sms_recipients_dentweb_patient
+  ON bulk_sms_recipients(dentweb_patient_id) WHERE dentweb_patient_id IS NOT NULL;
+
+-- 3) 템플릿
+CREATE TABLE IF NOT EXISTS bulk_sms_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  content TEXT NOT NULL,
+  is_default BOOLEAN NOT NULL DEFAULT false,
+  created_by UUID REFERENCES users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bulk_sms_templates_clinic
+  ON bulk_sms_templates(clinic_id);
+
+-- RLS
+ALTER TABLE bulk_sms_campaigns ENABLE ROW LEVEL SECURITY;
+ALTER TABLE bulk_sms_recipients ENABLE ROW LEVEL SECURITY;
+ALTER TABLE bulk_sms_templates ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "bulk_sms_campaigns_select" ON bulk_sms_campaigns
+  FOR SELECT TO authenticated
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+CREATE POLICY "bulk_sms_campaigns_service_all" ON bulk_sms_campaigns
+  FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY "bulk_sms_recipients_select" ON bulk_sms_recipients
+  FOR SELECT TO authenticated
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+CREATE POLICY "bulk_sms_recipients_service_all" ON bulk_sms_recipients
+  FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY "bulk_sms_templates_select" ON bulk_sms_templates
+  FOR SELECT TO authenticated
+  USING (clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid()));
+CREATE POLICY "bulk_sms_templates_service_all" ON bulk_sms_templates
+  FOR ALL USING (true) WITH CHECK (true);
+
+-- updated_at 자동 갱신
+CREATE OR REPLACE FUNCTION update_bulk_sms_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_bulk_sms_campaigns_updated_at
+  BEFORE UPDATE ON bulk_sms_campaigns
+  FOR EACH ROW EXECUTE FUNCTION update_bulk_sms_updated_at();
+
+CREATE TRIGGER trigger_bulk_sms_templates_updated_at
+  BEFORE UPDATE ON bulk_sms_templates
+  FOR EACH ROW EXECUTE FUNCTION update_bulk_sms_updated_at();

--- a/dental-clinic-manager/supabase/migrations/20260514_tighten_bulk_sms_rls.sql
+++ b/dental-clinic-manager/supabase/migrations/20260514_tighten_bulk_sms_rls.sql
@@ -1,0 +1,12 @@
+-- ============================================
+-- bulk_sms_* RLS service_all 정책 제거
+-- Migration: 20260514_tighten_bulk_sms_rls.sql
+--
+-- 이유: 기존 service_all 정책은 TO 절이 없어 모든 role(PUBLIC)에 적용되어
+--       _select 정책의 clinic 격리를 우회 가능. 서버는 service role 키로
+--       RLS를 bypass하므로 해당 정책이 불필요하다.
+-- ============================================
+
+DROP POLICY IF EXISTS "bulk_sms_campaigns_service_all" ON bulk_sms_campaigns;
+DROP POLICY IF EXISTS "bulk_sms_recipients_service_all" ON bulk_sms_recipients;
+DROP POLICY IF EXISTS "bulk_sms_templates_service_all" ON bulk_sms_templates;


### PR DESCRIPTION
## Summary

### AI 글쓰기 (page.tsx + NewPostForm.tsx)
1. **기본값 변경**
   - 어투: 친근체 → **정중체** (polite)
   - 품질 옵션 셋 다 기본 체크: `useResearch=true, factCheck=true, useSeoAnalysis=true`
   - 이미지 스타일: 인포그래픽만 (기존 유지)
2. **글 생성 완료 시 입력값 자동 초기화** (`resetInputsToDefaults`)
   - 결과 카드는 유지, 입력 필드 + `useFormDraft` 캐시 모두 기본값 복원
3. **키워드 mismatch 가드**
   - 입력 키워드 ≠ 분석된 키워드 → 미리보기 결과 자동 숨김
   - 새 주제 입력 후에도 이전 분석 결과가 계속 보이던 문제 해소
4. **인포그래픽 선택 시 시각 스타일 자동 = 사실적 사진**
5. `imageStyleAllocation` 타입 추가 (다음 PR 에서 multi-select UI/backend 연동)

### 단체 문자 스키마 (별도 작업)
- 단체 문자 캠페인/수신자/템플릿 테이블 추가
- RLS service_all 정책 제거 (클리닉 격리 강화)
- 타입 정의 추가

## Test plan
- [x] 빌드 통과
- [ ] AI 글쓰기 페이지 접속 → 기본값 (정중체/품질 셋다 체크/인포그래픽) 적용 확인
- [ ] 글 생성 후 입력 필드가 기본값으로 돌아가는지 확인
- [ ] 키워드 변경 후 이전 분석 결과가 숨겨지는지 확인
- [ ] 이미지 스타일을 "인포그래픽만" 으로 바꾸면 시각 스타일이 자동 "사실적 사진" 으로 동기화되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)