### PR TITLE
fix(marketing): 경쟁글 이미지 카운트 정확도 개선

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/package.json
+++ b/dental-clinic-manager/marketing-worker/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hayan-marketing-worker",
-  "version": "1.1.103",
+  "version": "1.1.104",
   "description": "하얀치과 마케팅 워커 - Electron 데스크탑 앱",
   "productName": "클리닉 매니저 워커",
   "private": true,

--- a/dental-clinic-manager/marketing-worker/electron/src/seo-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/seo-bridge.ts
@@ -447,19 +447,31 @@ async function scrapeAndAnalyzePost(page: any, url: string, keyword: string, ran
       bodyText = (clone.textContent || '').replace(/\s+/g, ' ').trim();
     }
     const collectContentImageSources = (): string[] => {
-      const bodyEl = document.querySelector('.se-main-container, #postViewArea');
+      const smartEditor = document.querySelector('.se-main-container');
+      const oldEditor = document.querySelector('#postViewArea');
+      const bodyEl = smartEditor || oldEditor;
       if (!bodyEl) return [];
 
-      const candidates = bodyEl.querySelectorAll('img');
       const sources = new Set<string>();
+      const getSrc = (img: Element) =>
+        (img.getAttribute('data-lazy-src') || img.getAttribute('data-src') || img.getAttribute('src') || '').trim();
 
-      candidates.forEach((img) => {
-        const src =
-          img.getAttribute('data-lazy-src') ||
-          img.getAttribute('data-src') ||
-          img.getAttribute('src') ||
-          '';
-        const normalizedSrc = src.trim();
+      // 스마트에디터(.se-main-container) — 본문 콘텐츠 이미지는 `se-image-resource` 클래스로 명확히 식별됨.
+      // 스티커(se-sticker-image), OG링크 썸네일(se-oglink-thumbnail-resource),
+      // 지도 타일/마커(se-map-image, map.pstatic.net) 등은 본문 이미지가 아니므로 화이트리스트로 명확히 차단.
+      // (사이즈 필터는 적용하지 않음 — 네이버가 모바일/반응형 렌더링 시 본문 이미지를 작은 naturalSize 로 표시할 수 있음)
+      if (smartEditor) {
+        smartEditor.querySelectorAll('img.se-image-resource').forEach((img) => {
+          const src = getSrc(img);
+          if (!src || src.startsWith('data:')) return;
+          sources.add(src);
+        });
+        return [...sources];
+      }
+
+      // 구 에디터(#postViewArea) — 명확한 콘텐츠 이미지 클래스가 없어 기존 블랙리스트 필터 유지.
+      oldEditor!.querySelectorAll('img').forEach((img) => {
+        const normalizedSrc = getSrc(img);
         if (!normalizedSrc || normalizedSrc.startsWith('data:')) return;
 
         const widthAttr = Number(img.getAttribute('width') || '0');
@@ -485,7 +497,9 @@ async function scrapeAndAnalyzePost(page: any, url: string, keyword: string, ran
         if (
           /\/(profile|thumbnail|thumb|icon|emoji|sticker|map|marker)\b/i.test(normalizedSrc) ||
           normalizedSrc.includes('staticmap') ||
-          normalizedSrc.includes('/MapService/')
+          normalizedSrc.includes('/MapService/') ||
+          normalizedSrc.includes('map.pstatic.net') ||
+          normalizedSrc.includes('editor-static.pstatic.net')
         ) {
           return;
         }

--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778776061449'
+const SW_VERSION = 'v1778822533570'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`


### PR DESCRIPTION
## Summary

경쟁글 분석 미리보기에서 1위 글의 이미지 갯수가 실제(예: 15장)와 다르게 적게(7장) 측정되던 문제 수정.

### 원인
- 스크래퍼의 `width/height < 80` 사이즈 필터가, 네이버 스마트에디터의 모바일 반응형 렌더링에서 본문 이미지를 `naturalSize` 80×53 등 작은 값으로 표시하는 케이스를 본문 이미지가 아니라고 잘못 판단하여 다수 제외
- `se-oglink-thumbnail-resource`(링크 카드 썸네일)가 본문 이미지가 아닌데 카운트됨

### 해결
- 스마트에디터 본문(`.se-main-container`)에서는 본문 콘텐츠 이미지 클래스인 `se-image-resource` 만 화이트리스트로 카운트
- 스티커/OG링크썸네일/지도타일 등은 화이트리스트로 자연스럽게 제외됨
- 구 에디터(`#postViewArea`)는 기존 블랙리스트 필터 유지 + `map.pstatic.net` / `editor-static.pstatic.net` URL 패턴 추가 차단

worker version: 1.1.103 → 1.1.104

## Test plan
- [x] 빌드 통과
- [ ] 워커 재배포 후 "성내동 임플란트" 재분석 → 1위 글 image_count 15장 근처로 측정되는지 확인
- [ ] 다른 키워드(스마트에디터/구 에디터 혼재) 재분석해 정상 작동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)