### PR TITLE
fix: Vercel Hobby cron 호환 + 단체 문자 재배포

### DIFF
--- a/dental-clinic-manager/vercel.json
+++ b/dental-clinic-manager/vercel.json
@@ -40,7 +40,7 @@
     },
     {
       "path": "/api/cron/bulk-sms",
-      "schedule": "*/5 * * * *"
+      "schedule": "0 0 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `vercel.json` 의 `/api/cron/bulk-sms` schedule 을 `*/5 * * * *` → `0 0 * * *` 로 변경
- 이전 PR #613 머지 후 Vercel Hobby plan 의 cron 1회/일 제한으로 빌드가 실패하여 production deployment 가 만들어지지 않아 `/dashboard/bulk-sms` 가 404 났던 문제 해결
- Vercel CLI 로 production 강제 배포까지 완료 (www.hi-clinic.co.kr)

## 후속 옵션 (별도)
- 분 단위 예약 발송 필요시 Vercel Pro 업그레이드 또는 Mac mini scraping-worker 에서 짧은 폴링

🤖 Generated with [Claude Code](https://claude.com/claude-code)