### PR TITLE
feat(marketing): OpenAI 이미지 모델을 gpt-image-2 로 적용 (quality=medium)

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778841313539'
+const SW_VERSION = 'v1778843299320'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/app/master/marketing/costs/ImageProviderSelector.tsx
+++ b/dental-clinic-manager/src/app/master/marketing/costs/ImageProviderSelector.tsx
@@ -11,9 +11,9 @@ const PROVIDER_INFO: Record<Provider, { label: string; description: string; mode
     description: 'Google 나노바나나 (기본)',
   },
   openai: {
-    label: 'OpenAI gpt-image-1.5',
-    model: 'gpt-image-1.5',
-    description: 'OpenAI 최신 이미지 생성 모델 (Images API)',
+    label: 'OpenAI gpt-image-2',
+    model: 'gpt-image-2',
+    description: 'OpenAI 최신 이미지 생성 모델 (Images API, quality=medium)',
   },
 }
 

--- a/dental-clinic-manager/src/lib/marketing/image-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/image-generator.ts
@@ -9,7 +9,7 @@ import { getImageProvider, type ImageProvider } from './image-provider-setting';
 import type { GeneratedImageMeta, ImageMarker, ImageStyleOption, ImageVisualStyle } from '@/types/marketing';
 
 // ============================================
-// AI 이미지 생성 (Gemini 3.0 Flash / OpenAI gpt-image-1.5)
+// AI 이미지 생성 (Gemini 3.0 Flash / OpenAI gpt-image-2)
 // - 마스터가 선택한 프로바이더로 디스패치
 // - 블로그 본문의 [IMAGE: 설명] 마커에서 이미지 생성
 // - 한글 파일명 자동 생성
@@ -17,10 +17,11 @@ import type { GeneratedImageMeta, ImageMarker, ImageStyleOption, ImageVisualStyl
 
 const GEMINI_IMAGE_MODEL = 'gemini-3.1-flash-image-preview';
 const GEMINI_LOG_MODEL = 'gemini-3.0-flash';
-// OpenAI Images API(/v1/images/generations) 가 model 파라미터로 인식하는 GPT 이미지 모델.
-// 공식 문서 기준: gpt-image-1.5 (최신), gpt-image-1, gpt-image-1-mini.
-// (gpt-image-2 는 Responses API 의 image_generation 툴 전용으로 Images API 에서는 invalid)
-const OPENAI_IMAGE_MODEL = 'gpt-image-1.5';
+// OpenAI Images API(/v1/images/generations, /v1/images/edits) 의 최신 GPT 이미지 모델.
+// 참고: https://developers.openai.com/cookbook/examples/multimodal/image-gen-models-prompting-guide
+// quality 파라미터(low/medium/high) 가 호출에 필요하므로 OPENAI_IMAGE_QUALITY 와 함께 전송.
+const OPENAI_IMAGE_MODEL = 'gpt-image-2';
+const OPENAI_IMAGE_QUALITY: 'low' | 'medium' | 'high' = 'medium';
 
 const genai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || '' });
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || '' });
@@ -514,7 +515,7 @@ async function generateImageWithGemini(
   }
 }
 
-// ─── OpenAI Images API 호출 (gpt-image-1.5) ───
+// ─── OpenAI Images API 호출 (gpt-image-2) ───
 
 interface OpenAIImageResult {
   imageBase64: string;
@@ -525,7 +526,7 @@ interface OpenAIImageResult {
   };
 }
 
-// gpt-image-1.5 지원 사이즈에 플랫폼 매핑
+// gpt-image-2 지원 사이즈에 플랫폼 매핑
 function resolveOpenAIImageSize(platform?: SocialPlatform): '1024x1024' | '1536x1024' | '1024x1536' {
   if (platform === 'facebook') return '1536x1024'; // 가로형
   return '1024x1024'; // 정사각형 (기본)
@@ -544,7 +545,7 @@ async function generateImageWithOpenAI(
     let usage: { input_tokens?: number; output_tokens?: number; total_tokens?: number } | undefined;
 
     if (imageStyle === 'use_own_image' && referenceImageBase64) {
-      // 참조 이미지 기반 편집
+      // 참조 이미지 기반 편집 — gpt-image-2 의 input_fidelity 는 disabled(출력이 이미 고품질)
       const imageFile = await toFile(
         Buffer.from(referenceImageBase64, 'base64'),
         'reference.png',
@@ -555,6 +556,7 @@ async function generateImageWithOpenAI(
         image: imageFile,
         prompt,
         size,
+        quality: OPENAI_IMAGE_QUALITY,
         n: 1,
       });
       b64 = response.data?.[0]?.b64_json;
@@ -564,6 +566,7 @@ async function generateImageWithOpenAI(
         model: OPENAI_IMAGE_MODEL,
         prompt,
         size,
+        quality: OPENAI_IMAGE_QUALITY,
         n: 1,
       });
       b64 = response.data?.[0]?.b64_json;


### PR DESCRIPTION
## Summary

OpenAI cookbook 가이드를 근거로 `gpt-image-2` 를 Images API 에서 사용. 이전 호출 실패 원인은 모델 비호환이 아니라 `quality` 파라미터 누락으로 추정.

참고: https://developers.openai.com/cookbook/examples/multimodal/image-gen-models-prompting-guide

## Changes

- `OPENAI_IMAGE_MODEL = 'gpt-image-2'` (gpt-image-1.5 → gpt-image-2 복원)
- `OPENAI_IMAGE_QUALITY = 'medium'` 신설
- `openai.images.generate` / `openai.images.edit` 호출에 `quality` 전달
- 마스터 UI 라벨/모델명 동기화

## Test plan
- [x] 빌드 통과
- [ ] production 재배포 후 AI 글 생성 시 이미지 정상 생성 확인
- [ ] 실패 시 새 에러 로그(`[ImageGen] OpenAI API 오류` — status/code/type/message 분리됨)로 추가 진단

🤖 Generated with [Claude Code](https://claude.com/claude-code)