### PR TITLE
style: 단체 문자 페이지 디자인 시스템 통일

### DIFF
--- a/dental-clinic-manager/src/components/BulkSms/BulkSmsManagement.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/BulkSmsManagement.tsx
@@ -20,32 +20,40 @@ export default function BulkSmsManagement() {
   const [tab, setTab] = useState<TabKey>('send')
 
   return (
-    <div className="p-4 sm:p-6 max-w-7xl mx-auto">
-      <header className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">단체 문자</h1>
-        <p className="mt-1 text-sm text-gray-500">환자들에게 단체 문자를 발송합니다. 리콜 제외 환자는 기본적으로 발송 대상에서 빠집니다.</p>
-      </header>
-
-      <div className="border-b border-gray-200">
-        <nav className="-mb-px flex gap-2 overflow-x-auto" aria-label="Tabs">
-          {TABS.map(({ key, label, icon: Icon }) => (
-            <button
-              key={key}
-              onClick={() => setTab(key)}
-              className={`whitespace-nowrap py-3 px-4 border-b-2 text-sm font-medium flex items-center gap-2 transition-colors ${
-                tab === key
-                  ? 'border-blue-500 text-blue-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-              }`}
-            >
-              <Icon className="w-4 h-4" />
-              {label}
-            </button>
-          ))}
-        </nav>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-[var(--at-accent-tag)] text-[var(--at-accent)]">
+            <MessageSquare className="h-5 w-5" />
+          </span>
+          <div>
+            <h1 className="text-lg font-semibold text-[var(--at-text-primary)]">단체 문자</h1>
+            <p className="text-xs text-[var(--at-text-secondary)]">환자들에게 단체 문자를 발송합니다. 리콜 제외 환자는 기본적으로 발송 대상에서 빠집니다.</p>
+          </div>
+        </div>
       </div>
 
-      <div className="mt-6">
+      <div className="flex items-center gap-1 border-b border-[var(--at-border)] overflow-x-auto">
+        {TABS.map(({ key, label, icon: Icon }) => (
+          <button
+            key={key}
+            onClick={() => setTab(key)}
+            className={`relative px-4 py-2.5 text-sm font-medium transition flex items-center gap-1.5 whitespace-nowrap ${
+              tab === key
+                ? 'text-[var(--at-accent)]'
+                : 'text-[var(--at-text-secondary)] hover:text-[var(--at-text-primary)]'
+            }`}
+          >
+            <Icon className="w-4 h-4" />
+            {label}
+            {tab === key && (
+              <span className="absolute inset-x-2 bottom-0 h-0.5 rounded-full bg-[var(--at-accent)]" />
+            )}
+          </button>
+        ))}
+      </div>
+
+      <div>
         {tab === 'send' && <SendTab />}
         {tab === 'history' && <HistoryTab />}
         {tab === 'scheduled' && <ScheduledTab />}

--- a/dental-clinic-manager/src/components/BulkSms/HistoryTab/CampaignDetailModal.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/HistoryTab/CampaignDetailModal.tsx
@@ -33,36 +33,36 @@ export default function CampaignDetailModal({ campaignId, onClose }: Props) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] flex flex-col">
-        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">캠페인 상세</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+      <div className="bg-white rounded-xl shadow-xl max-w-3xl w-full max-h-[90vh] flex flex-col">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--at-border)]">
+          <h2 className="text-lg font-semibold text-[var(--at-text-primary)]">캠페인 상세</h2>
+          <button onClick={onClose} className="text-[var(--at-text-weak)] hover:text-[var(--at-text-secondary)]">
             <X className="w-5 h-5" />
           </button>
         </div>
 
         {loading ? (
-          <div className="p-8 text-center text-sm text-gray-400">불러오는 중...</div>
+          <div className="p-8 text-center text-sm text-[var(--at-text-weak)]">불러오는 중...</div>
         ) : campaign && (
           <div className="overflow-y-auto">
-            <div className="px-4 py-3 border-b border-gray-200 space-y-2 text-sm">
+            <div className="px-4 py-3 border-b border-[var(--at-border)] space-y-2 text-sm">
               <div className="flex items-center gap-2">
                 <CampaignStatusBadge status={campaign.status} />
-                <span className="text-gray-500">{new Date(campaign.created_at).toLocaleString('ko-KR')}</span>
+                <span className="text-[var(--at-text-secondary)]">{new Date(campaign.created_at).toLocaleString('ko-KR')}</span>
               </div>
-              {campaign.title && <div><span className="text-gray-500">제목:</span> <span className="font-medium">{campaign.title}</span></div>}
+              {campaign.title && <div><span className="text-[var(--at-text-secondary)]">제목:</span> <span className="font-medium">{campaign.title}</span></div>}
               <div>
-                <span className="text-gray-500">결과:</span>
+                <span className="text-[var(--at-text-secondary)]">결과:</span>
                 <span className="ml-2">전체 {campaign.total_count} · 성공 {campaign.success_count} · 실패 {campaign.fail_count}</span>
               </div>
               <div>
-                <p className="text-gray-500 mb-1">본문</p>
-                <div className="bg-gray-50 border border-gray-200 rounded p-2 whitespace-pre-wrap text-xs">{campaign.message}</div>
+                <p className="text-[var(--at-text-secondary)] mb-1">본문</p>
+                <div className="bg-[var(--at-surface-alt)] border border-[var(--at-border)] rounded p-2 whitespace-pre-wrap text-xs">{campaign.message}</div>
               </div>
             </div>
 
             <table className="w-full text-sm">
-              <thead className="bg-gray-50 text-xs text-gray-500 sticky top-0">
+              <thead className="bg-[var(--at-surface-alt)] text-xs text-[var(--at-text-secondary)] sticky top-0">
                 <tr>
                   <th className="px-3 py-2 text-left">이름</th>
                   <th className="px-3 py-2 text-left">전화번호</th>
@@ -72,15 +72,15 @@ export default function CampaignDetailModal({ campaignId, onClose }: Props) {
               </thead>
               <tbody>
                 {recipients.map(r => (
-                  <tr key={r.id} className="border-t border-gray-100">
+                  <tr key={r.id} className="border-t border-[var(--at-border)]">
                     <td className="px-3 py-2">{r.patient_name ?? '-'}</td>
                     <td className="px-3 py-2 tabular-nums">{r.phone_number}</td>
                     <td className="px-3 py-2">
-                      <span className={r.status === 'success' ? 'text-green-700' : r.status === 'failed' ? 'text-red-700' : 'text-gray-500'}>
+                      <span className={r.status === 'success' ? 'text-green-700' : r.status === 'failed' ? 'text-red-700' : 'text-[var(--at-text-secondary)]'}>
                         {r.status === 'success' ? '성공' : r.status === 'failed' ? '실패' : '대기'}
                       </span>
                     </td>
-                    <td className="px-3 py-2 text-gray-500 text-xs">{r.error_message ?? '-'}</td>
+                    <td className="px-3 py-2 text-[var(--at-text-secondary)] text-xs">{r.error_message ?? '-'}</td>
                   </tr>
                 ))}
               </tbody>

--- a/dental-clinic-manager/src/components/BulkSms/HistoryTab/HistoryTab.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/HistoryTab/HistoryTab.tsx
@@ -17,14 +17,14 @@ export default function HistoryTab() {
       .finally(() => setLoading(false))
   }, [])
 
-  if (loading) return <div className="p-8 text-center text-sm text-gray-400">불러오는 중...</div>
-  if (campaigns.length === 0) return <div className="p-8 text-center text-sm text-gray-400">아직 발송 이력이 없습니다.</div>
+  if (loading) return <div className="p-8 text-center text-sm text-[var(--at-text-weak)]">불러오는 중...</div>
+  if (campaigns.length === 0) return <div className="p-8 text-center text-sm text-[var(--at-text-weak)]">아직 발송 이력이 없습니다.</div>
 
   return (
     <>
-      <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+      <div className="bg-[var(--at-surface)] border border-[var(--at-border)] rounded-xl overflow-hidden">
         <table className="w-full text-sm">
-          <thead className="bg-gray-50 text-xs text-gray-500">
+          <thead className="bg-[var(--at-surface-alt)] text-xs text-[var(--at-text-secondary)]">
             <tr>
               <th className="px-3 py-2 text-left">상태</th>
               <th className="px-3 py-2 text-left">제목</th>
@@ -37,21 +37,21 @@ export default function HistoryTab() {
           </thead>
           <tbody>
             {campaigns.map(c => (
-              <tr key={c.id} className="border-t border-gray-100 hover:bg-gray-50">
+              <tr key={c.id} className="border-t border-[var(--at-border)] hover:bg-[var(--at-surface-alt)]">
                 <td className="px-3 py-2"><CampaignStatusBadge status={c.status} /></td>
-                <td className="px-3 py-2 font-medium text-gray-900">{c.title || '-'}</td>
-                <td className="px-3 py-2 text-gray-500">{c.msg_type}</td>
+                <td className="px-3 py-2 font-medium text-[var(--at-text-primary)]">{c.title || '-'}</td>
+                <td className="px-3 py-2 text-[var(--at-text-secondary)]">{c.msg_type}</td>
                 <td className="px-3 py-2 tabular-nums">{c.total_count}</td>
                 <td className="px-3 py-2 tabular-nums">
                   <span className="text-green-700">{c.success_count}</span>
-                  <span className="text-gray-400"> / </span>
+                  <span className="text-[var(--at-text-weak)]"> / </span>
                   <span className="text-red-700">{c.fail_count}</span>
                 </td>
-                <td className="px-3 py-2 text-gray-500 text-xs">
+                <td className="px-3 py-2 text-[var(--at-text-secondary)] text-xs">
                   {c.sent_at ? new Date(c.sent_at).toLocaleString('ko-KR') : new Date(c.created_at).toLocaleString('ko-KR')}
                 </td>
                 <td className="px-3 py-2">
-                  <button onClick={() => setOpenId(c.id)} className="text-xs text-blue-600 hover:underline">상세</button>
+                  <button onClick={() => setOpenId(c.id)} className="text-xs text-[var(--at-accent)] hover:underline">상세</button>
                 </td>
               </tr>
             ))}

--- a/dental-clinic-manager/src/components/BulkSms/ScheduledTab/ScheduledTab.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/ScheduledTab/ScheduledTab.tsx
@@ -27,13 +27,13 @@ export default function ScheduledTab() {
     else alert(d.error || '취소 실패')
   }
 
-  if (loading) return <div className="p-8 text-center text-sm text-gray-400">불러오는 중...</div>
-  if (campaigns.length === 0) return <div className="p-8 text-center text-sm text-gray-400">예약된 캠페인이 없습니다.</div>
+  if (loading) return <div className="p-8 text-center text-sm text-[var(--at-text-weak)]">불러오는 중...</div>
+  if (campaigns.length === 0) return <div className="p-8 text-center text-sm text-[var(--at-text-weak)]">예약된 캠페인이 없습니다.</div>
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+    <div className="bg-[var(--at-surface)] border border-[var(--at-border)] rounded-xl overflow-hidden">
       <table className="w-full text-sm">
-        <thead className="bg-gray-50 text-xs text-gray-500">
+        <thead className="bg-[var(--at-surface-alt)] text-xs text-[var(--at-text-secondary)]">
           <tr>
             <th className="px-3 py-2 text-left">상태</th>
             <th className="px-3 py-2 text-left">제목</th>
@@ -44,11 +44,11 @@ export default function ScheduledTab() {
         </thead>
         <tbody>
           {campaigns.map(c => (
-            <tr key={c.id} className="border-t border-gray-100">
+            <tr key={c.id} className="border-t border-[var(--at-border)]">
               <td className="px-3 py-2"><CampaignStatusBadge status={c.status} /></td>
-              <td className="px-3 py-2 font-medium text-gray-900">{c.title || '-'}</td>
+              <td className="px-3 py-2 font-medium text-[var(--at-text-primary)]">{c.title || '-'}</td>
               <td className="px-3 py-2 tabular-nums">{c.total_count}명</td>
-              <td className="px-3 py-2 text-gray-700">
+              <td className="px-3 py-2 text-[var(--at-text-primary)]">
                 {c.scheduled_at ? new Date(c.scheduled_at).toLocaleString('ko-KR') : '-'}
               </td>
               <td className="px-3 py-2 text-right">

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/MessageEditor.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/MessageEditor.tsx
@@ -41,30 +41,30 @@ export default function MessageEditor({ message, onMessageChange, title, onTitle
   const insertVariable = (v: string) => onMessageChange(message + v)
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg p-4">
+    <div className="bg-[var(--at-surface)] border border-[var(--at-border)] rounded-xl p-4">
       <div className="flex items-center gap-2 mb-3">
-        <FileText className="w-4 h-4 text-gray-500" />
-        <h3 className="font-medium text-gray-900">메시지 작성</h3>
+        <FileText className="w-4 h-4 text-[var(--at-text-secondary)]" />
+        <h3 className="font-medium text-[var(--at-text-primary)]">메시지 작성</h3>
       </div>
 
       <div className="space-y-3">
         <div>
-          <label className="block text-xs text-gray-500 mb-1">제목 (LMS만 표시)</label>
+          <label className="block text-xs text-[var(--at-text-secondary)] mb-1">제목 (LMS만 표시)</label>
           <input
             type="text"
             value={title}
             onChange={e => onTitleChange(e.target.value)}
             placeholder="예: 5월 가정의달 안내"
-            className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm"
+            className="w-full px-3 py-1.5 border border-[var(--at-border)] rounded-lg text-sm"
           />
         </div>
 
         <div>
-          <label className="block text-xs text-gray-500 mb-1">템플릿 불러오기</label>
+          <label className="block text-xs text-[var(--at-text-secondary)] mb-1">템플릿 불러오기</label>
           <select
             value={selectedId}
             onChange={e => selectTemplate(e.target.value)}
-            className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm bg-white"
+            className="w-full px-3 py-1.5 border border-[var(--at-border)] rounded-lg text-sm bg-white"
           >
             <option value="">템플릿 선택…</option>
             {templates.map(t => (
@@ -75,14 +75,14 @@ export default function MessageEditor({ message, onMessageChange, title, onTitle
 
         <div>
           <div className="flex items-center justify-between mb-1">
-            <label className="block text-xs text-gray-500">본문</label>
+            <label className="block text-xs text-[var(--at-text-secondary)]">본문</label>
             <div className="flex gap-1">
               {['{환자명}', '{병원명}', '{전화번호}'].map(v => (
                 <button
                   key={v}
                   type="button"
                   onClick={() => insertVariable(v)}
-                  className="text-xs px-2 py-0.5 rounded border border-gray-300 text-gray-700 hover:bg-gray-50"
+                  className="text-xs px-2 py-0.5 rounded border border-[var(--at-border)] text-[var(--at-text-primary)] hover:bg-[var(--at-surface-alt)]"
                 >
                   {v}
                 </button>
@@ -94,7 +94,7 @@ export default function MessageEditor({ message, onMessageChange, title, onTitle
             onChange={e => onMessageChange(e.target.value)}
             rows={6}
             placeholder="안녕하세요 {환자명}님, {병원명}입니다."
-            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm font-mono"
+            className="w-full px-3 py-2 border border-[var(--at-border)] rounded-lg text-sm font-mono"
           />
           <div className="mt-1 flex justify-end">
             <MessageByteCounter text={message} />

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/PatientFilterPanel.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/PatientFilterPanel.tsx
@@ -49,26 +49,26 @@ export default function PatientFilterPanel({ value, onChange, onApply, loading }
   }
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg p-4">
+    <div className="bg-[var(--at-surface)] border border-[var(--at-border)] rounded-xl p-4">
       <div className="flex items-center gap-2 mb-4">
-        <Filter className="w-4 h-4 text-gray-500" />
-        <h3 className="font-medium text-gray-900">환자 필터</h3>
+        <Filter className="w-4 h-4 text-[var(--at-text-secondary)]" />
+        <h3 className="font-medium text-[var(--at-text-primary)]">환자 필터</h3>
       </div>
 
       <div className="space-y-4">
         {/* 성별 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">성별</label>
+          <label className="block text-sm font-medium text-[var(--at-text-primary)] mb-1.5">성별</label>
           <div className="flex gap-2">
             {(['all', 'male', 'female'] as const).map(g => (
               <button
                 key={g}
                 type="button"
                 onClick={() => update({ gender: g })}
-                className={`px-3 py-1.5 text-sm rounded-md border ${
+                className={`px-3 py-1.5 text-sm rounded-lg border ${
                   (value.gender ?? 'all') === g
-                    ? 'bg-blue-50 border-blue-300 text-blue-700'
-                    : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-50'
+                    ? 'bg-[var(--at-accent-tag)] border-[var(--at-accent)] text-[var(--at-accent)]'
+                    : 'bg-white border-[var(--at-border)] text-[var(--at-text-primary)] hover:bg-[var(--at-surface-alt)]'
                 }`}
               >
                 {g === 'all' ? '전체' : g === 'male' ? '남' : '여'}
@@ -79,35 +79,35 @@ export default function PatientFilterPanel({ value, onChange, onApply, loading }
 
         {/* 연령 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">연령</label>
+          <label className="block text-sm font-medium text-[var(--at-text-primary)] mb-1.5">연령</label>
           <div className="flex items-center gap-2">
             <input
               type="number" min={0} max={120} placeholder="최소"
-              className="w-20 px-2 py-1.5 border border-gray-300 rounded-md text-sm"
+              className="w-20 px-2 py-1.5 border border-[var(--at-border)] rounded-lg text-sm"
               value={value.ageMin ?? ''}
               onChange={e => update({ ageMin: e.target.value ? Number(e.target.value) : null })}
             />
-            <span className="text-gray-400">~</span>
+            <span className="text-[var(--at-text-weak)]">~</span>
             <input
               type="number" min={0} max={120} placeholder="최대"
-              className="w-20 px-2 py-1.5 border border-gray-300 rounded-md text-sm"
+              className="w-20 px-2 py-1.5 border border-[var(--at-border)] rounded-lg text-sm"
               value={value.ageMax ?? ''}
               onChange={e => update({ ageMax: e.target.value ? Number(e.target.value) : null })}
             />
-            <span className="text-sm text-gray-500">세</span>
+            <span className="text-sm text-[var(--at-text-secondary)]">세</span>
           </div>
         </div>
 
         {/* 최종 내원일 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">최종 내원일</label>
+          <label className="block text-sm font-medium text-[var(--at-text-primary)] mb-1.5">최종 내원일</label>
           <div className="flex flex-wrap gap-1.5 mb-2">
             {LAST_VISIT_PRESETS.map(p => (
               <button
                 key={p.label}
                 type="button"
                 onClick={() => applyPreset(p)}
-                className="px-2.5 py-1 text-xs rounded border border-gray-300 text-gray-700 hover:bg-gray-50"
+                className="px-2.5 py-1 text-xs rounded border border-[var(--at-border)] text-[var(--at-text-primary)] hover:bg-[var(--at-surface-alt)]"
               >
                 {p.label}
               </button>
@@ -116,14 +116,14 @@ export default function PatientFilterPanel({ value, onChange, onApply, loading }
           <div className="flex items-center gap-2">
             <input
               type="date"
-              className="px-2 py-1.5 border border-gray-300 rounded-md text-sm"
+              className="px-2 py-1.5 border border-[var(--at-border)] rounded-lg text-sm"
               value={value.lastVisitFrom ?? ''}
               onChange={e => update({ lastVisitFrom: e.target.value || null })}
             />
-            <span className="text-gray-400">~</span>
+            <span className="text-[var(--at-text-weak)]">~</span>
             <input
               type="date"
-              className="px-2 py-1.5 border border-gray-300 rounded-md text-sm"
+              className="px-2 py-1.5 border border-[var(--at-border)] rounded-lg text-sm"
               value={value.lastVisitTo ?? ''}
               onChange={e => update({ lastVisitTo: e.target.value || null })}
             />
@@ -132,7 +132,7 @@ export default function PatientFilterPanel({ value, onChange, onApply, loading }
 
         {/* 다음 예약 유무 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">다음 예약</label>
+          <label className="block text-sm font-medium text-[var(--at-text-primary)] mb-1.5">다음 예약</label>
           <div className="flex gap-2">
             {[
               { label: '전체', value: null },
@@ -143,10 +143,10 @@ export default function PatientFilterPanel({ value, onChange, onApply, loading }
                 key={String(opt.value)}
                 type="button"
                 onClick={() => update({ hasNextAppointment: opt.value })}
-                className={`px-3 py-1.5 text-sm rounded-md border ${
+                className={`px-3 py-1.5 text-sm rounded-lg border ${
                   (value.hasNextAppointment ?? null) === opt.value
-                    ? 'bg-blue-50 border-blue-300 text-blue-700'
-                    : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-50'
+                    ? 'bg-[var(--at-accent-tag)] border-[var(--at-accent)] text-[var(--at-accent)]'
+                    : 'bg-white border-[var(--at-border)] text-[var(--at-text-primary)] hover:bg-[var(--at-surface-alt)]'
                 }`}
               >
                 {opt.label}
@@ -157,7 +157,7 @@ export default function PatientFilterPanel({ value, onChange, onApply, loading }
 
         {/* 생일 월 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">생일 월</label>
+          <label className="block text-sm font-medium text-[var(--at-text-primary)] mb-1.5">생일 월</label>
           <div className="grid grid-cols-6 gap-1.5">
             {Array.from({ length: 12 }, (_, i) => i + 1).map(m => {
               const active = (value.birthMonths ?? []).includes(m)
@@ -168,8 +168,8 @@ export default function PatientFilterPanel({ value, onChange, onApply, loading }
                   onClick={() => toggleBirthMonth(m)}
                   className={`py-1 text-xs rounded border ${
                     active
-                      ? 'bg-blue-50 border-blue-300 text-blue-700'
-                      : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-50'
+                      ? 'bg-[var(--at-accent-tag)] border-[var(--at-accent)] text-[var(--at-accent)]'
+                      : 'bg-white border-[var(--at-border)] text-[var(--at-text-primary)] hover:bg-[var(--at-surface-alt)]'
                   }`}
                 >
                   {m}월
@@ -181,11 +181,11 @@ export default function PatientFilterPanel({ value, onChange, onApply, loading }
 
         {/* 이름/차트번호 검색 */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">이름·차트번호 검색</label>
+          <label className="block text-sm font-medium text-[var(--at-text-primary)] mb-1.5">이름·차트번호 검색</label>
           <input
             type="text"
             placeholder="이름 또는 차트번호 입력"
-            className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm"
+            className="w-full px-3 py-1.5 border border-[var(--at-border)] rounded-lg text-sm"
             value={keyword}
             onChange={e => setKeyword(e.target.value)}
             onBlur={() => update({ searchKeyword: keyword })}
@@ -197,7 +197,7 @@ export default function PatientFilterPanel({ value, onChange, onApply, loading }
         type="button"
         onClick={onApply}
         disabled={loading}
-        className="mt-4 w-full py-2 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
+        className="mt-4 w-full py-2 bg-[var(--at-accent)] text-white rounded-lg text-sm font-medium hover:opacity-90 disabled:opacity-50"
       >
         {loading ? '조회 중...' : '필터 적용'}
       </button>

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/PatientSelectionList.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/PatientSelectionList.tsx
@@ -19,27 +19,27 @@ export default function PatientSelectionList({
   const allChecked = patients.length > 0 && patients.every(p => selectedIds.has(p.dentweb_patient_id))
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg">
-      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+    <div className="bg-[var(--at-surface)] border border-[var(--at-border)] rounded-xl">
+      <div className="px-4 py-3 border-b border-[var(--at-border)] flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Users className="w-4 h-4 text-gray-500" />
-          <h3 className="font-medium text-gray-900">
+          <Users className="w-4 h-4 text-[var(--at-text-secondary)]" />
+          <h3 className="font-medium text-[var(--at-text-primary)]">
             발송 대상 {patients.length}명 (선택 {selectedIds.size}명)
           </h3>
         </div>
-        <label className="flex items-center gap-1.5 text-sm text-gray-600">
+        <label className="flex items-center gap-1.5 text-sm text-[var(--at-text-secondary)]">
           <input
             type="checkbox"
             checked={allChecked}
             onChange={e => onToggleAll(e.target.checked)}
-            className="rounded border-gray-300"
+            className="rounded border-[var(--at-border)]"
           />
           전체 선택
         </label>
       </div>
 
       {(excludedCount > 0 || noPhoneCount > 0) && (
-        <div className="px-4 py-2 bg-gray-50 border-b border-gray-200 text-xs text-gray-600">
+        <div className="px-4 py-2 bg-[var(--at-surface-alt)] border-b border-[var(--at-border)] text-xs text-[var(--at-text-secondary)]">
           {excludedCount > 0 && <span>리콜 제외 {excludedCount}명 </span>}
           {noPhoneCount > 0 && <span>· 전화번호 없는 환자 {noPhoneCount}명 </span>}
           자동 제외됨
@@ -48,12 +48,12 @@ export default function PatientSelectionList({
 
       <div className="max-h-[400px] overflow-y-auto">
         {loading ? (
-          <div className="p-8 text-center text-sm text-gray-400">조회 중...</div>
+          <div className="p-8 text-center text-sm text-[var(--at-text-weak)]">조회 중...</div>
         ) : patients.length === 0 ? (
-          <div className="p-8 text-center text-sm text-gray-400">조건에 맞는 환자가 없습니다.</div>
+          <div className="p-8 text-center text-sm text-[var(--at-text-weak)]">조건에 맞는 환자가 없습니다.</div>
         ) : (
           <table className="w-full text-sm">
-            <thead className="bg-gray-50 text-xs text-gray-500">
+            <thead className="bg-[var(--at-surface-alt)] text-xs text-[var(--at-text-secondary)]">
               <tr>
                 <th className="w-10 px-3 py-2"></th>
                 <th className="px-3 py-2 text-left">이름</th>
@@ -64,19 +64,19 @@ export default function PatientSelectionList({
             </thead>
             <tbody>
               {patients.map(p => (
-                <tr key={p.dentweb_patient_id} className="border-t border-gray-100 hover:bg-gray-50">
+                <tr key={p.dentweb_patient_id} className="border-t border-[var(--at-border)] hover:bg-[var(--at-surface-alt)]">
                   <td className="px-3 py-2">
                     <input
                       type="checkbox"
                       checked={selectedIds.has(p.dentweb_patient_id)}
                       onChange={() => onToggle(p.dentweb_patient_id)}
-                      className="rounded border-gray-300"
+                      className="rounded border-[var(--at-border)]"
                     />
                   </td>
-                  <td className="px-3 py-2 font-medium text-gray-900">{p.patient_name}</td>
-                  <td className="px-3 py-2 text-gray-700 tabular-nums">{p.phone_number}</td>
-                  <td className="px-3 py-2 text-gray-500">{p.last_visit_date ?? '-'}</td>
-                  <td className="px-3 py-2 text-gray-500">{p.last_treatment_type ?? '-'}</td>
+                  <td className="px-3 py-2 font-medium text-[var(--at-text-primary)]">{p.patient_name}</td>
+                  <td className="px-3 py-2 text-[var(--at-text-primary)] tabular-nums">{p.phone_number}</td>
+                  <td className="px-3 py-2 text-[var(--at-text-secondary)]">{p.last_visit_date ?? '-'}</td>
+                  <td className="px-3 py-2 text-[var(--at-text-secondary)]">{p.last_treatment_type ?? '-'}</td>
                 </tr>
               ))}
             </tbody>

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/RecallExcludeToggle.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/RecallExcludeToggle.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export default function RecallExcludeToggle({ enabled, onChange }: Props) {
   return (
-    <div className="bg-white border border-gray-200 rounded-lg p-3 flex items-start gap-3">
+    <div className="bg-[var(--at-surface)] border border-[var(--at-border)] rounded-xl p-3 flex items-start gap-3">
       <button
         type="button"
         role="switch"
@@ -30,8 +30,8 @@ export default function RecallExcludeToggle({ enabled, onChange }: Props) {
           <div className="text-sm flex items-start gap-2">
             <ShieldCheck className="w-4 h-4 text-green-600 mt-0.5" />
             <div>
-              <p className="text-gray-900 font-medium">리콜 제외 환자 자동 제외</p>
-              <p className="text-gray-500 text-xs">친인척·비우호 환자가 발송 대상에서 빠집니다.</p>
+              <p className="text-[var(--at-text-primary)] font-medium">리콜 제외 환자 자동 제외</p>
+              <p className="text-[var(--at-text-secondary)] text-xs">친인척·비우호 환자가 발송 대상에서 빠집니다.</p>
             </div>
           </div>
         ) : (

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/SendActionBar.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/SendActionBar.tsx
@@ -41,9 +41,9 @@ export default function SendActionBar({ canSend, onTestSend, onSubmitImmediate, 
   }
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-3">
+    <div className="bg-[var(--at-surface)] border border-[var(--at-border)] rounded-xl p-4 space-y-3">
       <div>
-        <label className="block text-xs text-gray-500 mb-1.5 flex items-center gap-1">
+        <label className="block text-xs text-[var(--at-text-secondary)] mb-1.5 flex items-center gap-1">
           <FlaskConical className="w-3.5 h-3.5" /> 테스트 발송 (본인 번호)
         </label>
         <div className="flex gap-2">
@@ -52,24 +52,24 @@ export default function SendActionBar({ canSend, onTestSend, onSubmitImmediate, 
             value={testPhone}
             onChange={e => setTestPhone(e.target.value)}
             placeholder="010-0000-0000"
-            className="flex-1 px-3 py-1.5 border border-gray-300 rounded-md text-sm"
+            className="flex-1 px-3 py-1.5 border border-[var(--at-border)] rounded-lg text-sm"
           />
           <button
             type="button"
             onClick={handleTest}
             disabled={testing || !testPhone}
-            className="px-3 py-1.5 text-sm rounded-md border border-gray-300 hover:bg-gray-50 disabled:opacity-50"
+            className="px-3 py-1.5 text-sm rounded-lg border border-[var(--at-border)] hover:bg-[var(--at-surface-alt)] disabled:opacity-50"
           >
             {testing ? '발송 중' : '테스트'}
           </button>
         </div>
-        {testMsg && <p className="mt-1 text-xs text-gray-600">{testMsg}</p>}
+        {testMsg && <p className="mt-1 text-xs text-[var(--at-text-secondary)]">{testMsg}</p>}
       </div>
 
-      <hr className="border-gray-200" />
+      <hr className="border-[var(--at-border)]" />
 
       <div>
-        <label className="block text-xs text-gray-500 mb-1.5">발송 방식</label>
+        <label className="block text-xs text-[var(--at-text-secondary)] mb-1.5">발송 방식</label>
         <div className="flex gap-2">
           {[
             { v: 'immediate', label: '즉시 발송', icon: Send },
@@ -79,8 +79,8 @@ export default function SendActionBar({ canSend, onTestSend, onSubmitImmediate, 
               key={opt.v}
               type="button"
               onClick={() => setMode(opt.v as 'immediate' | 'scheduled')}
-              className={`flex-1 py-2 text-sm rounded-md border flex items-center justify-center gap-1.5 ${
-                mode === opt.v ? 'bg-blue-50 border-blue-300 text-blue-700' : 'bg-white border-gray-300 text-gray-700'
+              className={`flex-1 py-2 text-sm rounded-lg border flex items-center justify-center gap-1.5 ${
+                mode === opt.v ? 'bg-[var(--at-accent-tag)] border-[var(--at-accent)] text-[var(--at-accent)]' : 'bg-white border-[var(--at-border)] text-[var(--at-text-primary)]'
               }`}
             >
               <opt.icon className="w-4 h-4" />
@@ -95,7 +95,7 @@ export default function SendActionBar({ canSend, onTestSend, onSubmitImmediate, 
           type="datetime-local"
           value={scheduledLocal}
           onChange={e => setScheduledLocal(e.target.value)}
-          className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm"
+          className="w-full px-3 py-1.5 border border-[var(--at-border)] rounded-lg text-sm"
         />
       )}
 
@@ -103,7 +103,7 @@ export default function SendActionBar({ canSend, onTestSend, onSubmitImmediate, 
         type="button"
         onClick={handleSubmit}
         disabled={!canSend || (mode === 'scheduled' && !scheduledLocal)}
-        className="w-full py-2.5 bg-blue-600 text-white rounded-md text-sm font-semibold hover:bg-blue-700 disabled:opacity-50"
+        className="w-full py-2.5 bg-[var(--at-accent)] text-white rounded-lg text-sm font-semibold hover:opacity-90 disabled:opacity-50"
       >
         {mode === 'immediate' ? '발송하기' : '예약하기'}
       </button>

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/SendConfirmDialog.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/SendConfirmDialog.tsx
@@ -35,34 +35,34 @@ export default function SendConfirmDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full">
-        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">발송 확인</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+      <div className="bg-white rounded-xl shadow-xl max-w-lg w-full">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--at-border)]">
+          <h2 className="text-lg font-semibold text-[var(--at-text-primary)]">발송 확인</h2>
+          <button onClick={onClose} className="text-[var(--at-text-weak)] hover:text-[var(--at-text-secondary)]">
             <X className="w-5 h-5" />
           </button>
         </div>
 
         <div className="px-4 py-4 space-y-3 text-sm">
           <div>
-            <span className="text-gray-500">발송 대상:</span>
-            <span className="ml-2 font-semibold text-gray-900">{selectedCount}명</span>
+            <span className="text-[var(--at-text-secondary)]">발송 대상:</span>
+            <span className="ml-2 font-semibold text-[var(--at-text-primary)]">{selectedCount}명</span>
           </div>
           {preview && (
             <>
               <div>
-                <span className="text-gray-500">메시지 유형:</span>
+                <span className="text-[var(--at-text-secondary)]">메시지 유형:</span>
                 <span className="ml-2 font-medium">{preview.msg_type}</span>
-                <span className="ml-2 text-xs text-gray-400">({preview.bytes} 바이트)</span>
+                <span className="ml-2 text-xs text-[var(--at-text-weak)]">({preview.bytes} 바이트)</span>
               </div>
               <div>
-                <p className="text-gray-500 mb-1">미리보기 ({sampleName || '홍길동'} 기준)</p>
-                <div className="bg-gray-50 border border-gray-200 rounded p-3 whitespace-pre-wrap text-gray-800 text-xs">{preview.preview}</div>
+                <p className="text-[var(--at-text-secondary)] mb-1">미리보기 ({sampleName || '홍길동'} 기준)</p>
+                <div className="bg-[var(--at-surface-alt)] border border-[var(--at-border)] rounded p-3 whitespace-pre-wrap text-[var(--at-text-primary)] text-xs">{preview.preview}</div>
               </div>
             </>
           )}
           <div>
-            <span className="text-gray-500">발송 방식:</span>
+            <span className="text-[var(--at-text-secondary)]">발송 방식:</span>
             <span className="ml-2 font-medium">
               {mode === 'immediate' ? '즉시 발송' : `예약 발송 (${scheduledAt ? new Date(scheduledAt).toLocaleString('ko-KR') : '-'})`}
             </span>
@@ -75,12 +75,12 @@ export default function SendConfirmDialog({
           )}
         </div>
 
-        <div className="px-4 py-3 border-t border-gray-200 flex justify-end gap-2">
-          <button onClick={onClose} disabled={sending} className="px-3 py-1.5 text-sm rounded-md border border-gray-300 hover:bg-gray-50">취소</button>
+        <div className="px-4 py-3 border-t border-[var(--at-border)] flex justify-end gap-2">
+          <button onClick={onClose} disabled={sending} className="px-3 py-1.5 text-sm rounded-lg border border-[var(--at-border)] hover:bg-[var(--at-surface-alt)]">취소</button>
           <button
             onClick={onConfirm}
             disabled={sending}
-            className="px-4 py-1.5 text-sm rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+            className="px-4 py-1.5 text-sm rounded-lg bg-[var(--at-accent)] text-white hover:opacity-90 disabled:opacity-50"
           >
             {sending ? '발송 중...' : `${selectedCount}명에게 발송`}
           </button>

--- a/dental-clinic-manager/src/components/BulkSms/TemplatesTab/TemplateEditModal.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/TemplatesTab/TemplateEditModal.tsx
@@ -59,14 +59,14 @@ export default function TemplateEditModal({ open, template, onClose, onSaved }: 
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full">
-        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+      <div className="bg-white rounded-xl shadow-xl max-w-lg w-full">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--at-border)]">
           <h2 className="text-lg font-semibold">
             {template ? '템플릿 수정' : '템플릿 추가'}
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600"
+            className="text-[var(--at-text-weak)] hover:text-[var(--at-text-secondary)]"
           >
             <X className="w-5 h-5" />
           </button>
@@ -74,19 +74,19 @@ export default function TemplateEditModal({ open, template, onClose, onSaved }: 
 
         <div className="p-4 space-y-3">
           <div>
-            <label className="block text-xs font-medium text-gray-700 mb-1">
+            <label className="block text-xs font-medium text-[var(--at-text-primary)] mb-1">
               이름
             </label>
             <input
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="예: 정기 검진 안내"
-              className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:outline-none focus:border-blue-500"
+              className="w-full px-3 py-1.5 border border-[var(--at-border)] rounded-lg text-sm focus:outline-none focus:border-blue-500"
             />
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-gray-700 mb-1">
+            <label className="block text-xs font-medium text-[var(--at-text-primary)] mb-1">
               내용 (변수: {'{환자명}'}, {'{병원명}'}, {'{전화번호}'})
             </label>
             <textarea
@@ -94,7 +94,7 @@ export default function TemplateEditModal({ open, template, onClose, onSaved }: 
               onChange={(e) => setContent(e.target.value)}
               placeholder="예: {환자명}님, 안녕하세요. {병원명}입니다."
               rows={6}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm font-mono focus:outline-none focus:border-blue-500"
+              className="w-full px-3 py-2 border border-[var(--at-border)] rounded-lg text-sm font-mono focus:outline-none focus:border-blue-500"
             />
             <div className="mt-1 flex justify-end">
               <MessageByteCounter text={content} />
@@ -106,24 +106,24 @@ export default function TemplateEditModal({ open, template, onClose, onSaved }: 
               type="checkbox"
               checked={isDefault}
               onChange={(e) => setIsDefault(e.target.checked)}
-              className="w-4 h-4 border-gray-300 rounded"
+              className="w-4 h-4 border-[var(--at-border)] rounded"
             />
             <span>기본 템플릿으로 설정</span>
           </label>
         </div>
 
-        <div className="px-4 py-3 border-t border-gray-200 flex justify-end gap-2">
+        <div className="px-4 py-3 border-t border-[var(--at-border)] flex justify-end gap-2">
           <button
             onClick={onClose}
             disabled={saving}
-            className="px-3 py-1.5 text-sm rounded-md border border-gray-300 hover:bg-gray-50 disabled:opacity-50"
+            className="px-3 py-1.5 text-sm rounded-lg border border-[var(--at-border)] hover:bg-[var(--at-surface-alt)] disabled:opacity-50"
           >
             취소
           </button>
           <button
             onClick={save}
             disabled={saving}
-            className="px-4 py-1.5 text-sm rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+            className="px-4 py-1.5 text-sm rounded-lg bg-[var(--at-accent)] text-white hover:opacity-90 disabled:opacity-50"
           >
             {saving ? '저장 중...' : '저장'}
           </button>

--- a/dental-clinic-manager/src/components/BulkSms/TemplatesTab/TemplatesTab.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/TemplatesTab/TemplatesTab.tsx
@@ -54,7 +54,7 @@ export default function TemplatesTab() {
             setEditing(null)
             setModalOpen(true)
           }}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700 transition-colors"
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--at-accent)] text-white rounded-lg text-sm font-medium hover:opacity-90 transition-colors"
         >
           <Plus className="w-4 h-4" />
           템플릿 추가
@@ -62,9 +62,9 @@ export default function TemplatesTab() {
       </div>
 
       {loading ? (
-        <div className="p-8 text-center text-sm text-gray-400">불러오는 중...</div>
+        <div className="p-8 text-center text-sm text-[var(--at-text-weak)]">불러오는 중...</div>
       ) : templates.length === 0 ? (
-        <div className="p-8 text-center text-sm text-gray-400">
+        <div className="p-8 text-center text-sm text-[var(--at-text-weak)]">
           등록된 템플릿이 없습니다.
         </div>
       ) : (
@@ -72,13 +72,13 @@ export default function TemplatesTab() {
           {templates.map((t) => (
             <div
               key={t.id}
-              className="bg-white border border-gray-200 rounded-lg p-4 hover:border-gray-300 transition-colors"
+              className="bg-[var(--at-surface)] border border-[var(--at-border)] rounded-xl p-4 hover:border-[var(--at-border)] transition-colors"
             >
               <div className="flex items-start justify-between gap-2 mb-3">
                 <div className="flex-1">
-                  <h4 className="font-medium text-gray-900 text-sm">{t.name}</h4>
+                  <h4 className="font-medium text-[var(--at-text-primary)] text-sm">{t.name}</h4>
                   {t.is_default && (
-                    <span className="inline-block mt-1 text-xs px-2 py-0.5 bg-blue-100 text-blue-700 rounded">
+                    <span className="inline-block mt-1 text-xs px-2 py-0.5 bg-blue-100 text-[var(--at-accent)] rounded">
                       기본 템플릿
                     </span>
                   )}
@@ -89,21 +89,21 @@ export default function TemplatesTab() {
                       setEditing(t)
                       setModalOpen(true)
                     }}
-                    className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded transition-colors"
+                    className="p-1.5 text-[var(--at-text-secondary)] hover:text-[var(--at-accent)] hover:bg-[var(--at-accent-tag)] rounded transition-colors"
                     title="편집"
                   >
                     <Pencil className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => remove(t.id)}
-                    className="p-1.5 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded transition-colors"
+                    className="p-1.5 text-[var(--at-text-secondary)] hover:text-red-600 hover:bg-red-50 rounded transition-colors"
                     title="삭제"
                   >
                     <Trash2 className="w-4 h-4" />
                   </button>
                 </div>
               </div>
-              <pre className="text-xs text-gray-600 whitespace-pre-wrap font-sans line-clamp-4 break-words">
+              <pre className="text-xs text-[var(--at-text-secondary)] whitespace-pre-wrap font-sans line-clamp-4 break-words">
                 {t.content}
               </pre>
             </div>

--- a/dental-clinic-manager/src/components/BulkSms/shared/CampaignStatusBadge.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/shared/CampaignStatusBadge.tsx
@@ -1,12 +1,12 @@
 import type { BulkSmsCampaignStatus } from '@/types/bulkSms'
 
 const STATUS_MAP: Record<BulkSmsCampaignStatus, { label: string; cls: string }> = {
-  draft:     { label: '임시저장', cls: 'bg-gray-100 text-gray-700' },
+  draft:     { label: '임시저장', cls: 'bg-gray-100 text-[var(--at-text-primary)]' },
   scheduled: { label: '예약',     cls: 'bg-amber-100 text-amber-800' },
   sending:   { label: '발송중',   cls: 'bg-blue-100 text-blue-800' },
   sent:      { label: '발송완료', cls: 'bg-green-100 text-green-800' },
   failed:    { label: '실패',     cls: 'bg-red-100 text-red-800' },
-  cancelled: { label: '취소',     cls: 'bg-gray-100 text-gray-500 line-through' },
+  cancelled: { label: '취소',     cls: 'bg-gray-100 text-[var(--at-text-secondary)] line-through' },
 }
 
 export default function CampaignStatusBadge({ status }: { status: BulkSmsCampaignStatus }) {

--- a/dental-clinic-manager/src/components/BulkSms/shared/MessageByteCounter.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/shared/MessageByteCounter.tsx
@@ -3,7 +3,7 @@
 export default function MessageByteCounter({ text }: { text: string }) {
   const bytes = new TextEncoder().encode(text).length
   const isLMS = bytes > 90
-  const cls = bytes > 2000 ? 'text-red-600' : isLMS ? 'text-amber-700' : 'text-gray-500'
+  const cls = bytes > 2000 ? 'text-red-600' : isLMS ? 'text-amber-700' : 'text-[var(--at-text-secondary)]'
   return (
     <div className={`text-xs ${cls}`}>
       {bytes} 바이트 · {isLMS ? 'LMS' : 'SMS'} {bytes > 2000 && '(2000바이트 초과)'}


### PR DESCRIPTION
## Summary
단체 문자 페이지가 다른 prod 페이지(Referral·Recall·Financial 등)와 다른 디자인이라 일괄 통일:

- 헤더를 아이콘 박스 + 제목/설명 패턴으로 (Referral 동일)
- 탭을 하단 underline + accent 색상으로 (border-b 큰 박스 대신)
- 모든 컨테이너/카드/입력/버튼/텍스트 색상을 `var(--at-*)` CSS 변수로
- `rounded-md` → `rounded-lg`, `rounded-lg` → `rounded-xl` 일관성

기능 변경 없음. 14개 파일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)