### PR TITLE
release: develop → main (전략 매트릭스 사전계산 시스템 통합)

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/src/dentweb-api-client.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/dentweb-api-client.ts
@@ -22,6 +22,7 @@ export interface PatientSyncData {
   last_visit_date?: string;
   last_treatment_type?: string;
   next_appointment_date?: string;
+  next_appointment_memo?: string | null;
   registration_date?: string;
   is_active?: boolean;
 }

--- a/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
@@ -154,6 +154,7 @@ function formatPatientRow(row: Record<string, unknown>) {
     last_visit_date: formatDentwebDate(row['sz최종내원일'] as string),
     last_treatment_type: (row['last_treatment_type'] as string) || null,
     next_appointment_date: formatDentwebDate(row['next_appointment_date'] as string),
+    next_appointment_memo: ((row['next_appointment_memo'] as string) || '').trim() || null,
     registration_date: formatDentwebDate((row['sz등록시각'] as string)?.slice(0, 8)),
     acquisition_channel: acquisitionChannel,
     customer_type: customerType,
@@ -207,7 +208,12 @@ function buildPatientQueryBase(): string {
       (SELECT TOP 1 LEFT(a.sz예약시각, 8)
        FROM TB_예약목록 a
        WHERE a.n환자ID = p.n환자ID AND a.sz예약시각 >= CONVERT(VARCHAR(8), GETDATE(), 112)
-       ORDER BY a.sz예약시각 ASC) AS next_appointment_date
+       ORDER BY a.sz예약시각 ASC) AS next_appointment_date,
+      -- 다음 예약의 내용/메모 (sz예약내용)
+      (SELECT TOP 1 a.sz예약내용
+       FROM TB_예약목록 a
+       WHERE a.n환자ID = p.n환자ID AND a.sz예약시각 >= CONVERT(VARCHAR(8), GETDATE(), 112)
+       ORDER BY a.sz예약시각 ASC) AS next_appointment_memo
     FROM TB_환자정보 p
     WHERE p.sz이름 IS NOT NULL AND p.sz이름 != ''
   `;

--- a/dental-clinic-manager/scripts/buildStrategyMatrix.mjs
+++ b/dental-clinic-manager/scripts/buildStrategyMatrix.mjs
@@ -1,0 +1,590 @@
+/**
+ * Strategy Matrix 사전계산 배치 워커
+ *
+ * 모든 (전략 × 시장 × 종목 × 기간) 조합을 백테스트하여 strategy_matrix_runs 에 저장한다.
+ * Mac mini M4 launchd 로 매일 19:00 KST 실행 (incremental, engine_version 변경 시 자동 재계산).
+ *
+ * CLI:
+ *   node scripts/buildStrategyMatrix.mjs                          # 전체 풀배치 (1,230종목 × 31+전략 × 4기간)
+ *   node scripts/buildStrategyMatrix.mjs --limit 100               # 최대 100건만 (시범)
+ *   node scripts/buildStrategyMatrix.mjs --markets KR              # KR 만
+ *   node scripts/buildStrategyMatrix.mjs --tickers 005930,AAPL     # 특정 종목 (콤마 구분)
+ *   node scripts/buildStrategyMatrix.mjs --presets rsi-oversold,golden-cross
+ *   node scripts/buildStrategyMatrix.mjs --windows 1Y,3Y           # 일부 윈도우만
+ *   node scripts/buildStrategyMatrix.mjs --concurrency 4           # 동시 백테스트 수 (기본 4)
+ *   node scripts/buildStrategyMatrix.mjs --skip-shared             # 공유 사용자 전략 건너뛰기
+ *   node scripts/buildStrategyMatrix.mjs --requeue-failed          # 이전 failed 잡 재시도
+ *
+ * 환경변수 (.env.local):
+ *   NEXT_PUBLIC_SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY
+ */
+
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import dotenv from 'dotenv'
+import ts from 'typescript'
+import { createClient } from '@supabase/supabase-js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const REPO_ROOT = path.resolve(__dirname, '..')
+
+dotenv.config({ path: path.join(REPO_ROOT, '.env.local') })
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!supabaseUrl || !supabaseServiceRoleKey) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing in .env.local')
+}
+
+const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+// CLI 파싱
+const args = parseArgs(process.argv.slice(2))
+
+const INITIAL_CAPITAL = 10_000_000
+const WINDOWS = ['1Y', '3Y', '5Y', '10Y']
+const WINDOW_YEARS = { '1Y': 1, '3Y': 3, '5Y': 5, '10Y': 10 }
+
+async function main() {
+  console.log('=== Strategy Matrix Builder ===')
+  console.log('args:', args)
+
+  const modules = await loadCanonicalModules()
+  const { fetchPrices, runBacktest, ENGINE_VERSION, PRESET_STRATEGIES, UNIVERSES } = modules
+
+  console.log(`engine_version=${ENGINE_VERSION}`)
+
+  // 1. 전략 목록 구성
+  const entries = await buildEntryList(PRESET_STRATEGIES, args)
+  console.log(`entries: ${entries.length} (presets=${entries.filter(e => e.type === 'preset').length}, shared=${entries.filter(e => e.type === 'shared').length})`)
+
+  // 2. universe 구성
+  const universe = buildUniverse(UNIVERSES, args)
+  console.log(`universe: ${universe.length} tickers (KR=${universe.filter(u => u.market === 'KR').length}, US=${universe.filter(u => u.market === 'US').length})`)
+
+  // 3. 윈도우 구성
+  const windows = (args.windows ?? WINDOWS).filter(w => WINDOWS.includes(w))
+  console.log(`windows: ${windows.join(', ')}`)
+
+  // 4. 작업 큐 큐잉 (engine_version 일치하는 기존 done 행은 skip)
+  const queued = await queueJobs({
+    entries,
+    universe,
+    windows,
+    engineVersion: ENGINE_VERSION,
+    requeueFailed: args.requeueFailed === true,
+  })
+  console.log(`queued: ${queued} new jobs`)
+
+  // 5. 워커 처리
+  const limit = args.limit ?? Infinity
+  const concurrency = Number(args.concurrency ?? 4)
+  const stats = await processJobs({
+    fetchPrices,
+    runBacktest,
+    engineVersion: ENGINE_VERSION,
+    limit,
+    concurrency,
+  })
+  console.log(`processed: done=${stats.done}, failed=${stats.failed}, skipped=${stats.skipped}`)
+
+  // 6. 머티리얼라이즈드 뷰 새로고침
+  if (stats.done > 0) {
+    console.log('refreshing strategy_matrix_market_stats ...')
+    try {
+      const { error } = await supabase.rpc('refresh_strategy_matrix_market_stats')
+      if (error) {
+        console.log(`(note: ${error.message}) — REFRESH 는 별도 RPC 함수 필요. 본 배치는 데이터 적재만 완료.`)
+      } else {
+        console.log('materialized view refreshed')
+      }
+    } catch (err) {
+      console.log(`(note: REFRESH RPC 호출 실패 ${err?.message ?? err}) — 데이터 적재만 완료`)
+    }
+  }
+
+  console.log('=== done ===')
+  process.exit(0)
+}
+
+function parseArgs(argv) {
+  const out = {}
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase())
+      const next = argv[i + 1]
+      if (next && !next.startsWith('--')) {
+        if (['markets', 'tickers', 'presets', 'windows'].includes(key)) {
+          out[key] = next.split(',').map(s => s.trim()).filter(Boolean)
+        } else if (['limit', 'concurrency'].includes(key)) {
+          out[key] = Number(next)
+        } else {
+          out[key] = next
+        }
+        i++
+      } else {
+        out[key] = true
+      }
+    }
+  }
+  return out
+}
+
+async function buildEntryList(PRESET_STRATEGIES, args) {
+  const entries = []
+  const presetFilter = args.presets ? new Set(args.presets) : null
+
+  for (const preset of PRESET_STRATEGIES) {
+    if (presetFilter && !presetFilter.has(preset.id)) continue
+    entries.push({
+      type: 'preset',
+      id: preset.id,
+      name: preset.name,
+      indicators: preset.indicators,
+      buyConditions: preset.buyConditions,
+      sellConditions: preset.sellConditions,
+      riskSettings: preset.riskSettings,
+    })
+  }
+
+  if (args.skipShared !== true) {
+    const { data: shared, error } = await supabase
+      .from('investment_strategies')
+      .select('id, name, indicators, buy_conditions, sell_conditions, risk_settings')
+      .eq('is_public', true)
+    if (error) {
+      console.warn('shared strategies fetch failed (계속 진행):', error.message)
+    } else if (shared) {
+      for (const s of shared) {
+        entries.push({
+          type: 'shared',
+          id: s.id,
+          name: s.name,
+          indicators: s.indicators ?? [],
+          buyConditions: s.buy_conditions,
+          sellConditions: s.sell_conditions,
+          riskSettings: s.risk_settings ?? {},
+        })
+      }
+    }
+  }
+
+  return entries
+}
+
+function buildUniverse(UNIVERSES, args) {
+  const marketFilter = args.markets ? new Set(args.markets) : null
+  const tickerFilter = args.tickers ? new Set(args.tickers) : null
+
+  const all = []
+  for (const u of UNIVERSES.KR_ALL.entries) all.push(u)
+  for (const u of UNIVERSES.US_ALL.entries) all.push(u)
+
+  return all.filter(e => {
+    if (marketFilter && !marketFilter.has(e.market)) return false
+    if (tickerFilter && !tickerFilter.has(e.ticker)) return false
+    return true
+  })
+}
+
+async function queueJobs({ entries, universe, windows, engineVersion, requeueFailed }) {
+  // 기존 done 행 미리 조회
+  const { data: existing } = await supabase
+    .from('strategy_matrix_runs')
+    .select('entry_type, entry_id, market, ticker, period_window')
+    .eq('engine_version', engineVersion)
+  const doneSet = new Set(
+    (existing ?? []).map(r => `${r.entry_type}|${r.entry_id}|${r.market}|${r.ticker}|${r.period_window}`)
+  )
+
+  if (requeueFailed) {
+    await supabase
+      .from('strategy_matrix_jobs')
+      .update({ status: 'queued', attempts: 0, error: null })
+      .eq('status', 'failed')
+  }
+
+  const toInsert = []
+  for (const entry of entries) {
+    for (const tick of universe) {
+      for (const win of windows) {
+        const key = `${entry.type}|${entry.id}|${tick.market}|${tick.ticker}|${win}`
+        if (doneSet.has(key)) continue
+        toInsert.push({
+          entry_type: entry.type,
+          entry_id: entry.id,
+          market: tick.market,
+          ticker: tick.ticker,
+          period_window: win,
+        })
+      }
+    }
+  }
+
+  // 청크 단위로 upsert
+  const CHUNK = 500
+  let queued = 0
+  for (let i = 0; i < toInsert.length; i += CHUNK) {
+    const chunk = toInsert.slice(i, i + CHUNK)
+    const { error } = await supabase
+      .from('strategy_matrix_jobs')
+      .upsert(chunk, {
+        onConflict: 'entry_type,entry_id,market,ticker,period_window',
+        ignoreDuplicates: true,
+      })
+    if (error) {
+      console.warn(`upsert chunk failed: ${error.message}`)
+    } else {
+      queued += chunk.length
+    }
+  }
+  return queued
+}
+
+async function processJobs({ fetchPrices, runBacktest, engineVersion, limit, concurrency }) {
+  const stats = { done: 0, failed: 0, skipped: 0 }
+
+  // 전략 데이터 캐시 (preset_id / strategy_id → 정의)
+  const entryCache = new Map()
+  // 가격 데이터 캐시 (ticker → 10Y OHLCV)
+  const priceCache = new Map()
+
+  while (stats.done + stats.failed < limit) {
+    // 다음 처리할 잡 N개 fetch
+    const batchSize = Math.min(concurrency * 5, limit - stats.done - stats.failed)
+    if (batchSize <= 0) break
+
+    const { data: jobs, error } = await supabase
+      .from('strategy_matrix_jobs')
+      .select('*')
+      .eq('status', 'queued')
+      .lt('attempts', 3)
+      .order('id', { ascending: true })
+      .limit(batchSize)
+
+    if (error) {
+      console.error('jobs fetch error:', error.message)
+      break
+    }
+    if (!jobs || jobs.length === 0) {
+      console.log('no more queued jobs')
+      break
+    }
+
+    // 동시 처리 (Promise pool)
+    const queue = [...jobs]
+    const workers = Array.from({ length: concurrency }, () => worker())
+
+    async function worker() {
+      while (queue.length > 0) {
+        const job = queue.shift()
+        if (!job) break
+        try {
+          const result = await processOne(job)
+          if (result === 'done') stats.done++
+          else if (result === 'skipped') stats.skipped++
+        } catch (err) {
+          stats.failed++
+          console.warn(`job ${job.id} failed: ${err?.message ?? err}`)
+          await supabase
+            .from('strategy_matrix_jobs')
+            .update({
+              status: 'failed',
+              attempts: (job.attempts ?? 0) + 1,
+              error: String(err?.message ?? err).slice(0, 500),
+              finished_at: new Date().toISOString(),
+            })
+            .eq('id', job.id)
+        }
+        if (stats.done % 50 === 0 && stats.done > 0) {
+          console.log(`  progress: done=${stats.done} failed=${stats.failed} skipped=${stats.skipped}`)
+        }
+      }
+    }
+
+    await Promise.all(workers)
+  }
+
+  async function processOne(job) {
+    // running 으로 마킹
+    await supabase
+      .from('strategy_matrix_jobs')
+      .update({ status: 'running', started_at: new Date().toISOString(), attempts: (job.attempts ?? 0) + 1 })
+      .eq('id', job.id)
+
+    // 전략 정의 로드 (캐시)
+    const entryKey = `${job.entry_type}|${job.entry_id}`
+    let entry = entryCache.get(entryKey)
+    if (!entry) {
+      entry = await loadEntry(job.entry_type, job.entry_id)
+      entryCache.set(entryKey, entry)
+    }
+    if (!entry) {
+      throw new Error(`entry not found: ${entryKey}`)
+    }
+
+    // 가격 데이터 로드 (캐시, 10Y 한 번만)
+    const priceKey = `${job.ticker}|${job.market}`
+    let prices10Y = priceCache.get(priceKey)
+    if (!prices10Y) {
+      const end = new Date()
+      const start = new Date(end.getTime())
+      start.setFullYear(start.getFullYear() - 10)
+      prices10Y = await fetchPrices(job.ticker, job.market, isoDate(start), isoDate(end))
+      // 캐시 크기 제한: 100 티커 LRU
+      if (priceCache.size > 100) priceCache.delete(priceCache.keys().next().value)
+      priceCache.set(priceKey, prices10Y)
+    }
+
+    if (!prices10Y || prices10Y.length === 0) {
+      throw new Error(`no price data for ${job.ticker}`)
+    }
+
+    // 윈도우 슬라이싱
+    const years = WINDOW_YEARS[job.period_window]
+    const totalDays = years * 365
+    const sliced = prices10Y.slice(-Math.max(years * 252, Math.floor(prices10Y.length * years / 10)))
+    if (sliced.length < 20) {
+      // 데이터 부족 (신규 상장 등) — failed 가 아니라 skipped 로 처리
+      await supabase
+        .from('strategy_matrix_jobs')
+        .update({ status: 'done', finished_at: new Date().toISOString() })
+        .eq('id', job.id)
+      return 'skipped'
+    }
+
+    const result = runBacktest({
+      prices: sliced,
+      indicators: entry.indicators,
+      buyConditions: entry.buyConditions,
+      sellConditions: entry.sellConditions,
+      riskSettings: entry.riskSettings ?? {},
+      initialCapital: INITIAL_CAPITAL,
+      market: job.market,
+      ticker: job.ticker,
+      useFullCapital: true,
+    })
+
+    const startDate = sliced[0]?.date
+    const endDate = sliced[sliced.length - 1]?.date
+    const equityCurveCompact = downsampleEquityCurve(result.equityCurve)
+
+    const { error: insertError } = await supabase
+      .from('strategy_matrix_runs')
+      .upsert({
+        entry_type: job.entry_type,
+        entry_id: job.entry_id,
+        market: job.market,
+        ticker: job.ticker,
+        sector: null,
+        period_window: job.period_window,
+        start_date: startDate,
+        end_date: endDate,
+        initial_capital: INITIAL_CAPITAL,
+        use_full_capital: true,
+        total_return: result.metrics?.totalReturn ?? null,
+        annualized_return: result.metrics?.annualizedReturn ?? null,
+        max_drawdown: result.metrics?.maxDrawdown ?? null,
+        sharpe_ratio: result.metrics?.sharpeRatio ?? null,
+        win_rate: result.metrics?.winRate ?? null,
+        profit_factor: result.metrics?.profitFactor ?? null,
+        total_trades: result.metrics?.totalTrades ?? null,
+        buy_hold_return: result.buyHold?.buyHoldReturn ?? null,
+        equity_curve_compact: equityCurveCompact,
+        engine_version: engineVersion,
+        computed_at: new Date().toISOString(),
+      }, {
+        onConflict: 'entry_type,entry_id,market,ticker,period_window,engine_version',
+      })
+
+    if (insertError) {
+      throw new Error(`insert failed: ${insertError.message}`)
+    }
+
+    await supabase
+      .from('strategy_matrix_jobs')
+      .update({ status: 'done', finished_at: new Date().toISOString(), error: null })
+      .eq('id', job.id)
+
+    return 'done'
+  }
+
+  async function loadEntry(type, id) {
+    if (type === 'preset') {
+      return globalPresetCache.get(id) ?? null
+    }
+    if (type === 'shared') {
+      const { data, error } = await supabase
+        .from('investment_strategies')
+        .select('id, name, indicators, buy_conditions, sell_conditions, risk_settings')
+        .eq('id', id)
+        .single()
+      if (error || !data) return null
+      return {
+        type: 'shared',
+        id: data.id,
+        name: data.name,
+        indicators: data.indicators ?? [],
+        buyConditions: data.buy_conditions,
+        sellConditions: data.sell_conditions,
+        riskSettings: data.risk_settings ?? {},
+      }
+    }
+    return null
+  }
+
+  return stats
+}
+
+// 글로벌 프리셋 캐시
+const globalPresetCache = new Map()
+
+function downsampleEquityCurve(curve) {
+  if (!curve || curve.length === 0) return []
+  // 월말 기준 샘플링 → ~120 points/10Y
+  const sampled = []
+  let lastMonth = null
+  for (const point of curve) {
+    const month = point.date?.slice(0, 7)
+    if (month !== lastMonth) {
+      sampled.push({ d: point.date, e: Math.round(point.equity ?? point.totalEquity ?? 0) })
+      lastMonth = month
+    }
+  }
+  // 마지막 포인트 포함
+  const last = curve[curve.length - 1]
+  if (last && sampled[sampled.length - 1]?.d !== last.date) {
+    sampled.push({ d: last.date, e: Math.round(last.equity ?? last.totalEquity ?? 0) })
+  }
+  return sampled
+}
+
+function isoDate(d) {
+  return d.toISOString().slice(0, 10)
+}
+
+// ============================================
+// TypeScript 모듈 transpile + load (verifyBacktests.mjs 패턴 재사용)
+// ============================================
+async function loadCanonicalModules() {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'matrix-builder-'))
+  try {
+    await fs.symlink(path.join(REPO_ROOT, 'node_modules'), path.join(tmpRoot, 'node_modules'), 'dir')
+  } catch (error) {
+    if (error?.code !== 'EEXIST') throw error
+  }
+
+  const targets = [
+    'src/lib/backtestEngine.ts',
+    'src/lib/indicatorEngine.ts',
+    'src/lib/signalEngine.ts',
+    'src/lib/stockDataService.ts',
+    'src/lib/supabase/admin.ts',
+    'src/lib/krTickerDict.ts',
+    'src/lib/usTickerDict.ts',
+    'src/lib/usTickerCatalog.ts',
+    'src/lib/screenerUniverses.ts',
+    'src/components/Investment/StrategyBuilder/presets.ts',
+  ]
+
+  for (const relPath of targets) {
+    await transpileModuleToTemp(relPath, tmpRoot)
+  }
+
+  // .json 데이터 파일을 .js ESM 모듈로 변환 (rewriteSpecifiers 가 .json → .js 로 변환하도록 매핑)
+  const jsonAssets = ['src/data/us-tickers.json']
+  for (const relPath of jsonAssets) {
+    const src = path.join(REPO_ROOT, relPath)
+    const dst = path.join(tmpRoot, relPath.replace(/\.json$/, '.js'))
+    try {
+      const content = await fs.readFile(src, 'utf8')
+      const wrapped = `export default ${content}\n`
+      await fs.mkdir(path.dirname(dst), { recursive: true })
+      await fs.writeFile(dst, wrapped, 'utf8')
+    } catch (err) {
+      console.warn(`json asset prep skipped (${relPath}): ${err?.message}`)
+    }
+  }
+
+  const backtestModule = await import(pathToFileURL(path.join(tmpRoot, 'src/lib/backtestEngine.js')).href)
+  const stockDataModule = await import(pathToFileURL(path.join(tmpRoot, 'src/lib/stockDataService.js')).href)
+  const presetModule = await import(pathToFileURL(path.join(tmpRoot, 'src/components/Investment/StrategyBuilder/presets.js')).href)
+  const universeModule = await import(pathToFileURL(path.join(tmpRoot, 'src/lib/screenerUniverses.js')).href)
+
+  // 글로벌 프리셋 캐시 채우기
+  for (const preset of presetModule.PRESET_STRATEGIES) {
+    globalPresetCache.set(preset.id, {
+      type: 'preset',
+      id: preset.id,
+      name: preset.name,
+      indicators: preset.indicators,
+      buyConditions: preset.buyConditions,
+      sellConditions: preset.sellConditions,
+      riskSettings: preset.riskSettings,
+    })
+  }
+
+  return {
+    runBacktest: backtestModule.runBacktest,
+    ENGINE_VERSION: backtestModule.ENGINE_VERSION,
+    fetchPrices: stockDataModule.fetchPrices,
+    PRESET_STRATEGIES: presetModule.PRESET_STRATEGIES,
+    UNIVERSES: universeModule.UNIVERSES,
+  }
+}
+
+async function transpileModuleToTemp(relPath, tmpRoot) {
+  const sourcePath = path.join(REPO_ROOT, relPath)
+  const outputPath = path.join(tmpRoot, relPath.replace(/\.tsx?$/, '.js'))
+  const source = await fs.readFile(sourcePath, 'utf8')
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      esModuleInterop: true,
+      jsx: ts.JsxEmit.Preserve,
+    },
+    fileName: sourcePath,
+  }).outputText
+  const rewritten = rewriteSpecifiers(transpiled, outputPath, tmpRoot)
+  await fs.mkdir(path.dirname(outputPath), { recursive: true })
+  await fs.writeFile(outputPath, rewritten, 'utf8')
+}
+
+function rewriteSpecifiers(code, outputPath, tmpRoot) {
+  const replaceSpecifier = (specifier) => {
+    if (!specifier.startsWith('@/') && !specifier.startsWith('./') && !specifier.startsWith('../')) {
+      return specifier
+    }
+    // .json 은 .js 로 재매핑 (json 자산은 .js ESM 모듈로 변환되어 복사됨)
+    let normalized = specifier.replace(/\.json$/, '.js')
+    const hasExt = /\.(js|mjs|cjs)$/.test(normalized)
+    let resolvedTarget
+    if (normalized.startsWith('@/')) {
+      const stripped = normalized.slice(2)
+      resolvedTarget = path.join(tmpRoot, 'src', stripped) + (hasExt ? '' : '.js')
+    } else {
+      resolvedTarget = path.resolve(path.dirname(outputPath), normalized) + (hasExt ? '' : '.js')
+    }
+    let next = path.relative(path.dirname(outputPath), resolvedTarget).replace(/\\/g, '/')
+    if (!next.startsWith('.')) next = `./${next}`
+    return next
+  }
+  return code
+    .replace(/from\s+['"]([^'"]+)['"]/g, (m, s) => `from "${replaceSpecifier(s)}"`)
+    .replace(/import\(\s*['"]([^'"]+)['"]\s*\)/g, (m, s) => `import("${replaceSpecifier(s)}")`)
+}
+
+main().catch(err => {
+  console.error('FATAL:', err)
+  process.exit(1)
+})

--- a/dental-clinic-manager/scripts/launchd/com.dental.strategy-matrix.plist
+++ b/dental-clinic-manager/scripts/launchd/com.dental.strategy-matrix.plist
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Strategy Matrix 야간 배치 launchd 설정 (Mac mini M4)
+
+  설치:
+    1) 본 plist 를 사용자 LaunchAgents 로 복사
+       cp scripts/launchd/com.dental.strategy-matrix.plist ~/Library/LaunchAgents/
+
+    2) 등록 (자동 실행 시작)
+       launchctl load ~/Library/LaunchAgents/com.dental.strategy-matrix.plist
+
+    3) 즉시 실행 (테스트용)
+       launchctl start com.dental.strategy-matrix
+
+    4) 해제
+       launchctl unload ~/Library/LaunchAgents/com.dental.strategy-matrix.plist
+
+  로그:
+    /Users/hhs/Library/Logs/strategy-matrix/out.log
+    /Users/hhs/Library/Logs/strategy-matrix/err.log
+
+  매일 KST 19:00 (장마감 후) 자동 실행.
+  StandardOutPath / StandardErrorPath 의 디렉토리는 미리 만들어둘 것:
+    mkdir -p ~/Library/Logs/strategy-matrix
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.dental.strategy-matrix</string>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/hhs/Project/dental-clinic-manager/dental-clinic-manager</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/node</string>
+    <string>/Users/hhs/Project/dental-clinic-manager/dental-clinic-manager/scripts/buildStrategyMatrix.mjs</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    <key>NODE_ENV</key>
+    <string>production</string>
+  </dict>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>19</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>KeepAlive</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/hhs/Library/Logs/strategy-matrix/out.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/hhs/Library/Logs/strategy-matrix/err.log</string>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+
+  <key>Nice</key>
+  <integer>10</integer>
+</dict>
+</plist>

--- a/dental-clinic-manager/src/app/api/dentweb/sync/route.ts
+++ b/dental-clinic-manager/src/app/api/dentweb/sync/route.ts
@@ -14,6 +14,7 @@ interface PatientSyncData {
   last_visit_date?: string
   last_treatment_type?: string
   next_appointment_date?: string
+  next_appointment_memo?: string | null
   registration_date?: string
   acquisition_channel?: string | null
   customer_type?: string | null
@@ -111,6 +112,9 @@ export async function POST(request: NextRequest) {
           last_visit_date: sanitizeDate(p.last_visit_date),
           last_treatment_type: p.last_treatment_type || null,
           next_appointment_date: sanitizeDate(p.next_appointment_date),
+          next_appointment_memo: typeof p.next_appointment_memo === 'string' && p.next_appointment_memo.trim()
+            ? p.next_appointment_memo.trim().slice(0, 500)
+            : null,
           registration_date: sanitizeDate(p.registration_date),
           acquisition_channel: p.acquisition_channel ?? null,
           customer_type: p.customer_type ?? null,

--- a/dental-clinic-manager/src/app/api/investment/matrix/aggregate/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/matrix/aggregate/route.ts
@@ -1,0 +1,141 @@
+/**
+ * Strategy Matrix 집계 API (Leaderboard)
+ *
+ * GET /api/investment/matrix/aggregate
+ *   ?period_window=5Y                (default 5Y)
+ *   &market=KR|US|ALL                (default ALL)
+ *   &group_by=market|none            (default market — 시장별 분할비교 뷰)
+ *   &entry_type=preset|shared        (optional)
+ *
+ * strategy_matrix_market_stats 머티리얼라이즈드 뷰 조회로 ~20ms 응답.
+ *
+ * 응답: { data: Array<{ entry_type, entry_id, market, period_window, sample_size, avg_return, ... }> }
+ */
+
+import { NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+export const dynamic = 'force-dynamic'
+
+const ALLOWED_WINDOWS = new Set(['1Y', '3Y', '5Y', '10Y'])
+
+export async function GET(req: Request) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 실패' }, { status: auth.status })
+  }
+
+  const supabase = getSupabaseAdmin()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+
+  const url = new URL(req.url)
+  const periodWindow = url.searchParams.get('period_window') ?? '5Y'
+  const market = (url.searchParams.get('market') ?? 'ALL').toUpperCase()
+  const groupBy = url.searchParams.get('group_by') ?? 'market'
+  const entryType = url.searchParams.get('entry_type')
+
+  if (!ALLOWED_WINDOWS.has(periodWindow)) {
+    return NextResponse.json({ error: `period_window must be one of ${[...ALLOWED_WINDOWS].join(', ')}` }, { status: 400 })
+  }
+
+  let q = supabase
+    .from('strategy_matrix_market_stats')
+    .select('*')
+    .eq('period_window', periodWindow)
+    .order('avg_return', { ascending: false })
+
+  if (market !== 'ALL') q = q.eq('market', market)
+  if (entryType) q = q.eq('entry_type', entryType)
+
+  const { data, error } = await q
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  // group_by=none 이면 시장 통합 평균 재집계
+  if (groupBy === 'none' && data) {
+    const map = new Map<string, ReturnType<typeof emptyAgg>>()
+    for (const row of data as MatrixStatsRow[]) {
+      const key = `${row.entry_type}|${row.entry_id}|${row.period_window}`
+      const acc = map.get(key) ?? emptyAgg(row)
+      mergeAgg(acc, row)
+      map.set(key, acc)
+    }
+    const merged = Array.from(map.values())
+      .map(finalizeAgg)
+      .sort((a, b) => (b.avg_return ?? 0) - (a.avg_return ?? 0))
+    return NextResponse.json({ data: merged })
+  }
+
+  return NextResponse.json({ data: data ?? [] })
+}
+
+interface MatrixStatsRow {
+  entry_type: string
+  entry_id: string
+  market: string
+  period_window: string
+  sample_size: number
+  avg_return: number | null
+  std_return: number | null
+  avg_annualized: number | null
+  avg_sharpe: number | null
+  avg_mdd: number | null
+  avg_winrate: number | null
+  avg_profit_factor: number | null
+  best_return: number | null
+  worst_return: number | null
+  median_return: number | null
+  positive_count: number
+  last_computed_window_end: string | null
+}
+
+function emptyAgg(row: MatrixStatsRow) {
+  return {
+    entry_type: row.entry_type,
+    entry_id: row.entry_id,
+    market: 'ALL',
+    period_window: row.period_window,
+    sample_size: 0,
+    sum_return: 0,
+    sum_sharpe: 0,
+    sum_mdd: 0,
+    sum_winrate: 0,
+    best_return: -Infinity,
+    worst_return: Infinity,
+    positive_count: 0,
+  }
+}
+
+function mergeAgg(acc: ReturnType<typeof emptyAgg>, row: MatrixStatsRow) {
+  const n = row.sample_size ?? 0
+  acc.sample_size += n
+  acc.sum_return += (row.avg_return ?? 0) * n
+  acc.sum_sharpe += (row.avg_sharpe ?? 0) * n
+  acc.sum_mdd += (row.avg_mdd ?? 0) * n
+  acc.sum_winrate += (row.avg_winrate ?? 0) * n
+  acc.best_return = Math.max(acc.best_return, row.best_return ?? -Infinity)
+  acc.worst_return = Math.min(acc.worst_return, row.worst_return ?? Infinity)
+  acc.positive_count += row.positive_count ?? 0
+}
+
+function finalizeAgg(acc: ReturnType<typeof emptyAgg>) {
+  const n = acc.sample_size || 1
+  return {
+    entry_type: acc.entry_type,
+    entry_id: acc.entry_id,
+    market: 'ALL',
+    period_window: acc.period_window,
+    sample_size: acc.sample_size,
+    avg_return: acc.sum_return / n,
+    avg_sharpe: acc.sum_sharpe / n,
+    avg_mdd: acc.sum_mdd / n,
+    avg_winrate: acc.sum_winrate / n,
+    best_return: acc.best_return === -Infinity ? null : acc.best_return,
+    worst_return: acc.worst_return === Infinity ? null : acc.worst_return,
+    positive_count: acc.positive_count,
+  }
+}

--- a/dental-clinic-manager/src/app/api/investment/matrix/query/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/matrix/query/route.ts
@@ -1,0 +1,90 @@
+/**
+ * Strategy Matrix 조회 API
+ *
+ * GET /api/investment/matrix/query
+ *   ?market=KR|US|ALL              (default ALL)
+ *   &period_window=1Y|3Y|5Y|10Y     (default 5Y)
+ *   &tickers=005930,000660          (optional, 콤마구분)
+ *   &entry_ids=rsi-oversold,uuid    (optional, 콤마구분 — preset_id 또는 strategy UUID)
+ *   &entry_type=preset|shared       (optional)
+ *   &sector=반도체                   (optional, market=KR/US 조합)
+ *   &limit=500                      (default 500, max 5000)
+ *   &include_curve=1                (default 0 — 응답 가벼움)
+ *
+ * 응답: { data: MatrixRow[] }
+ *
+ * 사용자가 ad-hoc 백테스트 없이 사전계산 결과를 즉시 조회.
+ */
+
+import { NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+export const dynamic = 'force-dynamic'
+
+const ALLOWED_WINDOWS = new Set(['1Y', '3Y', '5Y', '10Y'])
+const MAX_LIMIT = 5000
+
+export async function GET(req: Request) {
+  const auth = await requireAuth()
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 실패' }, { status: auth.status })
+  }
+
+  const supabase = getSupabaseAdmin()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+
+  const url = new URL(req.url)
+  const market = (url.searchParams.get('market') ?? 'ALL').toUpperCase()
+  const periodWindow = url.searchParams.get('period_window') ?? '5Y'
+  const tickersParam = url.searchParams.get('tickers')
+  const entryIdsParam = url.searchParams.get('entry_ids')
+  const entryType = url.searchParams.get('entry_type')
+  const sector = url.searchParams.get('sector')
+  const includeCurve = url.searchParams.get('include_curve') === '1'
+  const limit = Math.min(Math.max(parseInt(url.searchParams.get('limit') ?? '500', 10) || 500, 1), MAX_LIMIT)
+
+  if (!ALLOWED_WINDOWS.has(periodWindow)) {
+    return NextResponse.json({ error: `period_window must be one of ${[...ALLOWED_WINDOWS].join(', ')}` }, { status: 400 })
+  }
+  if (!['KR', 'US', 'ALL'].includes(market)) {
+    return NextResponse.json({ error: 'market must be KR | US | ALL' }, { status: 400 })
+  }
+
+  const columns = [
+    'id', 'entry_type', 'entry_id', 'market', 'ticker', 'sector', 'period_window',
+    'start_date', 'end_date', 'initial_capital',
+    'total_return', 'annualized_return', 'max_drawdown', 'sharpe_ratio',
+    'win_rate', 'profit_factor', 'total_trades', 'buy_hold_return',
+    'engine_version', 'computed_at',
+    ...(includeCurve ? ['equity_curve_compact'] : []),
+  ].join(', ')
+
+  let q = supabase
+    .from('strategy_matrix_runs')
+    .select(columns)
+    .eq('period_window', periodWindow)
+    .order('total_return', { ascending: false })
+    .limit(limit)
+
+  if (market !== 'ALL') q = q.eq('market', market)
+  if (entryType) q = q.eq('entry_type', entryType)
+  if (sector) q = q.eq('sector', sector)
+  if (tickersParam) {
+    const tickers = tickersParam.split(',').map(s => s.trim()).filter(Boolean)
+    if (tickers.length > 0) q = q.in('ticker', tickers)
+  }
+  if (entryIdsParam) {
+    const ids = entryIdsParam.split(',').map(s => s.trim()).filter(Boolean)
+    if (ids.length > 0) q = q.in('entry_id', ids)
+  }
+
+  const { data, error } = await q
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ data: data ?? [] })
+}

--- a/dental-clinic-manager/src/app/investment/compare/matrix/page.tsx
+++ b/dental-clinic-manager/src/app/investment/compare/matrix/page.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import MatrixContent from '@/components/Investment/Matrix/MatrixContent'
+
+export const dynamic = 'force-dynamic'
+
+export default function MatrixPage() {
+  return (
+    <Suspense fallback={<div className="p-8 text-gray-500">로딩 중...</div>}>
+      <MatrixContent />
+    </Suspense>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/CompareContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/CompareContent.tsx
@@ -489,14 +489,24 @@ function LiveCompareSection() {
   return (
     <div className="space-y-6 max-w-6xl">
       {/* 헤더 */}
-      <div>
-        <div className="flex items-center gap-2">
-          <GitCompare className="w-6 h-6 text-purple-500" />
-          <h1 className="text-xl font-bold text-at-text">전략 비교 백테스트</h1>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <GitCompare className="w-6 h-6 text-purple-500" />
+            <h1 className="text-xl font-bold text-at-text">전략 비교 백테스트</h1>
+          </div>
+          <p className="text-sm text-at-text-secondary mt-1">
+            하나의 종목에 대해 여러 전략을 동시에 백테스트하여 성과를 비교합니다. 최대 {MAX_COMPARE}개까지 동시 비교.
+          </p>
         </div>
-        <p className="text-sm text-at-text-secondary mt-1">
-          하나의 종목에 대해 여러 전략을 동시에 백테스트하여 성과를 비교합니다. 최대 {MAX_COMPARE}개까지 동시 비교.
-        </p>
+        <a
+          href="/investment/compare/matrix"
+          className="inline-flex items-center gap-1.5 rounded-md border border-blue-300 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-100"
+          title="사전계산된 모든 종목 × 모든 전략 매트릭스에서 필터링해 즉시 조회"
+        >
+          <LayoutGrid className="w-3.5 h-3.5" />
+          전략 매트릭스 (사전계산) →
+        </a>
       </div>
 
       {/* 비교 모드 안내 */}

--- a/dental-clinic-manager/src/components/Investment/Matrix/MatrixContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/Matrix/MatrixContent.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { PRESET_STRATEGIES } from '@/components/Investment/StrategyBuilder/presets'
+import MatrixFilters from './MatrixFilters'
+import MatrixLeaderboard from './MatrixLeaderboard'
+import MatrixGrid from './MatrixGrid'
+import MatrixDetailDrawer from './MatrixDetailDrawer'
+import type { MatrixRow, MatrixAggregateRow, MarketFilter, PeriodWindow } from './types'
+
+interface SharedStrategy {
+  id: string
+  name: string
+}
+
+export default function MatrixContent() {
+  const [market, setMarket] = useState<MarketFilter>('ALL')
+  const [periodWindow, setPeriodWindow] = useState<PeriodWindow>('5Y')
+  const [tickersText, setTickersText] = useState('')
+  const [selectedStrategies, setSelectedStrategies] = useState<string[]>(
+    PRESET_STRATEGIES.slice(0, 10).map(p => p.id)
+  )
+  const [sharedStrategies, setSharedStrategies] = useState<SharedStrategy[]>([])
+  const [matrixRows, setMatrixRows] = useState<MatrixRow[]>([])
+  const [aggregateRows, setAggregateRows] = useState<MatrixAggregateRow[]>([])
+  const [loading, setLoading] = useState(false)
+  const [selectedCell, setSelectedCell] = useState<MatrixRow | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [lastFetchInfo, setLastFetchInfo] = useState<{ count: number; ms: number } | null>(null)
+
+  // 사용 가능한 전략 리스트 = 프리셋 + 공유 사용자 전략
+  const availableStrategies = useMemo(() => {
+    const list: Array<{ id: string; name: string; type: 'preset' | 'shared' }> = []
+    for (const p of PRESET_STRATEGIES) list.push({ id: p.id, name: p.name, type: 'preset' })
+    for (const s of sharedStrategies) list.push({ id: s.id, name: s.name, type: 'shared' })
+    return list
+  }, [sharedStrategies])
+
+  const strategyNames = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const s of availableStrategies) map.set(s.id, s.name)
+    return map
+  }, [availableStrategies])
+
+  // 공유 전략 목록 로딩
+  useEffect(() => {
+    fetch('/api/investment/strategies?public=1')
+      .then(r => (r.ok ? r.json() : { data: [] }))
+      .then(j => {
+        const list = (j.data ?? []) as Array<{ id: string; name: string }>
+        setSharedStrategies(list)
+      })
+      .catch(() => setSharedStrategies([]))
+  }, [])
+
+  // 데이터 fetch
+  const fetchData = useCallback(async () => {
+    if (selectedStrategies.length === 0) {
+      setMatrixRows([])
+      setAggregateRows([])
+      return
+    }
+    setLoading(true)
+    setError(null)
+    const t0 = performance.now()
+
+    const queryParams = new URLSearchParams({
+      period_window: periodWindow,
+      entry_ids: selectedStrategies.join(','),
+      limit: '2000',
+    })
+    if (market === 'KR' || market === 'US') {
+      queryParams.set('market', market)
+    } else {
+      queryParams.set('market', 'ALL')
+    }
+    const tickers = tickersText.split(',').map(s => s.trim()).filter(Boolean)
+    if (tickers.length > 0) queryParams.set('tickers', tickers.join(','))
+
+    const aggParams = new URLSearchParams({
+      period_window: periodWindow,
+      group_by: market === 'SPLIT' || market === 'ALL' ? 'market' : 'market',
+    })
+    if (market === 'KR' || market === 'US') {
+      aggParams.set('market', market)
+    }
+
+    try {
+      const [queryRes, aggRes] = await Promise.all([
+        fetch(`/api/investment/matrix/query?${queryParams.toString()}`),
+        fetch(`/api/investment/matrix/aggregate?${aggParams.toString()}`),
+      ])
+      if (!queryRes.ok || !aggRes.ok) {
+        throw new Error(`API 응답 실패 (query=${queryRes.status}, aggregate=${aggRes.status})`)
+      }
+      const queryJson = await queryRes.json()
+      const aggJson = await aggRes.json()
+      const rows = (queryJson.data ?? []) as MatrixRow[]
+      // 선택된 전략으로 필터링 (aggregate)
+      const aggregateAll = (aggJson.data ?? []) as MatrixAggregateRow[]
+      const selectedSet = new Set(selectedStrategies)
+      const agg = aggregateAll.filter(r => selectedSet.has(r.entry_id))
+
+      setMatrixRows(rows)
+      setAggregateRows(agg)
+      setLastFetchInfo({ count: rows.length, ms: Math.round(performance.now() - t0) })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      setError(msg)
+      setMatrixRows([])
+      setAggregateRows([])
+    } finally {
+      setLoading(false)
+    }
+  }, [market, periodWindow, selectedStrategies, tickersText])
+
+  // 필터 변경 시 자동 fetch
+  useEffect(() => {
+    const id = setTimeout(fetchData, 250)
+    return () => clearTimeout(id)
+  }, [fetchData])
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-4 p-4 md:p-6">
+      <header className="flex flex-wrap items-baseline justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">전략 비교 매트릭스</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            모든 종목 × 모든 기간 × 모든 전략 백테스트가 사전계산되어 있습니다. 필터로 즉시 조회하세요.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Link
+            href="/dashboard?tab=investment&sub=compare"
+            className="text-sm text-blue-600 hover:underline"
+          >
+            ad-hoc 비교 모드 →
+          </Link>
+        </div>
+      </header>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          오류: {error}
+        </div>
+      )}
+
+      <MatrixFilters
+        market={market}
+        onMarketChange={setMarket}
+        periodWindow={periodWindow}
+        onPeriodChange={setPeriodWindow}
+        selectedStrategies={selectedStrategies}
+        onStrategiesChange={setSelectedStrategies}
+        availableStrategies={availableStrategies}
+        tickersText={tickersText}
+        onTickersChange={setTickersText}
+        loading={loading}
+      />
+
+      {lastFetchInfo && (
+        <div className="text-xs text-gray-500">
+          {lastFetchInfo.count.toLocaleString()}건 ({lastFetchInfo.ms}ms)
+          {loading && ' · 로딩 중...'}
+        </div>
+      )}
+
+      <MatrixLeaderboard
+        rows={aggregateRows}
+        market={market}
+        periodWindow={periodWindow}
+        strategyNames={strategyNames}
+      />
+
+      <MatrixGrid
+        rows={matrixRows}
+        market={market}
+        strategyNames={strategyNames}
+        onCellClick={setSelectedCell}
+      />
+
+      {selectedCell && (
+        <MatrixDetailDrawer
+          row={selectedCell}
+          strategyNames={strategyNames}
+          onClose={() => setSelectedCell(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/Matrix/MatrixDetailDrawer.tsx
+++ b/dental-clinic-manager/src/components/Investment/Matrix/MatrixDetailDrawer.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { MatrixRow } from './types'
+
+interface Props {
+  row: MatrixRow | null
+  strategyNames: Map<string, string>
+  onClose: () => void
+}
+
+// DB 저장 단위: total_return / annualized / mdd / win_rate / buy_hold 모두 % (백분율 그대로)
+function formatPct(v: number | null | undefined) {
+  if (v == null || !isFinite(v)) return '—'
+  return `${v >= 0 ? '+' : ''}${v.toFixed(2)}%`
+}
+
+export default function MatrixDetailDrawer({ row, strategyNames, onClose }: Props) {
+  const [detail, setDetail] = useState<MatrixRow | null>(null)
+  const [otherMarket, setOtherMarket] = useState<MatrixRow | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [showCrossMarket, setShowCrossMarket] = useState(false)
+
+  useEffect(() => {
+    if (!row) {
+      setDetail(null)
+      setOtherMarket(null)
+      return
+    }
+    setLoading(true)
+    // equity curve 포함 단건 조회
+    const params = new URLSearchParams({
+      market: row.market,
+      period_window: row.period_window,
+      tickers: row.ticker,
+      entry_ids: row.entry_id,
+      include_curve: '1',
+      limit: '5',
+    })
+    fetch(`/api/investment/matrix/query?${params.toString()}`)
+      .then(r => r.json())
+      .then(j => {
+        const found = (j.data ?? []).find((d: MatrixRow) => d.id === row.id) ?? j.data?.[0] ?? row
+        setDetail(found)
+      })
+      .finally(() => setLoading(false))
+  }, [row])
+
+  useEffect(() => {
+    if (!row || !showCrossMarket) {
+      setOtherMarket(null)
+      return
+    }
+    const opposite = row.market === 'KR' ? 'US' : 'KR'
+    const params = new URLSearchParams({
+      market: opposite,
+      period_window: row.period_window,
+      entry_ids: row.entry_id,
+      include_curve: '0',
+      limit: '20',
+    })
+    fetch(`/api/investment/matrix/query?${params.toString()}`)
+      .then(r => r.json())
+      .then(j => {
+        // 평균값 계산
+        const list = (j.data ?? []) as MatrixRow[]
+        if (list.length === 0) {
+          setOtherMarket(null)
+        } else {
+          const avg = list.reduce((acc, r) => acc + (r.total_return ?? 0), 0) / list.length
+          setOtherMarket({
+            ...list[0],
+            total_return: avg,
+            sharpe_ratio: list.reduce((a, r) => a + (r.sharpe_ratio ?? 0), 0) / list.length,
+            max_drawdown: list.reduce((a, r) => a + (r.max_drawdown ?? 0), 0) / list.length,
+          })
+        }
+      })
+  }, [row, showCrossMarket])
+
+  if (!row) return null
+
+  const d = detail ?? row
+
+  return (
+    <div className="fixed inset-0 z-50 flex">
+      <div className="flex-1 bg-black/30" onClick={onClose} />
+      <div className="flex h-full w-full max-w-2xl flex-col overflow-y-auto bg-white shadow-2xl">
+        <div className="sticky top-0 z-10 flex items-start justify-between border-b border-gray-200 bg-white px-6 py-4">
+          <div>
+            <div className="flex items-center gap-2">
+              <span className={`rounded px-2 py-0.5 text-xs font-medium ${d.market === 'KR' ? 'bg-red-50 text-red-700' : 'bg-blue-50 text-blue-700'}`}>
+                {d.market}
+              </span>
+              <h2 className="text-lg font-semibold text-gray-900">{d.ticker}</h2>
+              <span className="text-sm text-gray-500">· {d.period_window}</span>
+            </div>
+            <div className="mt-1 text-sm text-gray-600">
+              {strategyNames.get(d.entry_id) ?? d.entry_id}
+              {d.entry_type === 'shared' && (
+                <span className="ml-2 rounded bg-purple-100 px-1.5 py-0.5 text-xs text-purple-700">공유</span>
+              )}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="flex-1 space-y-5 px-6 py-5">
+          {/* 메트릭 카드 */}
+          <div className="grid grid-cols-2 gap-3">
+            <Metric label="수익률" value={formatPct(d.total_return)} color={(d.total_return ?? 0) >= 0 ? 'text-green-600' : 'text-red-600'} />
+            <Metric label="연환산 수익률" value={formatPct(d.annualized_return)} />
+            <Metric label="Buy & Hold" value={formatPct(d.buy_hold_return)} />
+            <Metric label="Sharpe Ratio" value={d.sharpe_ratio?.toFixed(2) ?? '—'} />
+            <Metric label="최대낙폭 (MDD)" value={d.max_drawdown != null ? `${d.max_drawdown.toFixed(2)}%` : '—'} color="text-red-600" />
+            <Metric label="승률" value={d.win_rate != null ? `${d.win_rate.toFixed(1)}%` : '—'} />
+            <Metric label="Profit Factor" value={d.profit_factor != null ? d.profit_factor.toFixed(2) : '—'} />
+            <Metric label="총 거래" value={d.total_trades != null ? `${d.total_trades}건` : '—'} />
+          </div>
+
+          {/* 기간 정보 */}
+          <div className="rounded-md bg-gray-50 p-3 text-xs text-gray-600">
+            <div>기간: {d.start_date} ~ {d.end_date}</div>
+            <div>초기자본: {d.initial_capital.toLocaleString()}원</div>
+            <div>엔진 버전: {d.engine_version} · 계산: {new Date(d.computed_at).toLocaleString('ko-KR')}</div>
+          </div>
+
+          {/* equity curve 미니 차트 */}
+          {d.equity_curve_compact && d.equity_curve_compact.length > 0 && (
+            <EquityCurveMiniChart data={d.equity_curve_compact} initial={d.initial_capital} />
+          )}
+
+          {/* 다른 시장 성과 토글 */}
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowCrossMarket(v => !v)}
+              className="w-full rounded-md border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-medium text-blue-700 hover:bg-blue-100"
+            >
+              {showCrossMarket ? '▾' : '▸'} 동일 전략 다른 시장 평균 성과 보기 ({d.market === 'KR' ? 'US' : 'KR'})
+            </button>
+            {showCrossMarket && (
+              <div className="mt-3 rounded-md border border-gray-200 bg-white p-3">
+                {otherMarket ? (
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="text-sm">
+                      <div className="text-xs text-gray-500">{d.market} 단일 ({d.ticker})</div>
+                      <div className={`text-lg font-bold ${(d.total_return ?? 0) >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                        {formatPct(d.total_return)}
+                      </div>
+                    </div>
+                    <div className="text-sm">
+                      <div className="text-xs text-gray-500">{d.market === 'KR' ? 'US' : 'KR'} 평균</div>
+                      <div className={`text-lg font-bold ${(otherMarket.total_return ?? 0) >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                        {formatPct(otherMarket.total_return)}
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="text-sm text-gray-400">{loading ? '조회 중...' : '비교 데이터 없음'}</div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* ad-hoc 백테스트 링크 */}
+          <a
+            href={`/dashboard?tab=investment&sub=compare&ticker=${d.ticker}&market=${d.market}`}
+            className="block w-full rounded-md bg-gray-800 px-4 py-2 text-center text-sm font-medium text-white hover:bg-gray-700"
+          >
+            이 전략으로 ad-hoc 백테스트 실행 →
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Metric({ label, value, color }: { label: string; value: string; color?: string }) {
+  return (
+    <div className="rounded-md border border-gray-200 bg-white p-3">
+      <div className="text-xs text-gray-500">{label}</div>
+      <div className={`mt-1 text-lg font-semibold ${color ?? 'text-gray-800'}`}>{value}</div>
+    </div>
+  )
+}
+
+function EquityCurveMiniChart({ data, initial }: { data: Array<{ d: string; e: number }>; initial: number }) {
+  if (data.length === 0) return null
+  const values = data.map(p => p.e)
+  const min = Math.min(initial, ...values)
+  const max = Math.max(initial, ...values)
+  const range = Math.max(max - min, 1)
+  const W = 600
+  const H = 160
+  const padding = 8
+  const xs = (i: number) => padding + (i / (data.length - 1 || 1)) * (W - 2 * padding)
+  const ys = (v: number) => H - padding - ((v - min) / range) * (H - 2 * padding)
+
+  const linePath = data.map((p, i) => `${i === 0 ? 'M' : 'L'} ${xs(i).toFixed(1)} ${ys(p.e).toFixed(1)}`).join(' ')
+  const areaPath = `${linePath} L ${xs(data.length - 1).toFixed(1)} ${(H - padding).toFixed(1)} L ${xs(0).toFixed(1)} ${(H - padding).toFixed(1)} Z`
+  const lastReturn = (data[data.length - 1].e - initial) / initial
+
+  return (
+    <div className="rounded-md border border-gray-200 bg-white p-3">
+      <div className="mb-2 flex items-baseline justify-between">
+        <div className="text-sm font-medium text-gray-700">자본 곡선 (월말 샘플링)</div>
+        <div className={`text-sm font-semibold ${lastReturn >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+          {lastReturn >= 0 ? '+' : ''}{(lastReturn * 100).toFixed(2)}%
+        </div>
+      </div>
+      <svg viewBox={`0 0 ${W} ${H}`} className="w-full">
+        {/* 초기자본 기준선 */}
+        <line
+          x1={padding} x2={W - padding}
+          y1={ys(initial)} y2={ys(initial)}
+          stroke="#9ca3af" strokeWidth={1} strokeDasharray="3 3"
+        />
+        <path d={areaPath} fill={lastReturn >= 0 ? '#dcfce7' : '#fee2e2'} opacity={0.6} />
+        <path d={linePath} fill="none" stroke={lastReturn >= 0 ? '#16a34a' : '#dc2626'} strokeWidth={1.5} />
+      </svg>
+      <div className="mt-1 flex justify-between text-xxs text-gray-500">
+        <span>{data[0]?.d}</span>
+        <span>{data[data.length - 1]?.d}</span>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/Matrix/MatrixFilters.tsx
+++ b/dental-clinic-manager/src/components/Investment/Matrix/MatrixFilters.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import { useMemo } from 'react'
+import type { PeriodWindow, MarketFilter } from './types'
+
+interface Props {
+  market: MarketFilter
+  onMarketChange: (m: MarketFilter) => void
+  periodWindow: PeriodWindow
+  onPeriodChange: (w: PeriodWindow) => void
+  selectedStrategies: string[]
+  onStrategiesChange: (ids: string[]) => void
+  availableStrategies: Array<{ id: string; name: string; type: 'preset' | 'shared' }>
+  tickersText: string
+  onTickersChange: (v: string) => void
+  loading?: boolean
+}
+
+const MARKETS: Array<{ value: MarketFilter; label: string; desc: string }> = [
+  { value: 'ALL', label: '전체', desc: 'KR + US 통합' },
+  { value: 'KR', label: 'KR만', desc: '국내 종목' },
+  { value: 'US', label: 'US만', desc: '미국 종목' },
+  { value: 'SPLIT', label: 'KR/US 분할비교', desc: '시장별 좌우 비교' },
+]
+
+const WINDOWS: PeriodWindow[] = ['1Y', '3Y', '5Y', '10Y']
+
+export default function MatrixFilters(props: Props) {
+  const {
+    market, onMarketChange,
+    periodWindow, onPeriodChange,
+    selectedStrategies, onStrategiesChange,
+    availableStrategies,
+    tickersText, onTickersChange,
+    loading,
+  } = props
+
+  const presets = useMemo(() => availableStrategies.filter(s => s.type === 'preset'), [availableStrategies])
+  const shared = useMemo(() => availableStrategies.filter(s => s.type === 'shared'), [availableStrategies])
+
+  const toggleStrategy = (id: string) => {
+    if (selectedStrategies.includes(id)) {
+      onStrategiesChange(selectedStrategies.filter(s => s !== id))
+    } else {
+      onStrategiesChange([...selectedStrategies, id])
+    }
+  }
+
+  const selectAll = () => onStrategiesChange(availableStrategies.map(s => s.id))
+  const clearAll = () => onStrategiesChange([])
+
+  return (
+    <div className="space-y-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      {/* 시장 토글 */}
+      <div>
+        <div className="mb-2 text-sm font-medium text-gray-700">시장</div>
+        <div className="flex flex-wrap gap-2">
+          {MARKETS.map(m => (
+            <button
+              key={m.value}
+              type="button"
+              onClick={() => onMarketChange(m.value)}
+              disabled={loading}
+              className={`rounded-md border px-3 py-1.5 text-sm font-medium transition ${
+                market === m.value
+                  ? 'border-blue-600 bg-blue-50 text-blue-700'
+                  : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
+              }`}
+              title={m.desc}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 기간 */}
+      <div>
+        <div className="mb-2 text-sm font-medium text-gray-700">기간 (Window)</div>
+        <div className="flex gap-2">
+          {WINDOWS.map(w => (
+            <button
+              key={w}
+              type="button"
+              onClick={() => onPeriodChange(w)}
+              disabled={loading}
+              className={`rounded-md border px-3 py-1.5 text-sm font-medium transition ${
+                periodWindow === w
+                  ? 'border-blue-600 bg-blue-50 text-blue-700'
+                  : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
+              }`}
+            >
+              {w}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 종목 필터 (콤마구분 입력) */}
+      <div>
+        <div className="mb-2 text-sm font-medium text-gray-700">
+          종목 필터 <span className="text-xs text-gray-400">(콤마구분, 비워두면 전체)</span>
+        </div>
+        <input
+          type="text"
+          value={tickersText}
+          onChange={e => onTickersChange(e.target.value)}
+          placeholder="예: 005930, AAPL, TSLA"
+          disabled={loading}
+          className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </div>
+
+      {/* 전략 다중 선택 */}
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <div className="text-sm font-medium text-gray-700">
+            전략 선택{' '}
+            <span className="text-xs text-gray-400">
+              ({selectedStrategies.length} / {availableStrategies.length})
+            </span>
+          </div>
+          <div className="flex gap-2 text-xs">
+            <button type="button" onClick={selectAll} className="text-blue-600 hover:underline">전체</button>
+            <button type="button" onClick={clearAll} className="text-gray-500 hover:underline">해제</button>
+          </div>
+        </div>
+        <div className="max-h-48 overflow-y-auto rounded-md border border-gray-200 p-2">
+          {presets.length > 0 && (
+            <>
+              <div className="mb-1 text-xs font-semibold text-gray-500">프리셋</div>
+              <div className="mb-3 flex flex-wrap gap-1.5">
+                {presets.map(s => (
+                  <button
+                    key={s.id}
+                    type="button"
+                    onClick={() => toggleStrategy(s.id)}
+                    className={`rounded border px-2 py-0.5 text-xs ${
+                      selectedStrategies.includes(s.id)
+                        ? 'border-blue-500 bg-blue-100 text-blue-800'
+                        : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
+                    }`}
+                  >
+                    {s.name}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+          {shared.length > 0 && (
+            <>
+              <div className="mb-1 text-xs font-semibold text-gray-500">공유 사용자 전략</div>
+              <div className="flex flex-wrap gap-1.5">
+                {shared.map(s => (
+                  <button
+                    key={s.id}
+                    type="button"
+                    onClick={() => toggleStrategy(s.id)}
+                    className={`rounded border px-2 py-0.5 text-xs ${
+                      selectedStrategies.includes(s.id)
+                        ? 'border-purple-500 bg-purple-100 text-purple-800'
+                        : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
+                    }`}
+                  >
+                    {s.name}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/Matrix/MatrixGrid.tsx
+++ b/dental-clinic-manager/src/components/Investment/Matrix/MatrixGrid.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useMemo } from 'react'
+import type { MatrixRow, MarketFilter } from './types'
+
+interface Props {
+  rows: MatrixRow[]
+  market: MarketFilter
+  strategyNames: Map<string, string>
+  onCellClick?: (row: MatrixRow) => void
+}
+
+// DB 단위: % (백분율 그대로 저장). 임계값도 % 단위.
+function returnBgClass(v: number | null) {
+  if (v == null) return 'bg-gray-50 text-gray-400'
+  if (v >= 100) return 'bg-green-700 text-white'
+  if (v >= 50) return 'bg-green-600 text-white'
+  if (v >= 20) return 'bg-green-500 text-white'
+  if (v >= 5) return 'bg-green-200 text-green-900'
+  if (v >= -5) return 'bg-gray-100 text-gray-700'
+  if (v >= -20) return 'bg-red-200 text-red-900'
+  if (v >= -50) return 'bg-red-500 text-white'
+  return 'bg-red-700 text-white'
+}
+
+function formatPct(v: number | null) {
+  if (v == null || !isFinite(v)) return '—'
+  return `${v >= 0 ? '+' : ''}${v.toFixed(1)}%`
+}
+
+export default function MatrixGrid({ rows, market, strategyNames, onCellClick }: Props) {
+  const { tickers, strategies, cellMap } = useMemo(() => {
+    const tickerSet = new Map<string, { ticker: string; market: 'KR' | 'US' }>()
+    const stratSet = new Map<string, { id: string; type: 'preset' | 'shared' }>()
+    const cellMap = new Map<string, MatrixRow>()
+    for (const r of rows) {
+      tickerSet.set(r.ticker, { ticker: r.ticker, market: r.market })
+      stratSet.set(r.entry_id, { id: r.entry_id, type: r.entry_type })
+      cellMap.set(`${r.entry_id}|${r.ticker}`, r)
+    }
+    const tickers = Array.from(tickerSet.values())
+    // 분할비교 모드: KR 그룹 → US 그룹 순으로 정렬
+    if (market === 'SPLIT' || market === 'ALL') {
+      tickers.sort((a, b) => {
+        if (a.market !== b.market) return a.market === 'KR' ? -1 : 1
+        return a.ticker.localeCompare(b.ticker)
+      })
+    } else {
+      tickers.sort((a, b) => a.ticker.localeCompare(b.ticker))
+    }
+    const strategies = Array.from(stratSet.values())
+    return { tickers, strategies, cellMap }
+  }, [rows, market])
+
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-8 text-center text-sm text-gray-400 shadow-sm">
+        조건에 맞는 매트릭스 데이터가 없습니다. 필터를 조정하거나 사전계산 배치가 끝났는지 확인하세요.
+      </div>
+    )
+  }
+
+  // KR과 US 사이 시각적 분할 인덱스
+  const splitIndex = (market === 'SPLIT' || market === 'ALL')
+    ? tickers.findIndex(t => t.market === 'US')
+    : -1
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="mb-3 flex items-baseline justify-between">
+        <h3 className="text-base font-semibold text-gray-800">전략 × 종목 매트릭스</h3>
+        <span className="text-xs text-gray-500">
+          {strategies.length}개 전략 × {tickers.length}개 종목 ({rows.length} cells)
+        </span>
+      </div>
+      <div className="overflow-auto" style={{ maxHeight: '600px' }}>
+        <table className="text-xs">
+          <thead className="sticky top-0 z-10 bg-white">
+            <tr>
+              <th className="sticky left-0 z-20 min-w-[160px] bg-gray-50 px-2 py-2 text-left font-medium text-gray-700">
+                전략 / 종목
+              </th>
+              {tickers.map((t, i) => (
+                <th
+                  key={t.ticker}
+                  className={`bg-gray-50 px-1.5 py-2 text-center font-mono font-medium text-gray-700 ${
+                    i === splitIndex ? 'border-l-2 border-gray-400' : ''
+                  }`}
+                  style={{ minWidth: 60 }}
+                >
+                  <span className={`block text-xxs ${t.market === 'KR' ? 'text-red-600' : 'text-blue-600'}`}>
+                    {t.market}
+                  </span>
+                  {t.ticker}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {strategies.map(s => (
+              <tr key={s.id} className="border-t border-gray-100">
+                <td className="sticky left-0 z-10 bg-white px-2 py-1.5 font-medium text-gray-800">
+                  {strategyNames.get(s.id) ?? s.id}
+                  {s.type === 'shared' && (
+                    <span className="ml-1 rounded bg-purple-100 px-1 text-xxs text-purple-700">공유</span>
+                  )}
+                </td>
+                {tickers.map((t, i) => {
+                  const cell = cellMap.get(`${s.id}|${t.ticker}`)
+                  return (
+                    <td
+                      key={t.ticker}
+                      className={`px-1 py-1.5 text-center font-mono ${returnBgClass(cell?.total_return ?? null)} ${
+                        i === splitIndex ? 'border-l-2 border-gray-400' : ''
+                      } ${cell ? 'cursor-pointer transition hover:opacity-80' : ''}`}
+                      title={cell
+                        ? `${strategyNames.get(s.id) ?? s.id} · ${t.market} ${t.ticker}\n수익률: ${formatPct(cell.total_return)}\nMDD: ${cell.max_drawdown != null ? cell.max_drawdown.toFixed(1) + '%' : '—'}\nSharpe: ${cell.sharpe_ratio?.toFixed(2) ?? '—'}\n거래: ${cell.total_trades ?? 0}건`
+                        : '데이터 없음'}
+                      onClick={() => cell && onCellClick?.(cell)}
+                    >
+                      {cell ? formatPct(cell.total_return) : '·'}
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-3 flex items-center gap-1 text-xxs text-gray-500">
+        <span>색상 범례:</span>
+        <span className="rounded bg-red-700 px-1.5 py-0.5 text-white">≤-50%</span>
+        <span className="rounded bg-red-200 px-1.5 py-0.5 text-red-900">~-5%</span>
+        <span className="rounded bg-gray-100 px-1.5 py-0.5">±5%</span>
+        <span className="rounded bg-green-200 px-1.5 py-0.5 text-green-900">+5~20%</span>
+        <span className="rounded bg-green-600 px-1.5 py-0.5 text-white">+50%↑</span>
+        <span className="rounded bg-green-700 px-1.5 py-0.5 text-white">+100%↑</span>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/Matrix/MatrixLeaderboard.tsx
+++ b/dental-clinic-manager/src/components/Investment/Matrix/MatrixLeaderboard.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import type { MatrixAggregateRow, MarketFilter, PeriodWindow } from './types'
+
+interface Props {
+  rows: MatrixAggregateRow[]
+  market: MarketFilter
+  periodWindow: PeriodWindow
+  strategyNames: Map<string, string>
+}
+
+// DB 저장 단위: total_return / annualized / mdd / win_rate 는 모두 % (백분율 그대로)
+function formatPct(v: number | null | undefined) {
+  if (v == null || !isFinite(v)) return '—'
+  return `${v >= 0 ? '+' : ''}${v.toFixed(2)}%`
+}
+
+function returnColor(v: number | null) {
+  if (v == null) return 'text-gray-500'
+  if (v > 20) return 'text-green-700'
+  if (v > 0) return 'text-green-600'
+  if (v < -20) return 'text-red-700'
+  if (v < 0) return 'text-red-600'
+  return 'text-gray-600'
+}
+
+export default function MatrixLeaderboard({ rows, market, periodWindow, strategyNames }: Props) {
+  // 시장별 분할비교 모드: KR/US 두 컬럼으로 표시
+  if (market === 'SPLIT') {
+    const byEntry = new Map<string, { kr?: MatrixAggregateRow; us?: MatrixAggregateRow }>()
+    for (const r of rows) {
+      const key = `${r.entry_type}|${r.entry_id}`
+      const acc = byEntry.get(key) ?? {}
+      if (r.market === 'KR') acc.kr = r
+      else if (r.market === 'US') acc.us = r
+      byEntry.set(key, acc)
+    }
+    const list = Array.from(byEntry.entries()).map(([key, v]) => {
+      const [type, id] = key.split('|')
+      return {
+        type, id,
+        name: strategyNames.get(id) ?? id,
+        kr: v.kr,
+        us: v.us,
+        diff: ((v.kr?.avg_return ?? 0) - (v.us?.avg_return ?? 0)),
+      }
+    })
+    list.sort((a, b) => ((b.kr?.avg_return ?? 0) + (b.us?.avg_return ?? 0)) - ((a.kr?.avg_return ?? 0) + (a.us?.avg_return ?? 0)))
+
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+        <div className="mb-3 flex items-baseline justify-between">
+          <h3 className="text-base font-semibold text-gray-800">시장별 분할 비교 ({periodWindow})</h3>
+          <span className="text-xs text-gray-500">동일 전략의 KR vs US 평균 수익률</span>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-xs uppercase text-gray-600">
+              <tr>
+                <th className="px-3 py-2 text-left">전략</th>
+                <th className="px-3 py-2 text-right">KR 평균</th>
+                <th className="px-3 py-2 text-right">KR 표본</th>
+                <th className="px-3 py-2 text-right">US 평균</th>
+                <th className="px-3 py-2 text-right">US 표본</th>
+                <th className="px-3 py-2 text-right">차이 (KR-US)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.map(item => (
+                <tr key={`${item.type}|${item.id}`} className="border-t border-gray-100">
+                  <td className="px-3 py-2 font-medium text-gray-800">
+                    {item.name}
+                    {item.type === 'shared' && (
+                      <span className="ml-2 rounded bg-purple-100 px-1.5 py-0.5 text-xs text-purple-700">공유</span>
+                    )}
+                  </td>
+                  <td className={`px-3 py-2 text-right font-semibold ${returnColor(item.kr?.avg_return ?? null)}`}>
+                    {formatPct(item.kr?.avg_return)}
+                  </td>
+                  <td className="px-3 py-2 text-right text-gray-500">{item.kr?.sample_size ?? 0}</td>
+                  <td className={`px-3 py-2 text-right font-semibold ${returnColor(item.us?.avg_return ?? null)}`}>
+                    {formatPct(item.us?.avg_return)}
+                  </td>
+                  <td className="px-3 py-2 text-right text-gray-500">{item.us?.sample_size ?? 0}</td>
+                  <td className={`px-3 py-2 text-right ${item.diff > 0 ? 'text-blue-600' : item.diff < 0 ? 'text-amber-600' : 'text-gray-500'}`}>
+                    {item.diff === 0 ? '—' : `${item.diff > 0 ? '▲' : '▼'} ${Math.abs(item.diff).toFixed(2)}%`}
+                  </td>
+                </tr>
+              ))}
+              {list.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-3 py-6 text-center text-gray-400">데이터 없음</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    )
+  }
+
+  // 단일 시장 / ALL 모드
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="mb-3 flex items-baseline justify-between">
+        <h3 className="text-base font-semibold text-gray-800">
+          전략 랭킹 ({market === 'ALL' ? '전체' : market}, {periodWindow})
+        </h3>
+        <span className="text-xs text-gray-500">평균 수익률 기준 정렬</span>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-xs uppercase text-gray-600">
+            <tr>
+              <th className="px-3 py-2 text-left">전략</th>
+              {market === 'ALL' && <th className="px-3 py-2 text-left">시장</th>}
+              <th className="px-3 py-2 text-right">평균 수익률</th>
+              <th className="px-3 py-2 text-right">Sharpe</th>
+              <th className="px-3 py-2 text-right">MDD</th>
+              <th className="px-3 py-2 text-right">승률</th>
+              <th className="px-3 py-2 text-right">최고</th>
+              <th className="px-3 py-2 text-right">최저</th>
+              <th className="px-3 py-2 text-right">표본수</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(r => (
+              <tr key={`${r.entry_type}|${r.entry_id}|${r.market}`} className="border-t border-gray-100">
+                <td className="px-3 py-2 font-medium text-gray-800">
+                  {strategyNames.get(r.entry_id) ?? r.entry_id}
+                  {r.entry_type === 'shared' && (
+                    <span className="ml-2 rounded bg-purple-100 px-1.5 py-0.5 text-xs text-purple-700">공유</span>
+                  )}
+                </td>
+                {market === 'ALL' && (
+                  <td className="px-3 py-2">
+                    <span className={`rounded px-1.5 py-0.5 text-xs ${r.market === 'KR' ? 'bg-red-50 text-red-700' : 'bg-blue-50 text-blue-700'}`}>
+                      {r.market}
+                    </span>
+                  </td>
+                )}
+                <td className={`px-3 py-2 text-right font-semibold ${returnColor(r.avg_return)}`}>
+                  {formatPct(r.avg_return)}
+                </td>
+                <td className="px-3 py-2 text-right text-gray-700">
+                  {r.avg_sharpe != null ? r.avg_sharpe.toFixed(2) : '—'}
+                </td>
+                <td className="px-3 py-2 text-right text-red-600">
+                  {r.avg_mdd != null ? `${r.avg_mdd.toFixed(1)}%` : '—'}
+                </td>
+                <td className="px-3 py-2 text-right text-gray-700">
+                  {r.avg_winrate != null ? `${r.avg_winrate.toFixed(0)}%` : '—'}
+                </td>
+                <td className={`px-3 py-2 text-right ${returnColor(r.best_return)}`}>
+                  {formatPct(r.best_return)}
+                </td>
+                <td className={`px-3 py-2 text-right ${returnColor(r.worst_return)}`}>
+                  {formatPct(r.worst_return)}
+                </td>
+                <td className="px-3 py-2 text-right text-gray-500">{r.sample_size}</td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={market === 'ALL' ? 9 : 8} className="px-3 py-6 text-center text-gray-400">데이터 없음</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/Matrix/types.ts
+++ b/dental-clinic-manager/src/components/Investment/Matrix/types.ts
@@ -1,0 +1,45 @@
+export type PeriodWindow = '1Y' | '3Y' | '5Y' | '10Y'
+export type MarketFilter = 'KR' | 'US' | 'ALL' | 'SPLIT'
+
+export interface MatrixRow {
+  id: number
+  entry_type: 'preset' | 'shared'
+  entry_id: string
+  market: 'KR' | 'US'
+  ticker: string
+  sector: string | null
+  period_window: PeriodWindow
+  start_date: string
+  end_date: string
+  initial_capital: number
+  total_return: number | null
+  annualized_return: number | null
+  max_drawdown: number | null
+  sharpe_ratio: number | null
+  win_rate: number | null
+  profit_factor: number | null
+  total_trades: number | null
+  buy_hold_return: number | null
+  engine_version: string
+  computed_at: string
+  equity_curve_compact?: Array<{ d: string; e: number }>
+}
+
+export interface MatrixAggregateRow {
+  entry_type: 'preset' | 'shared'
+  entry_id: string
+  market: 'KR' | 'US' | 'ALL'
+  period_window: PeriodWindow
+  sample_size: number
+  avg_return: number | null
+  std_return: number | null
+  avg_annualized: number | null
+  avg_sharpe: number | null
+  avg_mdd: number | null
+  avg_winrate: number | null
+  avg_profit_factor: number | null
+  best_return: number | null
+  worst_return: number | null
+  median_return: number | null
+  positive_count: number
+}

--- a/dental-clinic-manager/src/components/Recall/PatientList.tsx
+++ b/dental-clinic-manager/src/components/Recall/PatientList.tsx
@@ -627,27 +627,36 @@ export default function PatientList({
                     )}
                   </td>
 
-                  {/* 다음 예약 (덴트웹 차트의 next_appointment_date) */}
-                  <td className="px-4 py-3">
+                  {/* 다음 예약 (덴트웹 차트의 next_appointment_date + next_appointment_memo) */}
+                  <td className="px-4 py-3 max-w-[180px]">
                     {(() => {
                       const next = formatNextAppointment(patient.next_appointment_date)
                       if (!next) return <span className="text-sm text-at-text-weak">—</span>
+                      const memo = patient.next_appointment_memo?.trim() || null
                       return (
                         <div>
                           <p className={`text-sm ${next.isPast ? 'text-at-text-weak' : 'text-at-text'}`}>
                             {next.dateLabel}
+                            <span
+                              className={`ml-1.5 text-xs font-medium ${
+                                next.isPast
+                                  ? 'text-at-text-weak'
+                                  : next.dday === 'D-Day'
+                                    ? 'text-at-danger'
+                                    : 'text-at-accent'
+                              }`}
+                            >
+                              {next.dday}
+                            </span>
                           </p>
-                          <p
-                            className={`text-xs font-medium ${
-                              next.isPast
-                                ? 'text-at-text-weak'
-                                : next.dday === 'D-Day'
-                                  ? 'text-at-danger'
-                                  : 'text-at-accent'
-                            }`}
-                          >
-                            {next.dday}
-                          </p>
+                          {memo && (
+                            <p
+                              className="text-xs text-at-text-weak mt-0.5 truncate"
+                              title={memo}
+                            >
+                              {memo}
+                            </p>
+                          )}
                         </div>
                       )
                     })()}

--- a/dental-clinic-manager/src/lib/backtestEngine.ts
+++ b/dental-clinic-manager/src/lib/backtestEngine.ts
@@ -21,6 +21,12 @@ import { calculateIndicators, calcATR, type IndicatorResultMap } from './indicat
 import { evaluateConditionTreeWithMatches, type EvaluationContext } from './signalEngine'
 
 // ============================================
+// 엔진 버전 (매트릭스 캐시 무효화 키)
+// ============================================
+
+export const ENGINE_VERSION = '2026.05.16'
+
+// ============================================
 // 수수료 상수
 // ============================================
 

--- a/dental-clinic-manager/src/lib/recallService.ts
+++ b/dental-clinic-manager/src/lib/recallService.ts
@@ -519,17 +519,22 @@ export const recallPatientService = {
       if (chartNumbers.length > 0) {
         const { data: dentwebRows } = await supabase
           .from('dentweb_patients')
-          .select('chart_number, next_appointment_date')
+          .select('chart_number, next_appointment_date, next_appointment_memo')
           .eq('clinic_id', clinicId)
           .in('chart_number', chartNumbers)
         if (dentwebRows) {
-          const nextMap = new Map<string, string | null>()
-          for (const row of dentwebRows as { chart_number: string | null; next_appointment_date: string | null }[]) {
-            if (row.chart_number) nextMap.set(row.chart_number, row.next_appointment_date)
+          type DentwebNextRow = { chart_number: string | null; next_appointment_date: string | null; next_appointment_memo: string | null }
+          const nextMap = new Map<string, { date: string | null; memo: string | null }>()
+          for (const row of dentwebRows as DentwebNextRow[]) {
+            if (row.chart_number) {
+              nextMap.set(row.chart_number, { date: row.next_appointment_date, memo: row.next_appointment_memo })
+            }
           }
           for (const patient of deduplicated) {
             if (patient.chart_number && nextMap.has(patient.chart_number)) {
-              patient.next_appointment_date = nextMap.get(patient.chart_number) ?? null
+              const matched = nextMap.get(patient.chart_number)
+              patient.next_appointment_date = matched?.date ?? null
+              patient.next_appointment_memo = matched?.memo ?? null
             }
           }
         }

--- a/dental-clinic-manager/src/types/dentweb.ts
+++ b/dental-clinic-manager/src/types/dentweb.ts
@@ -32,6 +32,7 @@ export interface DentwebPatient {
   last_visit_date: string | null
   last_treatment_type: string | null
   next_appointment_date: string | null
+  next_appointment_memo: string | null
   registration_date: string | null
   acquisition_channel: string | null
   customer_type: string | null
@@ -89,6 +90,7 @@ export interface DentwebPatientSyncData {
   last_visit_date?: string
   last_treatment_type?: string
   next_appointment_date?: string
+  next_appointment_memo?: string | null
   registration_date?: string
   acquisition_channel?: string
   customer_type?: string

--- a/dental-clinic-manager/src/types/recall.ts
+++ b/dental-clinic-manager/src/types/recall.ts
@@ -118,8 +118,9 @@ export interface RecallPatient {
   // 조인 데이터
   campaign?: RecallCampaign
 
-  // 덴트웹 차트에서 매칭된 다음 예약일 (chart_number 매칭). dentweb_patients.next_appointment_date.
+  // 덴트웹 차트에서 매칭된 다음 예약 (chart_number 매칭). dentweb_patients.next_appointment_*.
   next_appointment_date?: string | null
+  next_appointment_memo?: string | null
 }
 
 // 환자 목록 업로드용 데이터 (CSV/Excel)

--- a/dental-clinic-manager/supabase/migrations/20260512_add_dentweb_next_appointment_memo.sql
+++ b/dental-clinic-manager/supabase/migrations/20260512_add_dentweb_next_appointment_memo.sql
@@ -1,0 +1,4 @@
+-- 덴트웹 다음 예약의 메모/내용 컬럼 추가 (TB_예약목록.sz예약내용 매핑).
+-- 리콜 환자 목록에서 다음 예약일과 함께 진료 내용을 즉시 확인하기 위함.
+ALTER TABLE dentweb_patients
+  ADD COLUMN IF NOT EXISTS next_appointment_memo TEXT;

--- a/dental-clinic-manager/supabase/migrations/20260516_strategy_matrix.sql
+++ b/dental-clinic-manager/supabase/migrations/20260516_strategy_matrix.sql
@@ -1,0 +1,102 @@
+-- ============================================
+-- 전략 비교 사전계산 매트릭스 시스템
+-- Migration: 20260516_strategy_matrix.sql
+-- Created: 2026-05-16
+--
+-- 배경: /investment/compare 가 매번 N×M 백테스트를 즉석 실행하던 것을,
+--       Mac mini 야간 배치로 사전계산해두고 사용자가 시장/종목/기간/전략을
+--       필터링해 즉시 조회하는 매트릭스 시스템으로 전환.
+--
+-- 정책:
+--   Universe: KR_ALL(230) + US_ALL(1,000) = 1,230 종목
+--   Window:   1Y / 3Y / 5Y / 10Y
+--   Entry:    프리셋 31 + is_public 공유 전략
+--   Worker:   Mac mini M4 Node 스크립트 (launchd 야간 19:00 KST)
+--
+-- 주의: `window` 는 PostgreSQL 예약어이므로 `period_window` 사용.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS strategy_matrix_runs (
+  id BIGSERIAL PRIMARY KEY,
+  entry_type TEXT NOT NULL CHECK (entry_type IN ('preset', 'shared')),
+  entry_id TEXT NOT NULL,
+  market TEXT NOT NULL CHECK (market IN ('KR', 'US')),
+  ticker TEXT NOT NULL,
+  sector TEXT,
+  period_window TEXT NOT NULL CHECK (period_window IN ('1Y', '3Y', '5Y', '10Y')),
+  start_date DATE NOT NULL,
+  end_date DATE NOT NULL,
+  initial_capital NUMERIC NOT NULL DEFAULT 10000000,
+  use_full_capital BOOLEAN NOT NULL DEFAULT TRUE,
+  total_return NUMERIC,
+  annualized_return NUMERIC,
+  max_drawdown NUMERIC,
+  sharpe_ratio NUMERIC,
+  win_rate NUMERIC,
+  profit_factor NUMERIC,
+  total_trades INT,
+  buy_hold_return NUMERIC,
+  equity_curve_compact JSONB,
+  engine_version TEXT NOT NULL,
+  computed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (entry_type, entry_id, market, ticker, period_window, engine_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_smr_market_window ON strategy_matrix_runs (market, period_window, entry_id);
+CREATE INDEX IF NOT EXISTS idx_smr_ticker ON strategy_matrix_runs (ticker, period_window);
+CREATE INDEX IF NOT EXISTS idx_smr_sector ON strategy_matrix_runs (market, sector, period_window);
+CREATE INDEX IF NOT EXISTS idx_smr_market_return ON strategy_matrix_runs (market, period_window, total_return DESC);
+
+CREATE TABLE IF NOT EXISTS strategy_matrix_jobs (
+  id BIGSERIAL PRIMARY KEY,
+  entry_type TEXT NOT NULL,
+  entry_id TEXT NOT NULL,
+  market TEXT NOT NULL,
+  ticker TEXT NOT NULL,
+  period_window TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued','running','done','failed')),
+  attempts INT NOT NULL DEFAULT 0,
+  error TEXT,
+  started_at TIMESTAMPTZ,
+  finished_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (entry_type, entry_id, market, ticker, period_window)
+);
+
+CREATE INDEX IF NOT EXISTS idx_smj_status ON strategy_matrix_jobs (status, attempts);
+
+DROP MATERIALIZED VIEW IF EXISTS strategy_matrix_market_stats;
+
+CREATE MATERIALIZED VIEW strategy_matrix_market_stats AS
+SELECT
+  entry_type,
+  entry_id,
+  market,
+  period_window,
+  COUNT(*)::INT AS sample_size,
+  AVG(total_return) AS avg_return,
+  STDDEV(total_return) AS std_return,
+  AVG(annualized_return) AS avg_annualized,
+  AVG(sharpe_ratio) AS avg_sharpe,
+  AVG(max_drawdown) AS avg_mdd,
+  AVG(win_rate) AS avg_winrate,
+  AVG(profit_factor) AS avg_profit_factor,
+  MAX(total_return) AS best_return,
+  MIN(total_return) AS worst_return,
+  PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY total_return) AS median_return,
+  COUNT(*) FILTER (WHERE total_return > 0)::INT AS positive_count,
+  MAX(end_date) AS last_computed_window_end
+FROM strategy_matrix_runs
+GROUP BY entry_type, entry_id, market, period_window;
+
+CREATE UNIQUE INDEX idx_smms_key ON strategy_matrix_market_stats (entry_type, entry_id, market, period_window);
+CREATE INDEX idx_smms_rank ON strategy_matrix_market_stats (market, period_window, avg_return DESC);
+
+ALTER TABLE strategy_matrix_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE strategy_matrix_jobs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS smr_select_authenticated ON strategy_matrix_runs;
+CREATE POLICY smr_select_authenticated ON strategy_matrix_runs FOR SELECT TO authenticated USING (true);
+
+DROP POLICY IF EXISTS smj_select_authenticated ON strategy_matrix_jobs;
+CREATE POLICY smj_select_authenticated ON strategy_matrix_jobs FOR SELECT TO authenticated USING (true);


### PR DESCRIPTION
## Summary
- **전략 비교 사전계산 매트릭스 시스템 (Phase 1 MVP)** — `/investment/compare` 의 즉석 N×M 백테스트 방식을 Mac mini 야간 배치 사전계산 + 즉시 조회 방식으로 전환
- Universe **KR_ALL(230) + US_ALL(1,000)** × 전략 31+ × 기간 **1Y/3Y/5Y/10Y** 매트릭스
- 시장(KR/US/ALL/분할비교) 4모드, 시장별 Leaderboard, 전략×종목 히트맵, equity curve drawer + 동일 전략의 시장간 성과 비교 토글
- 기존 ad-hoc compare 페이지는 그대로 유지, 상단에 매트릭스 진입 링크 추가

## 주요 변경
- DB: `strategy_matrix_runs` + `strategy_matrix_jobs` + `strategy_matrix_market_stats` 머티리얼라이즈드 뷰 + `refresh_strategy_matrix_market_stats` RPC
- 워커: `scripts/buildStrategyMatrix.mjs` (TS transpile + Node 직접 실행, incremental upsert)
- 스케줄: `scripts/launchd/com.dental.strategy-matrix.plist` (KST 19:00 일배치)
- API: `GET /api/investment/matrix/query`, `/aggregate`
- UI: `/investment/compare/matrix` 페이지 + Matrix/* 컴포넌트 일체
- `backtestEngine.ts`: `ENGINE_VERSION` 상수 export (캐시 무효화 키)

## Test plan
- [x] `npm run build` 통과 (`/investment/compare/matrix` 6.73kB)
- [x] 시범 배치 4건 (2전략 × 2종목 × 1윈도우) 정상 적재 검증
- [x] DB 단위(%)에 맞춰 UI 포맷 정합성 확인
- [ ] Mac mini 에서 풀배치 launchd 등록 + 첫 야간 배치 모니터링
- [ ] 매트릭스 페이지에서 KR/US 분할비교 모드 시각 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)