### PR TITLE
fix(marketing): 경쟁글 분석 권장값 자동 적용 무효화 문제 수정

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778822533570'
+const SW_VERSION = 'v1778839946956'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
@@ -252,9 +252,30 @@ export default function NewMarketingPostPage() {
   const recommendedImages = seoResult ? Math.max(0, Math.round(seoResult.avgImageCount)) : 0
   const recommendedLength = seoResult ? Math.max(1000, Math.round(seoResult.avgBodyLength / 100) * 100) : 1500
 
+  // 권장 이미지 수를 allocation 의 dominant 스타일에 흡수.
+  // allocation → imageCount 자동 sync useEffect 가 imageCount 를 덮어쓰기 때문에
+  // setImageCount 직접 호출은 무효화됨 → allocation 자체를 권장값으로 갱신해야 함.
+  const applyRecommendedImagesToAllocation = useCallback((target: number) => {
+    const clamped = clampImageCount(target)
+    setImageStyleAllocation(prev => {
+      const entries = Object.entries(prev) as [ImageStyleOption, number][]
+      const activeEntries = entries.filter(([, n]) => n > 0)
+      const dominant: ImageStyleOption = activeEntries.length > 0
+        ? activeEntries.reduce((a, c) => (c[1] > a[1] ? c : a))[0]
+        : 'infographic_only'
+      return {
+        infographic_only: 0,
+        allow_person: 0,
+        use_own_image: 0,
+        [dominant]: clamped,
+      } as Record<ImageStyleOption, number>
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dynamicImageMax])
+
   const applySeoRecommendations = () => {
     if (!seoResult) return
-    setImageCount(clampImageCount(recommendedImages))
+    applyRecommendedImagesToAllocation(recommendedImages)
     setTargetWordCount(recommendedLength)
   }
 
@@ -266,7 +287,7 @@ export default function NewMarketingPostPage() {
     if (!seoResult || !k) return
     if (lastAutoApplyKeyRef.current === k) return
     lastAutoApplyKeyRef.current = k
-    setImageCount(clampImageCount(recommendedImages))
+    applyRecommendedImagesToAllocation(recommendedImages)
     setTargetWordCount(recommendedLength)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [seoPreview.appliedKeyword, seoResult])

--- a/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
+++ b/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
@@ -267,10 +267,31 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
   const recommendedImages = seoResult ? Math.max(0, Math.round(seoResult.avgImageCount)) : 0
   const recommendedLength = seoResult ? Math.max(1000, Math.round(seoResult.avgBodyLength / 100) * 100) : 1500
 
+  // 권장 이미지 수를 allocation 의 dominant 스타일에 흡수.
+  // allocation → imageCount 자동 sync useEffect 가 imageCount 를 덮어쓰기 때문에
+  // setImageCount 직접 호출은 무효화됨 → allocation 자체를 권장값으로 갱신해야 함.
+  const applyRecommendedImagesToAllocation = useCallback((target: number) => {
+    const clamped = clampImageCount(target)
+    setImageStyleAllocation(prev => {
+      const entries = Object.entries(prev) as [ImageStyleOption, number][]
+      const activeEntries = entries.filter(([, n]) => n > 0)
+      const dominant: ImageStyleOption = activeEntries.length > 0
+        ? activeEntries.reduce((a, c) => (c[1] > a[1] ? c : a))[0]
+        : 'infographic_only'
+      return {
+        infographic_only: 0,
+        allow_person: 0,
+        use_own_image: 0,
+        [dominant]: clamped,
+      } as Record<ImageStyleOption, number>
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dynamicImageMax])
+
   // 분석 결과의 권장값을 imageCount/targetWordCount에 적용
   const applySeoRecommendations = () => {
     if (!seoResult) return
-    setImageCount(clampImageCount(recommendedImages))
+    applyRecommendedImagesToAllocation(recommendedImages)
     setTargetWordCount(recommendedLength)
   }
 
@@ -282,7 +303,7 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
     if (!seoResult || !k) return
     if (lastAutoApplyKeyRef.current === k) return
     lastAutoApplyKeyRef.current = k
-    setImageCount(clampImageCount(recommendedImages))
+    applyRecommendedImagesToAllocation(recommendedImages)
     setTargetWordCount(recommendedLength)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [seoPreview.appliedKeyword, seoResult])


### PR DESCRIPTION
## Summary

경쟁글 분석 미리보기 완료 직후 권장값(평균 글자수, 평균 이미지 수)이 입력 필드에 적용되지 않던 문제 수정.

### 원인
- `imageStyleAllocation` → `imageCount` 자동 sync useEffect 가 `setImageCount(권장값)` 직후 곧바로 `imageCount` 를 allocation 합(기본 3)으로 덮어씀
- 사용자 화면에는 분석 결과가 안 적용되어 보임

### 해결
- 자동/수동 적용 모두 `imageCount` 를 직접 setState 하지 않고 `imageStyleAllocation` 의 dominant 스타일(active 중 max, 없으면 `infographic_only`)에 권장값을 흡수
- 이후 sync useEffect 가 `imageCount` 를 권장값으로 정확히 맞춤

### 영향
- `/dashboard/marketing/posts/new` 페이지
- 마케팅 자동화 → AI 글쓰기 탭(`NewPostForm`)

## Test plan
- [x] 빌드 통과
- [ ] 키워드 입력 → 분석 → 인포그래픽 카운트가 평균 이미지 수에 자동 반영 확인
- [ ] 목표 글자수가 평균 글자수 권장값으로 자동 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)