### PR TITLE
feat: 단체 문자 발송 기능

### DIFF
--- a/dental-clinic-manager/src/app/api/bulk-sms/campaigns/[id]/cancel/route.ts
+++ b/dental-clinic-manager/src/app/api/bulk-sms/campaigns/[id]/cancel/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { getAuthedUserWithPermission } from '@/lib/bulkSmsAuth'
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const ctx = await getAuthedUserWithPermission('bulk_sms_send')
+  if (!ctx) return NextResponse.json({ success: false, error: '권한이 없습니다' }, { status: 403 })
+
+  const { id } = await params
+  const service = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  const { data, error } = await service
+    .from('bulk_sms_campaigns')
+    .update({ status: 'cancelled' })
+    .eq('id', id)
+    .eq('clinic_id', ctx.clinicId)
+    .eq('status', 'scheduled')
+    .select('id')
+    .maybeSingle()
+  if (error) return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+  if (!data) return NextResponse.json({ success: false, error: '취소할 수 없는 캠페인입니다 (이미 발송됨 또는 존재하지 않음)' }, { status: 400 })
+
+  return NextResponse.json({ success: true })
+}

--- a/dental-clinic-manager/src/app/api/bulk-sms/campaigns/[id]/route.ts
+++ b/dental-clinic-manager/src/app/api/bulk-sms/campaigns/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { getAuthedUserWithPermission } from '@/lib/bulkSmsAuth'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const ctx = await getAuthedUserWithPermission('bulk_sms_view')
+  if (!ctx) return NextResponse.json({ success: false, error: '권한이 없습니다' }, { status: 403 })
+
+  const { id } = await params
+  const service = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  const { data: campaign, error: cErr } = await service
+    .from('bulk_sms_campaigns')
+    .select('*')
+    .eq('id', id)
+    .eq('clinic_id', ctx.clinicId)
+    .single()
+  if (cErr || !campaign) return NextResponse.json({ success: false, error: '캠페인을 찾을 수 없습니다' }, { status: 404 })
+
+  const { data: recipients } = await service
+    .from('bulk_sms_recipients')
+    .select('id, patient_name, phone_number, personalized_message, status, error_message, sent_at')
+    .eq('campaign_id', id)
+    .order('created_at', { ascending: true })
+    .limit(2000)
+
+  return NextResponse.json({ success: true, campaign, recipients: recipients ?? [] })
+}

--- a/dental-clinic-manager/src/app/api/bulk-sms/campaigns/route.ts
+++ b/dental-clinic-manager/src/app/api/bulk-sms/campaigns/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { getAuthedUserWithPermission } from '@/lib/bulkSmsAuth'
+
+export async function GET(request: NextRequest) {
+  const ctx = await getAuthedUserWithPermission('bulk_sms_view')
+  if (!ctx) return NextResponse.json({ success: false, error: '권한이 없습니다' }, { status: 403 })
+
+  const { searchParams } = new URL(request.url)
+  const status = searchParams.get('status')
+  const limit = Math.min(parseInt(searchParams.get('limit') || '50', 10), 200)
+  const offset = parseInt(searchParams.get('offset') || '0', 10)
+
+  const service = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  let q = service
+    .from('bulk_sms_campaigns')
+    .select('id, title, message, msg_type, total_count, success_count, fail_count, status, scheduled_at, sent_at, completed_at, created_at, created_by', { count: 'exact' })
+    .eq('clinic_id', ctx.clinicId)
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1)
+  if (status) q = q.eq('status', status)
+
+  const { data, count, error } = await q
+  if (error) return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+
+  return NextResponse.json({ success: true, campaigns: data ?? [], total: count ?? 0 })
+}

--- a/dental-clinic-manager/src/app/api/bulk-sms/patients/route.ts
+++ b/dental-clinic-manager/src/app/api/bulk-sms/patients/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { getAuthedUserWithPermission } from '@/lib/bulkSmsAuth'
+import { getEligiblePatients } from '@/lib/bulkSmsService'
+import type { BulkSmsFilter } from '@/types/bulkSms'
+
+export const maxDuration = 60
+
+export async function POST(request: NextRequest) {
+  const ctx = await getAuthedUserWithPermission('bulk_sms_view')
+  if (!ctx) {
+    return NextResponse.json(
+      { success: false, error: '권한이 없습니다' },
+      { status: 403 }
+    )
+  }
+
+  const body = (await request.json()) as {
+    filter: BulkSmsFilter
+    excludeRecallExcluded?: boolean
+  }
+  const service = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  try {
+    const result = await getEligiblePatients(
+      service,
+      ctx.clinicId,
+      body.filter ?? {},
+      body.excludeRecallExcluded !== false
+    )
+    return NextResponse.json({ success: true, ...result })
+  } catch (e) {
+    return NextResponse.json(
+      { success: false, error: (e as Error).message },
+      { status: 500 }
+    )
+  }
+}

--- a/dental-clinic-manager/src/app/api/bulk-sms/preview/route.ts
+++ b/dental-clinic-manager/src/app/api/bulk-sms/preview/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getAuthedUserWithPermission } from '@/lib/bulkSmsAuth'
+import { applyVariables, determineMsgType } from '@/lib/bulkSmsService'
+
+export async function POST(request: NextRequest) {
+  const ctx = await getAuthedUserWithPermission('bulk_sms_view')
+  if (!ctx) return NextResponse.json({ success: false, error: '권한이 없습니다' }, { status: 403 })
+
+  const body = await request.json() as { message: string; samplePatientName?: string }
+  const personalized = applyVariables(body.message, {
+    patientName: body.samplePatientName || '홍길동',
+    clinicName: ctx.clinicName,
+    clinicPhone: ctx.clinicPhone,
+  })
+  const msgType = determineMsgType(personalized)
+  const bytes = new TextEncoder().encode(personalized).length
+
+  return NextResponse.json({
+    success: true,
+    preview: personalized,
+    msg_type: msgType,
+    bytes,
+  })
+}

--- a/dental-clinic-manager/src/app/api/bulk-sms/schedule/route.ts
+++ b/dental-clinic-manager/src/app/api/bulk-sms/schedule/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { getAuthedUserWithPermission } from '@/lib/bulkSmsAuth'
+import {
+  getEligiblePatients,
+  applyVariables,
+  normalizePhone,
+} from '@/lib/bulkSmsService'
+import type { BulkSmsFilter } from '@/types/bulkSms'
+
+export const maxDuration = 60
+
+interface ScheduleRequest {
+  filter: BulkSmsFilter
+  excludeRecallExcluded?: boolean
+  message: string
+  title?: string
+  scheduledAt: string  // ISO 8601
+  selectedPatientIds?: string[]
+}
+
+export async function POST(request: NextRequest) {
+  const ctx = await getAuthedUserWithPermission('bulk_sms_send')
+  if (!ctx) return NextResponse.json({ success: false, error: '권한이 없습니다' }, { status: 403 })
+
+  const body = await request.json() as ScheduleRequest
+  if (!body.message?.trim()) {
+    return NextResponse.json({ success: false, error: '메시지가 비어 있습니다' }, { status: 400 })
+  }
+  const scheduled = new Date(body.scheduledAt)
+  if (isNaN(scheduled.getTime())) {
+    return NextResponse.json({ success: false, error: '예약 시각이 올바르지 않습니다' }, { status: 400 })
+  }
+  if (scheduled.getTime() < Date.now() + 60_000) {
+    return NextResponse.json({ success: false, error: '예약 시각은 현재로부터 1분 이후여야 합니다' }, { status: 400 })
+  }
+
+  const service = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  const eligible = await getEligiblePatients(
+    service,
+    ctx.clinicId,
+    body.filter,
+    body.excludeRecallExcluded !== false
+  )
+  let patients = eligible.patients
+  if (body.selectedPatientIds && body.selectedPatientIds.length > 0) {
+    const allowed = new Set(body.selectedPatientIds)
+    patients = patients.filter(p => allowed.has(p.dentweb_patient_id))
+  }
+  if (patients.length === 0) {
+    return NextResponse.json({ success: false, error: '발송 대상이 없습니다' }, { status: 400 })
+  }
+
+  let maxBytes = 0
+  for (const p of patients) {
+    const m = applyVariables(body.message, {
+      patientName: p.patient_name,
+      clinicName: ctx.clinicName,
+      clinicPhone: ctx.clinicPhone,
+    })
+    const b = new TextEncoder().encode(m).length
+    if (b > maxBytes) maxBytes = b
+  }
+  if (maxBytes > 2000) {
+    return NextResponse.json({ success: false, error: '메시지가 2000바이트를 초과합니다' }, { status: 400 })
+  }
+  const msgType = maxBytes > 90 ? 'LMS' : 'SMS'
+
+  const { data: campaign, error: cErr } = await service
+    .from('bulk_sms_campaigns')
+    .insert({
+      clinic_id: ctx.clinicId,
+      created_by: ctx.userId,
+      title: body.title ?? null,
+      message: body.message,
+      msg_type: msgType,
+      total_count: patients.length,
+      status: 'scheduled',
+      scheduled_at: scheduled.toISOString(),
+      filter_snapshot: body.filter,
+      exclude_recall_excluded: body.excludeRecallExcluded !== false,
+    })
+    .select('id')
+    .single()
+  if (cErr || !campaign) {
+    return NextResponse.json({ success: false, error: cErr?.message || '캠페인 생성 실패' }, { status: 500 })
+  }
+
+  const rows = patients.map(p => ({
+    campaign_id: campaign.id,
+    clinic_id: ctx.clinicId,
+    dentweb_patient_id: p.dentweb_patient_id,
+    patient_name: p.patient_name,
+    phone_number: normalizePhone(p.phone_number),
+    personalized_message: applyVariables(body.message, {
+      patientName: p.patient_name,
+      clinicName: ctx.clinicName,
+      clinicPhone: ctx.clinicPhone,
+    }),
+    status: 'pending' as const,
+  }))
+  for (let i = 0; i < rows.length; i += 1000) {
+    const slice = rows.slice(i, i + 1000)
+    const { error } = await service.from('bulk_sms_recipients').insert(slice)
+    if (error) {
+      await service.from('bulk_sms_campaigns').delete().eq('id', campaign.id)
+      return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+    }
+  }
+
+  return NextResponse.json({
+    success: true,
+    campaign_id: campaign.id,
+    scheduled_at: scheduled.toISOString(),
+    total: patients.length,
+  })
+}

