### PR TITLE
feat(master): 마스터 프리미엄 기능 관리에 '부동산 경매' 토글 추가

### DIFF
--- a/dental-clinic-manager/src/components/Master/PremiumFeatureModal.tsx
+++ b/dental-clinic-manager/src/components/Master/PremiumFeatureModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import { dataService } from '@/lib/dataService'
 import { PREMIUM_FEATURE_IDS, PREMIUM_FEATURE_LABELS } from '@/config/menuConfig'
 import type { PremiumFeatureId } from '@/config/menuConfig'
-import { X, Sparkles, BarChart3, Megaphone, PhoneCall, FileBarChart2, Heart } from 'lucide-react'
+import { X, Sparkles, BarChart3, Megaphone, PhoneCall, FileBarChart2, Heart, Gavel } from 'lucide-react'
 
 interface PremiumFeatureModalProps {
   clinic: { id: string; name: string }
@@ -21,6 +21,7 @@ const FEATURE_ICONS: Record<PremiumFeatureId, React.ElementType> = {
   'referral': Heart,
   'marketing': Megaphone,
   'investment': BarChart3,
+  'auction': Gavel,
 }
 
 export default function PremiumFeatureModal({ clinic, grantedBy, onClose, onUpdated }: PremiumFeatureModalProps) {

--- a/dental-clinic-manager/src/config/menuConfig.ts
+++ b/dental-clinic-manager/src/config/menuConfig.ts
@@ -18,7 +18,7 @@ export const INVESTMENT_ALLOWED_CLINIC_IDS = [
 ] as const
 
 // 프리미엄 기능 ID 상수
-export const PREMIUM_FEATURE_IDS = ['recall', 'ai-analysis', 'financial', 'monthly-report', 'referral', 'marketing', 'investment'] as const
+export const PREMIUM_FEATURE_IDS = ['recall', 'ai-analysis', 'financial', 'monthly-report', 'referral', 'marketing', 'investment', 'auction'] as const
 export type PremiumFeatureId = typeof PREMIUM_FEATURE_IDS[number]
 
 // 프리미엄 기능 라벨 맵
@@ -30,6 +30,7 @@ export const PREMIUM_FEATURE_LABELS: Record<PremiumFeatureId, string> = {
   'referral': '소개환자 관리',
   'marketing': '마케팅 자동화',
   'investment': '주식 자동매매',
+  'auction': '부동산 경매',
 }
 
 // 프리미엄 기능별 데모 오버레이에 표시할 두 가지 플랜 옵션
@@ -99,6 +100,13 @@ export const PREMIUM_FEATURE_INFO: Record<PremiumFeatureId, {
     description: 'AI 기반 자동매매 전략으로 자산을 운용합니다.',
     plans: [
       { planFeatureId: 'investment', name: '주식 자동매매', priceLabel: '수익의 5%', includes: ['AI 자동매매', '전략 백테스트', '실시간 포트폴리오'], recommended: true },
+    ],
+  },
+  'auction': {
+    title: '부동산 경매',
+    description: '전국 법원 경매 물건을 실시간으로 수집하고 ROI·권리분석까지 자동으로 분석합니다.',
+    plans: [
+      { planFeatureId: 'auction', name: '부동산 경매', priceLabel: '월 49,000원', includes: ['전국 경매 물건', '3단계 ROI 시뮬레이션', 'AI 권리분석', '실거래가 시세 매칭'], recommended: true },
     ],
   },
 }


### PR DESCRIPTION
## Summary
마스터 → 클리닉 → "프리미엄 기능 관리" 모달에 **부동산 경매** 토글이 표시되도록 수정.

원인: `menuConfig.ts` 에서 auction 메뉴는 `premiumFeature: true` 였지만 `PREMIUM_FEATURE_IDS` 배열에 누락되어 모달이 자동 렌더하지 못했음.

## 변경
- `PREMIUM_FEATURE_IDS` 배열에 `'auction'` 추가 (모달이 이 배열을 순회하여 토글 자동 렌더)
- `PREMIUM_FEATURE_LABELS`: `'auction': '부동산 경매'` 추가
- `PREMIUM_FEATURE_INFO`: 잠금 화면용 설명/플랜 정보 추가
- `PremiumFeatureModal.tsx`: `FEATURE_ICONS` 에 Gavel 아이콘 매핑

## Test plan
- [x] `npm run build` 통과
- [ ] 마스터 계정으로 로그인 → 클리닉 → "프리미엄" 컬럼 클릭 → 모달에 "부동산 경매" 토글 표시 확인
- [ ] 하얀치과의 "부동산 경매" 토글 ON → owner 로그인 → 사이드바 "부동산 경매" 진입 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)