### PR TITLE
release: develop → main (엘리어트 파동 지표/프리셋 + Codex P1 후속 + 랭킹 최적화 등)

### DIFF
--- a/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
@@ -246,8 +246,8 @@ export async function POST(request: NextRequest) {
           credentialId: kisCredential.credentialId,
           credential: krCredential,
           ticker,
-          startDate: toKisDateString(past),
-          endDate: toKisDateString(today),
+          startDate: toKisDateString(past, 'KR'),
+          endDate: toKisDateString(today, 'KR'),
         })
         dailyBars = krDailyBars.map((b) => ({
           datetime: b.date,
@@ -311,7 +311,12 @@ export async function POST(request: NextRequest) {
         const todayD = new Date()
         const pastD = new Date()
         pastD.setDate(pastD.getDate() - 90)
-        const daily = await fetchPrices(ticker, yMarket, toDateString(pastD), toDateString(todayD))
+        const daily = await fetchPrices(
+          ticker,
+          yMarket,
+          marketDateString(pastD, market),
+          marketDateString(todayD, market),
+        )
         if (daily && daily.length > 0) {
           dailyBars = daily.map((b) => ({
             datetime: b.date,
@@ -1106,7 +1111,24 @@ async function processAlerts(
 // 헬퍼: 날짜 포맷
 // ============================================
 
-function toDateString(d: Date): string {
+function formatDateInTimeZone(d: Date, timeZone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat('en', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(d)
+    const year = parts.find((part) => part.type === 'year')?.value
+    const month = parts.find((part) => part.type === 'month')?.value
+    const day = parts.find((part) => part.type === 'day')?.value
+    if (year && month && day) {
+      return `${year}-${month}-${day}`
+    }
+  } catch {
+    // fall through to local date formatting
+  }
+
   const y = d.getFullYear()
   const m = String(d.getMonth() + 1).padStart(2, '0')
   const day = String(d.getDate()).padStart(2, '0')
@@ -1116,15 +1138,9 @@ function toDateString(d: Date): string {
 function marketDateString(d: Date, market: Market): string {
   const tz = market === 'US' ? 'America/New_York' : 'Asia/Seoul'
   try {
-    const fmt = new Intl.DateTimeFormat('en-CA', {
-      timeZone: tz,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    })
-    return fmt.format(d)
+    return formatDateInTimeZone(d, tz)
   } catch {
-    return market === 'KR' ? toKstDateString(d) : toDateString(d)
+    return market === 'KR' ? toKstDateString(d) : formatDateInTimeZone(d, 'UTC')
   }
 }
 
@@ -1137,9 +1153,9 @@ function toKstDateString(d: Date): string {
   return `${y}-${m}-${day}`
 }
 
-function toKisDateString(d: Date): string {
+function toKisDateString(d: Date, market: Extract<Market, 'KR'> = 'KR'): string {
   // KIS는 YYYYMMDD 포맷
-  return toDateString(d).replace(/-/g, '')
+  return marketDateString(d, market).replace(/-/g, '')
 }
 
 /**

--- a/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/smart-money/analyze/route.ts
@@ -50,11 +50,23 @@ import { analyzeSession, type SessionBar } from '@/lib/smartMoney/sessionAnalyze
 import { analyzeNewsContext, type NewsBar } from '@/lib/smartMoney/newsContextEngine'
 import type { Market, OHLCV } from '@/types/investment'
 import type {
+  AlgoFootprintResult,
   SmartMoneyAnalysis,
   SmartMoneyAlert,
   InvestorTrendRow,
   InvestorFlowResult,
   DailyAnalysis,
+  LiquidityResult,
+  MarketStructureResult,
+  NewsContextResult,
+  OrderBlockFvgResult,
+  SessionResult,
+  SmartMoneyAnalyzeErrorResponse,
+  TrapResult,
+  VSAResult,
+  VWAPResult,
+  WyckoffPhaseResult,
+  WyckoffResult,
 } from '@/types/smartMoney'
 
 export const dynamic = 'force-dynamic'
@@ -102,6 +114,18 @@ interface AnalysisResponse extends SmartMoneyAnalysis {
   newsSignalIntegration?: 'active' | 'inactive'
 }
 
+function errorResponse(
+  status: number,
+  error: string,
+  code: string,
+  reason?: string
+) {
+  const payload: SmartMoneyAnalyzeErrorResponse = reason
+    ? { error, code, reason }
+    : { error, code }
+  return NextResponse.json(payload, { status })
+}
+
 // ============================================
 // 메인 핸들러
 // ============================================
@@ -110,7 +134,7 @@ export async function POST(request: NextRequest) {
   // 1. 인증
   const auth = await requireAuth()
   if (auth.error || !auth.user) {
-    return NextResponse.json({ error: auth.error ?? '인증 실패' }, { status: auth.status })
+    return errorResponse(auth.status, auth.error ?? '인증 실패', 'AUTH_REQUIRED')
   }
   const userId = auth.user.id
 
@@ -119,7 +143,7 @@ export async function POST(request: NextRequest) {
   try {
     body = await request.json()
   } catch {
-    return NextResponse.json({ error: '요청 본문이 올바르지 않습니다.' }, { status: 400 })
+    return errorResponse(400, '요청 본문이 올바르지 않습니다.', 'INVALID_JSON')
   }
 
   const ticker = typeof body.ticker === 'string' ? body.ticker.trim().toUpperCase() : ''
@@ -129,15 +153,15 @@ export async function POST(request: NextRequest) {
   const includePreMarket = Boolean(body.includePreMarket) && market === 'US'
 
   if (!ticker) {
-    return NextResponse.json({ error: 'ticker는 필수입니다.' }, { status: 400 })
+    return errorResponse(400, 'ticker는 필수입니다.', 'INVALID_TICKER')
   }
   if (!market) {
-    return NextResponse.json({ error: 'market은 KR 또는 US여야 합니다.' }, { status: 400 })
+    return errorResponse(400, 'market은 KR 또는 US여야 합니다.', 'INVALID_MARKET')
   }
 
   const supabase = getSupabaseAdmin()
   if (!supabase) {
-    return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+    return errorResponse(500, 'Server configuration error', 'SERVER_CONFIG_ERROR')
   }
 
   // 3. KIS credential (KR엔 필수, US엔 옵션)
@@ -321,16 +345,14 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     const message = err instanceof Error ? err.message : '시장 데이터 조회 실패'
     console.error('[smart-money/analyze] 데이터 수집 실패:', err)
-    return NextResponse.json(
-      { error: `시장 데이터 조회 실패: ${message}`, reason: message },
-      { status: 502 }
-    )
+    return errorResponse(502, `시장 데이터 조회 실패: ${message}`, 'MARKET_DATA_FETCH_FAILED', message)
   }
 
   if (bars.length === 0 && dailyBars.length === 0) {
-    return NextResponse.json(
-      { error: '분봉/일봉 데이터를 모두 받지 못했습니다. 종목 코드를 확인해주세요.' },
-      { status: 422 }
+    return errorResponse(
+      422,
+      '분봉/일봉 데이터를 모두 받지 못했습니다. 종목 코드를 확인해주세요.',
+      'NO_MARKET_DATA'
     )
   }
   const regularBars = bars.filter((b) => isRegularTradingHours(b.datetime, market))
@@ -340,8 +362,25 @@ export async function POST(request: NextRequest) {
       : []
 
   // 5. 엔진 호출
-  let vwap, wyckoff, wyckoffIntraday, algoFootprint, investorFlow: InvestorFlowResult | null, scoreResult
-  let wyckoffPhase, liquidity, marketStructure, orderBlocksFvg, traps, vsa, session, newsContext
+  let vwap: VWAPResult
+  let wyckoff: WyckoffResult
+  let wyckoffIntraday: WyckoffResult | undefined
+  let algoFootprint: AlgoFootprintResult
+  let investorFlow: InvestorFlowResult | null
+  let scoreResult: {
+    overallScore: number
+    interpretation: SmartMoneyAnalysis['interpretation']
+    signalDetails: SmartMoneyAnalysis['signalDetails']
+    manipulationRiskScore: number
+  }
+  let wyckoffPhase: WyckoffPhaseResult | undefined
+  let liquidity: LiquidityResult | undefined
+  let marketStructure: MarketStructureResult | undefined
+  let orderBlocksFvg: OrderBlockFvgResult | undefined
+  let traps: TrapResult | undefined
+  let vsa: VSAResult | undefined
+  let session: SessionResult | undefined
+  let newsContext: NewsContextResult | undefined
   let byDay: DailyAnalysis[] = []
   try {
     // ================================================================
@@ -680,7 +719,7 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     const message = err instanceof Error ? err.message : '분석 엔진 실패'
     console.error('[smart-money/analyze] 엔진 실행 실패:', err)
-    return NextResponse.json({ error: `분석 실패: ${message}` }, { status: 500 })
+    return errorResponse(500, `분석 실패: ${message}`, 'ANALYSIS_ENGINE_FAILED', message)
   }
 
   // recent20DayHigh/Low — UI display용 (현재는 noop, 향후 사용 가능)
@@ -711,7 +750,7 @@ export async function POST(request: NextRequest) {
     newsContext = preferredByDay.newsContext
     scoreResult = {
       ...scoreResult,
-      manipulationRiskScore: preferredByDay.manipulationRiskScore,
+      manipulationRiskScore: preferredByDay.manipulationRiskScore ?? scoreResult.manipulationRiskScore,
       overallScore: preferredByDay.overallScore,
       interpretation: preferredByDay.interpretation,
       signalDetails: preferredByDay.signalDetails,

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/PatientFilterPanel.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/PatientFilterPanel.tsx
@@ -155,28 +155,49 @@ export default function PatientFilterPanel({ value, onChange, onApply, loading }
           </div>
         </div>
 
-        {/* 생일 월 */}
+        {/* 생일 */}
         <div>
-          <label className="block text-sm font-medium text-[var(--at-text-primary)] mb-1.5">생일 월</label>
-          <div className="grid grid-cols-6 gap-1.5">
-            {Array.from({ length: 12 }, (_, i) => i + 1).map(m => {
-              const active = (value.birthMonths ?? []).includes(m)
-              return (
-                <button
-                  key={m}
-                  type="button"
-                  onClick={() => toggleBirthMonth(m)}
-                  className={`py-1 text-xs rounded border ${
-                    active
-                      ? 'bg-[var(--at-accent-tag)] border-[var(--at-accent)] text-[var(--at-accent)]'
-                      : 'bg-white border-[var(--at-border)] text-[var(--at-text-primary)] hover:bg-[var(--at-surface-alt)]'
-                  }`}
-                >
-                  {m}월
-                </button>
-              )
-            })}
+          <label className="block text-sm font-medium text-[var(--at-text-primary)] mb-1.5">생일</label>
+          <div className="flex gap-2 mb-2">
+            {[
+              { label: '🎂 오늘 생일자만', value: true },
+              { label: '월별 선택', value: false },
+            ].map(opt => (
+              <button
+                key={String(opt.value)}
+                type="button"
+                onClick={() => update({ birthToday: opt.value, ...(opt.value ? { birthMonths: [] } : {}) })}
+                className={`flex-1 px-3 py-1.5 text-sm rounded-lg border ${
+                  (value.birthToday ?? false) === opt.value
+                    ? 'bg-[var(--at-accent-tag)] border-[var(--at-accent)] text-[var(--at-accent)]'
+                    : 'bg-white border-[var(--at-border)] text-[var(--at-text-primary)] hover:bg-[var(--at-surface-alt)]'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
           </div>
+          {!value.birthToday && (
+            <div className="grid grid-cols-6 gap-1.5">
+              {Array.from({ length: 12 }, (_, i) => i + 1).map(m => {
+                const active = (value.birthMonths ?? []).includes(m)
+                return (
+                  <button
+                    key={m}
+                    type="button"
+                    onClick={() => toggleBirthMonth(m)}
+                    className={`py-1 text-xs rounded border ${
+                      active
+                        ? 'bg-[var(--at-accent-tag)] border-[var(--at-accent)] text-[var(--at-accent)]'
+                        : 'bg-white border-[var(--at-border)] text-[var(--at-text-primary)] hover:bg-[var(--at-surface-alt)]'
+                    }`}
+                  >
+                    {m}월
+                  </button>
+                )
+              })}
+            </div>
+          )}
         </div>
 
         {/* 이름/차트번호 검색 */}

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/SendTab.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/SendTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import PatientFilterPanel from './PatientFilterPanel'
 import PatientSelectionList from './PatientSelectionList'
 import RecallExcludeToggle from './RecallExcludeToggle'
@@ -9,11 +9,12 @@ import SendActionBar from './SendActionBar'
 import SendConfirmDialog from './SendConfirmDialog'
 import type { BulkSmsFilter, BulkSmsEligiblePatient } from '@/types/bulkSms'
 
+// 진입 시 기본값: "오늘 생일자" 자동 조회 — 데스크의 주요 use case
 const INITIAL_FILTER: BulkSmsFilter = {
   gender: 'all', ageMin: null, ageMax: null,
   lastVisitFrom: null, lastVisitTo: null,
   lastTreatmentTypes: [], hasNextAppointment: null,
-  birthMonths: [], searchKeyword: '', activeOnly: true,
+  birthMonths: [], birthToday: true, searchKeyword: '', activeOnly: true,
 }
 
 export default function SendTab() {
@@ -31,7 +32,7 @@ export default function SendTab() {
   const [pendingScheduledAt, setPendingScheduledAt] = useState<string | undefined>()
   const [sending, setSending] = useState(false)
 
-  const fetchPatients = async () => {
+  const fetchPatients = useCallback(async () => {
     setLoading(true)
     try {
       const res = await fetch('/api/bulk-sms/patients', {
@@ -51,7 +52,15 @@ export default function SendTab() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [filter, excludeRecall])
+
+  // 진입 시 1회 자동 조회 (기본 필터 = 오늘 생일자)
+  const didAutoLoadRef = useRef(false)
+  useEffect(() => {
+    if (didAutoLoadRef.current) return
+    didAutoLoadRef.current = true
+    fetchPatients()
+  }, [fetchPatients])
 
   const toggleOne = (id: string) => {
     const next = new Set(selectedIds)

--- a/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
@@ -116,6 +116,75 @@ const INTERPRETATION_COLOR: Record<Interpretation, string> = {
   'strong-distribution': 'bg-rose-500 text-white',
 }
 
+const BULLISH_SIGNAL_TYPES = new Set<SignalType>([
+  'spring',
+  'iceberg-buy',
+  'sniper-buy',
+  'twap-accumulation',
+  'vwap-accumulation',
+  'moo-accumulation',
+  'moc-accumulation',
+  'foreigner-accumulation',
+  'institution-accumulation',
+  'liquidity-sweep-bullish',
+  'choch-bullish',
+  'bos-bullish',
+  'order-block-bullish',
+  'fvg-bullish',
+  'bear-trap',
+  'no-supply',
+  'selling-climax',
+  'stopping-volume',
+  'po3-accumulation',
+  'bad-news-accumulation',
+  'wyckoff-phase-c',
+  'wyckoff-sos',
+  'wyckoff-lps',
+])
+
+const BEARISH_SIGNAL_TYPES = new Set<SignalType>([
+  'upthrust',
+  'iceberg-sell',
+  'sniper-sell',
+  'twap-distribution',
+  'vwap-distribution',
+  'moo-distribution',
+  'moc-distribution',
+  'foreigner-distribution',
+  'institution-distribution',
+  'liquidity-sweep-bearish',
+  'choch-bearish',
+  'bos-bearish',
+  'order-block-bearish',
+  'fvg-bearish',
+  'bull-trap',
+  'no-demand',
+  'buying-climax',
+  'po3-distribution',
+  'news-fade',
+  'sell-the-news',
+  'wyckoff-utad',
+  'wyckoff-sow',
+  'wyckoff-lpsy',
+])
+
+function getWyckoffMajorCycleLabel(
+  majorCycle?: 'accumulation' | 'markup' | 'distribution' | 'markdown' | null
+): string {
+  switch (majorCycle) {
+    case 'accumulation':
+      return '축적'
+    case 'markup':
+      return '상승'
+    case 'distribution':
+      return '분배'
+    case 'markdown':
+      return '하락'
+    default:
+      return '판단 보류'
+  }
+}
+
 function formatDateInTimeZone(date: Date, timeZone: string): string {
   try {
     const parts = new Intl.DateTimeFormat('en', {
@@ -462,6 +531,11 @@ export function SmartMoneyContent() {
   const scorePct = Math.max(0, Math.min(100, (overallScore + 100) / 2))
   const scoreColor =
     overallScore > 30 ? 'bg-emerald-500' : overallScore < -30 ? 'bg-rose-500' : 'bg-slate-400'
+  const wyckoffPhaseSummary = viewAnalysis?.wyckoffPhase
+  const wyckoffMajorLabel = getWyckoffMajorCycleLabel(wyckoffPhaseSummary?.majorCycle)
+  const wyckoffPhaseLabel = wyckoffPhaseSummary?.phase ? `Phase ${wyckoffPhaseSummary.phase}` : '페이즈 미확정'
+  const wyckoffPhaseConfidence = Math.round(wyckoffPhaseSummary?.confidence ?? 0)
+  const wyckoffRecentEvents = wyckoffPhaseSummary?.events.slice(-3).map((event) => event.type).join(' · ') ?? ''
 
   const isKisError = errorCode === 'NO_CREDENTIAL' || (error || '').toLowerCase().includes('kis')
 
@@ -768,6 +842,32 @@ export function SmartMoneyContent() {
                 </div>
               </div>
 
+              {wyckoffPhaseSummary && (
+                <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-2">
+                  <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
+                    <div className="text-[10px] font-semibold text-slate-500 uppercase tracking-wide">Wyckoff 사이클</div>
+                    <div className="mt-1 text-sm font-bold text-slate-900">{wyckoffMajorLabel}</div>
+                    <div className="text-[11px] text-slate-500">
+                      {wyckoffPhaseSummary.cycle === 'accumulation'
+                        ? 'Accumulation 계열'
+                        : wyckoffPhaseSummary.cycle === 'distribution'
+                          ? 'Distribution 계열'
+                          : '판단 보류'}
+                    </div>
+                  </div>
+                  <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
+                    <div className="text-[10px] font-semibold text-slate-500 uppercase tracking-wide">현재 페이즈</div>
+                    <div className="mt-1 text-sm font-bold text-slate-900">{wyckoffPhaseLabel}</div>
+                    <div className="text-[11px] text-slate-500">신뢰도 {wyckoffPhaseConfidence}/100</div>
+                  </div>
+                  <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
+                    <div className="text-[10px] font-semibold text-slate-500 uppercase tracking-wide">핵심 이벤트</div>
+                    <div className="mt-1 text-sm font-bold text-slate-900">{wyckoffRecentEvents || '없음'}</div>
+                    <div className="text-[11px] text-slate-500">최근 3개 이벤트 기준</div>
+                  </div>
+                </div>
+              )}
+
               {/* 점수 게이지 + 해석 */}
               <div className="mt-4">
                 <div className="flex items-center justify-between mb-1.5">
@@ -862,10 +962,8 @@ export function SmartMoneyContent() {
               ) : (
                 <ul className="space-y-2">
                   {topSignals.map((sig, i) => {
-                    const isAccum =
-                      sig.type.includes('accumulation') || sig.type === 'spring' || sig.type === 'iceberg-buy' || sig.type === 'sniper-buy'
-                    const isDist =
-                      sig.type.includes('distribution') || sig.type === 'upthrust' || sig.type === 'iceberg-sell' || sig.type === 'sniper-sell'
+                    const isAccum = BULLISH_SIGNAL_TYPES.has(sig.type)
+                    const isDist = BEARISH_SIGNAL_TYPES.has(sig.type)
                     const tone = isAccum
                       ? 'bg-emerald-50 border-emerald-200'
                       : isDist

--- a/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
@@ -38,6 +38,8 @@ import type {
   Interpretation,
   SignalType,
   SmartMoneyAnalysis,
+  SmartMoneyAnalyzeErrorResponse,
+  SmartMoneyAnalyzeResponse,
 } from '@/types/smartMoney'
 
 interface Selected {
@@ -238,7 +240,11 @@ export function SmartMoneyContent() {
   // 메모리 캐시 (ticker:market:date → analysis)
   const cacheRef = useRef<Map<string, SmartMoneyAnalysis>>(new Map())
 
-  const cacheKey = (s: Selected) => `${s.market}:${s.ticker}:${todayKey()}`
+  const cacheKey = useCallback(
+    (s: Selected, withPreMarket: boolean) =>
+      `${s.market}:${s.ticker}:${marketTodayKey(s.market)}:${withPreMarket && s.market === 'US' ? 'pre' : 'regular'}`,
+    [],
+  )
 
   const { add: rememberTicker } = useRecentTickers()
 
@@ -251,13 +257,46 @@ export function SmartMoneyContent() {
     setActiveDayIdx(null)
     rememberTicker(ticker, name || ticker, market)
     // 캐시에 있으면 즉시 표시
-    const cached = cacheRef.current.get(`${next.market}:${next.ticker}:${todayKey()}`)
+    const cached = cacheRef.current.get(cacheKey(next, includePreMarket))
     if (cached) setAnalysis(cached)
     else setAnalysis(null)
-  }, [rememberTicker])
+  }, [cacheKey, includePreMarket, rememberTicker])
+
+  const fetchLlmComment = useCallback(async (
+    base: SmartMoneyAnalysis,
+    targetSelection: Selected,
+    targetPreMarket: boolean,
+  ) => {
+    setLlmLoading(true)
+    try {
+      const res = await fetch('/api/investment/smart-money/llm-comment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ analysis: base }),
+      })
+      const json = await res.json().catch(() => ({} as { data?: { comment?: string; perCard?: SmartMoneyAnalysis['perCardComments'] } }))
+      const comment = json.data?.comment
+      const perCard = json.data?.perCard
+      if (comment) {
+        const updated: SmartMoneyAnalysis = { ...base, naturalLanguageComment: comment, perCardComments: perCard }
+        setAnalysis((prev) => (
+          prev && prev.ticker === base.ticker && prev.market === base.market
+            ? updated
+            : prev
+        ))
+        cacheRef.current.set(cacheKey(targetSelection, targetPreMarket), updated)
+      }
+    } catch {
+      /* ignore */
+    } finally {
+      setLlmLoading(false)
+    }
+  }, [cacheKey])
 
   const runAnalyze = useCallback(async () => {
     if (!selected) return
+    const requestSelection = selected
+    const requestPreMarket = includePreMarket && requestSelection.market === 'US'
     setLoading(true)
     setError(null)
     setErrorCode(null)
@@ -267,31 +306,31 @@ export function SmartMoneyContent() {
         headers: { 'Content-Type': 'application/json' },
         cache: 'no-store',
         body: JSON.stringify({
-          ticker: selected.ticker,
-          market: selected.market,
+          ticker: requestSelection.ticker,
+          market: requestSelection.market,
           includeLLM: true,
-          includePreMarket: includePreMarket && selected.market === 'US',
+          includePreMarket: requestPreMarket,
         }),
       })
-      const json = await res.json().catch(() => ({}))
+      const json: SmartMoneyAnalyzeResponse | SmartMoneyAnalyzeErrorResponse =
+        await res.json().catch(() => ({ error: '응답을 해석하지 못했습니다.' }))
       if (!res.ok) {
-        setError(json?.error || '분석 요청에 실패했습니다.')
-        setErrorCode(typeof json?.code === 'string' ? json.code : null)
+        setError('error' in json ? json.error : '분석 요청에 실패했습니다.')
+        setErrorCode('error' in json && typeof json.code === 'string' ? json.code : null)
         setAnalysis(null)
         return
       }
-      const data: SmartMoneyAnalysis | undefined = json?.data
+      const data = 'data' in json ? json.data : undefined
       if (!data) {
         setError('분석 결과를 받지 못했습니다.')
         return
       }
       setAnalysis(data)
       setActiveDayIdx(null) // 가장 최근 일자 default
-      cacheRef.current.set(cacheKey(selected), data)
+      cacheRef.current.set(cacheKey(requestSelection, requestPreMarket), data)
 
-      // LLM 코멘트가 비어 있으면 별도 호출
       if (!data.naturalLanguageComment) {
-        fetchLlmComment(data)
+        fetchLlmComment(data, requestSelection, requestPreMarket)
       }
     } catch {
       setError('네트워크 오류가 발생했습니다.')
@@ -299,12 +338,14 @@ export function SmartMoneyContent() {
     } finally {
       setLoading(false)
     }
-  }, [selected, includePreMarket])
+  }, [cacheKey, fetchLlmComment, includePreMarket, selected])
 
   /** 백그라운드 재분석 — 자동 갱신 시 사용. LLM 스킵, 큰 로딩 UI 없이 조용히 갱신.
    *  실패는 silent (기존 분석 유지). 기존 LLM 코멘트는 보존. */
   const runAnalyzeBackground = useCallback(async () => {
     if (!selected) return
+    const requestSelection = selected
+    const requestPreMarket = includePreMarket && requestSelection.market === 'US'
     setRefreshing(true)
     try {
       const res = await fetch('/api/investment/smart-money/analyze', {
@@ -312,62 +353,39 @@ export function SmartMoneyContent() {
         headers: { 'Content-Type': 'application/json' },
         cache: 'no-store',
         body: JSON.stringify({
-          ticker: selected.ticker,
-          market: selected.market,
+          ticker: requestSelection.ticker,
+          market: requestSelection.market,
           includeLLM: false,
-          includePreMarket: includePreMarket && selected.market === 'US',
+          includePreMarket: requestPreMarket,
         }),
       })
       if (!res.ok) return
-      const json = await res.json().catch(() => null)
-      const data: SmartMoneyAnalysis | undefined = json?.data
+      const json: SmartMoneyAnalyzeResponse | null = await res.json().catch(() => null)
+      const data = json?.data
       if (!data) return
-      setAnalysis(prev => {
+      let nextAnalysis: SmartMoneyAnalysis | null = null
+      setAnalysis((prev) => {
         if (!prev || prev.ticker !== data.ticker || prev.market !== data.market) return data
-        // LLM 코멘트 보존 — 폴링은 includeLLM=false라서 새로 안 옴
-        return {
+        nextAnalysis = {
           ...data,
           naturalLanguageComment: prev.naturalLanguageComment ?? data.naturalLanguageComment,
           perCardComments: prev.perCardComments ?? data.perCardComments,
-          // byDay 각 일자의 LLM 코멘트도 보존
-          byDay: data.byDay?.map(d => {
-            const prevDay = prev.byDay?.find(p => p.asOfDate === d.asOfDate)
+          byDay: data.byDay?.map((d) => {
+            const prevDay = prev.byDay?.find((p) => p.asOfDate === d.asOfDate)
             return prevDay?.naturalLanguageComment
               ? { ...d, naturalLanguageComment: prevDay.naturalLanguageComment }
               : d
           }),
         }
+        return nextAnalysis
       })
-      cacheRef.current.set(cacheKey(selected), data)
+      cacheRef.current.set(cacheKey(requestSelection, requestPreMarket), nextAnalysis ?? data)
     } catch {
       /* silent — 폴링 실패는 사용자 차단 안 함 */
     } finally {
       setRefreshing(false)
     }
-  }, [selected, includePreMarket])
-
-  const fetchLlmComment = useCallback(async (base: SmartMoneyAnalysis) => {
-    setLlmLoading(true)
-    try {
-      const res = await fetch('/api/investment/smart-money/llm-comment', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ analysis: base }),
-      })
-      const json = await res.json().catch(() => ({}))
-      const comment: string | undefined = json?.data?.comment
-      const perCard = json?.data?.perCard as SmartMoneyAnalysis['perCardComments']
-      if (comment) {
-        const updated: SmartMoneyAnalysis = { ...base, naturalLanguageComment: comment, perCardComments: perCard }
-        setAnalysis(prev => (prev && prev.ticker === base.ticker ? updated : prev))
-        if (selected) cacheRef.current.set(cacheKey(selected), updated)
-      }
-    } catch {
-      /* ignore */
-    } finally {
-      setLlmLoading(false)
-    }
-  }, [selected])
+  }, [cacheKey, includePreMarket, selected])
 
   // 활성 일자 분석 객체 — byDay에서 선택된 일자가 있으면 그 항목으로 SmartMoneyAnalysis를 합성.
   // 일자별 탭이 클릭됐을 때 표시 데이터(점수/시그널/패널/LLM)가 모두 그 일자 기준으로 전환됨.
@@ -405,6 +423,11 @@ export function SmartMoneyContent() {
       perCardComments: day.asOfDate === analysis.asOfDate ? analysis.perCardComments : undefined,
     }
   }, [analysis, activeDayIdx])
+
+  const defaultDayIdx = useMemo(() => {
+    if (!analysis?.byDay?.length) return 0
+    return findDefaultDayIndex(analysis.byDay, analysis.asOfDate)
+  }, [analysis])
 
   const topSignals = useMemo(() => {
     if (!viewAnalysis) return []
@@ -587,8 +610,7 @@ export function SmartMoneyContent() {
               <section className="bg-white rounded-2xl border border-slate-200 p-2 shadow-sm">
                 <div role="tablist" className="flex gap-1">
                   {analysis.byDay.map((day, i) => {
-                    const defaultIdx = findDefaultDayIndex(analysis.byDay!, analysis.asOfDate)
-                    const isActive = (activeDayIdx ?? defaultIdx) === i
+                    const isActive = (activeDayIdx ?? defaultDayIdx) === i
                     return (
                       <button
                         key={day.asOfDate}
@@ -788,7 +810,11 @@ export function SmartMoneyContent() {
                   ) : viewAnalysis.asOfDate === analysis.asOfDate ? (
                     <button
                       type="button"
-                      onClick={() => analysis && fetchLlmComment(analysis)}
+                      onClick={() => analysis && fetchLlmComment(
+                        analysis,
+                        { ticker: analysis.ticker, market: analysis.market, name: analysis.name },
+                        includePreMarket && analysis.market === 'US',
+                      )}
                       className="text-xs text-purple-700 hover:underline"
                     >
                       AI 코멘트 생성하기

--- a/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/SmartMoneyContent.tsx
@@ -116,23 +116,41 @@ const INTERPRETATION_COLOR: Record<Interpretation, string> = {
   'strong-distribution': 'bg-rose-500 text-white',
 }
 
-/** KST 기준 'YYYY-MM-DD' — Vercel UTC 또는 사용자 로컬 timezone에 영향 받지 않음 */
-function todayKey() {
-  const kst = new Date(Date.now() + 9 * 3600_000)
+function formatDateInTimeZone(date: Date, timeZone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat('en', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(date)
+    const year = parts.find((part) => part.type === 'year')?.value
+    const month = parts.find((part) => part.type === 'month')?.value
+    const day = parts.find((part) => part.type === 'day')?.value
+    if (year && month && day) {
+      return `${year}-${month}-${day}`
+    }
+  } catch {
+    // fall through to fixed-offset fallback for KST only
+  }
+
+  const kst = new Date(date.getTime() + 9 * 3600_000)
   const y = kst.getUTCFullYear()
   const m = String(kst.getUTCMonth() + 1).padStart(2, '0')
   const d = String(kst.getUTCDate()).padStart(2, '0')
   return `${y}-${m}-${d}`
 }
 
+/** KST 기준 'YYYY-MM-DD' — 브라우저 로컬 timezone에 영향 받지 않음 */
+function todayKey() {
+  return formatDateInTimeZone(new Date(), 'Asia/Seoul')
+}
+
 /** 시장 timezone 기준 'YYYY-MM-DD' — '오늘' 라벨 기준일 */
 function marketTodayKey(market: Market): string {
   const tz = market === 'US' ? 'America/New_York' : 'Asia/Seoul'
   try {
-    const fmt = new Intl.DateTimeFormat('en-CA', {
-      timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit',
-    })
-    return fmt.format(new Date())
+    return formatDateInTimeZone(new Date(), tz)
   } catch {
     return todayKey()
   }

--- a/dental-clinic-manager/src/components/Investment/SmartMoney/WyckoffPhaseTimeline.tsx
+++ b/dental-clinic-manager/src/components/Investment/SmartMoney/WyckoffPhaseTimeline.tsx
@@ -84,6 +84,12 @@ export function WyckoffPhaseTimeline({ phase }: Props) {
   const recentEvents = [...phase.events].slice(-5).reverse()
 
   const cycleLabel = isAccumulation ? '매집 사이클' : isDistribution ? '분배 사이클' : '판단 보류'
+  const majorCycleLabel =
+    phase.majorCycle === 'accumulation' ? '4단계: 축적'
+      : phase.majorCycle === 'markup' ? '4단계: 상승'
+        : phase.majorCycle === 'distribution' ? '4단계: 분배'
+          : phase.majorCycle === 'markdown' ? '4단계: 하락'
+            : '4단계: 판단 보류'
   const cycleBadge = isAccumulation
     ? 'bg-emerald-100 text-emerald-700'
     : isDistribution
@@ -96,6 +102,7 @@ export function WyckoffPhaseTimeline({ phase }: Props) {
         <h3 className="text-sm font-semibold text-slate-900">와이코프 페이즈</h3>
         <div className="flex items-center gap-1">
           <span className={`text-[10px] px-2 py-0.5 rounded-full font-bold ${cycleBadge}`}>{cycleLabel}</span>
+          <span className="text-[10px] px-2 py-0.5 rounded-full font-bold bg-slate-100 text-slate-600">{majorCycleLabel}</span>
           <button
             type="button"
             onClick={() => setHelpOpen((o) => !o)}
@@ -225,6 +232,21 @@ export function WyckoffPhaseTimeline({ phase }: Props) {
               </p>
             </div>
           )}
+
+          <div className="grid grid-cols-2 gap-2 mb-2">
+            <div className="rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-2">
+              <div className="text-[10px] text-slate-500">신뢰도</div>
+              <div className="text-sm font-bold text-slate-900">{Math.round(phase.confidence)}/100</div>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-2">
+              <div className="text-[10px] text-slate-500">TR 범위</div>
+              <div className="text-[11px] font-mono font-bold text-slate-900">
+                {phase.rangeLow && phase.rangeHigh
+                  ? `${phase.rangeLow.toFixed(2)} - ${phase.rangeHigh.toFixed(2)}`
+                  : '미확정'}
+              </div>
+            </div>
+          </div>
 
           {/* Events */}
           {recentEvents.length > 0 && (

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/ConditionBuilder.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/ConditionBuilder.tsx
@@ -29,6 +29,7 @@ const INDICATOR_PROPERTIES: Record<string, string[]> = {
   BB: ['upper', 'middle', 'lower'],
   STOCH: ['k', 'd'],
   ADX: ['adx', 'pdi', 'mdi'],
+  ELLIOTT: ['wave_number', 'direction', 'confidence', 'retracement'],
 }
 
 function getAvailableRefs(indicators: IndicatorConfig[]): { value: string; label: string; ref: IndicatorRef }[] {

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/IndicatorPanel.tsx
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/IndicatorPanel.tsx
@@ -123,6 +123,13 @@ const TEMPLATES: IndicatorTemplate[] = [
     defaultParams: { volPeriod: 20 },
     paramLabels: { volPeriod: '거래량 기간' },
   },
+  {
+    type: 'ELLIOTT',
+    label: '🌊 엘리어트 파동 (Wave Theory)',
+    description: 'ZigZag swing + 피보나치 비율로 5파/조정파 자동 인식. wave_number(1~8) / direction(±1) / confidence(0~100) 출력',
+    defaultParams: { deviationPct: 3, lookback: 80 },
+    paramLabels: { deviationPct: 'ZigZag %', lookback: '룩백 봉수' },
+  },
 ]
 
 function generateId(type: IndicatorType, params: Record<string, number>): string {

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets-metadata.ts
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets-metadata.ts
@@ -355,4 +355,40 @@ export const PRESET_METADATA: Record<string, PresetMetadata> = {
     ],
     source: 'Constance Brown (1999, "Technical Analysis for the Trading Professional")',
   },
+  'elliott-wave3-entry': {
+    longDescription:
+      'Ralph Nelson Elliott (1938) 의 파동 이론 — 가격은 5파 충격(impulse) + 3파 조정(corrective) 사이클로 움직인다는 가정. 본 전략은 ZigZag(3%) 기반으로 1·2파를 자동 인식한 뒤 2파 조정 종료를 RSI 회복(>50)과 결합해 3파 시작 시점에 진입한다. 3파는 통상 가장 길고 강한 상승파(Wave 1 의 1.618배 내외)이므로 추세 추종 전략의 핵심 진입점이다. 5파 완료(엘리어트 패턴 매칭 신뢰도) 또는 RSI 과매수(>75) 시 매도.',
+    bestFor: ['추세 종목 (성장주·테크 대형주)', '시장 전반 강세 국면', '거래량 풍부한 우량주'],
+    marketConditions: ['weak-uptrend', 'strong-uptrend'],
+    typicalHolding: '2주~2개월',
+    pros: [
+      '추세 초입에서 진입 가능 (3파 = 최강 상승)',
+      '피보나치 비율 검증으로 false signal 감소',
+      '엘리어트 규칙(Wave 2 ≤ 86%, Wave 3 ≥ Wave 1)으로 명확한 진입 기준',
+    ],
+    cons: [
+      '엘리어트 파동 자동 인식 자체가 휴리스틱 — 학술적으로 어려운 문제',
+      '횡보장에서는 swing 패턴이 모호해 false positive',
+      '5파 완료 판정이 늦어 차익 일부 반납 가능',
+    ],
+    source: 'Ralph Nelson Elliott (1938, "The Wave Principle"), Robert Prechter (1978, "Elliott Wave Principle")',
+  },
+  'elliott-wave4-pullback': {
+    longDescription:
+      '엘리어트 3파 상승 후 4파 조정이 진행되는 동안 RSI 둔화(<50) + 4파 인식 + 상승 방향 일치를 만족하면 5파 상승을 노리고 매수. 보수적 엘리어트 전략 — 3파 진입을 놓쳤거나 더 안전한 진입을 원할 때 사용. 5파 인식 또는 RSI 과매수(>70) 시 매도. 4파는 보통 Wave 3 의 23.6~50% 되돌림 구간.',
+    bestFor: ['이미 명확한 상승 추세에 있는 종목', '대형주·우량주', '거래량 안정적인 종목'],
+    marketConditions: ['weak-uptrend', 'strong-uptrend'],
+    typicalHolding: '2주~1.5개월',
+    pros: [
+      '3파 추격 매수 대비 진입가가 낮음 (조정 활용)',
+      '엘리어트 비중첩 규칙(Wave 4 vs Wave 1) 으로 손절 폭 명확',
+      'RSI 둔화 조건으로 가격 안정성 확보',
+    ],
+    cons: [
+      '4파 조정이 깊어지면 손절 발생 위험',
+      '5파가 짧거나 truncation(미완성) 시 수익률 제한적',
+      '엘리어트 패턴이 일찍 무효화되면 손실 누적',
+    ],
+    source: 'Ralph Nelson Elliott (1938, "The Wave Principle"), A.J. Frost & Robert Prechter (1978)',
+  },
 }

--- a/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets.ts
+++ b/dental-clinic-manager/src/components/Investment/StrategyBuilder/presets.ts
@@ -1623,4 +1623,126 @@ export const PRESET_STRATEGIES: PresetStrategy[] = [
       maxHoldingDays: 30,
     },
   },
+  // ============================================
+  // 엘리어트 파동 (Elliott Wave Theory) 기반
+  // ============================================
+  {
+    id: 'elliott-wave3-entry',
+    name: '엘리어트 3파 진입',
+    description: '엘리어트 파동에서 2파 조정 후 3파 시작 시점에 매수. 3파는 가장 길고 강한 상승 — 추세 추종의 핵심 진입점. 5파 완료 추정 시 매도.',
+    indicators: [
+      { id: 'ELLIOTT_3_80', type: 'ELLIOTT', params: { deviationPct: 3, lookback: 80 } },
+      { id: 'RSI_14', type: 'RSI', params: { period: 14 } },
+    ],
+    buyConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'ELLIOTT_3_80', property: 'wave_number' },
+          operator: '==',
+          right: { type: 'constant', value: 3 },
+        },
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'ELLIOTT_3_80', property: 'direction' },
+          operator: '==',
+          right: { type: 'constant', value: 1 },
+        },
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'ELLIOTT_3_80', property: 'confidence' },
+          operator: '>=',
+          right: { type: 'constant', value: 60 },
+        },
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'RSI_14' },
+          operator: '>',
+          right: { type: 'constant', value: 50 },
+        },
+      ],
+    },
+    sellConditions: {
+      type: 'group',
+      operator: 'OR',
+      conditions: [
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'ELLIOTT_3_80', property: 'wave_number' },
+          operator: '==',
+          right: { type: 'constant', value: 5 },
+        },
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'RSI_14' },
+          operator: '>',
+          right: { type: 'constant', value: 75 },
+        },
+      ],
+    },
+    riskSettings: {
+      stopLossPercent: 6,
+      takeProfitPercent: 18,
+      maxHoldingDays: 60,
+    },
+  },
+  {
+    id: 'elliott-wave4-pullback',
+    name: '엘리어트 4파 눌림목 매수',
+    description: '엘리어트 3파 후 4파 조정이 완료되는 지점에서 5파 상승을 노리고 매수. 보수적 추세 동참 — 4파 매수 후 5파 종료(또는 조정파 A 진입) 시 매도.',
+    indicators: [
+      { id: 'ELLIOTT_3_80', type: 'ELLIOTT', params: { deviationPct: 3, lookback: 80 } },
+      { id: 'RSI_14', type: 'RSI', params: { period: 14 } },
+      { id: 'EMA_20', type: 'EMA', params: { period: 20 } },
+    ],
+    buyConditions: {
+      type: 'group',
+      operator: 'AND',
+      conditions: [
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'ELLIOTT_3_80', property: 'wave_number' },
+          operator: '==',
+          right: { type: 'constant', value: 4 },
+        },
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'ELLIOTT_3_80', property: 'direction' },
+          operator: '==',
+          right: { type: 'constant', value: 1 },
+        },
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'RSI_14' },
+          operator: '<',
+          right: { type: 'constant', value: 50 },
+        },
+      ],
+    },
+    sellConditions: {
+      type: 'group',
+      operator: 'OR',
+      conditions: [
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'ELLIOTT_3_80', property: 'wave_number' },
+          operator: '==',
+          right: { type: 'constant', value: 5 },
+        },
+        {
+          type: 'leaf',
+          left: { type: 'indicator', id: 'RSI_14' },
+          operator: '>',
+          right: { type: 'constant', value: 70 },
+        },
+      ],
+    },
+    riskSettings: {
+      stopLossPercent: 5,
+      takeProfitPercent: 14,
+      maxHoldingDays: 45,
+    },
+  },
 ]

--- a/dental-clinic-manager/src/lib/bulkSmsService.ts
+++ b/dental-clinic-manager/src/lib/bulkSmsService.ts
@@ -123,8 +123,19 @@ export async function getEligiblePatients(
     })
   }
 
-  // 생일 월 필터
-  if (filter.birthMonths && filter.birthMonths.length > 0) {
+  // 생일 필터 — birthToday 우선, 그 다음 birthMonths
+  if (filter.birthToday) {
+    // KST 기준 오늘의 월·일
+    const kstNow = new Date(Date.now() + 9 * 60 * 60 * 1000)
+    const todayMonth = kstNow.getUTCMonth() + 1
+    const todayDay = kstNow.getUTCDate()
+    rows = rows.filter(r => {
+      if (!r.birth_date) return false
+      const b = new Date(r.birth_date)
+      if (isNaN(b.getTime())) return false
+      return (b.getMonth() + 1) === todayMonth && b.getDate() === todayDay
+    })
+  } else if (filter.birthMonths && filter.birthMonths.length > 0) {
     const months = new Set(filter.birthMonths)
     rows = rows.filter(r => {
       if (!r.birth_date) return false

--- a/dental-clinic-manager/src/lib/indicatorEngine.ts
+++ b/dental-clinic-manager/src/lib/indicatorEngine.ts
@@ -709,6 +709,277 @@ function calcIntradayPulse(prices: OHLCV[], params: Record<string, number>): num
 }
 
 // ============================================
+// 엘리어트 파동 자동 감지
+//
+// 5파 충격(impulse) + 3파 조정(corrective) 자동 인식 휴리스틱.
+// 1) ZigZag swing 추출 (deviation 임계 기반)
+// 2) 최근 swing 시퀀스가 1-2-3-4-5 패턴 + Wave 규칙 + 피보나치 비율 만족하는지 평가
+//    - Wave 2 retracement: Wave 1 의 38.2~78.6%
+//    - Wave 3 길이 ≥ Wave 1 길이 (보통 161.8%) 이고 Wave 3 은 1·3·5 중 가장 짧지 않음
+//    - Wave 4 retracement: Wave 3 의 23.6~50%, Wave 1 끝점과 비중첩
+//    - Wave 5 길이: Wave 1 의 61.8%~161.8%
+// 3) 현재 추정 단계를 wave_number 로 노출:
+//    1~5 = 충격파 진행, 6/7/8 = 조정 A/B/C, 0 = 미확정
+//
+// 한계: 엘리어트 파동의 정확한 자동 라벨링은 학술적으로 어려운 문제.
+//       본 구현은 ZigZag 기반 휴리스틱으로 high-confidence 케이스만 매칭한다.
+//       사용자 매매 전략에서 단독 시그널보다 다른 지표(RSI/MACD 등)와 조합 권장.
+// ============================================
+
+interface ZigZagPoint {
+  index: number
+  price: number
+  type: 'high' | 'low'
+}
+
+/**
+ * ZigZag 알고리즘 — deviation 임계(%) 이상 가격이 반전하면 swing 점 확정.
+ *
+ * 마지막 잠정 extreme 은 미확정 상태 그대로 마지막 swing 으로 포함 (실시간 추적용).
+ */
+function extractZigZagSwings(prices: OHLCV[], deviationPct: number): ZigZagPoint[] {
+  if (!prices || prices.length < 3) return []
+  const threshold = deviationPct / 100
+  if (threshold <= 0) return []
+
+  const swings: ZigZagPoint[] = []
+  let pivot: ZigZagPoint = { index: 0, price: prices[0].close, type: 'low' }
+  let extreme: ZigZagPoint = pivot
+  let direction: 'up' | 'down' | null = null
+
+  for (let i = 1; i < prices.length; i++) {
+    const high = prices[i].high
+    const low = prices[i].low
+    if (direction === null) {
+      if (pivot.price > 0 && (high - pivot.price) / pivot.price >= threshold) {
+        direction = 'up'
+        extreme = { index: i, price: high, type: 'high' }
+      } else if (pivot.price > 0 && (pivot.price - low) / pivot.price >= threshold) {
+        direction = 'down'
+        extreme = { index: i, price: low, type: 'low' }
+      }
+      continue
+    }
+    if (direction === 'up') {
+      if (high > extreme.price) {
+        extreme = { index: i, price: high, type: 'high' }
+      } else if (extreme.price > 0 && (extreme.price - low) / extreme.price >= threshold) {
+        swings.push(pivot)
+        pivot = extreme
+        direction = 'down'
+        extreme = { index: i, price: low, type: 'low' }
+      }
+    } else {
+      if (low < extreme.price) {
+        extreme = { index: i, price: low, type: 'low' }
+      } else if (extreme.price > 0 && (high - extreme.price) / extreme.price >= threshold) {
+        swings.push(pivot)
+        pivot = extreme
+        direction = 'up'
+        extreme = { index: i, price: high, type: 'high' }
+      }
+    }
+  }
+  swings.push(pivot)
+  if (extreme.index !== pivot.index) swings.push(extreme)
+  return swings
+}
+
+/** 두 swing 사이 가격 변화량 (절댓값). */
+function swingDist(a: ZigZagPoint, b: ZigZagPoint): number {
+  return Math.abs(b.price - a.price)
+}
+
+/**
+ * 5파 충격 패턴 검증.
+ *
+ * @param points 5 swing 점 (시간순)
+ * @param trend 'up' = 1·3·5 상승, 'down' = 1·3·5 하락 가정
+ * @returns 통과 시 1.0 (high confidence), 부분 통과 0~1, 실패 0
+ */
+function scoreImpulse(points: ZigZagPoint[], trend: 'up' | 'down'): number {
+  if (points.length < 5) return 0
+  const [p0, p1, p2, p3, p4] = points
+  // Wave 라벨링: p0→p1 = Wave 1, p1→p2 = Wave 2, p2→p3 = Wave 3, p3→p4 = Wave 4. 5번째 swing 은 별도.
+  // 단순화를 위해 5파 종결 직전(Wave 4 완료 시점) 기준으로 검증.
+  const w1 = swingDist(p0, p1)
+  const w2 = swingDist(p1, p2)
+  const w3 = swingDist(p2, p3)
+  const w4 = swingDist(p3, p4)
+  if (w1 <= 0 || w3 <= 0) return 0
+
+  // 방향 확인 (1·3 추세 방향)
+  if (trend === 'up') {
+    if (p1.price <= p0.price || p3.price <= p2.price) return 0
+    if (p2.price <= p0.price) return 0           // Wave 2 가 Wave 1 시작점 아래로 못 감
+    if (p3.price <= p1.price) return 0           // Wave 3 끝이 Wave 1 끝보다 위 (추세 지속)
+    if (p4.price <= p1.price) return 0           // Wave 4 가 Wave 1 끝점 아래로 못 감 (impulse 규칙)
+  } else {
+    if (p1.price >= p0.price || p3.price >= p2.price) return 0
+    if (p2.price >= p0.price) return 0
+    if (p3.price >= p1.price) return 0
+    if (p4.price >= p1.price) return 0
+  }
+
+  let score = 0.4   // 기본 통과 점수
+  // Wave 2 retracement: 38.2%~78.6% 이면 +
+  const w2Ret = w2 / w1
+  if (w2Ret >= 0.382 && w2Ret <= 0.786) score += 0.2
+  // Wave 3 길이: Wave 1 이상 이면 +, 161.8% 이상이면 추가 +
+  if (w3 >= w1 * 1.0) score += 0.15
+  if (w3 >= w1 * 1.618) score += 0.1
+  // Wave 4 retracement: 23.6%~50% 이면 +
+  const w4Ret = w4 / w3
+  if (w4Ret >= 0.236 && w4Ret <= 0.5) score += 0.15
+  return Math.min(1.0, score)
+}
+
+/**
+ * 현재 시점 엘리어트 파동 위치 추정.
+ *
+ * 가장 최근 swing N개를 검사해 패턴 매칭이 가장 강한 후보 채택.
+ */
+function analyzeElliottPosition(swings: ZigZagPoint[]): {
+  waveNumber: number
+  direction: number
+  confidence: number
+  retracement: number
+} {
+  if (swings.length < 2) {
+    return { waveNumber: 0, direction: 0, confidence: 0, retracement: 0 }
+  }
+
+  // 가장 최근부터 시작해 다양한 길이 후보 검사
+  // - 5 swing: 1-2-3-4 완료, Wave 5 진행 중 (또는 완료)
+  // - 4 swing: 1-2-3 완료, Wave 4 진행 중
+  // - 3 swing: 1-2 완료, Wave 3 진행 중 (가장 강한 매수)
+  // - 2 swing: Wave 1 완료, Wave 2 진행 중 (조정)
+  const n = swings.length
+
+  // 5 swing 패턴 (Wave 4 종료 → Wave 5 진행)
+  if (n >= 5) {
+    const recent = swings.slice(-5)
+    // 트렌드 추정: p0 → p4 전체 방향
+    const trend: 'up' | 'down' = recent[4].price > recent[0].price ? 'up' : 'down'
+    const score = scoreImpulse(recent, trend)
+    if (score >= 0.6) {
+      const w4Ret = swingDist(recent[3], recent[4]) / Math.max(1e-9, swingDist(recent[2], recent[3]))
+      return {
+        waveNumber: 5,
+        direction: trend === 'up' ? 1 : -1,
+        confidence: Math.round(score * 100),
+        retracement: Math.round(w4Ret * 1000) / 1000,
+      }
+    }
+  }
+
+  // 4 swing — Wave 3 종료 후 Wave 4 진행 중
+  if (n >= 4) {
+    const recent = swings.slice(-4)
+    const [p0, p1, p2, p3] = recent
+    const w1 = swingDist(p0, p1)
+    const w2 = swingDist(p1, p2)
+    const w3 = swingDist(p2, p3)
+    if (w1 > 0 && w3 > 0) {
+      const trend: 'up' | 'down' = p3.price > p0.price ? 'up' : 'down'
+      const okTrend = trend === 'up'
+        ? p1.price > p0.price && p3.price > p2.price && p2.price > p0.price && p3.price > p1.price
+        : p1.price < p0.price && p3.price < p2.price && p2.price < p0.price && p3.price < p1.price
+      const w2Ret = w2 / w1
+      const w2Ok = w2Ret >= 0.236 && w2Ret <= 0.886
+      const w3Ok = w3 >= w1 * 0.9
+      if (okTrend && w2Ok && w3Ok) {
+        const conf = Math.round(((w3Ok ? 0.45 : 0.3) + (w2Ret >= 0.382 && w2Ret <= 0.786 ? 0.25 : 0.1) + (w3 >= w1 * 1.618 ? 0.2 : 0.1)) * 100)
+        return {
+          waveNumber: 4,
+          direction: trend === 'up' ? 1 : -1,
+          confidence: Math.min(95, conf),
+          retracement: 0,
+        }
+      }
+    }
+  }
+
+  // 3 swing — Wave 2 완료, Wave 3 진행 중 (가장 가치있는 진입점)
+  if (n >= 3) {
+    const recent = swings.slice(-3)
+    const [p0, p1, p2] = recent
+    const w1 = swingDist(p0, p1)
+    const w2 = swingDist(p1, p2)
+    if (w1 > 0) {
+      const trend: 'up' | 'down' = p1.price > p0.price ? 'up' : 'down'
+      const okTrend = trend === 'up'
+        ? p2.price > p0.price && p2.price < p1.price
+        : p2.price < p0.price && p2.price > p1.price
+      const w2Ret = w2 / w1
+      const w2Ok = w2Ret >= 0.236 && w2Ret <= 0.886
+      if (okTrend && w2Ok) {
+        const conf = w2Ret >= 0.382 && w2Ret <= 0.786 ? 75 : 55
+        return {
+          waveNumber: 3,
+          direction: trend === 'up' ? 1 : -1,
+          confidence: conf,
+          retracement: Math.round(w2Ret * 1000) / 1000,
+        }
+      }
+    }
+  }
+
+  // 2 swing — Wave 1 완료, Wave 2 (조정) 진행 중
+  if (n >= 2) {
+    const [p0, p1] = swings.slice(-2)
+    const trend: 'up' | 'down' = p1.price > p0.price ? 'up' : 'down'
+    return {
+      waveNumber: 2,
+      direction: trend === 'up' ? 1 : -1,
+      confidence: 35,
+      retracement: 0,
+    }
+  }
+
+  return { waveNumber: 0, direction: 0, confidence: 0, retracement: 0 }
+}
+
+/**
+ * 엘리어트 파동 지표 계산.
+ *
+ * 출력 (각 봉마다):
+ *   - wave_number: 0=미확정, 1~5=충격파 진행 단계, 6=Wave A, 7=Wave B, 8=Wave C
+ *   - direction: 1=상승(impulse up), -1=하락(impulse down), 0=미확정
+ *   - confidence: 0~100 패턴 신뢰도
+ *   - retracement: 마지막 조정파의 retracement 비율 (없으면 0)
+ *
+ * 매매 활용 예시:
+ *   - Wave 3 진입 매수: wave_number == 3 AND direction == 1 AND confidence >= 60
+ *   - Wave 4 종료 후 Wave 5 매수: wave_number == 4 AND direction == 1
+ *   - Wave 5 종료 매도: wave_number == 5 AND direction == 1
+ */
+function calcElliott(prices: OHLCV[], params: Record<string, number>): Record<string, number>[] {
+  const deviationPct = Math.max(0.5, Math.min(15, params.deviationPct ?? 3))
+  const lookback = Math.max(20, Math.min(300, Math.floor(params.lookback ?? 80)))
+  const n = prices.length
+  const result: Record<string, number>[] = []
+
+  for (let i = 0; i < n; i++) {
+    if (i < 10) {
+      result.push({ wave_number: 0, direction: 0, confidence: 0, retracement: 0 })
+      continue
+    }
+    const start = Math.max(0, i - lookback + 1)
+    const window = prices.slice(start, i + 1)
+    const swings = extractZigZagSwings(window, deviationPct)
+    const analysis = analyzeElliottPosition(swings)
+    result.push({
+      wave_number: analysis.waveNumber,
+      direction: analysis.direction,
+      confidence: analysis.confidence,
+      retracement: analysis.retracement,
+    })
+  }
+  return result
+}
+
+// ============================================
 // 지표 계산기 매핑
 // ============================================
 
@@ -733,6 +1004,7 @@ const INDICATOR_CALCULATORS: Record<IndicatorType, (prices: OHLCV[], params: Rec
   LARGE_BLOCK: calcLargeBlock,
   CLOSING_PRESSURE: calcClosingPressure,
   INTRADAY_PULSE: calcIntradayPulse,
+  ELLIOTT: calcElliott,
 }
 
 // ============================================

--- a/dental-clinic-manager/src/lib/indicatorEngine.ts
+++ b/dental-clinic-manager/src/lib/indicatorEngine.ts
@@ -790,6 +790,27 @@ function swingDist(a: ZigZagPoint, b: ZigZagPoint): number {
   return Math.abs(b.price - a.price)
 }
 
+function roundTo(value: number, digits: number): number {
+  const scale = 10 ** digits
+  return Math.round(value * scale) / scale
+}
+
+function hasAlternatingSwingTypes(points: ZigZagPoint[]): boolean {
+  for (let i = 1; i < points.length; i++) {
+    if (points[i].type === points[i - 1].type) return false
+    if (points[i].index <= points[i - 1].index) return false
+  }
+  return true
+}
+
+function isTrendMove(a: ZigZagPoint, b: ZigZagPoint, trend: 'up' | 'down'): boolean {
+  return trend === 'up' ? b.price > a.price : b.price < a.price
+}
+
+function isCounterTrendMove(a: ZigZagPoint, b: ZigZagPoint, trend: 'up' | 'down'): boolean {
+  return trend === 'up' ? b.price < a.price : b.price > a.price
+}
+
 /**
  * 5파 충격 패턴 검증.
  *
@@ -799,9 +820,10 @@ function swingDist(a: ZigZagPoint, b: ZigZagPoint): number {
  */
 function scoreImpulse(points: ZigZagPoint[], trend: 'up' | 'down'): number {
   if (points.length < 5) return 0
+  if (!hasAlternatingSwingTypes(points)) return 0
   const [p0, p1, p2, p3, p4] = points
-  // Wave 라벨링: p0→p1 = Wave 1, p1→p2 = Wave 2, p2→p3 = Wave 3, p3→p4 = Wave 4. 5번째 swing 은 별도.
-  // 단순화를 위해 5파 종결 직전(Wave 4 완료 시점) 기준으로 검증.
+  // extractZigZagSwings 는 마지막 잠정 extreme 도 포함하므로
+  // p0→p1 = Wave 1, p1→p2 = Wave 2, p2→p3 = Wave 3, p3→p4 = Wave 4 진행/완료 상태를 뜻한다.
   const w1 = swingDist(p0, p1)
   const w2 = swingDist(p1, p2)
   const w3 = swingDist(p2, p3)
@@ -834,10 +856,98 @@ function scoreImpulse(points: ZigZagPoint[], trend: 'up' | 'down'): number {
   return Math.min(1.0, score)
 }
 
+function scoreCompletedImpulse(points: ZigZagPoint[], trend: 'up' | 'down'): number {
+  if (points.length < 6) return 0
+  if (!hasAlternatingSwingTypes(points)) return 0
+
+  const baseScore = scoreImpulse(points.slice(0, 5), trend)
+  if (baseScore < 0.55) return 0
+
+  const [p0, p1, p2, p3, p4, p5] = points
+  const w1 = swingDist(p0, p1)
+  const w3 = swingDist(p2, p3)
+  const w5 = swingDist(p4, p5)
+  if (w1 <= 0 || w3 <= 0 || w5 <= 0) return 0
+
+  if (trend === 'up') {
+    if (!isTrendMove(p4, p5, trend) || p5.price <= p3.price) return 0
+  } else {
+    if (!isTrendMove(p4, p5, trend) || p5.price >= p3.price) return 0
+  }
+
+  let score = Math.max(baseScore, 0.6)
+  if (w5 >= w1 * 0.618 && w5 <= w1 * 1.618) score += 0.15
+  if (w3 >= Math.min(w1, w5)) score += 0.1
+  if (w3 > w1 && w3 > w5) score += 0.05
+  return Math.min(1, score)
+}
+
+function scoreCorrectiveA(points: ZigZagPoint[], trend: 'up' | 'down'): number {
+  if (points.length < 7) return 0
+  const impulseScore = scoreCompletedImpulse(points.slice(0, 6), trend)
+  if (impulseScore < 0.6) return 0
+
+  const [p0, , , , p4, p5, p6] = points
+  if (!isCounterTrendMove(p5, p6, trend)) return 0
+
+  const impulseLength = swingDist(p0, p5)
+  const waveALength = swingDist(p5, p6)
+  if (impulseLength <= 0 || waveALength <= 0) return 0
+
+  let score = 0.55
+  const retracement = waveALength / impulseLength
+  if (retracement >= 0.236 && retracement <= 0.786) score += 0.2
+  if (trend === 'up' ? p6.price > p4.price : p6.price < p4.price) score += 0.1
+  score += Math.min(0.15, impulseScore * 0.15)
+  return Math.min(1, score)
+}
+
+function scoreCorrectiveB(points: ZigZagPoint[], trend: 'up' | 'down'): number {
+  if (points.length < 8) return 0
+  const waveAScore = scoreCorrectiveA(points.slice(0, 7), trend)
+  if (waveAScore < 0.6) return 0
+
+  const [, , , , , p5, p6, p7] = points
+  if (!isTrendMove(p6, p7, trend)) return 0
+
+  const waveA = swingDist(p5, p6)
+  const waveB = swingDist(p6, p7)
+  if (waveA <= 0 || waveB <= 0) return 0
+
+  let score = 0.55
+  const retracement = waveB / waveA
+  if (retracement >= 0.236 && retracement <= 0.886) score += 0.2
+  if (trend === 'up' ? p7.price < p5.price : p7.price > p5.price) score += 0.1
+  score += Math.min(0.15, waveAScore * 0.15)
+  return Math.min(1, score)
+}
+
+function scoreCorrectiveC(points: ZigZagPoint[], trend: 'up' | 'down'): number {
+  if (points.length < 9) return 0
+  const waveBScore = scoreCorrectiveB(points.slice(0, 8), trend)
+  if (waveBScore < 0.6) return 0
+
+  const [, , , , , , p6, p7, p8] = points
+  if (!isCounterTrendMove(p7, p8, trend)) return 0
+
+  const waveA = swingDist(points[5], p6)
+  const waveC = swingDist(p7, p8)
+  if (waveA <= 0 || waveC <= 0) return 0
+
+  let score = 0.6
+  const extension = waveC / waveA
+  if (extension >= 0.618 && extension <= 1.618) score += 0.2
+  if (trend === 'up' ? p8.price < p6.price : p8.price > p6.price) score += 0.1
+  score += Math.min(0.1, waveBScore * 0.1)
+  return Math.min(1, score)
+}
+
 /**
  * 현재 시점 엘리어트 파동 위치 추정.
  *
- * 가장 최근 swing N개를 검사해 패턴 매칭이 가장 강한 후보 채택.
+ * extractZigZagSwings 가 마지막 잠정 extreme 도 포함하므로
+ * 2~9 swing 을 각각 Wave 1 진행, 2, 3, 4, 5, A, B, C 단계 후보로 본다.
+ * 가장 긴(더 완성된) 패턴부터 검사해 매칭이 강한 후보를 채택한다.
  */
 function analyzeElliottPosition(swings: ZigZagPoint[]): {
   waveNumber: number
@@ -849,91 +959,139 @@ function analyzeElliottPosition(swings: ZigZagPoint[]): {
     return { waveNumber: 0, direction: 0, confidence: 0, retracement: 0 }
   }
 
-  // 가장 최근부터 시작해 다양한 길이 후보 검사
-  // - 5 swing: 1-2-3-4 완료, Wave 5 진행 중 (또는 완료)
-  // - 4 swing: 1-2-3 완료, Wave 4 진행 중
-  // - 3 swing: 1-2 완료, Wave 3 진행 중 (가장 강한 매수)
-  // - 2 swing: Wave 1 완료, Wave 2 진행 중 (조정)
-  const n = swings.length
+  const candidates = swings.slice(-9)
+  if (!hasAlternatingSwingTypes(candidates)) {
+    return { waveNumber: 0, direction: 0, confidence: 0, retracement: 0 }
+  }
 
-  // 5 swing 패턴 (Wave 4 종료 → Wave 5 진행)
-  if (n >= 5) {
-    const recent = swings.slice(-5)
-    // 트렌드 추정: p0 → p4 전체 방향
-    const trend: 'up' | 'down' = recent[4].price > recent[0].price ? 'up' : 'down'
-    const score = scoreImpulse(recent, trend)
+  const trend: 'up' | 'down' = candidates[1].price > candidates[0].price ? 'up' : 'down'
+  const direction = trend === 'up' ? 1 : -1
+  const n = candidates.length
+
+  if (n >= 9) {
+    const recent = candidates.slice(-9)
+    const score = scoreCorrectiveC(recent, trend)
     if (score >= 0.6) {
-      const w4Ret = swingDist(recent[3], recent[4]) / Math.max(1e-9, swingDist(recent[2], recent[3]))
+      const ratio = swingDist(recent[7], recent[8]) / Math.max(1e-9, swingDist(recent[5], recent[6]))
       return {
-        waveNumber: 5,
-        direction: trend === 'up' ? 1 : -1,
+        waveNumber: 8,
+        direction,
         confidence: Math.round(score * 100),
-        retracement: Math.round(w4Ret * 1000) / 1000,
+        retracement: roundTo(ratio, 3),
       }
     }
   }
 
-  // 4 swing — Wave 3 종료 후 Wave 4 진행 중
+  if (n >= 8) {
+    const recent = candidates.slice(-8)
+    const score = scoreCorrectiveB(recent, trend)
+    if (score >= 0.6) {
+      const ratio = swingDist(recent[6], recent[7]) / Math.max(1e-9, swingDist(recent[5], recent[6]))
+      return {
+        waveNumber: 7,
+        direction,
+        confidence: Math.round(score * 100),
+        retracement: roundTo(ratio, 3),
+      }
+    }
+  }
+
+  if (n >= 7) {
+    const recent = candidates.slice(-7)
+    const score = scoreCorrectiveA(recent, trend)
+    if (score >= 0.6) {
+      const ratio = swingDist(recent[5], recent[6]) / Math.max(1e-9, swingDist(recent[0], recent[5]))
+      return {
+        waveNumber: 6,
+        direction,
+        confidence: Math.round(score * 100),
+        retracement: roundTo(ratio, 3),
+      }
+    }
+  }
+
+  if (n >= 6) {
+    const recent = candidates.slice(-6)
+    const score = scoreCompletedImpulse(recent, trend)
+    if (score >= 0.6) {
+      const ratio = swingDist(recent[4], recent[5]) / Math.max(1e-9, swingDist(recent[0], recent[1]))
+      return {
+        waveNumber: 5,
+        direction,
+        confidence: Math.round(score * 100),
+        retracement: roundTo(ratio, 3),
+      }
+    }
+  }
+
+  if (n >= 5) {
+    const recent = candidates.slice(-5)
+    const score = scoreImpulse(recent, trend)
+    if (score >= 0.55) {
+      const ratio = swingDist(recent[3], recent[4]) / Math.max(1e-9, swingDist(recent[2], recent[3]))
+      return {
+        waveNumber: 4,
+        direction,
+        confidence: Math.round(score * 100),
+        retracement: roundTo(ratio, 3),
+      }
+    }
+  }
+
   if (n >= 4) {
-    const recent = swings.slice(-4)
+    const recent = candidates.slice(-4)
     const [p0, p1, p2, p3] = recent
     const w1 = swingDist(p0, p1)
     const w2 = swingDist(p1, p2)
     const w3 = swingDist(p2, p3)
-    if (w1 > 0 && w3 > 0) {
-      const trend: 'up' | 'down' = p3.price > p0.price ? 'up' : 'down'
-      const okTrend = trend === 'up'
-        ? p1.price > p0.price && p3.price > p2.price && p2.price > p0.price && p3.price > p1.price
-        : p1.price < p0.price && p3.price < p2.price && p2.price < p0.price && p3.price < p1.price
+    if (w1 > 0 && w2 > 0 && w3 > 0 && isTrendMove(p0, p1, trend) && isCounterTrendMove(p1, p2, trend) && isTrendMove(p2, p3, trend)) {
       const w2Ret = w2 / w1
-      const w2Ok = w2Ret >= 0.236 && w2Ret <= 0.886
-      const w3Ok = w3 >= w1 * 0.9
-      if (okTrend && w2Ok && w3Ok) {
-        const conf = Math.round(((w3Ok ? 0.45 : 0.3) + (w2Ret >= 0.382 && w2Ret <= 0.786 ? 0.25 : 0.1) + (w3 >= w1 * 1.618 ? 0.2 : 0.1)) * 100)
+      const validRetracement = w2Ret >= 0.236 && w2Ret <= 0.886
+      const wave3Breakout = trend === 'up' ? p3.price > p1.price : p3.price < p1.price
+      if (validRetracement && wave3Breakout) {
+        let score = 0.45
+        if (w3 >= w1) score += 0.15
+        if (w3 >= w1 * 1.618) score += 0.15
+        if (w2Ret >= 0.382 && w2Ret <= 0.786) score += 0.15
         return {
-          waveNumber: 4,
-          direction: trend === 'up' ? 1 : -1,
-          confidence: Math.min(95, conf),
-          retracement: 0,
+          waveNumber: 3,
+          direction,
+          confidence: Math.round(Math.min(0.95, score) * 100),
+          retracement: roundTo(w2Ret, 3),
         }
       }
     }
   }
 
-  // 3 swing — Wave 2 완료, Wave 3 진행 중 (가장 가치있는 진입점)
   if (n >= 3) {
-    const recent = swings.slice(-3)
+    const recent = candidates.slice(-3)
     const [p0, p1, p2] = recent
     const w1 = swingDist(p0, p1)
     const w2 = swingDist(p1, p2)
-    if (w1 > 0) {
-      const trend: 'up' | 'down' = p1.price > p0.price ? 'up' : 'down'
-      const okTrend = trend === 'up'
-        ? p2.price > p0.price && p2.price < p1.price
-        : p2.price < p0.price && p2.price > p1.price
+    if (w1 > 0 && w2 > 0 && isTrendMove(p0, p1, trend) && isCounterTrendMove(p1, p2, trend)) {
       const w2Ret = w2 / w1
-      const w2Ok = w2Ret >= 0.236 && w2Ret <= 0.886
-      if (okTrend && w2Ok) {
-        const conf = w2Ret >= 0.382 && w2Ret <= 0.786 ? 75 : 55
+      const wave2Valid = (trend === 'up' ? p2.price > p0.price : p2.price < p0.price) && w2Ret <= 0.886
+      if (wave2Valid) {
+        const score = w2Ret >= 0.382 && w2Ret <= 0.786 ? 0.7 : 0.5
         return {
-          waveNumber: 3,
-          direction: trend === 'up' ? 1 : -1,
-          confidence: conf,
-          retracement: Math.round(w2Ret * 1000) / 1000,
+          waveNumber: 2,
+          direction,
+          confidence: Math.round(score * 100),
+          retracement: roundTo(w2Ret, 3),
         }
       }
     }
   }
 
-  // 2 swing — Wave 1 완료, Wave 2 (조정) 진행 중
   if (n >= 2) {
-    const [p0, p1] = swings.slice(-2)
-    const trend: 'up' | 'down' = p1.price > p0.price ? 'up' : 'down'
-    return {
-      waveNumber: 2,
-      direction: trend === 'up' ? 1 : -1,
-      confidence: 35,
-      retracement: 0,
+    const [p0, p1] = candidates.slice(-2)
+    if (p1.price !== p0.price) {
+      return {
+        waveNumber: 1,
+        direction,
+        confidence: 35,
+        retracement: 0,
+      }
     }
   }
 

--- a/dental-clinic-manager/src/lib/smartMoney/smartMoneyScorer.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/smartMoneyScorer.ts
@@ -155,9 +155,12 @@ export function computeSmartMoneyScore(input: ScorerInput): ScorerOutput {
       wyckoffPhase.phase === 'E' ? 1.0
         : wyckoffPhase.phase === 'D' ? 0.85
           : wyckoffPhase.phase === 'C' ? 0.7
-            : wyckoffPhase.phase === 'B' ? 0.5
+        : wyckoffPhase.phase === 'B' ? 0.5
               : 0.35
-    wyckoffPhaseComponent = cycleSign * phaseWeight * (wyckoffPhase.confidence / 100) * WEIGHTS.wyckoffPhase
+    const eventDiversity = new Set(wyckoffPhase.events.map((e) => e.type)).size
+    const qualityMultiplier = clamp(0.65 + eventDiversity * 0.06, 0.65, 1)
+    wyckoffPhaseComponent =
+      cycleSign * phaseWeight * qualityMultiplier * (wyckoffPhase.confidence / 100) * WEIGHTS.wyckoffPhase
 
     // Phase C/D/E 핵심 이벤트는 별도 SignalDetail
     const eventTypes = wyckoffPhase.events.map((e) => e.type)

--- a/dental-clinic-manager/src/lib/smartMoney/wyckoffEngine.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/wyckoffEngine.ts
@@ -7,12 +7,14 @@
  *
  * 패턴:
  * - Spring   : 직전 LOOKBACK 봉의 저점을 (RANGE_MIN ~ RANGE_MAX) 비율로 깨고
- *              같은/다음 봉에서 close가 직전저점 위로 회복 + 거래량 평균 대비 N배↑
- * - Upthrust : 직전 LOOKBACK 봉의 고점을 같은 비율로 돌파 후 즉시 회복 실패
- *              (close < 직전고점) + 거래량 평균 대비 N배↑
+ *              같은/다음 봉에서 close가 직전저점 위로 회복
+ * - Upthrust : 직전 LOOKBACK 봉의 고점을 같은 비율로 돌파 후
+ *              같은/다음 봉에서 close가 직전고점 아래로 복귀
  * - Absorption: 거래량 z-score ≥ VOL_Z, 가격 변화율 절댓값 < PRICE_THRESHOLD
  *
- * 검사 방식: 최근 SCAN_WINDOW 봉을 슬라이딩하며 Spring/Upthrust는 OR, Absorption은 best score.
+ * 검사 방식: 최근 SCAN_WINDOW 봉을 슬라이딩하며 Spring/Upthrust는
+ *            '범위 이탈 + 즉시 복귀'를 우선 보고, 거래량 증가는 보조 증거로만 사용한다.
+ *            Absorption은 best score.
  */
 
 import type { WyckoffResult } from '@/types/smartMoney'
@@ -117,24 +119,31 @@ export function detectWyckoff(
     const stdVol = window.length > 0 ? Math.sqrt(varSum / window.length) : 0
 
     const isVolSpike = avgVol > 0 && target.volume >= avgVol * base.volumeSpikeMult
+    const nextBar = i + 1 < bars.length ? bars[i + 1] : null
 
-    if (!springDetected && prevLow > 0 && isVolSpike) {
+    if (!springDetected && prevLow > 0) {
       const breakRatio = (prevLow - target.low) / prevLow
+      const reclaimedSameBar = target.close > prevLow
+      const reclaimedNextBar = nextBar ? nextBar.close > prevLow : false
       if (
         breakRatio >= base.springRangeMin &&
         breakRatio <= base.springRangeMax &&
-        target.close > prevLow
+        (reclaimedSameBar || reclaimedNextBar) &&
+        (isVolSpike || reclaimedNextBar)
       ) {
         springDetected = true
       }
     }
 
-    if (!upthrustDetected && prevHigh > 0 && isVolSpike) {
+    if (!upthrustDetected && prevHigh > 0) {
       const breakoutRatio = (target.high - prevHigh) / prevHigh
+      const failedSameBar = target.close < prevHigh
+      const failedNextBar = nextBar ? nextBar.close < prevHigh : false
       if (
         breakoutRatio >= base.springRangeMin &&
         breakoutRatio <= base.springRangeMax &&
-        target.close < prevHigh
+        (failedSameBar || failedNextBar) &&
+        (isVolSpike || failedNextBar)
       ) {
         upthrustDetected = true
       }

--- a/dental-clinic-manager/src/lib/smartMoney/wyckoffPhaseEngine.ts
+++ b/dental-clinic-manager/src/lib/smartMoney/wyckoffPhaseEngine.ts
@@ -9,7 +9,8 @@
  *   - SC    : 거래량 1.8배 + 음봉 + 하단 wick > 35% + 구간 저점 부근
  *   - AR    : SC 이후 10봉 내 최고가 (자동 반등)
  *   - ST    : SC 저점을 1% 이내로 재테스트 + SC 대비 거래량 감소
- *   - Spring: SC/ST 저점을 0.3~2% 침범 후 회복 마감 + 거래량 1.5배
+ *   - Spring: SC/ST 저점을 0.3~2% 침범 후 회복 마감
+ *   - Test  : Spring 이후 더 높은 저점 + 더 낮은 거래량으로 공급 고갈 확인
  *   - SOS   : AR 고점 돌파 양봉 + 거래량 1.5배
  *   - LPS   : SOS 이후 직전 저항대 위에서 거래량 감소하며 눌림
  *
@@ -18,7 +19,8 @@
  *   - BC   : 거래량 1.8배 + 양봉 + 상단 wick > 35% + 구간 고점 부근
  *   - AR   : BC 이후 10봉 내 최저가
  *   - ST   : BC 고점 1% 이내 재테스트 + BC 대비 거래량 감소
- *   - UTAD : BC/ST 고점 0.3~2% 돌파 후 종가가 다시 아래로 마감 + 거래량 증가
+ *   - UTAD : BC/ST 고점 0.3~2% 돌파 후 종가가 다시 아래로 마감
+ *   - Test : UTAD 이후 더 낮은 고점 + 더 낮은 거래량으로 수요 실패 확인
  *   - SOW  : AR 저점 하향 돌파 음봉 + 거래량 증가
  *   - LPSY : SOW 이후 직전 지지대 아래서 반등 실패
  *
@@ -29,8 +31,9 @@
  *   - D : B 또는 C 후 SOS 발견 시 (또는 SOW)
  *   - E : D 후 LPS 발견 시 (또는 LPSY)
  *
- * - cycle  : accumulation/distribution 이벤트 카운트 비교 (≥2개 우세 쪽)
- * - confidence : clamp(eventsCount * 15 + (phase ? 25 : 0), 0, 100)
+ * - cycle  : 단순 이벤트 개수 대신 품질 가중 점수(score) 비교
+ * - majorCycle : 4단계 사이클(Accumulation/Markup/Distribution/Markdown)으로 재매핑
+ * - confidence : 이벤트 다양성 + 시퀀스 완성도 + 반대편 점수 대비 우위 반영
  */
 
 import type { WyckoffPhaseResult, WyckoffPhaseEvent } from '@/types/smartMoney'
@@ -83,6 +86,20 @@ function upperWickRatio(bar: PhaseBar): number {
   return (bar.high - bodyHigh) / range
 }
 
+function avgRangeBefore(bars: PhaseBar[], endExclusive: number, window: number): number {
+  const start = Math.max(0, endExclusive - window)
+  let sum = 0
+  let count = 0
+  for (let i = start; i < endExclusive; i++) {
+    const currentRange = rangeOf(bars[i])
+    if (currentRange > 0) {
+      sum += currentRange
+      count++
+    }
+  }
+  return count > 0 ? sum / count : 0
+}
+
 // ============================================
 // 매집 사이클 이벤트 스캔
 // ============================================
@@ -92,13 +109,14 @@ interface AccumulationEvents {
   ar: WyckoffPhaseEvent | null
   sts: WyckoffPhaseEvent[]
   spring: WyckoffPhaseEvent | null
+  test: WyckoffPhaseEvent | null
   sos: WyckoffPhaseEvent | null
   lps: WyckoffPhaseEvent | null
 }
 
 function detectAccumulation(bars: PhaseBar[]): AccumulationEvents {
   const result: AccumulationEvents = {
-    ps: null, sc: null, ar: null, sts: [], spring: null, sos: null, lps: null,
+    ps: null, sc: null, ar: null, sts: [], spring: null, test: null, sos: null, lps: null,
   }
 
   const n = bars.length
@@ -190,7 +208,8 @@ function detectAccumulation(bars: PhaseBar[]): AccumulationEvents {
       })
     }
 
-    // Spring: SC/ST 저가를 0.3~2% 이탈 후 종가가 그 위에서 마감, vol > 1.5x avg
+    // Spring: SC/ST 저가를 0.3~2% 이탈 후 종가가 그 위에서 마감.
+    // 정통 Wyckoff에서는 '범위 하단 이탈 후 재진입'이 핵심이며 고거래량은 필수 조건이 아니다.
     const refLow = scLow
     const springStart = scIdx + 1
     for (let i = springStart; i < n; i++) {
@@ -199,9 +218,6 @@ function detectAccumulation(bars: PhaseBar[]): AccumulationEvents {
       const piercePct = (refLow - b.low) / refLow
       if (piercePct < 0.003 || piercePct > 0.02) continue
       if (b.close <= refLow) continue
-      const avg = avgVolume(bars, i, VOL_WINDOW)
-      if (avg <= 0) continue
-      if (b.volume / avg <= 1.5) continue
       result.spring = {
         type: 'Spring',
         barIndex: i,
@@ -211,17 +227,40 @@ function detectAccumulation(bars: PhaseBar[]): AccumulationEvents {
       break
     }
 
+    if (result.spring) {
+      const springBar = bars[result.spring.barIndex]
+      for (let i = result.spring.barIndex + 1; i < n; i++) {
+        const b = bars[i]
+        if (b.low < springBar.low) continue
+        if (b.close < refLow) continue
+        if (b.volume >= springBar.volume) continue
+        result.test = {
+          type: 'Test',
+          barIndex: i,
+          price: b.low,
+          description: 'Successful Test after Spring',
+        }
+        break
+      }
+    }
+
     // SOS: 양봉, vol > 1.5x avg, close > AR high
     if (result.ar) {
       const arHighRef = result.ar.price
-      const sosStart = result.spring ? result.spring.barIndex + 1 : result.ar.barIndex + 1
+      const sosStart = result.test
+        ? result.test.barIndex + 1
+        : result.spring
+          ? result.spring.barIndex + 1
+          : result.ar.barIndex + 1
       for (let i = sosStart; i < n; i++) {
         const b = bars[i]
         if (b.close <= b.open) continue
         const avg = avgVolume(bars, i, VOL_WINDOW)
         if (avg <= 0) continue
         if (b.volume / avg <= 1.5) continue
-        if (b.close <= arHighRef) continue
+        const avgSpread = avgRangeBefore(bars, i, 10)
+        if (b.close <= arHighRef && b.high <= arHighRef) continue
+        if (avgSpread > 0 && rangeOf(b) < avgSpread * 1.1) continue
         result.sos = {
           type: 'SOS',
           barIndex: i,
@@ -264,13 +303,14 @@ interface DistributionEvents {
   ar: WyckoffPhaseEvent | null
   sts: WyckoffPhaseEvent[]
   utad: WyckoffPhaseEvent | null
+  test: WyckoffPhaseEvent | null
   sow: WyckoffPhaseEvent | null
   lpsy: WyckoffPhaseEvent | null
 }
 
 function detectDistribution(bars: PhaseBar[]): DistributionEvents {
   const result: DistributionEvents = {
-    psy: null, bc: null, ar: null, sts: [], utad: null, sow: null, lpsy: null,
+    psy: null, bc: null, ar: null, sts: [], utad: null, test: null, sow: null, lpsy: null,
   }
 
   const n = bars.length
@@ -360,7 +400,8 @@ function detectDistribution(bars: PhaseBar[]): DistributionEvents {
       })
     }
 
-    // UTAD: BC/ST 고가 0.3~2% 돌파 후 종가가 그 아래에서 마감, vol 큰 봉
+    // UTAD: BC/ST 고가 0.3~2% 돌파 후 종가가 그 아래에서 마감.
+    // 핵심은 범위 상단 돌파 실패이며 초고거래량은 보조 증거로만 본다.
     const refHigh = bcHigh
     for (let i = bcIdx + 1; i < n; i++) {
       const b = bars[i]
@@ -368,9 +409,6 @@ function detectDistribution(bars: PhaseBar[]): DistributionEvents {
       const piercePct = (b.high - refHigh) / refHigh
       if (piercePct < 0.003 || piercePct > 0.02) continue
       if (b.close >= refHigh) continue
-      const avg = avgVolume(bars, i, VOL_WINDOW)
-      if (avg <= 0) continue
-      if (b.volume / avg <= 1.5) continue
       result.utad = {
         type: 'UTAD',
         barIndex: i,
@@ -380,17 +418,40 @@ function detectDistribution(bars: PhaseBar[]): DistributionEvents {
       break
     }
 
+    if (result.utad) {
+      const utadBar = bars[result.utad.barIndex]
+      for (let i = result.utad.barIndex + 1; i < n; i++) {
+        const b = bars[i]
+        if (b.high > utadBar.high) continue
+        if (b.close > refHigh) continue
+        if (b.volume >= utadBar.volume) continue
+        result.test = {
+          type: 'Test',
+          barIndex: i,
+          price: b.high,
+          description: 'Failed Test after UTAD',
+        }
+        break
+      }
+    }
+
     // SOW: AR 저가 하향 돌파, 음봉, 거래량 증가
     if (result.ar) {
       const arLowRef = result.ar.price
-      const sowStart = result.utad ? result.utad.barIndex + 1 : result.ar.barIndex + 1
+      const sowStart = result.test
+        ? result.test.barIndex + 1
+        : result.utad
+          ? result.utad.barIndex + 1
+          : result.ar.barIndex + 1
       for (let i = sowStart; i < n; i++) {
         const b = bars[i]
         if (b.close >= b.open) continue
         const avg = avgVolume(bars, i, VOL_WINDOW)
         if (avg <= 0) continue
         if (b.volume / avg <= 1.5) continue
-        if (b.close >= arLowRef) continue
+        const avgSpread = avgRangeBefore(bars, i, 10)
+        if (b.close >= arLowRef && b.low >= arLowRef) continue
+        if (avgSpread > 0 && rangeOf(b) < avgSpread * 1.1) continue
         result.sow = {
           type: 'SOW',
           barIndex: i,
@@ -424,6 +485,49 @@ function detectDistribution(bars: PhaseBar[]): DistributionEvents {
   return result
 }
 
+function computeEventScore(events: {
+  ps?: WyckoffPhaseEvent | null
+  sc?: WyckoffPhaseEvent | null
+  ar?: WyckoffPhaseEvent | null
+  sts?: WyckoffPhaseEvent[]
+  spring?: WyckoffPhaseEvent | null
+  test?: WyckoffPhaseEvent | null
+  sos?: WyckoffPhaseEvent | null
+  lps?: WyckoffPhaseEvent | null
+  psy?: WyckoffPhaseEvent | null
+  bc?: WyckoffPhaseEvent | null
+  utad?: WyckoffPhaseEvent | null
+  sow?: WyckoffPhaseEvent | null
+  lpsy?: WyckoffPhaseEvent | null
+}): number {
+  return (
+    (events.ps ? 0.8 : 0) +
+    (events.sc ? 2.0 : 0) +
+    (events.ar ? 1.2 : 0) +
+    Math.min((events.sts?.length ?? 0) * 0.5, 1.5) +
+    (events.spring ? 1.8 : 0) +
+    (events.test ? 1.0 : 0) +
+    (events.sos ? 2.2 : 0) +
+    (events.lps ? 1.6 : 0) +
+    (events.psy ? 0.8 : 0) +
+    (events.bc ? 2.0 : 0) +
+    (events.utad ? 1.8 : 0) +
+    (events.sow ? 2.2 : 0) +
+    (events.lpsy ? 1.6 : 0)
+  )
+}
+
+function inferMajorCycle(
+  cycle: WyckoffPhaseResult['cycle'],
+  phase: WyckoffPhaseResult['phase'],
+): WyckoffPhaseResult['majorCycle'] {
+  if (!cycle) return null
+  if (cycle === 'accumulation') {
+    return phase === 'D' || phase === 'E' ? 'markup' : 'accumulation'
+  }
+  return phase === 'D' || phase === 'E' ? 'markdown' : 'distribution'
+}
+
 // ============================================
 // 메인 엔트리
 // ============================================
@@ -435,7 +539,16 @@ export function detectWyckoffPhase(
   // 일봉이 충분히 제공되면 일봉을 우선 사용한다 (분봉은 fallback).
   const sourceBars = dailyBars && dailyBars.length >= MIN_BARS ? dailyBars : bars
   if (!sourceBars || sourceBars.length < MIN_BARS) {
-    return { cycle: null, phase: null, events: [], confidence: 0, description: '데이터 부족' }
+    return {
+      cycle: null,
+      phase: null,
+      events: [],
+      confidence: 0,
+      description: '데이터 부족',
+      majorCycle: null,
+      rangeHigh: null,
+      rangeLow: null,
+    }
   }
 
   const acc = detectAccumulation(sourceBars)
@@ -447,6 +560,7 @@ export function detectWyckoffPhase(
   if (acc.ar) accEvents.push(acc.ar)
   for (const st of acc.sts) accEvents.push(st)
   if (acc.spring) accEvents.push(acc.spring)
+  if (acc.test) accEvents.push(acc.test)
   if (acc.sos) accEvents.push(acc.sos)
   if (acc.lps) accEvents.push(acc.lps)
 
@@ -456,16 +570,20 @@ export function detectWyckoffPhase(
   if (dist.ar) distEvents.push(dist.ar)
   for (const st of dist.sts) distEvents.push(st)
   if (dist.utad) distEvents.push(dist.utad)
+  if (dist.test) distEvents.push(dist.test)
   if (dist.sow) distEvents.push(dist.sow)
   if (dist.lpsy) distEvents.push(dist.lpsy)
+
+  const accScore = computeEventScore(acc)
+  const distScore = computeEventScore(dist)
 
   // cycle 결정
   let cycle: WyckoffPhaseResult['cycle'] = null
   let events: WyckoffPhaseEvent[] = []
-  if (accEvents.length > distEvents.length && accEvents.length >= 2) {
+  if (accScore >= distScore + 1.25 && accScore >= 3) {
     cycle = 'accumulation'
     events = accEvents
-  } else if (distEvents.length > accEvents.length && distEvents.length >= 2) {
+  } else if (distScore >= accScore + 1.25 && distScore >= 3) {
     cycle = 'distribution'
     events = distEvents
   } else if (accEvents.length === 0 && distEvents.length === 0) {
@@ -492,6 +610,9 @@ export function detectWyckoffPhase(
         events: [],
         confidence: 0,
         description: trendDesc,
+        majorCycle: trendPct >= 0.03 ? 'markup' : trendPct <= -0.03 ? 'markdown' : null,
+        rangeHigh: null,
+        rangeLow: null,
         trendHeuristic: {
           cycle,
           lookbackDays: 30,
@@ -500,10 +621,19 @@ export function detectWyckoffPhase(
         },
       }
     }
-    return { cycle: null, phase: null, events: [], confidence: 0, description: '이벤트 없음 — 횡보' }
+    return {
+      cycle: null,
+      phase: null,
+      events: [],
+      confidence: 0,
+      description: '이벤트 없음 — 횡보',
+      majorCycle: null,
+      rangeHigh: null,
+      rangeLow: null,
+    }
   } else {
-    // 동률 또는 2개 미만 — 더 많은 쪽만 노출, cycle 미정
-    events = accEvents.length >= distEvents.length ? accEvents : distEvents
+    // 근소한 접전이면 우세한 쪽 이벤트만 보여주고 cycle은 보류
+    events = accScore >= distScore ? accEvents : distEvents
   }
 
   // phase 결정 — prerequisite 시퀀스 강제 (Spring/SOS/LPS 단독 발견만으로는
@@ -534,12 +664,48 @@ export function detectWyckoffPhase(
   }
 
   events.sort((a, b) => a.barIndex - b.barIndex)
-  const confidence = Math.max(0, Math.min(100, events.length * 15 + (phase ? 25 : 0)))
+  const majorCycle = inferMajorCycle(cycle, phase)
+  const dominantScore = cycle === 'accumulation'
+    ? accScore
+    : cycle === 'distribution'
+      ? distScore
+      : Math.max(accScore, distScore)
+  const opposingScore = cycle === 'accumulation'
+    ? distScore
+    : cycle === 'distribution'
+      ? accScore
+      : Math.min(accScore, distScore)
+  const phaseBonus =
+    phase === 'E' ? 24
+      : phase === 'D' ? 20
+        : phase === 'C' ? 15
+          : phase === 'B' ? 10
+            : phase === 'A' ? 6
+              : 0
+  const confidence = Math.round(Math.max(
+    0,
+    Math.min(100, dominantScore * 10 + phaseBonus + Math.max(0, (dominantScore - opposingScore) * 4)),
+  ))
 
   const eventLabels = events.map(e => e.type).join(', ')
   const cycleLabel = cycle === 'accumulation' ? '매집' : cycle === 'distribution' ? '분배' : '중립'
+  const majorLabel =
+    majorCycle === 'accumulation' ? '축적'
+      : majorCycle === 'markup' ? '상승'
+        : majorCycle === 'distribution' ? '분배'
+          : majorCycle === 'markdown' ? '하락'
+            : '판단 보류'
   const phaseLabel = phase ? `Phase ${phase}` : '페이즈 미확정'
-  const description = `${cycleLabel} 사이클 / ${phaseLabel} — 이벤트: ${eventLabels || '없음'}`
+  const description = `${majorLabel} 단계 / ${cycleLabel} 사이클 / ${phaseLabel} — 이벤트: ${eventLabels || '없음'}`
 
-  return { cycle, phase, events, confidence, description }
+  return {
+    cycle,
+    phase,
+    events,
+    confidence,
+    description,
+    majorCycle,
+    rangeHigh: acc.ar?.price ?? dist.bc?.price ?? null,
+    rangeLow: acc.sc?.price ?? dist.ar?.price ?? null,
+  }
 }

--- a/dental-clinic-manager/src/types/bulkSms.ts
+++ b/dental-clinic-manager/src/types/bulkSms.ts
@@ -62,7 +62,8 @@ export interface BulkSmsFilter {
   lastVisitTo?: string | null
   lastTreatmentTypes?: string[]      // 다중 선택
   hasNextAppointment?: boolean | null  // null=전체, true=있음, false=없음
-  birthMonths?: number[]             // 1..12
+  birthMonths?: number[]             // 1..12 (birthToday=true 면 무시)
+  birthToday?: boolean               // true 면 오늘이 생일인 환자만 (KST 기준 month/day 일치)
   searchKeyword?: string             // 이름/차트번호
   activeOnly?: boolean               // 기본 true
 }

--- a/dental-clinic-manager/src/types/investment.ts
+++ b/dental-clinic-manager/src/types/investment.ts
@@ -72,6 +72,8 @@ export type IndicatorType =
   | 'LARGE_BLOCK'       // 대형 거래 감지 (현재 봉 거래량 / 최근 N봉 평균 비율)
   | 'CLOSING_PRESSURE'  // 장 마감 압박 (마감 N봉 거래량 점유율 %)
   | 'INTRADAY_PULSE'    // 분봉판 일일 펄스 (-100~+100)
+  // ===== 파동 이론 (Wave Theory) =====
+  | 'ELLIOTT'           // 엘리어트 파동 자동 감지 (현재 추정 wave_number / direction / confidence)
 
 /** 전략 모드: swing(일봉/스윙) vs daytrading(분봉/단타) */
 export type StrategyMode = 'swing' | 'daytrading'

--- a/dental-clinic-manager/src/types/smartMoney.ts
+++ b/dental-clinic-manager/src/types/smartMoney.ts
@@ -130,6 +130,9 @@ export interface WyckoffPhaseResult {
   events: WyckoffPhaseEvent[]
   confidence: number
   description: string
+  majorCycle?: 'accumulation' | 'markup' | 'distribution' | 'markdown' | null
+  rangeHigh?: number | null
+  rangeLow?: number | null
   trendHeuristic?: {
     cycle: NonNullable<WyckoffCycle>
     lookbackDays: number

--- a/dental-clinic-manager/src/types/smartMoney.ts
+++ b/dental-clinic-manager/src/types/smartMoney.ts
@@ -408,3 +408,27 @@ export interface InvestorTrendRow {
   total_value: number | null
   fetched_at: string
 }
+
+// ============================================
+// Smart Money Analyze API
+// ============================================
+
+export interface TriggeredSmartMoneyAlertSummary {
+  id: string
+  ticker: string
+  market: Market
+  signal_types: SignalType[]
+}
+
+export interface SmartMoneyAnalyzeResponse {
+  data: SmartMoneyAnalysis & {
+    triggeredAlerts?: TriggeredSmartMoneyAlertSummary[]
+    newsSignalIntegration?: 'active' | 'inactive'
+  }
+}
+
+export interface SmartMoneyAnalyzeErrorResponse {
+  error: string
+  code?: string
+  reason?: string
+}


### PR DESCRIPTION
## Summary
- 🌊 엘리어트 파동(Elliott Wave Theory) 자동 감지 지표 + 프리셋 2종 추가
  - ZigZag swing + 피보나치 비율 + 엘리어트 5파 규칙 검증
  - 출력: wave_number(1~5 충격, 6~8 조정, 0 미확정) / direction / confidence / retracement
  - 프리셋: '엘리어트 3파 진입', '엘리어트 4파 눌림목 매수'
- TSLA 심리분석 narrative 누락 보강 (별도 repair 호출)
- 전략 랭킹 사전 집계 테이블 + trigger (응답 3~5초 → <200ms)
- Codex review P1 후속 (DST 경계 / scorer rebalance 제거 / news flag)
- 스마트 머니 9개 엔진 결함 일괄 수정
- BRK 등 초고가 종목 백테스트 사전 검증

## Test plan
- [ ] /investment/strategy/new → "엘리어트 파동" 지표 선택 시 wave_number/direction/confidence/retracement 속성 노출
- [ ] 프리셋 "엘리어트 3파 진입" 적용 후 추세 종목(예: AAPL, NVDA) 백테스트 시 매수/매도 시점 합리적
- [ ] 프리셋 "엘리어트 4파 눌림목 매수" 도 동일 검증
- [ ] confidence < 60 시 false positive 감소 확인