--- a/dental-clinic-manager/src/app/api/bulk-sms/send/route.ts
+++ b/dental-clinic-manager/src/app/api/bulk-sms/send/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { getAuthedUserWithPermission } from '@/lib/bulkSmsAuth'
+import {
+  getEligiblePatients,
+  applyVariables,
+  normalizePhone,
+  sendCampaign,
+} from '@/lib/bulkSmsService'
+import type { BulkSmsFilter } from '@/types/bulkSms'
+
+export const maxDuration = 60
+
+interface SendRequest {
+  filter: BulkSmsFilter
+  excludeRecallExcluded?: boolean
+  message: string
+  title?: string
+  // 사용자가 결과 리스트에서 일부 환자만 선택했을 경우, 그 dentweb_patient_id 화이트리스트
+  selectedPatientIds?: string[]
+}
+
+export async function POST(request: NextRequest) {
+  const ctx = await getAuthedUserWithPermission('bulk_sms_send')
+  if (!ctx) return NextResponse.json({ success: false, error: '권한이 없습니다' }, { status: 403 })
+
+  const body = await request.json() as SendRequest
+  if (!body.message?.trim()) {
+    return NextResponse.json({ success: false, error: '메시지가 비어 있습니다' }, { status: 400 })
+  }
+
+  const service = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  // 1) 대상 환자 다시 조회 (클라가 보낸 명단을 신뢰하지 않음)
+  const eligible = await getEligiblePatients(
+    service,
+    ctx.clinicId,
+    body.filter,
+    body.excludeRecallExcluded !== false
+  )
+  let patients = eligible.patients
+  if (body.selectedPatientIds && body.selectedPatientIds.length > 0) {
+    const allowed = new Set(body.selectedPatientIds)
+    patients = patients.filter(p => allowed.has(p.dentweb_patient_id))
+  }
+  if (patients.length === 0) {
+    return NextResponse.json({ success: false, error: '발송 대상이 없습니다' }, { status: 400 })
+  }
+
+  // 2) 가장 긴 치환 결과 기준으로 통일된 msg_type 결정
+  let maxBytes = 0
+  for (const p of patients) {
+    const m = applyVariables(body.message, {
+      patientName: p.patient_name,
+      clinicName: ctx.clinicName,
+      clinicPhone: ctx.clinicPhone,
+    })
+    const b = new TextEncoder().encode(m).length
+    if (b > maxBytes) maxBytes = b
+  }
+  const msgType = maxBytes > 90 ? 'LMS' : 'SMS'
+  if (maxBytes > 2000) {
+    return NextResponse.json({ success: false, error: '메시지가 2000바이트를 초과합니다' }, { status: 400 })
+  }
+
+  // 3) 캠페인 생성 (status='sending')
+  const { data: campaign, error: cErr } = await service
+    .from('bulk_sms_campaigns')
+    .insert({
+      clinic_id: ctx.clinicId,
+      created_by: ctx.userId,
+      title: body.title ?? null,
+      message: body.message,
+      msg_type: msgType,
+      total_count: patients.length,
+      status: 'sending',
+      filter_snapshot: body.filter,
+      exclude_recall_excluded: body.excludeRecallExcluded !== false,
+      sent_at: new Date().toISOString(),
+    })
+    .select('id')
+    .single()
+  if (cErr || !campaign) {
+    return NextResponse.json({ success: false, error: cErr?.message || '캠페인 생성 실패' }, { status: 500 })
+  }
+
+  // 4) 수신자 행 일괄 INSERT
+  const rows = patients.map(p => ({
+    campaign_id: campaign.id,
+    clinic_id: ctx.clinicId,
+    dentweb_patient_id: p.dentweb_patient_id,
+    patient_name: p.patient_name,
+    phone_number: normalizePhone(p.phone_number),
+    personalized_message: applyVariables(body.message, {
+      patientName: p.patient_name,
+      clinicName: ctx.clinicName,
+      clinicPhone: ctx.clinicPhone,
+    }),
+    status: 'pending' as const,
+  }))
+  // 1,000행 단위 분할 insert
+  for (let i = 0; i < rows.length; i += 1000) {
+    const slice = rows.slice(i, i + 1000)
+    const { error } = await service.from('bulk_sms_recipients').insert(slice)
+    if (error) {
+      await service.from('bulk_sms_campaigns')
+        .update({ status: 'failed', completed_at: new Date().toISOString() })
+        .eq('id', campaign.id)
+      return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+    }
+  }
+
+  // 5) 실제 발송
+  try {
+    const r = await sendCampaign(service, campaign.id)
+    return NextResponse.json({
+      success: true,
+      campaign_id: campaign.id,
+      total: patients.length,
+      success_count: r.success,
+      fail_count: r.fail,
+    })
+  } catch (e) {
+    return NextResponse.json({
+      success: false,
+      campaign_id: campaign.id,
+      error: (e as Error).message,
+    }, { status: 500 })
+  }
+}

--- a/dental-clinic-manager/src/app/api/bulk-sms/templates/[id]/route.ts
+++ b/dental-clinic-manager/src/app/api/bulk-sms/templates/[id]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { getAuthedUserWithPermission } from '@/lib/bulkSmsAuth'
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const ctx = await getAuthedUserWithPermission('bulk_sms_manage')
+  if (!ctx) return NextResponse.json({ success: false, error: '권한이 없습니다' }, { status: 403 })
+
+  const { id } = await params
+  const body = await request.json() as { name?: string; content?: string; is_default?: boolean }
+
+  const service = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  if (body.is_default === true) {
+    await service.from('bulk_sms_templates')
+      .update({ is_default: false })
+      .eq('clinic_id', ctx.clinicId)
+      .eq('is_default', true)
+  }
+
+  const patch: Record<string, unknown> = {}
+  if (body.name !== undefined) patch.name = body.name.trim()
+  if (body.content !== undefined) patch.content = body.content
+  if (body.is_default !== undefined) patch.is_default = body.is_default
+
+  const { data, error } = await service
+    .from('bulk_sms_templates')
+    .update(patch)
+    .eq('id', id)
+    .eq('clinic_id', ctx.clinicId)
+    .select('*')
+    .single()
+  if (error) return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+
+  return NextResponse.json({ success: true, template: data })
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const ctx = await getAuthedUserWithPermission('bulk_sms_manage')
+  if (!ctx) return NextResponse.json({ success: false, error: '권한이 없습니다' }, { status: 403 })
+
+  const { id } = await params
+  const service = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+  const { error } = await service
+    .from('bulk_sms_templates')
+    .delete()
+    .eq('id', id)
+    .eq('clinic_id', ctx.clinicId)
+  if (error) return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+
+  return NextResponse.json({ success: true })
+}

--- a/dental-clinic-manager/src/app/api/bulk-sms/templates/route.ts
+++ b/dental-clinic-manager/src/app/api/bulk-sms/templates/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { getAuthedUserWithPermission } from '@/lib/bulkSmsAuth'
+
+export async function GET() {
+  const ctx = await getAuthedUserWithPermission('bulk_sms_view')
+  if (!ctx) return NextResponse.json({ success: false, error: '권한이 없습니다' }, { status: 403 })
+
+  const service = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+  const { data, error } = await service
+    .from('bulk_sms_templates')
+    .select('*')
+    .eq('clinic_id', ctx.clinicId)
+    .order('is_default', { ascending: false })
+    .order('created_at', { ascending: false })
+  if (error) return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+
+  return NextResponse.json({ success: true, templates: data ?? [] })
+}
+
+export async function POST(request: NextRequest) {
+  const ctx = await getAuthedUserWithPermission('bulk_sms_manage')
+  if (!ctx) return NextResponse.json({ success: false, error: '권한이 없습니다' }, { status: 403 })
+
+  const body = await request.json() as { name: string; content: string; is_default?: boolean }
+  if (!body.name?.trim() || !body.content?.trim()) {
+    return NextResponse.json({ success: false, error: '이름과 내용이 필요합니다' }, { status: 400 })
+  }
+
+  const service = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  if (body.is_default) {
+    await service.from('bulk_sms_templates')
+      .update({ is_default: false })
+      .eq('clinic_id', ctx.clinicId)
+      .eq('is_default', true)
+  }
+
+  const { data, error } = await service
+    .from('bulk_sms_templates')
+    .insert({
+      clinic_id: ctx.clinicId,
+      name: body.name.trim(),
+      content: body.content,
+      is_default: !!body.is_default,
+      created_by: ctx.userId,
+    })
+    .select('*')
+    .single()
+  if (error) return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+
+  return NextResponse.json({ success: true, template: data })
+}

--- a/dental-clinic-manager/src/app/api/bulk-sms/test-send/route.ts
+++ b/dental-clinic-manager/src/app/api/bulk-sms/test-send/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { getAuthedUserWithPermission } from '@/lib/bulkSmsAuth'
+import { applyVariables, determineMsgType, normalizePhone, sendBatch } from '@/lib/bulkSmsService'
+
+export const maxDuration = 60
+
+export async function POST(request: NextRequest) {
+  const ctx = await getAuthedUserWithPermission('bulk_sms_send')
+  if (!ctx) return NextResponse.json({ success: false, error: '권한이 없습니다' }, { status: 403 })
+
+  const body = await request.json() as { message: string; phoneNumber: string; samplePatientName?: string; title?: string }
+  const phone = normalizePhone(body.phoneNumber)
+  if (phone.length < 9) {
+    return NextResponse.json({ success: false, error: '전화번호 형식이 올바르지 않습니다' }, { status: 400 })
+  }
+
+  const service = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+  const { data: aligo } = await service
+    .from('aligo_settings')
+    .select('api_key, user_id, sender_number')
+    .eq('clinic_id', ctx.clinicId)
+    .single()
+
+  if (!aligo?.api_key || !aligo.user_id || !aligo.sender_number) {
+    return NextResponse.json({ success: false, error: '알리고 설정이 없습니다' }, { status: 400 })
+  }
+
+  const personalized = applyVariables(body.message, {
+    patientName: body.samplePatientName || '테스트',
+    clinicName: ctx.clinicName,
+    clinicPhone: ctx.clinicPhone,
+  })
+  const result = await sendBatch({
+    apiKey: aligo.api_key,
+    userId: aligo.user_id,
+    sender: aligo.sender_number,
+    receivers: [phone],
+    message: personalized,
+    msgType: determineMsgType(personalized),
+    title: body.title,
+  })
+
+  if (!result.ok) {
+    return NextResponse.json({ success: false, error: result.error || '발송 실패' }, { status: 500 })
+  }
+  return NextResponse.json({ success: true, msg_id: result.msg_id ?? null })
+}

--- a/dental-clinic-manager/src/app/api/cron/bulk-sms/route.ts
+++ b/dental-clinic-manager/src/app/api/cron/bulk-sms/route.ts
@@ -1,0 +1,62 @@
+// 예약 발송 처리 Cron
+// Vercel Cron schedule: "*/5 * * * *" — 매 5분마다 실행
+// scheduled_at <= NOW() 이고 status='scheduled'인 캠페인을 점유하여 발송한다
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { sendCampaign } from '@/lib/bulkSmsService'
+
+export const maxDuration = 60
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization')
+  const cronSecret = process.env.CRON_SECRET
+  const isVercelCron = request.headers.get('x-vercel-cron') === '1'
+  if (!isVercelCron) {
+    if (!cronSecret || authHeader !== `Bearer ${cronSecret.trim()}`) {
+      return new NextResponse('Unauthorized', { status: 401 })
+    }
+  }
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  // 발송 시각 도래한 scheduled 캠페인 목록 조회
+  const { data: candidates, error } = await supabase
+    .from('bulk_sms_campaigns')
+    .select('id')
+    .eq('status', 'scheduled')
+    .lte('scheduled_at', new Date().toISOString())
+    .limit(10)
+  if (error) return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+
+  const summary = { processed: 0, success_count: 0, fail_count: 0, errors: [] as string[] }
+
+  for (const c of candidates ?? []) {
+    // 원자적 점유: scheduled → sending
+    const { data: claimed } = await supabase
+      .from('bulk_sms_campaigns')
+      .update({ status: 'sending', sent_at: new Date().toISOString() })
+      .eq('id', c.id)
+      .eq('status', 'scheduled')
+      .select('id')
+      .maybeSingle()
+    if (!claimed) continue
+
+    summary.processed++
+    try {
+      const r = await sendCampaign(supabase, c.id)
+      summary.success_count += r.success
+      summary.fail_count += r.fail
+    } catch (e) {
+      summary.errors.push(`${c.id}: ${(e as Error).message}`)
+      await supabase
+        .from('bulk_sms_campaigns')
+        .update({ status: 'failed', completed_at: new Date().toISOString() })
+        .eq('id', c.id)
+    }
+  }
+
+  return NextResponse.json({ success: true, ...summary })
+}

--- a/dental-clinic-manager/src/app/dashboard/bulk-sms/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/bulk-sms/page.tsx
@@ -1,0 +1,7 @@
+import BulkSmsManagement from '@/components/BulkSms/BulkSmsManagement'
+
+export const dynamic = 'force-dynamic'
+
+export default function BulkSmsPage() {
+  return <BulkSmsManagement />
+}

--- a/dental-clinic-manager/src/components/BulkSms/BulkSmsManagement.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/BulkSmsManagement.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { MessageSquare, History, Clock, FileText } from 'lucide-react'
+import SendTab from './SendTab/SendTab'
 
 type TabKey = 'send' | 'history' | 'scheduled' | 'templates'
 
