### PR TITLE
feat(marketing): AI 이미지 스타일 multi-select + 스타일별 카운트 분배

### DIFF
--- a/dental-clinic-manager/src/app/api/marketing/generate/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/generate/route.ts
@@ -76,6 +76,9 @@ export async function POST(request: NextRequest) {
             threads: false,
           },
           imageStyle: body.imageStyle || undefined,
+          imageStyleAllocation: body.imageStyleAllocation && typeof body.imageStyleAllocation === 'object'
+            ? body.imageStyleAllocation as Partial<Record<'infographic_only' | 'allow_person' | 'use_own_image', number>>
+            : undefined,
           imageVisualStyle: body.imageVisualStyle || undefined,
           imageCount: body.imageCount !== undefined ? Number(body.imageCount) : 3,
           targetWordCount: body.targetWordCount !== undefined ? Number(body.targetWordCount) : undefined,
@@ -309,13 +312,28 @@ export async function POST(request: NextRequest) {
           let completedCount = 0;
           const progressStart = 60;
           const progressEnd = 90;
+          // 마커 prompt 의 STYLE= 토큰을 파싱해 마커별 스타일 결정 (allocation 모드)
+          const parseMarkerStyle = (raw: string): typeof options.imageStyle | null => {
+            const m = raw.match(/STYLE\s*=\s*(infographic|person|own)\b/i)
+            if (!m) return null
+            const k = m[1].toLowerCase()
+            if (k === 'infographic') return 'infographic_only'
+            if (k === 'person') return 'allow_person'
+            if (k === 'own') return 'use_own_image'
+            return null
+          }
           const imagePromises = imageMarkers.map(async (marker) => {
             try {
               const timeoutPromise = new Promise<never>((_, reject) =>
                 setTimeout(() => reject(new Error('이미지 생성 타임아웃 (90s)')), 90000)
               );
+              // 마커별 스타일 분기 (없으면 글로벌 imageStyle 폴백)
+              const markerStyle = parseMarkerStyle(marker.prompt) || options.imageStyle
+              const cleanPrompt = marker.prompt.replace(/\s*\|\s*STYLE\s*=\s*\S+/gi, '').trim()
+              // use_own_image 스타일이지만 referenceImage 가 없으면 인포그래픽으로 폴백
+              const effectiveStyle = (markerStyle === 'use_own_image' && !options.referenceImageBase64) ? 'infographic_only' : markerStyle
               const { imageBase64, fileName } = await Promise.race([
-                generateBlogImage(marker.prompt, options.imageStyle, options.referenceImageBase64, userData.clinic_id, undefined, options.imageVisualStyle, generationSessionId, userData.clinic_id),
+                generateBlogImage(cleanPrompt, effectiveStyle, effectiveStyle === 'use_own_image' ? options.referenceImageBase64 : undefined, userData.clinic_id, undefined, options.imageVisualStyle, generationSessionId, userData.clinic_id),
                 timeoutPromise,
               ]);
 

--- a/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
@@ -104,6 +104,12 @@ export default function NewMarketingPostPage() {
   const [platforms, setPlatforms] = useState<PlatformOptions>(DEFAULT_PLATFORM_PRESETS.informational)
   const [imageStyle, setImageStyle] = useState<ImageStyleOption>('infographic_only')
   const [imageVisualStyle, setImageVisualStyle] = useState<ImageVisualStyle>('realistic')
+  // 이미지 스타일별 카운트 분배 (multi-select). 합계 = imageCount, 가장 큰 스타일 = imageStyle (dominant)
+  const [imageStyleAllocation, setImageStyleAllocation] = useState<Record<ImageStyleOption, number>>({
+    infographic_only: 3,
+    allow_person: 0,
+    use_own_image: 0,
+  })
   const [imageCount, setImageCount] = useState(3)
   const [targetWordCount, setTargetWordCount] = useState<number>(1500)
   const [useSeoAnalysis, setUseSeoAnalysis] = useState(true)
@@ -160,7 +166,7 @@ export default function NewMarketingPostPage() {
     DRAFT_KEY,
     {
       topic, keyword, postType, tone, useResearch, factCheck,
-      platforms, imageStyle, imageVisualStyle, imageCount, targetWordCount, useSeoAnalysis,
+      platforms, imageStyle, imageStyleAllocation, imageVisualStyle, imageCount, targetWordCount, useSeoAnalysis,
     },
     (restored) => {
       if (typeof restored.topic === 'string') setTopic(restored.topic)
@@ -171,6 +177,14 @@ export default function NewMarketingPostPage() {
       if (typeof restored.factCheck === 'boolean') setFactCheck(restored.factCheck)
       if (restored.platforms && typeof restored.platforms === 'object') setPlatforms(restored.platforms as PlatformOptions)
       if (typeof restored.imageStyle === 'string') setImageStyle(restored.imageStyle as ImageStyleOption)
+      if (restored.imageStyleAllocation && typeof restored.imageStyleAllocation === 'object') {
+        const r = restored.imageStyleAllocation as Record<string, number>
+        setImageStyleAllocation({
+          infographic_only: Math.max(0, Math.floor(r.infographic_only ?? 0)),
+          allow_person: Math.max(0, Math.floor(r.allow_person ?? 0)),
+          use_own_image: Math.max(0, Math.floor(r.use_own_image ?? 0)),
+        })
+      }
       if (typeof restored.imageVisualStyle === 'string') setImageVisualStyle(restored.imageVisualStyle as ImageVisualStyle)
       if (typeof restored.imageCount === 'number') setImageCount(restored.imageCount)
       if (typeof restored.targetWordCount === 'number') setTargetWordCount(restored.targetWordCount)
@@ -197,6 +211,35 @@ export default function NewMarketingPostPage() {
     return Math.max(20, Math.ceil(avg / 5) * 5 + 5)
   })()
   const clampImageCount = (n: number) => Math.min(dynamicImageMax, Math.max(0, Math.floor(n)))
+
+  // 스타일별 카운트 변경: 합계가 dynamicImageMax 를 넘지 않게 클램프
+  const setStyleCount = (style: ImageStyleOption, value: number) => {
+    setImageStyleAllocation(prev => {
+      const v = Math.max(0, Math.floor(Number.isFinite(value) ? value : 0))
+      const otherSum = (Object.entries(prev) as [ImageStyleOption, number][])
+        .filter(([k]) => k !== style)
+        .reduce((s, [, n]) => s + n, 0)
+      const allowed = Math.max(0, dynamicImageMax - otherSum)
+      return { ...prev, [style]: Math.min(v, allowed) }
+    })
+  }
+
+  // 스타일 체크박스 토글: 비활성 시 0, 활성 시 최소 1 (다른 스타일과 합쳐 max 초과 금지)
+  const toggleStyleActive = (style: ImageStyleOption, active: boolean) => {
+    if (!active) setStyleCount(style, 0)
+    else if ((imageStyleAllocation[style] ?? 0) === 0) setStyleCount(style, 1)
+  }
+
+  // allocation → imageCount(합), imageStyle(dominant) 자동 sync — 하위 호환 + 단일 필드 사용처 보호
+  useEffect(() => {
+    const total = (Object.values(imageStyleAllocation) as number[]).reduce((s, n) => s + n, 0)
+    setImageCount(total)
+    if (total > 0) {
+      const dominant = (Object.entries(imageStyleAllocation) as [ImageStyleOption, number][])
+        .reduce((acc, cur) => (cur[1] > acc[1] ? cur : acc), ['infographic_only', 0] as [ImageStyleOption, number])
+      if (dominant[1] > 0) setImageStyle(dominant[0])
+    }
+  }, [imageStyleAllocation])
 
   // 글자수 입력의 동적 최대값 — 경쟁 평균이 max 를 넘기면 평균 + 1,000자, 100의 배수로 올림, 기본 5,000자
   const dynamicWordMax = (() => {
@@ -240,6 +283,7 @@ export default function NewMarketingPostPage() {
     setPlatforms(DEFAULT_PLATFORM_PRESETS.informational)
     setImageStyle('infographic_only')
     setImageVisualStyle('realistic')
+    setImageStyleAllocation({ infographic_only: 3, allow_person: 0, use_own_image: 0 })
     setImageCount(3)
     setTargetWordCount(1500)
     setBrandImageOptions({
@@ -306,8 +350,8 @@ export default function NewMarketingPostPage() {
     setHasUnsavedChanges(false)
     aiGen.startGeneration({
       topic, keyword, postType, tone, useResearch, factCheck, useSeoAnalysis, platforms,
-      imageStyle, imageVisualStyle, imageCount, targetWordCount,
-      referenceImageBase64: imageStyle === 'use_own_image' ? referenceImageBase64 : undefined,
+      imageStyle, imageStyleAllocation, imageVisualStyle, imageCount, targetWordCount,
+      referenceImageBase64: (imageStyleAllocation.use_own_image ?? 0) > 0 ? referenceImageBase64 : undefined,
       brandImageOptions: postType !== 'clinical' ? brandImageOptions : undefined,
     })
   }
@@ -681,75 +725,69 @@ export default function NewMarketingPostPage() {
       <section>
         <SectionHeader number={3} title="이미지 옵션" icon={PaintBrushIcon} iconColor="text-emerald-600" iconBg="bg-emerald-50" />
         <fieldset disabled={isFormDisabled} className={`space-y-5 transition-opacity ${isFormDisabled ? 'opacity-50' : ''}`}>
-          {/* 이미지 개수 */}
+          {/* 이미지 스타일 + 개수 분배 (multi-select). 합계 = 총 이미지 개수 */}
           <div>
             <label className="block text-sm font-medium text-at-text-secondary mb-2">
-              이미지 개수
+              이미지 스타일 및 개수 분배
               {seoResult && (
                 <span className="ml-2 text-[11px] text-at-text-weak">(경쟁 평균 {seoResult.avgImageCount.toFixed(1)}장)</span>
               )}
             </label>
-            <div className="flex items-center gap-3 flex-wrap">
-              <input
-                type="number"
-                min={0}
-                max={dynamicImageMax}
-                value={imageCount}
-                onChange={(e) => {
-                  const v = Number(e.target.value)
-                  if (Number.isNaN(v)) return setImageCount(0)
-                  setImageCount(clampImageCount(v))
-                }}
-                className="w-20 h-9 px-2 rounded-lg border border-at-border bg-white text-sm font-semibold text-at-text text-center focus:outline-none focus:ring-2 focus:ring-at-accent"
-              />
-              <input
-                type="range"
-                min={0}
-                max={dynamicImageMax}
-                step={1}
-                value={imageCount}
-                onChange={(e) => setImageCount(Number(e.target.value))}
-                className="flex-1 min-w-[160px] max-w-[320px] accent-at-accent cursor-pointer"
-              />
-              <span className="text-xs text-at-text-weak">
-                {imageCount === 0 ? '이미지 없이 글만 생성' : `${imageCount}개 생성 (0~${dynamicImageMax})`}
-              </span>
+            <p className="text-[11px] text-at-text-weak mb-2">
+              생성할 스타일에 체크하고 각각 몇 장씩 만들지 입력하세요. 합계가 총 이미지 개수입니다 (최대 {dynamicImageMax}장).
+            </p>
+            <div className="space-y-2">
+              {(Object.entries(IMAGE_STYLE_LABELS) as [ImageStyleOption, { label: string; description: string }][]).map(
+                ([value, { label, description }]) => {
+                  const count = imageStyleAllocation[value] ?? 0
+                  const active = count > 0
+                  return (
+                    <div key={value} className={`flex items-center gap-3 px-3 py-2 rounded-lg border ${active ? 'border-at-accent bg-emerald-50/40' : 'border-at-border bg-white'}`}>
+                      <input
+                        type="checkbox"
+                        checked={active}
+                        onChange={(e) => {
+                          toggleStyleActive(value, e.target.checked)
+                          if (e.target.checked && value === 'infographic_only') setImageVisualStyle('realistic')
+                          if (!e.target.checked && value === 'use_own_image') { setReferenceImageBase64(''); setReferenceImagePreview('') }
+                        }}
+                        className="w-4 h-4 text-at-accent border-at-border focus:ring-at-accent"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <span className="text-sm font-medium text-at-text">{label}</span>
+                        <span className="text-[11px] text-at-text-weak ml-2">{description}</span>
+                      </div>
+                      <input
+                        type="number"
+                        min={0}
+                        max={dynamicImageMax}
+                        value={count}
+                        onChange={(e) => {
+                          const v = Number(e.target.value)
+                          setStyleCount(value, Number.isFinite(v) ? v : 0)
+                          if (v > 0 && value === 'infographic_only') setImageVisualStyle('realistic')
+                          if (v === 0 && value === 'use_own_image') { setReferenceImageBase64(''); setReferenceImagePreview('') }
+                        }}
+                        className="w-16 h-8 px-2 rounded-md border border-at-border bg-white text-sm font-semibold text-at-text text-center focus:outline-none focus:ring-2 focus:ring-at-accent"
+                      />
+                      <span className="text-[11px] text-at-text-weak w-5 text-left">장</span>
+                    </div>
+                  )
+                }
+              )}
+            </div>
+            <div className="mt-2 flex items-center justify-between text-xs">
+              <span className="text-at-text-weak">총 이미지 개수: <span className="font-semibold text-at-text">{imageCount}</span>장 (최대 {dynamicImageMax}장)</span>
+              {imageCount === 0 && <span className="text-amber-600">스타일을 1개 이상 체크해주세요 (또는 이미지 없이 글만 생성)</span>}
             </div>
           </div>
 
           {imageCount > 0 && (
             <>
-              <div className="border-t border-at-border" />
-              <div className="space-y-2.5">
-                <label className="block text-sm font-medium text-at-text-secondary">이미지 스타일</label>
-                {(Object.entries(IMAGE_STYLE_LABELS) as [ImageStyleOption, { label: string; description: string }][]).map(
-                  ([value, { label, description }]) => (
-                    <label key={value} className="flex items-start gap-3 cursor-pointer">
-                      <input
-                        type="radio"
-                        name="imageStyle"
-                        value={value}
-                        checked={imageStyle === value}
-                        onChange={() => {
-                          setImageStyle(value)
-                          if (value !== 'use_own_image') { setReferenceImageBase64(''); setReferenceImagePreview('') }
-                          // 인포그래픽 선택 시 시각 스타일을 사실적 사진으로 자동 동기화
-                          if (value === 'infographic_only') setImageVisualStyle('realistic')
-                        }}
-                        className="mt-0.5 w-4 h-4 text-at-accent border-at-border focus:ring-at-accent"
-                      />
-                      <div>
-                        <span className="text-sm font-medium text-at-text">{label}</span>
-                        <span className="text-xs text-at-text-weak ml-2">{description}</span>
-                      </div>
-                    </label>
-                  )
-                )}
-              </div>
 
-              {imageStyle === 'use_own_image' && (
+              {(imageStyleAllocation.use_own_image ?? 0) > 0 && (
                 <div className="ml-7 p-4 bg-at-surface-alt rounded-xl border border-at-border space-y-2">
-                  <label className="block text-xs font-medium text-at-text-secondary">참조 이미지 업로드</label>
+                  <label className="block text-xs font-medium text-at-text-secondary">참조 이미지 업로드 (본인 이미지 활용 {imageStyleAllocation.use_own_image}장용)</label>
                   <div className="flex items-center gap-3">
                     <label className="cursor-pointer inline-flex items-center gap-2 px-3 py-1.5 border border-at-border text-at-text-secondary rounded-lg hover:bg-white transition-colors text-xs font-medium">
                       <PhotoIcon className="h-4 w-4" />

--- a/dental-clinic-manager/src/config/menuConfig.ts
+++ b/dental-clinic-manager/src/config/menuConfig.ts
@@ -361,6 +361,16 @@ export const MENU_CONFIG: MenuConfigItem[] = [
     premiumFeature: true,
   },
   {
+    id: 'bulk-sms',
+    label: '단체 문자',
+    icon: 'MessageSquare',
+    route: '/dashboard/bulk-sms',
+    permissions: ['bulk_sms_view'],
+    categoryId: 'operations',
+    order: 15.8,
+    visible: true,
+  },
+  {
     id: 'marketing',
     label: '마케팅 자동화',
     icon: 'Sparkles',

--- a/dental-clinic-manager/src/contexts/AIGenerationContext.tsx
+++ b/dental-clinic-manager/src/contexts/AIGenerationContext.tsx
@@ -20,6 +20,8 @@ interface GenerationOptions {
   useSeoAnalysis: boolean
   platforms: PlatformOptions
   imageStyle: string
+  /** 스타일별 이미지 개수 분배 (multi-select 시). 합계가 imageCount 와 같아야 함. */
+  imageStyleAllocation?: Partial<Record<'infographic_only' | 'allow_person' | 'use_own_image', number>>
   imageVisualStyle: string
   imageCount: number
   /** 사용자가 정한 목표 본문 길이(자). 미지정 시 서버에서 기본값 사용. */
@@ -111,8 +113,11 @@ export function AIGenerationProvider({ children }: { children: ReactNode }) {
             imageStyle: options.imageStyle,
             imageVisualStyle: options.imageVisualStyle,
             imageCount: options.imageCount,
+            ...(options.imageStyleAllocation ? { imageStyleAllocation: options.imageStyleAllocation } : {}),
             ...(options.targetWordCount ? { targetWordCount: options.targetWordCount } : {}),
-            ...(options.imageStyle === 'use_own_image' && options.referenceImageBase64
+            ...((options.imageStyleAllocation?.use_own_image ?? 0) > 0 && options.referenceImageBase64
+              ? { referenceImageBase64: options.referenceImageBase64 }
+              : options.imageStyle === 'use_own_image' && options.referenceImageBase64
               ? { referenceImageBase64: options.referenceImageBase64 }
               : {}),
             ...(options.clinical ? { clinical: options.clinical } : {}),

--- a/dental-clinic-manager/src/lib/marketing/content-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/content-generator.ts
@@ -162,7 +162,12 @@ export async function generateContent(
 
   // 2. 이미지 개수 및 스타일 지시문 생성
   let imageStyleInstruction = '';
-  const imgCount = options.imageCount ?? 3;
+  // imageStyleAllocation 이 있으면 그 합을 우선, 없으면 imageCount fallback
+  const allocation = options.imageStyleAllocation
+  const allocSum = allocation
+    ? (allocation.infographic_only ?? 0) + (allocation.allow_person ?? 0) + (allocation.use_own_image ?? 0)
+    : 0
+  const imgCount = allocSum > 0 ? allocSum : (options.imageCount ?? 3);
   if (imgCount === 0) {
     imageStyleInstruction = '\n\n## 이미지 마커 지침\n[IMAGE:] 마커를 사용하지 마세요. 텍스트만 작성하세요.';
   } else {
@@ -184,7 +189,22 @@ export async function generateContent(
       `5) **반드시 핵심 키워드를 텍스트에 포함**시켜 환자가 카드만 봐도 메시지를 알 수 있게.\n`;
 
     let styleNote = '';
-    if (options.imageStyle === 'allow_person') {
+    // multi-select allocation 이 지정된 경우 — 각 스타일별 카운트를 명시
+    if (allocation && allocSum > 0) {
+      const distribLines: string[] = []
+      const infoN = allocation.infographic_only ?? 0
+      const personN = allocation.allow_person ?? 0
+      const ownN = allocation.use_own_image ?? 0
+      if (infoN > 0) distribLines.push(`- 인포그래픽 카드: ${infoN}장 (사람 얼굴 금지, 텍스트가 화면의 60% 이상)`)
+      if (personN > 0) distribLines.push(`- 인물 포함 카드: ${personN}장 (환자/치과의사 등장 가능, 텍스트는 그대로 메인)`)
+      if (ownN > 0) distribLines.push(`- 본인 이미지 카드: ${ownN}장 (참조된 치과 원장/직원 등장, 텍스트는 그대로 메인)`)
+      styleNote =
+        `\n### 시각 스타일 분배 (사용자 지정)\n` +
+        `${imgCount}장의 이미지를 다음 스타일로 분배해주세요. 모든 카드 텍스트는 위 형식(TITLE/CHECK)을 유지:\n` +
+        distribLines.join('\n') + '\n' +
+        `각 [IMAGE: ...] 마커 끝에 \`| STYLE=infographic\` / \`| STYLE=person\` / \`| STYLE=own\` 을 명시해 어떤 스타일로 생성할지 표기하세요 (예: \`[IMAGE: TITLE=... | CHECK=... | STYLE=infographic]\`). ` +
+        `STYLE 미표기 시 인포그래픽으로 처리됩니다.`;
+    } else if (options.imageStyle === 'allow_person') {
       styleNote =
         `\n### 시각 스타일 보조\n` +
         `위 텍스트가 메인이며, 카드 배경/중간 영역에는 사람(환자·치과의사 등)이 자연스럽게 등장하는 ` +

--- a/dental-clinic-manager/src/types/bulkSms.ts
+++ b/dental-clinic-manager/src/types/bulkSms.ts
@@ -52,10 +52,10 @@ export interface BulkSmsTemplate {
 }
 
 // 필터
-export type Gender = 'male' | 'female' | 'all'
+export type BulkSmsGender = 'male' | 'female' | 'all'
 
 export interface BulkSmsFilter {
-  gender?: Gender                    // 'all' 또는 미지정 = 전체
+  gender?: BulkSmsGender                    // 'all' 또는 미지정 = 전체
   ageMin?: number | null
   ageMax?: number | null
   lastVisitFrom?: string | null      // ISO date 'YYYY-MM-DD'

--- a/dental-clinic-manager/src/types/permissions.ts
+++ b/dental-clinic-manager/src/types/permissions.ts
@@ -110,6 +110,10 @@ export type Permission =
   | 'auction_view'             // 부동산 경매 물건 조회
   | 'auction_favorite'         // 관심물건 저장 및 시뮬레이션
   | 'auction_ai'               // AI 권리분석 코멘트 생성
+  // 단체 문자 발송 권한
+  | 'bulk_sms_view'             // 단체 문자 조회
+  | 'bulk_sms_send'             // 단체 문자 발송
+  | 'bulk_sms_manage'           // 단체 문자 템플릿 관리
 
 // 역할별 기본 권한 설정
 export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
@@ -167,7 +171,9 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     // 소개환자 관리 (모든 권한)
     'referral_view', 'referral_manage', 'referral_sms_send', 'referral_points_adjust',
     // 부동산 경매 관리 (모든 권한)
-    'auction_view', 'auction_favorite', 'auction_ai'
+    'auction_view', 'auction_favorite', 'auction_ai',
+    // 단체 문자 (모든 권한)
+    'bulk_sms_view', 'bulk_sms_send', 'bulk_sms_manage'
   ],
   vice_director: [
     // 부원장은 직원 관리와 병원 설정, 프로토콜 삭제 제외한 모든 권한
@@ -234,7 +240,9 @@ export const DEFAULT_PERMISSIONS: Record<string, Permission[]> = {
     // 병원 게시판 (조회/관리)
     'bulletin_view', 'bulletin_manage',
     // 커뮤니티 (조회/작성)
-    'community_view', 'community_post'
+    'community_view', 'community_post',
+    // 단체 문자 (조회/발송/관리)
+    'bulk_sms_view', 'bulk_sms_send', 'bulk_sms_manage'
   ],
   team_leader: [
     // 팀장은 프로토콜 조회와 히스토리만 가능, 자신의 계약서 조회 및 서명만 가능
@@ -316,6 +324,7 @@ export const NEW_FEATURE_PREFIXES = [
   'monthly_report_',
   'referral_',
   'auction_',
+  'bulk_sms_',
 ] as const
 
 // 기존 그룹에 추가된 단독 신규 권한 (prefix 보충 대상이 아니라 직접 보충)
@@ -462,6 +471,11 @@ export const PERMISSION_GROUPS = {
     { key: 'auction_favorite', label: '관심물건 저장 및 시뮬레이션' },
     { key: 'auction_ai', label: 'AI 권리분석 코멘트' }
   ],
+  '단체 문자': [
+    { key: 'bulk_sms_view', label: '단체 문자 조회' },
+    { key: 'bulk_sms_send', label: '단체 문자 발송' },
+    { key: 'bulk_sms_manage', label: '템플릿 관리' }
+  ],
   '기타': [
     { key: 'guide_view', label: '사용 안내 보기' }
   ]
@@ -579,4 +593,8 @@ export const PERMISSION_DESCRIPTIONS: Record<Permission, string> = {
   'auction_view': '부동산 경매 물건 목록과 상세를 조회할 수 있습니다.',
   'auction_favorite': '관심물건을 저장하고 입찰 시뮬레이션을 사용할 수 있습니다.',
   'auction_ai': 'AI 권리분석 코멘트를 생성할 수 있습니다 (Claude Haiku 4.5 호출).',
+  // 단체 문자 발송 권한 설명
+  'bulk_sms_view': '단체 문자 메뉴와 발송 이력을 조회할 수 있습니다.',
+  'bulk_sms_send': '환자들에게 단체 문자를 발송할 수 있습니다.',
+  'bulk_sms_manage': '단체 문자 템플릿을 생성·수정·삭제할 수 있습니다.',
 }


### PR DESCRIPTION
## Summary
AI 글쓰기에서 이미지 스타일을 단일 선택(라디오) 에서 **multi-select(체크박스) + 스타일별 개수 분배** 로 전환.

### UI (posts/new 페이지)
- 인포그래픽 / 인물 포함 / 본인 이미지 각각 체크박스 + number input
- 합계 = 총 이미지 개수 (max = dynamicImageMax)
- 인포그래픽 카운트 > 0 시 시각 스타일 자동 = 사실적 사진
- 본인 이미지 카운트 > 0 시 참조 이미지 업로드 영역 노출

### 데이터
- 새 필드 `imageStyleAllocation: Record<style, number>`
- `imageStyle` 단일 필드는 dominant 스타일로 자동 sync (하위 호환)
- `imageCount` = sum (derived)
- useFormDraft 자동 저장/복원에 포함

### Backend
- `/api/marketing/generate` 에 `imageStyleAllocation` 전달
- `content-generator`: allocation 있으면 LLM 지시에 "스타일별 N장" 명시 + 각 마커 끝에 `STYLE=infographic/person/own` 토큰 추가하도록 안내
- generate route: 마커별 STYLE 토큰 파싱 → 해당 스타일로 이미지 생성, STYLE 토큰은 prompt 에서 제거, `use_own_image` + 참조 없음 시 인포그래픽 폴백

### Scope
- posts/new 페이지만 적용. NewPostForm(마케팅 자동화 → AI 글쓰기 탭) 은 기존 단일 라디오 유지 (향후 통일)

## Test plan
- [x] 빌드 통과
- [ ] 이미지 스타일 multi 체크 후 총 N개 분배 확인
- [ ] 각 스타일별 N개 생성됐는지 확인 (인포그래픽 + 인물 + 본인 동시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)