@@ -42,7 +43,7 @@ export default function BulkSmsManagement() {
       </div>
 
       <div className="mt-6">
-        {tab === 'send' && <div className="text-gray-400 text-sm">발송하기 (Task 14 ~ 16에서 구현)</div>}
+        {tab === 'send' && <SendTab />}
         {tab === 'history' && <div className="text-gray-400 text-sm">발송 이력 (Task 17에서 구현)</div>}
         {tab === 'scheduled' && <div className="text-gray-400 text-sm">예약 캠페인 (Task 18에서 구현)</div>}
         {tab === 'templates' && <div className="text-gray-400 text-sm">템플릿 관리 (Task 19에서 구현)</div>}

--- a/dental-clinic-manager/src/components/BulkSms/BulkSmsManagement.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/BulkSmsManagement.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { MessageSquare, History, Clock, FileText } from 'lucide-react'
 import SendTab from './SendTab/SendTab'
+import HistoryTab from './HistoryTab/HistoryTab'
 
 type TabKey = 'send' | 'history' | 'scheduled' | 'templates'
 
@@ -44,7 +45,7 @@ export default function BulkSmsManagement() {
 
       <div className="mt-6">
         {tab === 'send' && <SendTab />}
-        {tab === 'history' && <div className="text-gray-400 text-sm">발송 이력 (Task 17에서 구현)</div>}
+        {tab === 'history' && <HistoryTab />}
         {tab === 'scheduled' && <div className="text-gray-400 text-sm">예약 캠페인 (Task 18에서 구현)</div>}
         {tab === 'templates' && <div className="text-gray-400 text-sm">템플릿 관리 (Task 19에서 구현)</div>}
       </div>

--- a/dental-clinic-manager/src/components/BulkSms/BulkSmsManagement.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/BulkSmsManagement.tsx
@@ -5,6 +5,7 @@ import { MessageSquare, History, Clock, FileText } from 'lucide-react'
 import SendTab from './SendTab/SendTab'
 import HistoryTab from './HistoryTab/HistoryTab'
 import ScheduledTab from './ScheduledTab/ScheduledTab'
+import TemplatesTab from './TemplatesTab/TemplatesTab'
 
 type TabKey = 'send' | 'history' | 'scheduled' | 'templates'
 
@@ -48,7 +49,7 @@ export default function BulkSmsManagement() {
         {tab === 'send' && <SendTab />}
         {tab === 'history' && <HistoryTab />}
         {tab === 'scheduled' && <ScheduledTab />}
-        {tab === 'templates' && <div className="text-gray-400 text-sm">템플릿 관리 (Task 19에서 구현)</div>}
+        {tab === 'templates' && <TemplatesTab />}
       </div>
     </div>
   )

--- a/dental-clinic-manager/src/components/BulkSms/BulkSmsManagement.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/BulkSmsManagement.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useState } from 'react'
+import { MessageSquare, History, Clock, FileText } from 'lucide-react'
+
+type TabKey = 'send' | 'history' | 'scheduled' | 'templates'
+
+const TABS: { key: TabKey; label: string; icon: typeof MessageSquare }[] = [
+  { key: 'send', label: '발송하기', icon: MessageSquare },
+  { key: 'history', label: '발송 이력', icon: History },
+  { key: 'scheduled', label: '예약 캠페인', icon: Clock },
+  { key: 'templates', label: '템플릿 관리', icon: FileText },
+]
+
+export default function BulkSmsManagement() {
+  const [tab, setTab] = useState<TabKey>('send')
+
+  return (
+    <div className="p-4 sm:p-6 max-w-7xl mx-auto">
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">단체 문자</h1>
+        <p className="mt-1 text-sm text-gray-500">환자들에게 단체 문자를 발송합니다. 리콜 제외 환자는 기본적으로 발송 대상에서 빠집니다.</p>
+      </header>
+
+      <div className="border-b border-gray-200">
+        <nav className="-mb-px flex gap-2 overflow-x-auto" aria-label="Tabs">
+          {TABS.map(({ key, label, icon: Icon }) => (
+            <button
+              key={key}
+              onClick={() => setTab(key)}
+              className={`whitespace-nowrap py-3 px-4 border-b-2 text-sm font-medium flex items-center gap-2 transition-colors ${
+                tab === key
+                  ? 'border-blue-500 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+              }`}
+            >
+              <Icon className="w-4 h-4" />
+              {label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      <div className="mt-6">
+        {tab === 'send' && <div className="text-gray-400 text-sm">발송하기 (Task 14 ~ 16에서 구현)</div>}
+        {tab === 'history' && <div className="text-gray-400 text-sm">발송 이력 (Task 17에서 구현)</div>}
+        {tab === 'scheduled' && <div className="text-gray-400 text-sm">예약 캠페인 (Task 18에서 구현)</div>}
+        {tab === 'templates' && <div className="text-gray-400 text-sm">템플릿 관리 (Task 19에서 구현)</div>}
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/BulkSmsManagement.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/BulkSmsManagement.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { MessageSquare, History, Clock, FileText } from 'lucide-react'
 import SendTab from './SendTab/SendTab'
 import HistoryTab from './HistoryTab/HistoryTab'
+import ScheduledTab from './ScheduledTab/ScheduledTab'
 
 type TabKey = 'send' | 'history' | 'scheduled' | 'templates'
 
@@ -46,7 +47,7 @@ export default function BulkSmsManagement() {
       <div className="mt-6">
         {tab === 'send' && <SendTab />}
         {tab === 'history' && <HistoryTab />}
-        {tab === 'scheduled' && <div className="text-gray-400 text-sm">예약 캠페인 (Task 18에서 구현)</div>}
+        {tab === 'scheduled' && <ScheduledTab />}
         {tab === 'templates' && <div className="text-gray-400 text-sm">템플릿 관리 (Task 19에서 구현)</div>}
       </div>
     </div>

--- a/dental-clinic-manager/src/components/BulkSms/HistoryTab/CampaignDetailModal.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/HistoryTab/CampaignDetailModal.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { X } from 'lucide-react'
+import CampaignStatusBadge from '../shared/CampaignStatusBadge'
+import type { BulkSmsCampaign, BulkSmsRecipient } from '@/types/bulkSms'
+
+interface Props {
+  campaignId: string | null
+  onClose: () => void
+}
+
+export default function CampaignDetailModal({ campaignId, onClose }: Props) {
+  const [campaign, setCampaign] = useState<BulkSmsCampaign | null>(null)
+  const [recipients, setRecipients] = useState<BulkSmsRecipient[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!campaignId) return
+    setLoading(true)
+    fetch(`/api/bulk-sms/campaigns/${campaignId}`)
+      .then(r => r.json())
+      .then(d => {
+        if (d.success) {
+          setCampaign(d.campaign)
+          setRecipients(d.recipients)
+        }
+      })
+      .finally(() => setLoading(false))
+  }, [campaignId])
+
+  if (!campaignId) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] flex flex-col">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">캠페인 상세</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="p-8 text-center text-sm text-gray-400">불러오는 중...</div>
+        ) : campaign && (
+          <div className="overflow-y-auto">
+            <div className="px-4 py-3 border-b border-gray-200 space-y-2 text-sm">
+              <div className="flex items-center gap-2">
+                <CampaignStatusBadge status={campaign.status} />
+                <span className="text-gray-500">{new Date(campaign.created_at).toLocaleString('ko-KR')}</span>
+              </div>
+              {campaign.title && <div><span className="text-gray-500">제목:</span> <span className="font-medium">{campaign.title}</span></div>}
+              <div>
+                <span className="text-gray-500">결과:</span>
+                <span className="ml-2">전체 {campaign.total_count} · 성공 {campaign.success_count} · 실패 {campaign.fail_count}</span>
+              </div>
+              <div>
+                <p className="text-gray-500 mb-1">본문</p>
+                <div className="bg-gray-50 border border-gray-200 rounded p-2 whitespace-pre-wrap text-xs">{campaign.message}</div>
+              </div>
+            </div>
+
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-xs text-gray-500 sticky top-0">
+                <tr>
+                  <th className="px-3 py-2 text-left">이름</th>
+                  <th className="px-3 py-2 text-left">전화번호</th>
+                  <th className="px-3 py-2 text-left">상태</th>
+                  <th className="px-3 py-2 text-left">사유</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recipients.map(r => (
+                  <tr key={r.id} className="border-t border-gray-100">
+                    <td className="px-3 py-2">{r.patient_name ?? '-'}</td>
+                    <td className="px-3 py-2 tabular-nums">{r.phone_number}</td>
+                    <td className="px-3 py-2">
+                      <span className={r.status === 'success' ? 'text-green-700' : r.status === 'failed' ? 'text-red-700' : 'text-gray-500'}>
+                        {r.status === 'success' ? '성공' : r.status === 'failed' ? '실패' : '대기'}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-gray-500 text-xs">{r.error_message ?? '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/HistoryTab/HistoryTab.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/HistoryTab/HistoryTab.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import CampaignStatusBadge from '../shared/CampaignStatusBadge'
+import CampaignDetailModal from './CampaignDetailModal'
+import type { BulkSmsCampaign } from '@/types/bulkSms'
+
+export default function HistoryTab() {
+  const [campaigns, setCampaigns] = useState<BulkSmsCampaign[]>([])
+  const [loading, setLoading] = useState(true)
+  const [openId, setOpenId] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch('/api/bulk-sms/campaigns')
+      .then(r => r.json())
+      .then(d => { if (d.success) setCampaigns(d.campaigns) })
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return <div className="p-8 text-center text-sm text-gray-400">불러오는 중...</div>
+  if (campaigns.length === 0) return <div className="p-8 text-center text-sm text-gray-400">아직 발송 이력이 없습니다.</div>
+
+  return (
+    <>
+      <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-xs text-gray-500">
+            <tr>
+              <th className="px-3 py-2 text-left">상태</th>
+              <th className="px-3 py-2 text-left">제목</th>
+              <th className="px-3 py-2 text-left">유형</th>
+              <th className="px-3 py-2 text-left">대상</th>
+              <th className="px-3 py-2 text-left">성공/실패</th>
+              <th className="px-3 py-2 text-left">생성/발송</th>
+              <th className="w-16"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {campaigns.map(c => (
+              <tr key={c.id} className="border-t border-gray-100 hover:bg-gray-50">
+                <td className="px-3 py-2"><CampaignStatusBadge status={c.status} /></td>
+                <td className="px-3 py-2 font-medium text-gray-900">{c.title || '-'}</td>
+                <td className="px-3 py-2 text-gray-500">{c.msg_type}</td>
+                <td className="px-3 py-2 tabular-nums">{c.total_count}</td>
+                <td className="px-3 py-2 tabular-nums">
+                  <span className="text-green-700">{c.success_count}</span>
+                  <span className="text-gray-400"> / </span>
+                  <span className="text-red-700">{c.fail_count}</span>
+                </td>
+                <td className="px-3 py-2 text-gray-500 text-xs">
+                  {c.sent_at ? new Date(c.sent_at).toLocaleString('ko-KR') : new Date(c.created_at).toLocaleString('ko-KR')}
+                </td>
+                <td className="px-3 py-2">
+                  <button onClick={() => setOpenId(c.id)} className="text-xs text-blue-600 hover:underline">상세</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <CampaignDetailModal campaignId={openId} onClose={() => setOpenId(null)} />
+    </>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/ScheduledTab/ScheduledTab.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/ScheduledTab/ScheduledTab.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { XCircle } from 'lucide-react'
+import CampaignStatusBadge from '../shared/CampaignStatusBadge'
+import type { BulkSmsCampaign } from '@/types/bulkSms'
+
+export default function ScheduledTab() {
+  const [campaigns, setCampaigns] = useState<BulkSmsCampaign[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const load = async () => {
+    setLoading(true)
+    const res = await fetch('/api/bulk-sms/campaigns?status=scheduled')
+    const d = await res.json()
+    if (d.success) setCampaigns(d.campaigns)
+    setLoading(false)
+  }
+
+  useEffect(() => { load() }, [])
+
+  const cancel = async (id: string) => {
+    if (!confirm('이 예약 캠페인을 취소하시겠습니까?')) return
+    const res = await fetch(`/api/bulk-sms/campaigns/${id}/cancel`, { method: 'POST' })
+    const d = await res.json()
+    if (d.success) load()
+    else alert(d.error || '취소 실패')
+  }
+
+  if (loading) return <div className="p-8 text-center text-sm text-gray-400">불러오는 중...</div>
+  if (campaigns.length === 0) return <div className="p-8 text-center text-sm text-gray-400">예약된 캠페인이 없습니다.</div>
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50 text-xs text-gray-500">
+          <tr>
+            <th className="px-3 py-2 text-left">상태</th>
+            <th className="px-3 py-2 text-left">제목</th>
+            <th className="px-3 py-2 text-left">대상</th>
+            <th className="px-3 py-2 text-left">예약 시각</th>
+            <th className="w-24"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {campaigns.map(c => (
+            <tr key={c.id} className="border-t border-gray-100">
+              <td className="px-3 py-2"><CampaignStatusBadge status={c.status} /></td>
+              <td className="px-3 py-2 font-medium text-gray-900">{c.title || '-'}</td>
+              <td className="px-3 py-2 tabular-nums">{c.total_count}명</td>
+              <td className="px-3 py-2 text-gray-700">
+                {c.scheduled_at ? new Date(c.scheduled_at).toLocaleString('ko-KR') : '-'}
+              </td>
+              <td className="px-3 py-2 text-right">
+                <button
+                  onClick={() => cancel(c.id)}
+                  className="text-xs text-red-600 hover:underline flex items-center gap-1"
+                >
+                  <XCircle className="w-3.5 h-3.5" /> 취소
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/MessageEditor.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/MessageEditor.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { FileText } from 'lucide-react'
+import MessageByteCounter from '@/components/BulkSms/shared/MessageByteCounter'
+import type { BulkSmsTemplate } from '@/types/bulkSms'
+
+interface Props {
+  message: string
+  onMessageChange: (v: string) => void
+  title: string
+  onTitleChange: (v: string) => void
+}
+
+export default function MessageEditor({ message, onMessageChange, title, onTitleChange }: Props) {
+  const [templates, setTemplates] = useState<BulkSmsTemplate[]>([])
+  const [selectedId, setSelectedId] = useState<string>('')
+
+  useEffect(() => {
+    fetch('/api/bulk-sms/templates')
+      .then(r => r.json())
+      .then(d => {
+        if (d.success) {
+          setTemplates(d.templates)
+          const def = (d.templates as BulkSmsTemplate[]).find(t => t.is_default)
+          if (def && !message) {
+            setSelectedId(def.id)
+            onMessageChange(def.content)
+          }
+        }
+      })
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const selectTemplate = (id: string) => {
+    setSelectedId(id)
+    const t = templates.find(x => x.id === id)
+    if (t) onMessageChange(t.content)
+  }
+
+  const insertVariable = (v: string) => onMessageChange(message + v)
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <FileText className="w-4 h-4 text-gray-500" />
+        <h3 className="font-medium text-gray-900">메시지 작성</h3>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">제목 (LMS만 표시)</label>
+          <input
+            type="text"
+            value={title}
+            onChange={e => onTitleChange(e.target.value)}
+            placeholder="예: 5월 가정의달 안내"
+            className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm"
+          />
+        </div>
+
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">템플릿 불러오기</label>
+          <select
+            value={selectedId}
+            onChange={e => selectTemplate(e.target.value)}
+            className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm bg-white"
+          >
+            <option value="">템플릿 선택…</option>
+            {templates.map(t => (
+              <option key={t.id} value={t.id}>{t.name}{t.is_default ? ' (기본)' : ''}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <label className="block text-xs text-gray-500">본문</label>
+            <div className="flex gap-1">
+              {['{환자명}', '{병원명}', '{전화번호}'].map(v => (
+                <button
+                  key={v}
+                  type="button"
+                  onClick={() => insertVariable(v)}
+                  className="text-xs px-2 py-0.5 rounded border border-gray-300 text-gray-700 hover:bg-gray-50"
+                >
+                  {v}
+                </button>
+              ))}
+            </div>
+          </div>
+          <textarea
+            value={message}
+            onChange={e => onMessageChange(e.target.value)}
+            rows={6}
+            placeholder="안녕하세요 {환자명}님, {병원명}입니다."
+            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm font-mono"
+          />
+          <div className="mt-1 flex justify-end">
+            <MessageByteCounter text={message} />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/PatientFilterPanel.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/PatientFilterPanel.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import { useState } from 'react'
+import { Filter } from 'lucide-react'
+import type { BulkSmsFilter } from '@/types/bulkSms'
+
+interface Props {
+  value: BulkSmsFilter
+  onChange: (next: BulkSmsFilter) => void
+  onApply: () => void
+  loading?: boolean
+}
+
+const LAST_VISIT_PRESETS = [
+  { label: '전체', from: null, to: null },
+  { label: '최근 30일', daysFrom: 30, daysTo: 0 },
+  { label: '최근 60일', daysFrom: 60, daysTo: 0 },
+  { label: '최근 90일', daysFrom: 90, daysTo: 0 },
+  { label: '90일 이상 미내원', daysFrom: null, daysTo: 90 },
+  { label: '180일 이상 미내원', daysFrom: null, daysTo: 180 },
+]
+
+function daysAgo(d: number): string {
+  const date = new Date()
+  date.setDate(date.getDate() - d)
+  return date.toISOString().slice(0, 10)
+}
+
+export default function PatientFilterPanel({ value, onChange, onApply, loading }: Props) {
+  const [keyword, setKeyword] = useState(value.searchKeyword ?? '')
+
+  const update = (patch: Partial<BulkSmsFilter>) => onChange({ ...value, ...patch })
+
+  const applyPreset = (preset: typeof LAST_VISIT_PRESETS[number]) => {
+    if (preset.from === null && preset.to === null && !('daysFrom' in preset)) {
+      update({ lastVisitFrom: null, lastVisitTo: null })
+      return
+    }
+    const p = preset as { daysFrom: number | null; daysTo: number | null }
+    update({
+      lastVisitFrom: p.daysFrom != null ? daysAgo(p.daysFrom) : null,
+      lastVisitTo: p.daysTo != null ? daysAgo(p.daysTo) : null,
+    })
+  }
+
+  const toggleBirthMonth = (m: number) => {
+    const cur = value.birthMonths ?? []
+    update({ birthMonths: cur.includes(m) ? cur.filter(x => x !== m) : [...cur, m] })
+  }
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4">
+      <div className="flex items-center gap-2 mb-4">
+        <Filter className="w-4 h-4 text-gray-500" />
+        <h3 className="font-medium text-gray-900">환자 필터</h3>
+      </div>
+
+      <div className="space-y-4">
+        {/* 성별 */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1.5">성별</label>
+          <div className="flex gap-2">
+            {(['all', 'male', 'female'] as const).map(g => (
+              <button
+                key={g}
+                type="button"
+                onClick={() => update({ gender: g })}
+                className={`px-3 py-1.5 text-sm rounded-md border ${
+                  (value.gender ?? 'all') === g
+                    ? 'bg-blue-50 border-blue-300 text-blue-700'
+                    : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                {g === 'all' ? '전체' : g === 'male' ? '남' : '여'}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 연령 */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1.5">연령</label>
+          <div className="flex items-center gap-2">
+            <input
+              type="number" min={0} max={120} placeholder="최소"
+              className="w-20 px-2 py-1.5 border border-gray-300 rounded-md text-sm"
+              value={value.ageMin ?? ''}
+              onChange={e => update({ ageMin: e.target.value ? Number(e.target.value) : null })}
+            />
+            <span className="text-gray-400">~</span>
+            <input
+              type="number" min={0} max={120} placeholder="최대"
+              className="w-20 px-2 py-1.5 border border-gray-300 rounded-md text-sm"
+              value={value.ageMax ?? ''}
+              onChange={e => update({ ageMax: e.target.value ? Number(e.target.value) : null })}
+            />
+            <span className="text-sm text-gray-500">세</span>
+          </div>
+        </div>
+
+        {/* 최종 내원일 */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1.5">최종 내원일</label>
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {LAST_VISIT_PRESETS.map(p => (
+              <button
+                key={p.label}
+                type="button"
+                onClick={() => applyPreset(p)}
+                className="px-2.5 py-1 text-xs rounded border border-gray-300 text-gray-700 hover:bg-gray-50"
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="date"
+              className="px-2 py-1.5 border border-gray-300 rounded-md text-sm"
+              value={value.lastVisitFrom ?? ''}
+              onChange={e => update({ lastVisitFrom: e.target.value || null })}
+            />
+            <span className="text-gray-400">~</span>
+            <input
+              type="date"
+              className="px-2 py-1.5 border border-gray-300 rounded-md text-sm"
+              value={value.lastVisitTo ?? ''}
+              onChange={e => update({ lastVisitTo: e.target.value || null })}
+            />
+          </div>
+        </div>
+
+        {/* 다음 예약 유무 */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1.5">다음 예약</label>
+          <div className="flex gap-2">
+            {[
+              { label: '전체', value: null },
+              { label: '예약 있음', value: true },
+              { label: '예약 없음', value: false },
+            ].map(opt => (
+              <button
+                key={String(opt.value)}
+                type="button"
+                onClick={() => update({ hasNextAppointment: opt.value })}
+                className={`px-3 py-1.5 text-sm rounded-md border ${
+                  (value.hasNextAppointment ?? null) === opt.value
+                    ? 'bg-blue-50 border-blue-300 text-blue-700'
+                    : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 생일 월 */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1.5">생일 월</label>
+          <div className="grid grid-cols-6 gap-1.5">
+            {Array.from({ length: 12 }, (_, i) => i + 1).map(m => {
+              const active = (value.birthMonths ?? []).includes(m)
+              return (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => toggleBirthMonth(m)}
+                  className={`py-1 text-xs rounded border ${
+                    active
+                      ? 'bg-blue-50 border-blue-300 text-blue-700'
+                      : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  {m}월
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* 이름/차트번호 검색 */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1.5">이름·차트번호 검색</label>
+          <input
+            type="text"
+            placeholder="이름 또는 차트번호 입력"
+            className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm"
+            value={keyword}
+            onChange={e => setKeyword(e.target.value)}
+            onBlur={() => update({ searchKeyword: keyword })}
+          />
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onApply}
+        disabled={loading}
+        className="mt-4 w-full py-2 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
+      >
+        {loading ? '조회 중...' : '필터 적용'}
+      </button>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/PatientSelectionList.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/PatientSelectionList.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { Users } from 'lucide-react'
+import type { BulkSmsEligiblePatient } from '@/types/bulkSms'
+
+interface Props {
+  patients: BulkSmsEligiblePatient[]
+  selectedIds: Set<string>
+  onToggle: (id: string) => void
+  onToggleAll: (checked: boolean) => void
+  excludedCount: number
+  noPhoneCount: number
+  loading?: boolean
+}
+
+export default function PatientSelectionList({
+  patients, selectedIds, onToggle, onToggleAll, excludedCount, noPhoneCount, loading
+}: Props) {
+  const allChecked = patients.length > 0 && patients.every(p => selectedIds.has(p.dentweb_patient_id))
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg">
+      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Users className="w-4 h-4 text-gray-500" />
+          <h3 className="font-medium text-gray-900">
+            발송 대상 {patients.length}명 (선택 {selectedIds.size}명)
+          </h3>
+        </div>
+        <label className="flex items-center gap-1.5 text-sm text-gray-600">
+          <input
+            type="checkbox"
+            checked={allChecked}
+            onChange={e => onToggleAll(e.target.checked)}
+            className="rounded border-gray-300"
+          />
+          전체 선택
+        </label>
+      </div>
+
+      {(excludedCount > 0 || noPhoneCount > 0) && (
+        <div className="px-4 py-2 bg-gray-50 border-b border-gray-200 text-xs text-gray-600">
+          {excludedCount > 0 && <span>리콜 제외 {excludedCount}명 </span>}
+          {noPhoneCount > 0 && <span>· 전화번호 없는 환자 {noPhoneCount}명 </span>}
+          자동 제외됨
+        </div>
+      )}
+
+      <div className="max-h-[400px] overflow-y-auto">
+        {loading ? (
+          <div className="p-8 text-center text-sm text-gray-400">조회 중...</div>
+        ) : patients.length === 0 ? (
+          <div className="p-8 text-center text-sm text-gray-400">조건에 맞는 환자가 없습니다.</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-xs text-gray-500">
+              <tr>
+                <th className="w-10 px-3 py-2"></th>
+                <th className="px-3 py-2 text-left">이름</th>
+                <th className="px-3 py-2 text-left">전화번호</th>
+                <th className="px-3 py-2 text-left">최종 내원</th>
+                <th className="px-3 py-2 text-left">진료</th>
+              </tr>
+            </thead>
+            <tbody>
+              {patients.map(p => (
+                <tr key={p.dentweb_patient_id} className="border-t border-gray-100 hover:bg-gray-50">
+                  <td className="px-3 py-2">
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(p.dentweb_patient_id)}
+                      onChange={() => onToggle(p.dentweb_patient_id)}
+                      className="rounded border-gray-300"
+                    />
+                  </td>
+                  <td className="px-3 py-2 font-medium text-gray-900">{p.patient_name}</td>
+                  <td className="px-3 py-2 text-gray-700 tabular-nums">{p.phone_number}</td>
+                  <td className="px-3 py-2 text-gray-500">{p.last_visit_date ?? '-'}</td>
+                  <td className="px-3 py-2 text-gray-500">{p.last_treatment_type ?? '-'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/RecallExcludeToggle.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/RecallExcludeToggle.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { AlertTriangle, ShieldCheck } from 'lucide-react'
+
+interface Props {
+  enabled: boolean
+  onChange: (v: boolean) => void
+}
+
+export default function RecallExcludeToggle({ enabled, onChange }: Props) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-3 flex items-start gap-3">
+      <button
+        type="button"
+        role="switch"
+        aria-checked={enabled}
+        onClick={() => onChange(!enabled)}
+        className={`relative inline-flex h-6 w-11 flex-shrink-0 rounded-full transition-colors ${
+          enabled ? 'bg-green-500' : 'bg-gray-300'
+        }`}
+      >
+        <span
+          className={`absolute top-0.5 left-0.5 inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+            enabled ? 'translate-x-5' : 'translate-x-0'
+          }`}
+        />
+      </button>
+      <div className="flex-1">
+        {enabled ? (
+          <div className="text-sm flex items-start gap-2">
+            <ShieldCheck className="w-4 h-4 text-green-600 mt-0.5" />
+            <div>
+              <p className="text-gray-900 font-medium">리콜 제외 환자 자동 제외</p>
+              <p className="text-gray-500 text-xs">친인척·비우호 환자가 발송 대상에서 빠집니다.</p>
+            </div>
+          </div>
+        ) : (
+          <div className="text-sm flex items-start gap-2">
+            <AlertTriangle className="w-4 h-4 text-amber-600 mt-0.5" />
+            <div>
+              <p className="text-amber-900 font-medium">제외 환자도 포함</p>
+              <p className="text-amber-700 text-xs">리콜에서 제외했던 환자들에게도 발송됩니다.</p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/SendActionBar.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/SendActionBar.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useState } from 'react'
+import { Send, Clock, FlaskConical } from 'lucide-react'
+
+interface Props {
+  canSend: boolean
+  onTestSend: (phone: string) => Promise<void>
+  onSubmitImmediate: () => void
+  onSubmitScheduled: (scheduledAtIso: string) => void
+}
+
+export default function SendActionBar({ canSend, onTestSend, onSubmitImmediate, onSubmitScheduled }: Props) {
+  const [mode, setMode] = useState<'immediate' | 'scheduled'>('immediate')
+  const [scheduledLocal, setScheduledLocal] = useState('')
+  const [testPhone, setTestPhone] = useState('')
+  const [testing, setTesting] = useState(false)
+  const [testMsg, setTestMsg] = useState<string | null>(null)
+
+  const handleTest = async () => {
+    if (!testPhone) return
+    setTesting(true)
+    setTestMsg(null)
+    try {
+      await onTestSend(testPhone)
+      setTestMsg('테스트 발송 완료')
+    } catch (e) {
+      setTestMsg(`실패: ${(e as Error).message}`)
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const handleSubmit = () => {
+    if (mode === 'immediate') onSubmitImmediate()
+    else {
+      if (!scheduledLocal) return
+      const iso = new Date(scheduledLocal).toISOString()
+      onSubmitScheduled(iso)
+    }
+  }
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-3">
+      <div>
+        <label className="block text-xs text-gray-500 mb-1.5 flex items-center gap-1">
+          <FlaskConical className="w-3.5 h-3.5" /> 테스트 발송 (본인 번호)
+        </label>
+        <div className="flex gap-2">
+          <input
+            type="tel"
+            value={testPhone}
+            onChange={e => setTestPhone(e.target.value)}
+            placeholder="010-0000-0000"
+            className="flex-1 px-3 py-1.5 border border-gray-300 rounded-md text-sm"
+          />
+          <button
+            type="button"
+            onClick={handleTest}
+            disabled={testing || !testPhone}
+            className="px-3 py-1.5 text-sm rounded-md border border-gray-300 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {testing ? '발송 중' : '테스트'}
+          </button>
+        </div>
+        {testMsg && <p className="mt-1 text-xs text-gray-600">{testMsg}</p>}
+      </div>
+
+      <hr className="border-gray-200" />
+
+      <div>
+        <label className="block text-xs text-gray-500 mb-1.5">발송 방식</label>
+        <div className="flex gap-2">
+          {[
+            { v: 'immediate', label: '즉시 발송', icon: Send },
+            { v: 'scheduled', label: '예약 발송', icon: Clock },
+          ].map(opt => (
+            <button
+              key={opt.v}
+              type="button"
+              onClick={() => setMode(opt.v as 'immediate' | 'scheduled')}
+              className={`flex-1 py-2 text-sm rounded-md border flex items-center justify-center gap-1.5 ${
+                mode === opt.v ? 'bg-blue-50 border-blue-300 text-blue-700' : 'bg-white border-gray-300 text-gray-700'
+              }`}
+            >
+              <opt.icon className="w-4 h-4" />
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {mode === 'scheduled' && (
+        <input
+          type="datetime-local"
+          value={scheduledLocal}
+          onChange={e => setScheduledLocal(e.target.value)}
+          className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm"
+        />
+      )}
+
+      <button
+        type="button"
+        onClick={handleSubmit}
+        disabled={!canSend || (mode === 'scheduled' && !scheduledLocal)}
+        className="w-full py-2.5 bg-blue-600 text-white rounded-md text-sm font-semibold hover:bg-blue-700 disabled:opacity-50"
+      >
+        {mode === 'immediate' ? '발송하기' : '예약하기'}
+      </button>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/SendConfirmDialog.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/SendConfirmDialog.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { AlertTriangle, X } from 'lucide-react'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onConfirm: () => void
+  selectedCount: number
+  message: string
+  sampleName: string
+  excludeRecallExcluded: boolean
+  mode: 'immediate' | 'scheduled'
+  scheduledAt?: string
+  sending: boolean
+}
+
+export default function SendConfirmDialog({
+  open, onClose, onConfirm, selectedCount, message, sampleName,
+  excludeRecallExcluded, mode, scheduledAt, sending,
+}: Props) {
+  const [preview, setPreview] = useState<{ preview: string; msg_type: 'SMS' | 'LMS'; bytes: number } | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    fetch('/api/bulk-sms/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message, samplePatientName: sampleName || '홍길동' }),
+    }).then(r => r.json()).then(d => { if (d.success) setPreview({ preview: d.preview, msg_type: d.msg_type, bytes: d.bytes }) })
+  }, [open, message, sampleName])
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">발송 확인</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="px-4 py-4 space-y-3 text-sm">
+          <div>
+            <span className="text-gray-500">발송 대상:</span>
+            <span className="ml-2 font-semibold text-gray-900">{selectedCount}명</span>
+          </div>
+          {preview && (
+            <>
+              <div>
+                <span className="text-gray-500">메시지 유형:</span>
+                <span className="ml-2 font-medium">{preview.msg_type}</span>
+                <span className="ml-2 text-xs text-gray-400">({preview.bytes} 바이트)</span>
+              </div>
+              <div>
+                <p className="text-gray-500 mb-1">미리보기 ({sampleName || '홍길동'} 기준)</p>
+                <div className="bg-gray-50 border border-gray-200 rounded p-3 whitespace-pre-wrap text-gray-800 text-xs">{preview.preview}</div>
+              </div>
+            </>
+          )}
+          <div>
+            <span className="text-gray-500">발송 방식:</span>
+            <span className="ml-2 font-medium">
+              {mode === 'immediate' ? '즉시 발송' : `예약 발송 (${scheduledAt ? new Date(scheduledAt).toLocaleString('ko-KR') : '-'})`}
+            </span>
+          </div>
+          {!excludeRecallExcluded && (
+            <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded p-2">
+              <AlertTriangle className="w-4 h-4 text-amber-600 mt-0.5" />
+              <p className="text-amber-800 text-xs">리콜 제외 환자도 포함되어 발송됩니다.</p>
+            </div>
+          )}
+        </div>
+
+        <div className="px-4 py-3 border-t border-gray-200 flex justify-end gap-2">
+          <button onClick={onClose} disabled={sending} className="px-3 py-1.5 text-sm rounded-md border border-gray-300 hover:bg-gray-50">취소</button>
+          <button
+            onClick={onConfirm}
+            disabled={sending}
+            className="px-4 py-1.5 text-sm rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {sending ? '발송 중...' : `${selectedCount}명에게 발송`}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/SendTab.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/SendTab.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { useState } from 'react'
+import PatientFilterPanel from './PatientFilterPanel'
+import PatientSelectionList from './PatientSelectionList'
+import RecallExcludeToggle from './RecallExcludeToggle'
+import MessageEditor from './MessageEditor'
+import SendActionBar from './SendActionBar'
+import SendConfirmDialog from './SendConfirmDialog'
+import type { BulkSmsFilter, BulkSmsEligiblePatient } from '@/types/bulkSms'
+
+const INITIAL_FILTER: BulkSmsFilter = {
+  gender: 'all', ageMin: null, ageMax: null,
+  lastVisitFrom: null, lastVisitTo: null,
+  lastTreatmentTypes: [], hasNextAppointment: null,
+  birthMonths: [], searchKeyword: '', activeOnly: true,
+}
+
+export default function SendTab() {
+  const [filter, setFilter] = useState<BulkSmsFilter>(INITIAL_FILTER)
+  const [excludeRecall, setExcludeRecall] = useState(true)
+  const [patients, setPatients] = useState<BulkSmsEligiblePatient[]>([])
+  const [excludedCount, setExcludedCount] = useState(0)
+  const [noPhoneCount, setNoPhoneCount] = useState(0)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState('')
+  const [title, setTitle] = useState('')
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [pendingMode, setPendingMode] = useState<'immediate' | 'scheduled'>('immediate')
+  const [pendingScheduledAt, setPendingScheduledAt] = useState<string | undefined>()
+  const [sending, setSending] = useState(false)
+
+  const fetchPatients = async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/bulk-sms/patients', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filter, excludeRecallExcluded: excludeRecall }),
+      })
+      const d = await res.json()
+      if (d.success) {
+        setPatients(d.patients)
+        setExcludedCount(d.excluded_count)
+        setNoPhoneCount(d.no_phone_count)
+        setSelectedIds(new Set(d.patients.map((p: BulkSmsEligiblePatient) => p.dentweb_patient_id)))
+      } else {
+        alert(d.error || '조회 실패')
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const toggleOne = (id: string) => {
+    const next = new Set(selectedIds)
+    if (next.has(id)) next.delete(id); else next.add(id)
+    setSelectedIds(next)
+  }
+  const toggleAll = (checked: boolean) => {
+    setSelectedIds(checked ? new Set(patients.map(p => p.dentweb_patient_id)) : new Set())
+  }
+
+  const handleTest = async (phone: string) => {
+    const res = await fetch('/api/bulk-sms/test-send', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message, phoneNumber: phone, title, samplePatientName: '테스트' }),
+    })
+    const d = await res.json()
+    if (!d.success) throw new Error(d.error || '발송 실패')
+  }
+
+  const openConfirm = (mode: 'immediate' | 'scheduled', scheduledAt?: string) => {
+    if (!message.trim()) { alert('메시지를 입력하세요'); return }
+    if (selectedIds.size === 0) { alert('선택된 환자가 없습니다'); return }
+    setPendingMode(mode)
+    setPendingScheduledAt(scheduledAt)
+    setConfirmOpen(true)
+  }
+
+  const confirmSend = async () => {
+    setSending(true)
+    try {
+      const endpoint = pendingMode === 'immediate' ? '/api/bulk-sms/send' : '/api/bulk-sms/schedule'
+      const body = {
+        filter,
+        excludeRecallExcluded: excludeRecall,
+        message,
+        title: title || undefined,
+        selectedPatientIds: Array.from(selectedIds),
+        ...(pendingMode === 'scheduled' ? { scheduledAt: pendingScheduledAt } : {}),
+      }
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const d = await res.json()
+      if (d.success) {
+        alert(pendingMode === 'immediate'
+          ? `발송 완료: 성공 ${d.success_count}건 / 실패 ${d.fail_count}건`
+          : `예약 완료: ${new Date(d.scheduled_at).toLocaleString('ko-KR')}`)
+        setConfirmOpen(false)
+        setMessage('')
+        setTitle('')
+        setSelectedIds(new Set())
+        setPatients([])
+      } else {
+        alert(d.error || '발송 실패')
+      }
+    } finally {
+      setSending(false)
+    }
+  }
+
+  const sampleName = patients.find(p => selectedIds.has(p.dentweb_patient_id))?.patient_name ?? '홍길동'
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+      <div className="lg:col-span-1 space-y-4">
+        <PatientFilterPanel value={filter} onChange={setFilter} onApply={fetchPatients} loading={loading} />
+        <RecallExcludeToggle enabled={excludeRecall} onChange={(v) => { setExcludeRecall(v); fetchPatients() }} />
+      </div>
+      <div className="lg:col-span-2 space-y-4">
+        <PatientSelectionList
+          patients={patients}
+          selectedIds={selectedIds}
+          onToggle={toggleOne}
+          onToggleAll={toggleAll}
+          excludedCount={excludedCount}
+          noPhoneCount={noPhoneCount}
+          loading={loading}
+        />
+        <MessageEditor message={message} onMessageChange={setMessage} title={title} onTitleChange={setTitle} />
+        <SendActionBar
+          canSend={selectedIds.size > 0 && message.trim().length > 0}
+          onTestSend={handleTest}
+          onSubmitImmediate={() => openConfirm('immediate')}
+          onSubmitScheduled={(iso) => openConfirm('scheduled', iso)}
+        />
+      </div>
+
+      <SendConfirmDialog
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={confirmSend}
+        selectedCount={selectedIds.size}
+        message={message}
+        sampleName={sampleName}
+        excludeRecallExcluded={excludeRecall}
+        mode={pendingMode}
+        scheduledAt={pendingScheduledAt}
+        sending={sending}
+      />
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/TemplatesTab/TemplateEditModal.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/TemplatesTab/TemplateEditModal.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { X } from 'lucide-react'
+import MessageByteCounter from '../shared/MessageByteCounter'
+import type { BulkSmsTemplate } from '@/types/bulkSms'
+
+interface Props {
+  open: boolean
+  template: BulkSmsTemplate | null
+  onClose: () => void
+  onSaved: () => void
+}
+
+export default function TemplateEditModal({ open, template, onClose, onSaved }: Props) {
+  const [name, setName] = useState('')
+  const [content, setContent] = useState('')
+  const [isDefault, setIsDefault] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    setName(template?.name ?? '')
+    setContent(template?.content ?? '')
+    setIsDefault(template?.is_default ?? false)
+  }, [open, template])
+
+  if (!open) return null
+
+  const save = async () => {
+    if (!name.trim() || !content.trim()) {
+      alert('이름과 내용을 입력하세요')
+      return
+    }
+
+    setSaving(true)
+    const url = template ? `/api/bulk-sms/templates/${template.id}` : '/api/bulk-sms/templates'
+    const method = template ? 'PATCH' : 'POST'
+
+    try {
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim(), content, is_default: isDefault }),
+      })
+      const d = await res.json()
+      setSaving(false)
+
+      if (d.success) {
+        onSaved()
+      } else {
+        alert(d.error || '저장 실패')
+      }
+    } catch (err) {
+      setSaving(false)
+      alert('저장 중 오류가 발생했습니다')
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+          <h2 className="text-lg font-semibold">
+            {template ? '템플릿 수정' : '템플릿 추가'}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-4 space-y-3">
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">
+              이름
+            </label>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="예: 정기 검진 안내"
+              className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:outline-none focus:border-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">
+              내용 (변수: {'{환자명}'}, {'{병원명}'}, {'{전화번호}'})
+            </label>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="예: {환자명}님, 안녕하세요. {병원명}입니다."
+              rows={6}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm font-mono focus:outline-none focus:border-blue-500"
+            />
+            <div className="mt-1 flex justify-end">
+              <MessageByteCounter text={content} />
+            </div>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={isDefault}
+              onChange={(e) => setIsDefault(e.target.checked)}
+              className="w-4 h-4 border-gray-300 rounded"
+            />
+            <span>기본 템플릿으로 설정</span>
+          </label>
+        </div>
+
+        <div className="px-4 py-3 border-t border-gray-200 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="px-3 py-1.5 text-sm rounded-md border border-gray-300 hover:bg-gray-50 disabled:opacity-50"
+          >
+            취소
+          </button>
+          <button
+            onClick={save}
+            disabled={saving}
+            className="px-4 py-1.5 text-sm rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? '저장 중...' : '저장'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/TemplatesTab/TemplatesTab.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/TemplatesTab/TemplatesTab.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Plus, Pencil, Trash2 } from 'lucide-react'
+import TemplateEditModal from './TemplateEditModal'
+import type { BulkSmsTemplate } from '@/types/bulkSms'
+
+export default function TemplatesTab() {
+  const [templates, setTemplates] = useState<BulkSmsTemplate[]>([])
+  const [loading, setLoading] = useState(true)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editing, setEditing] = useState<BulkSmsTemplate | null>(null)
+
+  const load = async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/bulk-sms/templates')
+      const d = await res.json()
+      if (d.success) {
+        setTemplates(d.templates || [])
+      }
+    } catch (err) {
+      console.error('Failed to load templates:', err)
+    }
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const remove = async (id: string) => {
+    if (!confirm('이 템플릿을 삭제하시겠습니까?')) return
+
+    try {
+      const res = await fetch(`/api/bulk-sms/templates/${id}`, { method: 'DELETE' })
+      const d = await res.json()
+
+      if (d.success) {
+        load()
+      } else {
+        alert(d.error || '삭제 실패')
+      }
+    } catch (err) {
+      alert('삭제 중 오류가 발생했습니다')
+    }
+  }
+
+  return (
+    <>
+      <div className="flex justify-end mb-4">
+        <button
+          onClick={() => {
+            setEditing(null)
+            setModalOpen(true)
+          }}
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700 transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+          템플릿 추가
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="p-8 text-center text-sm text-gray-400">불러오는 중...</div>
+      ) : templates.length === 0 ? (
+        <div className="p-8 text-center text-sm text-gray-400">
+          등록된 템플릿이 없습니다.
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {templates.map((t) => (
+            <div
+              key={t.id}
+              className="bg-white border border-gray-200 rounded-lg p-4 hover:border-gray-300 transition-colors"
+            >
+              <div className="flex items-start justify-between gap-2 mb-3">
+                <div className="flex-1">
+                  <h4 className="font-medium text-gray-900 text-sm">{t.name}</h4>
+                  {t.is_default && (
+                    <span className="inline-block mt-1 text-xs px-2 py-0.5 bg-blue-100 text-blue-700 rounded">
+                      기본 템플릿
+                    </span>
+                  )}
+                </div>
+                <div className="flex gap-1">
+                  <button
+                    onClick={() => {
+                      setEditing(t)
+                      setModalOpen(true)
+                    }}
+                    className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded transition-colors"
+                    title="편집"
+                  >
+                    <Pencil className="w-4 h-4" />
+                  </button>
+                  <button
+                    onClick={() => remove(t.id)}
+                    className="p-1.5 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded transition-colors"
+                    title="삭제"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+              </div>
+              <pre className="text-xs text-gray-600 whitespace-pre-wrap font-sans line-clamp-4 break-words">
+                {t.content}
+              </pre>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <TemplateEditModal
+        open={modalOpen}
+        template={editing}
+        onClose={() => setModalOpen(false)}
+        onSaved={() => {
+          setModalOpen(false)
+          load()
+        }}
+      />
+    </>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/shared/CampaignStatusBadge.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/shared/CampaignStatusBadge.tsx
@@ -1,0 +1,19 @@
+import type { BulkSmsCampaignStatus } from '@/types/bulkSms'
+
+const STATUS_MAP: Record<BulkSmsCampaignStatus, { label: string; cls: string }> = {
+  draft:     { label: '임시저장', cls: 'bg-gray-100 text-gray-700' },
+  scheduled: { label: '예약',     cls: 'bg-amber-100 text-amber-800' },
+  sending:   { label: '발송중',   cls: 'bg-blue-100 text-blue-800' },
+  sent:      { label: '발송완료', cls: 'bg-green-100 text-green-800' },
+  failed:    { label: '실패',     cls: 'bg-red-100 text-red-800' },
+  cancelled: { label: '취소',     cls: 'bg-gray-100 text-gray-500 line-through' },
+}
+
+export default function CampaignStatusBadge({ status }: { status: BulkSmsCampaignStatus }) {
+  const s = STATUS_MAP[status] ?? STATUS_MAP.draft
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${s.cls}`}>
+      {s.label}
+    </span>
+  )
+}

--- a/dental-clinic-manager/src/components/BulkSms/shared/MessageByteCounter.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/shared/MessageByteCounter.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+export default function MessageByteCounter({ text }: { text: string }) {
+  const bytes = new TextEncoder().encode(text).length
+  const isLMS = bytes > 90
+  const cls = bytes > 2000 ? 'text-red-600' : isLMS ? 'text-amber-700' : 'text-gray-500'
+  return (
+    <div className={`text-xs ${cls}`}>
+      {bytes} 바이트 · {isLMS ? 'LMS' : 'SMS'} {bytes > 2000 && '(2000바이트 초과)'}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/lib/__tests__/bulkSmsService.test.ts
+++ b/dental-clinic-manager/src/lib/__tests__/bulkSmsService.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { normalizePhone, calculateAge, applyVariables, isExcluded } from '@/lib/bulkSmsService'
+
+describe('normalizePhone', () => {
+  it('하이픈·공백 제거 후 숫자만 반환', () => {
+    expect(normalizePhone('010-1234-5678')).toBe('01012345678')
+    expect(normalizePhone(' 010 1234 5678 ')).toBe('01012345678')
+    expect(normalizePhone(null)).toBe('')
+    expect(normalizePhone(undefined)).toBe('')
+  })
+})
+
+describe('calculateAge', () => {
+  it('생년월일 기준 만 나이를 계산한다', () => {
+    const today = new Date('2026-05-14')
+    expect(calculateAge('2000-01-01', today)).toBe(26)
+    expect(calculateAge('2000-12-31', today)).toBe(25)  // 아직 생일 전
+    expect(calculateAge(null, today)).toBeNull()
+  })
+})
+
+describe('applyVariables', () => {
+  it('환자명/병원명/전화번호 변수를 치환', () => {
+    const t = '안녕하세요 {환자명}님, {병원명}입니다. 문의: {전화번호}'
+    const r = applyVariables(t, { patientName: '홍길동', clinicName: '하얀치과', clinicPhone: '02-1234-5678' })
+    expect(r).toBe('안녕하세요 홍길동님, 하얀치과입니다. 문의: 02-1234-5678')
+  })
+
+  it('환자명이 없을 때는 변수를 그대로 둔다', () => {
+    const r = applyVariables('{환자명}님 안녕하세요', { clinicName: '', clinicPhone: '' })
+    expect(r).toBe('{환자명}님 안녕하세요')
+  })
+})
+
+describe('isExcluded', () => {
+  it('전화번호 일치 시 제외', () => {
+    const rules = [{ phone_number: '010-1111-2222', patient_name: null, chart_number: null }]
+    expect(isExcluded({ phone_number: '01011112222', patient_name: '김철수', chart_number: null }, rules)).toBe(true)
+  })
+
+  it('차트번호 일치 시 제외', () => {
+    const rules = [{ phone_number: null, patient_name: null, chart_number: 'C-100' }]
+    expect(isExcluded({ phone_number: '010', patient_name: '김', chart_number: 'C-100' }, rules)).toBe(true)
+  })
+
+  it('이름만 일치 + 다른 키 모두 NULL 인 룰은 환자 이름이 동일할 때 제외', () => {
+    const rules = [{ phone_number: null, patient_name: '홍길동', chart_number: null }]
+    expect(isExcluded({ phone_number: '010', patient_name: '홍길동', chart_number: 'X' }, rules)).toBe(true)
+  })
+
+  it('어떤 키도 일치하지 않으면 포함', () => {
+    const rules = [{ phone_number: '010-9999-9999', patient_name: '아무개', chart_number: 'Z-1' }]
+    expect(isExcluded({ phone_number: '01011112222', patient_name: '김철수', chart_number: 'C-100' }, rules)).toBe(false)
+  })
+})

--- a/dental-clinic-manager/src/lib/bulkSmsAuth.ts
+++ b/dental-clinic-manager/src/lib/bulkSmsAuth.ts
@@ -1,0 +1,99 @@
+// 단체 문자 API 공용 권한 체크 헬퍼
+// 클라이언트 cookie 세션으로 사용자 식별 + service role로 권한·클리닉 정보 로드
+import { createClient } from '@supabase/supabase-js'
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import type { Permission } from '@/types/permissions'
+import {
+  DEFAULT_PERMISSIONS,
+  NEW_FEATURE_PREFIXES,
+  NEW_INDIVIDUAL_PERMISSIONS,
+} from '@/types/permissions'
+
+export interface AuthedContext {
+  userId: string
+  clinicId: string
+  clinicName: string
+  clinicPhone: string
+}
+
+// 현재 로그인 사용자의 권한이 `required`를 포함하는지 검사.
+// 권한 부족이면 null 반환.
+export async function getAuthedUserWithPermission(
+  required: Permission
+): Promise<AuthedContext | null> {
+  const cookieStore = await cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll() {
+          /* readonly in route handlers; middleware refreshes */
+        },
+      },
+    }
+  )
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return null
+
+  // Service Role로 사용자 + 클리닉 조회 (RLS 우회)
+  const service = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  const { data: u } = await service
+    .from('users')
+    .select('id, clinic_id, role, permissions')
+    .eq('id', user.id)
+    .single()
+  if (!u || !u.clinic_id) return null
+
+  // owner는 모든 권한
+  let hasPermission = u.role === 'owner'
+
+  if (!hasPermission) {
+    // 사용자에게 직접 할당된 권한이 있으면 그것 사용 (usePermissions hook 패턴과 동일)
+    let userPermissions: Permission[] = []
+    if (Array.isArray(u.permissions) && u.permissions.length > 0) {
+      userPermissions = [...(u.permissions as Permission[])]
+      const roleDefaults = DEFAULT_PERMISSIONS[u.role as string] ?? []
+      for (const prefix of NEW_FEATURE_PREFIXES) {
+        const hasFeaturePerms = userPermissions.some((p) => p.startsWith(prefix))
+        if (!hasFeaturePerms) {
+          userPermissions.push(...roleDefaults.filter((p) => p.startsWith(prefix)))
+        }
+      }
+      for (const perm of NEW_INDIVIDUAL_PERMISSIONS) {
+        if (!userPermissions.includes(perm) && roleDefaults.includes(perm)) {
+          userPermissions.push(perm)
+        }
+      }
+    } else {
+      userPermissions = DEFAULT_PERMISSIONS[u.role as string] ?? []
+    }
+    hasPermission = userPermissions.includes(required)
+  }
+
+  if (!hasPermission) return null
+
+  // 클리닉 정보 별도 조회 (관계 join 회피)
+  const { data: clinic } = await service
+    .from('clinics')
+    .select('name, phone')
+    .eq('id', u.clinic_id)
+    .single()
+
+  return {
+    userId: u.id,
+    clinicId: u.clinic_id,
+    clinicName: clinic?.name ?? '',
+    clinicPhone: clinic?.phone ?? '',
+  }
+}

--- a/dental-clinic-manager/src/lib/bulkSmsService.ts
+++ b/dental-clinic-manager/src/lib/bulkSmsService.ts
@@ -276,9 +276,7 @@ export async function sendCampaign(
   // 본문이 동일한 그룹(변수 미사용)은 1회 호출, 그 외는 개별 호출
   // 동일 메시지 그룹화
   const byMessage = new Map<string, Array<{ id: string; phone: string }>>()
-  const recipientRows = recipients as Array<{ id: string; phone_number: string; personalized_message: string }>
-  for (let idx = 0; idx < recipientRows.length; idx++) {
-    const r = recipientRows[idx]
+  for (const r of recipients as Array<{ id: string; phone_number: string; personalized_message: string }>) {
     const arr = byMessage.get(r.personalized_message) ?? []
     arr.push({ id: r.id, phone: r.phone_number })
     byMessage.set(r.personalized_message, arr)
@@ -288,14 +286,9 @@ export async function sendCampaign(
   let totalFail = 0
   const nowIso = new Date().toISOString()
 
-  const msgType = campaign.msg_type as 'SMS' | 'LMS'
-  byMessage.forEach((group, message) => {
-    // 1,000명 단위 분할 처리는 Promise.all로 병렬 처리를 위해 async 지연
-  })
-
   // 메시지별 처리
-  for (const messageKey of Array.from(byMessage.keys())) {
-    const group = byMessage.get(messageKey)!
+  for (const [message, group] of byMessage.entries()) {
+    const msgType = campaign.msg_type as 'SMS' | 'LMS'
     // 1,000명 단위 분할
     for (let i = 0; i < group.length; i += ALIGO_BATCH_SIZE) {
       const batch = group.slice(i, i + ALIGO_BATCH_SIZE)
@@ -304,7 +297,7 @@ export async function sendCampaign(
         userId: aligo.user_id,
         sender: aligo.sender_number,
         receivers: batch.map(b => normalizePhone(b.phone)),
-        message: messageKey,
+        message,
         msgType,
         title: campaign.title || undefined,
       })

--- a/dental-clinic-manager/src/lib/bulkSmsService.ts
+++ b/dental-clinic-manager/src/lib/bulkSmsService.ts
@@ -1,0 +1,237 @@
+// 단체 문자 발송 핵심 서비스
+// - 환자 조회(DentWeb + 필터 + 리콜 제외 환자 매칭)
+// - 변수 치환
+// - 발송 실행 (즉시·예약 공용)
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
+import { aligoFetch } from '@/lib/aligoFetch'
+import type {
+  BulkSmsFilter,
+  BulkSmsEligiblePatient,
+  BulkSmsEligibleResponse,
+  BulkSmsCampaign,
+} from '@/types/bulkSms'
+
+const ALIGO_API_URL = 'https://apis.aligo.in'
+const ALIGO_BATCH_SIZE = 1000  // 알리고 단일 호출 최대 수신자 수
+const SMS_BYTE_LIMIT = 90      // 90바이트 초과 시 LMS
+
+export function normalizePhone(phone: string | null | undefined): string {
+  if (!phone) return ''
+  return String(phone).replace(/[^0-9]/g, '')
+}
+
+export function calculateAge(birthDate: string | null | undefined, today: Date = new Date()): number | null {
+  if (!birthDate) return null
+  const b = new Date(birthDate)
+  if (isNaN(b.getTime())) return null
+  let age = today.getFullYear() - b.getFullYear()
+  const m = today.getMonth() - b.getMonth()
+  if (m < 0 || (m === 0 && today.getDate() < b.getDate())) age--
+  return age
+}
+
+export function applyVariables(
+  template: string,
+  vars: { patientName?: string; clinicName?: string; clinicPhone?: string }
+): string {
+  let out = template
+  if (vars.patientName) out = out.replace(/\{환자명\}/g, vars.patientName)
+  if (vars.clinicName !== undefined) out = out.replace(/\{병원명\}/g, vars.clinicName)
+  if (vars.clinicPhone !== undefined) out = out.replace(/\{전화번호\}/g, vars.clinicPhone)
+  return out
+}
+
+export function determineMsgType(message: string): 'SMS' | 'LMS' {
+  const bytes = new TextEncoder().encode(message).length
+  return bytes > SMS_BYTE_LIMIT ? 'LMS' : 'SMS'
+}
+
+// 제외 룰 매칭 (전화번호 > 차트번호 > 이름 우선)
+export interface ExcludeRule {
+  phone_number: string | null
+  patient_name: string | null
+  chart_number: string | null
+}
+
+export function isExcluded(
+  patient: { phone_number: string; patient_name: string; chart_number: string | null },
+  rules: ExcludeRule[]
+): boolean {
+  const pPhone = normalizePhone(patient.phone_number)
+  const pName = (patient.patient_name || '').trim()
+  const pChart = (patient.chart_number || '').trim()
+
+  for (const r of rules) {
+    if (r.phone_number && normalizePhone(r.phone_number) === pPhone && pPhone) return true
+    if (r.chart_number && r.chart_number.trim() === pChart && pChart) return true
+    // 이름만 매칭은 다른 키가 NULL일 때만(동명이인 위험 회피)
+    if (r.patient_name && !r.phone_number && !r.chart_number) {
+      if (r.patient_name.trim() === pName && pName) return true
+    }
+  }
+  return false
+}
+
+// 발송 대상 환자 조회 (DentWeb + 필터 + 리콜 제외 적용)
+export async function getEligiblePatients(
+  supabase: SupabaseClient,
+  clinicId: string,
+  filter: BulkSmsFilter,
+  excludeRecallExcluded: boolean
+): Promise<BulkSmsEligibleResponse> {
+  let q = supabase
+    .from('dentweb_patients')
+    .select('id, patient_name, phone_number, chart_number, birth_date, gender, last_visit_date, last_treatment_type, next_appointment_date, is_active')
+    .eq('clinic_id', clinicId)
+
+  if (filter.activeOnly !== false) q = q.eq('is_active', true)
+  if (filter.gender && filter.gender !== 'all') {
+    const g = filter.gender === 'male' ? 'M' : 'F'
+    q = q.eq('gender', g)
+  }
+  if (filter.lastVisitFrom) q = q.gte('last_visit_date', filter.lastVisitFrom)
+  if (filter.lastVisitTo) q = q.lte('last_visit_date', filter.lastVisitTo)
+  if (filter.lastTreatmentTypes && filter.lastTreatmentTypes.length > 0) {
+    q = q.in('last_treatment_type', filter.lastTreatmentTypes)
+  }
+  if (filter.hasNextAppointment === true) q = q.not('next_appointment_date', 'is', null)
+  if (filter.hasNextAppointment === false) q = q.is('next_appointment_date', null)
+  if (filter.searchKeyword && filter.searchKeyword.trim()) {
+    const kw = filter.searchKeyword.trim()
+    q = q.or(`patient_name.ilike.%${kw}%,chart_number.ilike.%${kw}%`)
+  }
+
+  const { data, error } = await q.limit(5000)
+  if (error) throw new Error(`환자 조회 실패: ${error.message}`)
+
+  const today = new Date()
+  let rows = (data ?? []) as Array<{
+    id: string; patient_name: string; phone_number: string | null; chart_number: string | null;
+    birth_date: string | null; gender: string | null;
+    last_visit_date: string | null; last_treatment_type: string | null;
+    next_appointment_date: string | null; is_active: boolean;
+  }>
+
+  // 나이 필터
+  if (filter.ageMin != null || filter.ageMax != null) {
+    rows = rows.filter(r => {
+      const age = calculateAge(r.birth_date, today)
+      if (age == null) return false
+      if (filter.ageMin != null && age < filter.ageMin) return false
+      if (filter.ageMax != null && age > filter.ageMax) return false
+      return true
+    })
+  }
+
+  // 생일 월 필터
+  if (filter.birthMonths && filter.birthMonths.length > 0) {
+    const months = new Set(filter.birthMonths)
+    rows = rows.filter(r => {
+      if (!r.birth_date) return false
+      const m = new Date(r.birth_date).getMonth() + 1
+      return months.has(m)
+    })
+  }
+
+  // 전화번호 없는 환자 제외
+  const beforeNoPhone = rows.length
+  rows = rows.filter(r => !!r.phone_number && normalizePhone(r.phone_number).length >= 9)
+  const noPhoneCount = beforeNoPhone - rows.length
+
+  // 리콜 제외 환자 제거
+  let excludedCount = 0
+  if (excludeRecallExcluded) {
+    const rules = await fetchExcludeRules(supabase, clinicId)
+    const before = rows.length
+    rows = rows.filter(r => !isExcluded({
+      phone_number: r.phone_number!,
+      patient_name: r.patient_name,
+      chart_number: r.chart_number
+    }, rules))
+    excludedCount = before - rows.length
+  }
+
+  const patients: BulkSmsEligiblePatient[] = rows.map(r => ({
+    dentweb_patient_id: r.id,
+    patient_name: r.patient_name,
+    phone_number: r.phone_number!,
+    chart_number: r.chart_number,
+    birth_date: r.birth_date,
+    gender: r.gender,
+    last_visit_date: r.last_visit_date,
+    last_treatment_type: r.last_treatment_type,
+    next_appointment_date: r.next_appointment_date,
+  }))
+
+  return { patients, total: patients.length, excluded_count: excludedCount, no_phone_count: noPhoneCount }
+}
+
+// 제외 룰 수집: recall_patients(exclude_reason IS NOT NULL) + recall_exclude_rules(is_active=true)
+async function fetchExcludeRules(supabase: SupabaseClient, clinicId: string): Promise<ExcludeRule[]> {
+  const [{ data: rp }, { data: rer }] = await Promise.all([
+    supabase
+      .from('recall_patients')
+      .select('phone_number, patient_name, chart_number')
+      .eq('clinic_id', clinicId)
+      .not('exclude_reason', 'is', null),
+    supabase
+      .from('recall_exclude_rules')
+      .select('phone_number, patient_name, chart_number')
+      .eq('clinic_id', clinicId)
+      .eq('is_active', true),
+  ])
+  const rules: ExcludeRule[] = []
+  ;(rp ?? []).forEach((r: { phone_number: string | null; patient_name: string | null; chart_number: string | null }) => rules.push(r))
+  ;(rer ?? []).forEach((r: { phone_number: string | null; patient_name: string | null; chart_number: string | null }) => rules.push(r))
+  return rules
+}
+
+// 알리고 발송 결과
+export interface AligoSendResult {
+  ok: boolean
+  msg_id?: string
+  success_cnt: number
+  error_cnt: number
+  error?: string
+}
+
+// 단일 호출 (수신자 콤마 결합 — 최대 1,000명, 동일 본문)
+export async function sendBatch(params: {
+  apiKey: string
+  userId: string
+  sender: string
+  receivers: string[]
+  message: string
+  msgType: 'SMS' | 'LMS'
+  title?: string
+}): Promise<AligoSendResult> {
+  const body = new URLSearchParams()
+  body.append('key', params.apiKey)
+  body.append('user_id', params.userId)
+  body.append('sender', params.sender)
+  body.append('receiver', params.receivers.join(','))
+  body.append('msg', params.message)
+  body.append('msg_type', params.msgType)
+  if (params.title && params.msgType !== 'SMS') body.append('title', params.title)
+
+  try {
+    const res = await aligoFetch(`${ALIGO_API_URL}/send/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    })
+    const json = await res.json() as { result_code: string | number; message?: string; msg_id?: string; success_cnt?: number; error_cnt?: number }
+    const ok = String(json.result_code) === '1'
+    return {
+      ok,
+      msg_id: json.msg_id,
+      success_cnt: json.success_cnt ?? (ok ? params.receivers.length : 0),
+      error_cnt: json.error_cnt ?? (ok ? 0 : params.receivers.length),
+      error: ok ? undefined : (json.message || 'aligo error'),
+    }
+  } catch (e) {
+    return { ok: false, success_cnt: 0, error_cnt: params.receivers.length, error: (e as Error).message }
+  }
+}
+
+export { ALIGO_BATCH_SIZE, SMS_BYTE_LIMIT }

--- a/dental-clinic-manager/src/lib/bulkSmsService.ts
+++ b/dental-clinic-manager/src/lib/bulkSmsService.ts
@@ -234,4 +234,107 @@ export async function sendBatch(params: {
   }
 }
 
+// 캠페인 발송 실행 (즉시 + Cron 공용)
+// 전제: 호출 전에 bulk_sms_campaigns.status='sending'으로 점유되어 있어야 함
+export async function sendCampaign(
+  supabase: SupabaseClient,
+  campaignId: string
+): Promise<{ success: number; fail: number }> {
+  // 캠페인 + 수신자 + aligo 설정 로드
+  const { data: campaign, error: cErr } = await supabase
+    .from('bulk_sms_campaigns')
+    .select('id, clinic_id, message, msg_type, title')
+    .eq('id', campaignId)
+    .single()
+  if (cErr || !campaign) throw new Error('캠페인을 찾을 수 없습니다')
+
+  const { data: aligo } = await supabase
+    .from('aligo_settings')
+    .select('api_key, user_id, sender_number')
+    .eq('clinic_id', campaign.clinic_id)
+    .single()
+  if (!aligo?.api_key || !aligo.user_id || !aligo.sender_number) {
+    await supabase.from('bulk_sms_campaigns')
+      .update({ status: 'failed', completed_at: new Date().toISOString() })
+      .eq('id', campaignId)
+    throw new Error('알리고 설정이 없습니다')
+  }
+
+  const { data: recipients, error: rErr } = await supabase
+    .from('bulk_sms_recipients')
+    .select('id, phone_number, personalized_message')
+    .eq('campaign_id', campaignId)
+    .eq('status', 'pending')
+  if (rErr) throw new Error(rErr.message)
+  if (!recipients || recipients.length === 0) {
+    await supabase.from('bulk_sms_campaigns')
+      .update({ status: 'sent', completed_at: new Date().toISOString() })
+      .eq('id', campaignId)
+    return { success: 0, fail: 0 }
+  }
+
+  // 본문이 동일한 그룹(변수 미사용)은 1회 호출, 그 외는 개별 호출
+  // 동일 메시지 그룹화
+  const byMessage = new Map<string, Array<{ id: string; phone: string }>>()
+  const recipientRows = recipients as Array<{ id: string; phone_number: string; personalized_message: string }>
+  for (let idx = 0; idx < recipientRows.length; idx++) {
+    const r = recipientRows[idx]
+    const arr = byMessage.get(r.personalized_message) ?? []
+    arr.push({ id: r.id, phone: r.phone_number })
+    byMessage.set(r.personalized_message, arr)
+  }
+
+  let totalSuccess = 0
+  let totalFail = 0
+  const nowIso = new Date().toISOString()
+
+  const msgType = campaign.msg_type as 'SMS' | 'LMS'
+  byMessage.forEach((group, message) => {
+    // 1,000명 단위 분할 처리는 Promise.all로 병렬 처리를 위해 async 지연
+  })
+
+  // 메시지별 처리
+  for (const messageKey of Array.from(byMessage.keys())) {
+    const group = byMessage.get(messageKey)!
+    // 1,000명 단위 분할
+    for (let i = 0; i < group.length; i += ALIGO_BATCH_SIZE) {
+      const batch = group.slice(i, i + ALIGO_BATCH_SIZE)
+      const result = await sendBatch({
+        apiKey: aligo.api_key,
+        userId: aligo.user_id,
+        sender: aligo.sender_number,
+        receivers: batch.map(b => normalizePhone(b.phone)),
+        message: messageKey,
+        msgType,
+        title: campaign.title || undefined,
+      })
+
+      if (result.ok) {
+        // 알리고는 batch 단위로 결과를 주므로 전부 success 로 표시
+        await supabase.from('bulk_sms_recipients')
+          .update({ status: 'success', aligo_msg_id: result.msg_id ?? null, sent_at: nowIso })
+          .in('id', batch.map(b => b.id))
+        totalSuccess += batch.length
+      } else {
+        await supabase.from('bulk_sms_recipients')
+          .update({ status: 'failed', error_message: result.error ?? 'unknown', sent_at: nowIso })
+          .in('id', batch.map(b => b.id))
+        totalFail += batch.length
+      }
+    }
+  }
+
+  const finalStatus = totalFail > 0 && totalSuccess === 0 ? 'failed' : 'sent'
+  await supabase.from('bulk_sms_campaigns')
+    .update({
+      status: finalStatus,
+      success_count: totalSuccess,
+      fail_count: totalFail,
+      completed_at: new Date().toISOString(),
+    })
+    .eq('id', campaignId)
+
+  return { success: totalSuccess, fail: totalFail }
+}
+
 export { ALIGO_BATCH_SIZE, SMS_BYTE_LIMIT }

--- a/dental-clinic-manager/vercel.json
+++ b/dental-clinic-manager/vercel.json
@@ -37,6 +37,10 @@
     {
       "path": "/api/cron/billing-retry",
       "schedule": "0 18 * * *"
+    },
+    {
+      "path": "/api/cron/bulk-sms",
+      "schedule": "*/5 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- DentWeb 환자 데이터 기반 단체 문자 발송 기능 추가 (사이드바 신규 메뉴 "단체 문자")
- 환자 필터: 성별 · 연령 · 최종 내원일(프리셋+커스텀) · 다음 예약 유무 · 생일 월 · 이름/차트번호 검색
- 리콜 제외 환자 자동 적용 + 토글로 해제 가능 (해제 시 경고 배지)
- 변수 치환: `{환자명}`, `{병원명}`, `{전화번호}`
- 즉시 발송 + 예약 발송 (Vercel Cron `*/5 * * * *` 폴링, 원자적 점유로 중복 발송 방지)
- 1,000명 단위 분할 호출 + 동일 본문 그룹화로 알리고 API 호출 최적화
- 캠페인·수신자별 발송 결과 로그 저장 + 발송 이력 탭에서 상세 조회
- 템플릿 CRUD (기본 템플릿 1개 지정 가능)
- 권한: owner / manager에게만 발송 권한 부여 (vice_director 등 미부여)

## DB 변경
- 신규 테이블: `bulk_sms_campaigns`, `bulk_sms_recipients`, `bulk_sms_templates`
- RLS: 클리닉 격리 SELECT 정책 (쓰기는 service role 키로 처리)
- 마이그레이션: `20260514_create_bulk_sms.sql`, `20260514_tighten_bulk_sms_rls.sql`

## Spec / Plan
- spec: `dental-clinic-manager/docs/superpowers/specs/2026-05-14-bulk-sms-design.md`
- plan: `dental-clinic-manager/docs/superpowers/plans/2026-05-14-bulk-sms.md`

## Test plan
- [x] DB 마이그레이션 적용 (Supabase MCP)
- [x] 권한 정합성 검증 (`npm run check:permissions`) — 95/95 통과
- [x] 빌드 (`npm run build`) — 통과
- [x] 단위 테스트 (`bulkSmsService` — normalizePhone/calculateAge/applyVariables/isExcluded 8개) — 통과
- [x] 로그인 → /dashboard/bulk-sms 접근 → 필터 적용 → 환자 811명 조회 확인
- [x] 메시지 작성 → 발송 확인 다이얼로그 (대상 수·SMS/LMS·치환 미리보기) 노출 확인
- [x] 모든 API 라우트 헬스체크: 미인증 403 / Cron 미인증 401
- [ ] 실제 SMS 발송 (비용 발생 — 사용자가 직접 검증 예정)
- [ ] 예약 발송 + Cron 실행 (사용자가 직접 검증 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)