### PR TITLE
fix(marketing): gpt-image-2 이미지 생성 안정화 — 모델 체인 폴백 + Storage 폴백

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778843299320'
+const SW_VERSION = 'v1778845462664'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/app/api/marketing/generate/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/generate/route.ts
@@ -4,6 +4,7 @@ import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import { generateContent } from '@/lib/marketing/content-generator';
 import { extractKeywordsFromPosts } from '@/lib/marketing/seo-text-miner';
 import { generateBlogImage, generatePlatformImage } from '@/lib/marketing/image-generator';
+import { buildImageDataUrl, uploadMarketingImage } from '@/lib/marketing/image-storage';
 import { resolveBrandMarkers } from '@/lib/marketing/brand/marker-resolver';
 import { transformToInstagram } from '@/lib/marketing/platform-adapters/instagram';
 import { transformToFacebook } from '@/lib/marketing/platform-adapters/facebook';
@@ -338,31 +339,9 @@ export async function POST(request: NextRequest) {
               ]);
 
               // Supabase Storage에 업로드
-              let imagePath = '';
-              if (admin) {
-                try {
-                  const buffer = Buffer.from(imageBase64, 'base64');
-                  const safeFileName = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}.png`;
-                  const storagePath = `generated/${safeFileName}`;
-                  const { error: uploadError } = await admin.storage
-                    .from('marketing-images')
-                    .upload(storagePath, buffer, {
-                      contentType: 'image/png',
-                      upsert: true,
-                    });
-                  if (!uploadError) {
-                    const { data: urlData } = admin.storage
-                      .from('marketing-images')
-                      .getPublicUrl(storagePath);
-                    imagePath = urlData.publicUrl;
-                  }
-                } catch (uploadErr) {
-                  console.error('[API] Storage 업로드 실패:', uploadErr);
-                }
-              }
-
-              if (!imagePath && imageBase64.length < 500000) {
-                imagePath = `data:image/png;base64,${imageBase64}`;
+              let imagePath = await uploadMarketingImage(imageBase64, 'generated');
+              if (!imagePath) {
+                imagePath = buildImageDataUrl(imageBase64);
               }
 
               return imagePath ? { fileName, prompt: marker.prompt, path: imagePath } : null;
@@ -430,17 +409,8 @@ export async function POST(request: NextRequest) {
                     const { imageBase64, fileName } = await generatePlatformImage(
                       firstImagePrompt, 'instagram', options.imageStyle, options.referenceImageBase64, options.imageVisualStyle, generationSessionId, userData.clinic_id
                     );
-                    let imagePath = '';
-                    if (admin) {
-                      try {
-                        const buffer = Buffer.from(imageBase64, 'base64');
-                        const safeFileName = `insta_${Date.now()}_${Math.random().toString(36).slice(2, 6)}.png`;
-                        const storagePath = `generated/${safeFileName}`;
-                        const { error: upErr } = await admin.storage.from('marketing-images').upload(storagePath, buffer, { contentType: 'image/png', upsert: true });
-                        if (!upErr) imagePath = admin.storage.from('marketing-images').getPublicUrl(storagePath).data.publicUrl;
-                      } catch { /* fallback */ }
-                    }
-                    if (!imagePath && imageBase64.length < 500000) imagePath = `data:image/png;base64,${imageBase64}`;
+                    let imagePath = await uploadMarketingImage(imageBase64, 'insta');
+                    if (!imagePath) imagePath = buildImageDataUrl(imageBase64);
                     if (imagePath) {
                       instaImages = [{ fileName, prompt: firstImagePrompt, path: imagePath, width: 1080, height: 1080 }, ...generatedImages];
                     }
@@ -464,17 +434,8 @@ export async function POST(request: NextRequest) {
                     const { imageBase64, fileName } = await generatePlatformImage(
                       firstImagePrompt, 'facebook', options.imageStyle, options.referenceImageBase64, options.imageVisualStyle, generationSessionId, userData.clinic_id
                     );
-                    let imagePath = '';
-                    if (admin) {
-                      try {
-                        const buffer = Buffer.from(imageBase64, 'base64');
-                        const safeFileName = `fb_${Date.now()}_${Math.random().toString(36).slice(2, 6)}.png`;
-                        const storagePath = `generated/${safeFileName}`;
-                        const { error: upErr } = await admin.storage.from('marketing-images').upload(storagePath, buffer, { contentType: 'image/png', upsert: true });
-                        if (!upErr) imagePath = admin.storage.from('marketing-images').getPublicUrl(storagePath).data.publicUrl;
-                      } catch { /* fallback */ }
-                    }
-                    if (!imagePath && imageBase64.length < 500000) imagePath = `data:image/png;base64,${imageBase64}`;
+                    let imagePath = await uploadMarketingImage(imageBase64, 'fb');
+                    if (!imagePath) imagePath = buildImageDataUrl(imageBase64);
                     if (imagePath) {
                       fbImages = [{ fileName, prompt: firstImagePrompt, path: imagePath }];
                     }
@@ -498,17 +459,8 @@ export async function POST(request: NextRequest) {
                     const { imageBase64, fileName } = await generatePlatformImage(
                       firstImagePrompt, 'threads', options.imageStyle, options.referenceImageBase64, options.imageVisualStyle, generationSessionId, userData.clinic_id
                     );
-                    let imagePath = '';
-                    if (admin) {
-                      try {
-                        const buffer = Buffer.from(imageBase64, 'base64');
-                        const safeFileName = `threads_${Date.now()}_${Math.random().toString(36).slice(2, 6)}.png`;
-                        const storagePath = `generated/${safeFileName}`;
-                        const { error: upErr } = await admin.storage.from('marketing-images').upload(storagePath, buffer, { contentType: 'image/png', upsert: true });
-                        if (!upErr) imagePath = admin.storage.from('marketing-images').getPublicUrl(storagePath).data.publicUrl;
-                      } catch { /* fallback */ }
-                    }
-                    if (!imagePath && imageBase64.length < 500000) imagePath = `data:image/png;base64,${imageBase64}`;
+                    let imagePath = await uploadMarketingImage(imageBase64, 'threads');
+                    if (!imagePath) imagePath = buildImageDataUrl(imageBase64);
                     if (imagePath) {
                       threadsImages = [{ fileName, prompt: firstImagePrompt, path: imagePath }];
                     }

--- a/dental-clinic-manager/src/app/api/marketing/prompts/test/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/prompts/test/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import { generateContent } from '@/lib/marketing/content-generator';
 import { generateBlogImage } from '@/lib/marketing/image-generator';
+import { buildImageDataUrl, uploadMarketingImage } from '@/lib/marketing/image-storage';
 import type { PromptCategory } from '@/types/marketing';
 
 export const maxDuration = 90;
@@ -64,30 +64,8 @@ export async function POST(request: NextRequest) {
         ]);
 
         const { imageBase64, fileName } = imageResult;
-        const admin = getSupabaseAdmin();
-
-        let imagePath = '';
-        if (admin && imageBase64) {
-          try {
-            const buffer = Buffer.from(imageBase64, 'base64');
-            const safeFileName = `test_${Date.now()}.png`;
-            const storagePath = `generated/${safeFileName}`;
-            const { error: uploadError } = await admin.storage
-              .from('marketing-images')
-              .upload(storagePath, buffer, { contentType: 'image/png', upsert: true });
-            if (!uploadError) {
-              const { data: urlData } = admin.storage
-                .from('marketing-images')
-                .getPublicUrl(storagePath);
-              imagePath = urlData.publicUrl;
-            }
-          } catch {
-            // Storage 실패 시 base64로 폴백
-          }
-        }
-        if (!imagePath && imageBase64) {
-          imagePath = `data:image/png;base64,${imageBase64}`;
-        }
+        let imagePath = await uploadMarketingImage(imageBase64, 'test');
+        if (!imagePath) imagePath = buildImageDataUrl(imageBase64);
 
         return NextResponse.json({
           data: {

--- a/dental-clinic-manager/src/app/api/marketing/regenerate-image/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/regenerate-image/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import { generateBlogImage } from '@/lib/marketing/image-generator';
+import { buildImageDataUrl, uploadMarketingImage } from '@/lib/marketing/image-storage';
 import type { ImageStyleOption, ImageVisualStyle } from '@/types/marketing';
 
 // Gemini 이미지 생성 타임아웃 대응
@@ -64,34 +64,10 @@ export async function POST(request: NextRequest) {
     );
 
     // Supabase Storage에 업로드
-    let imagePath = '';
-    const admin = getSupabaseAdmin();
-    if (admin) {
-      try {
-        const buffer = Buffer.from(imageBase64, 'base64');
-        const safeFileName = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}.png`;
-        const storagePath = `generated/${safeFileName}`;
-        const { error: uploadError } = await admin.storage
-          .from('marketing-images')
-          .upload(storagePath, buffer, {
-            contentType: 'image/png',
-            upsert: true,
-          });
-        if (!uploadError) {
-          const { data: urlData } = admin.storage
-            .from('marketing-images')
-            .getPublicUrl(storagePath);
-          imagePath = urlData.publicUrl;
-        }
-      } catch (uploadErr) {
-        console.error('[API] Storage 업로드 실패:', uploadErr);
-      }
-    }
+    let imagePath = await uploadMarketingImage(imageBase64, 'regenerated');
 
-    // Storage 업로드 실패 시 base64 폴백
-    if (!imagePath && imageBase64.length < 500000) {
-      imagePath = `data:image/png;base64,${imageBase64}`;
-    }
+    // Storage 업로드 실패 시 data URL 폴백
+    if (!imagePath) imagePath = buildImageDataUrl(imageBase64);
 
     if (!imagePath) {
       return NextResponse.json({ error: '이미지 업로드에 실패했습니다.' }, { status: 500 });

--- a/dental-clinic-manager/src/lib/marketing/image-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/image-generator.ts
@@ -17,10 +17,12 @@ import type { GeneratedImageMeta, ImageMarker, ImageStyleOption, ImageVisualStyl
 
 const GEMINI_IMAGE_MODEL = 'gemini-3.1-flash-image-preview';
 const GEMINI_LOG_MODEL = 'gemini-3.0-flash';
-// OpenAI Images API(/v1/images/generations, /v1/images/edits) 의 최신 GPT 이미지 모델.
+// OpenAI Images API(/v1/images/generations, /v1/images/edits) 의 GPT 이미지 모델 체인.
 // 참고: https://developers.openai.com/cookbook/examples/multimodal/image-gen-models-prompting-guide
-// quality 파라미터(low/medium/high) 가 호출에 필요하므로 OPENAI_IMAGE_QUALITY 와 함께 전송.
-const OPENAI_IMAGE_MODEL = 'gpt-image-2';
+// 첫 모델이 비활성/액세스 불가/요청 거부일 때 자동으로 다음 모델로 폴백.
+// gpt-image-2 는 계정/조직에 따라 access verification 이 필요할 수 있어 1.5 / 1 로 graceful fallback.
+const OPENAI_IMAGE_MODEL_CHAIN = ['gpt-image-2', 'gpt-image-1.5', 'gpt-image-1'] as const;
+const OPENAI_IMAGE_MODEL = OPENAI_IMAGE_MODEL_CHAIN[0]; // 로깅·UI 표시용 대표 모델
 const OPENAI_IMAGE_QUALITY: 'low' | 'medium' | 'high' = 'medium';
 
 const genai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || '' });
@@ -540,62 +542,84 @@ async function generateImageWithOpenAI(
 ): Promise<OpenAIImageResult> {
   const size = resolveOpenAIImageSize(platform);
 
-  try {
-    let b64: string | undefined;
-    let usage: { input_tokens?: number; output_tokens?: number; total_tokens?: number } | undefined;
+  // 모델 호환성/액세스 문제는 status 400/404, code/type 에 model 관련 키워드가 들어옴.
+  const isModelAccessIssue = (err: { status?: number; code?: string; type?: string; message?: string; error?: { message?: string } }) => {
+    const status = err?.status;
+    const blob = `${err?.code || ''} ${err?.type || ''} ${err?.message || ''} ${err?.error?.message || ''}`.toLowerCase();
+    if (status === 404) return true;
+    if (status === 400 && /model|invalid|unsupported|not.+available|access/i.test(blob)) return true;
+    if (/model_not_found|invalid_model|unsupported_model|model_not_supported/i.test(blob)) return true;
+    return false;
+  };
 
-    if (imageStyle === 'use_own_image' && referenceImageBase64) {
-      // 참조 이미지 기반 편집 — gpt-image-2 의 input_fidelity 는 disabled(출력이 이미 고품질)
-      const imageFile = await toFile(
-        Buffer.from(referenceImageBase64, 'base64'),
-        'reference.png',
-        { type: 'image/png' },
-      );
-      const response = await openai.images.edit({
-        model: OPENAI_IMAGE_MODEL,
-        image: imageFile,
-        prompt,
-        size,
-        quality: OPENAI_IMAGE_QUALITY,
-        n: 1,
+  let lastErr: unknown;
+  for (let i = 0; i < OPENAI_IMAGE_MODEL_CHAIN.length; i++) {
+    const model = OPENAI_IMAGE_MODEL_CHAIN[i];
+    try {
+      let b64: string | undefined;
+      let usage: { input_tokens?: number; output_tokens?: number; total_tokens?: number } | undefined;
+
+      if (imageStyle === 'use_own_image' && referenceImageBase64) {
+        const imageFile = await toFile(
+          Buffer.from(referenceImageBase64, 'base64'),
+          'reference.png',
+          { type: 'image/png' },
+        );
+        const response = await openai.images.edit({
+          model,
+          image: imageFile,
+          prompt,
+          size,
+          quality: OPENAI_IMAGE_QUALITY,
+          output_format: 'png',
+          n: 1,
+        });
+        b64 = response.data?.[0]?.b64_json;
+        usage = (response as { usage?: typeof usage }).usage;
+      } else {
+        const response = await openai.images.generate({
+          model,
+          prompt,
+          size,
+          quality: OPENAI_IMAGE_QUALITY,
+          output_format: 'png',
+          n: 1,
+        });
+        b64 = response.data?.[0]?.b64_json;
+        usage = (response as { usage?: typeof usage }).usage;
+      }
+
+      if (!b64) throw new Error('응답에 이미지가 포함되지 않았습니다');
+
+      if (i > 0) {
+        console.warn(`[ImageGen] OpenAI 폴백 모델 사용: ${model} (1순위 모델 액세스 불가)`);
+      }
+      return {
+        imageBase64: b64,
+        usage: {
+          inputTokens: usage?.input_tokens ?? 0,
+          outputTokens: usage?.output_tokens ?? 0,
+          totalTokens: usage?.total_tokens ?? 0,
+        },
+      };
+    } catch (error) {
+      lastErr = error;
+      const err = error as { status?: number; code?: string; type?: string; message?: string; error?: { message?: string } };
+      console.error('[ImageGen] OpenAI API 오류:', {
+        model,
+        status: err?.status,
+        code: err?.code,
+        type: err?.type,
+        message: err?.message || err?.error?.message,
       });
-      b64 = response.data?.[0]?.b64_json;
-      usage = (response as { usage?: typeof usage }).usage;
-    } else {
-      const response = await openai.images.generate({
-        model: OPENAI_IMAGE_MODEL,
-        prompt,
-        size,
-        quality: OPENAI_IMAGE_QUALITY,
-        n: 1,
-      });
-      b64 = response.data?.[0]?.b64_json;
-      usage = (response as { usage?: typeof usage }).usage;
+      // 모델 액세스/호환 문제면 다음 모델로 폴백. 그 외 에러(rate limit, content policy 등)는 즉시 throw.
+      if (i < OPENAI_IMAGE_MODEL_CHAIN.length - 1 && isModelAccessIssue(err)) {
+        continue;
+      }
+      throw error;
     }
-
-    if (!b64) throw new Error('응답에 이미지가 포함되지 않았습니다');
-
-    return {
-      imageBase64: b64,
-      usage: {
-        inputTokens: usage?.input_tokens ?? 0,
-        outputTokens: usage?.output_tokens ?? 0,
-        totalTokens: usage?.total_tokens ?? 0,
-      },
-    };
-  } catch (error) {
-    // OpenAI SDK 에러는 status / code / type / message 가 분리돼 있어 평이 로깅으로는 잘려서 안 보임.
-    // 운영 디버깅을 위해 핵심 필드를 풀어서 함께 기록.
-    const err = error as { status?: number; code?: string; type?: string; message?: string; error?: { message?: string } };
-    console.error('[ImageGen] OpenAI API 오류:', {
-      model: OPENAI_IMAGE_MODEL,
-      status: err?.status,
-      code: err?.code,
-      type: err?.type,
-      message: err?.message || err?.error?.message,
-    });
-    throw error;
   }
+  throw lastErr instanceof Error ? lastErr : new Error('OpenAI 이미지 생성 실패 (모든 폴백 모델 실패)');
 }
 
 // ─── 한글 파일명 생성 (Claude Haiku) ───

--- a/dental-clinic-manager/src/lib/marketing/image-storage.ts
+++ b/dental-clinic-manager/src/lib/marketing/image-storage.ts
@@ -1,0 +1,42 @@
+import { getSupabaseAdmin } from '@/lib/supabase/admin';
+
+export function buildImageDataUrl(imageBase64: string, mimeType: string = 'image/png'): string {
+  return `data:${mimeType};base64,${imageBase64}`;
+}
+
+export async function uploadMarketingImage(
+  imageBase64: string,
+  filePrefix: string = 'generated',
+): Promise<string | null> {
+  const admin = getSupabaseAdmin();
+  if (!admin || !imageBase64) return null;
+
+  try {
+    const buffer = Buffer.from(imageBase64, 'base64');
+    const safeFileName = `${filePrefix}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}.png`;
+    const storagePath = `generated/${safeFileName}`;
+    const { error: uploadError } = await admin.storage
+      .from('marketing-images')
+      .upload(storagePath, buffer, {
+        contentType: 'image/png',
+        upsert: true,
+      });
+
+    if (uploadError) {
+      console.error('[ImageStorage] Storage 업로드 실패:', {
+        filePrefix,
+        bytes: buffer.byteLength,
+        message: uploadError.message,
+      });
+      return null;
+    }
+
+    const { data: urlData } = admin.storage
+      .from('marketing-images')
+      .getPublicUrl(storagePath);
+    return urlData.publicUrl || null;
+  } catch (error) {
+    console.error('[ImageStorage] Storage 업로드 예외:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

OpenAI 이미지 모델 선택 시 본문에 `[IMAGE: TITLE=... | CHECK=... | STYLE=...]` 플레이스홀더만 보이고 실제 이미지가 안 들어오던 문제 수정.

## 근본 원인 (2가지 누적)

1. `gpt-image-2` 모델이 일부 OpenAI 계정/조직에서 access verification 이 필요해 호출 자체가 실패 → `imageBase64` 가 비어 `generatedImages[].path` 가 빈 채로 frontend 도달 → 본문 마커 위치에 "이미지 생성 실패" placeholder 가 prompt 와 함께 표시 (사용자가 본 텍스트가 정확히 이 placeholder 내부)
2. 호출이 성공해도 Supabase Storage 업로드 실패 시 path 가 비어 동일 증상

## 해결

- **모델 체인 폴백**: `OPENAI_IMAGE_MODEL_CHAIN = [gpt-image-2, gpt-image-1.5, gpt-image-1]`
  - 모델 액세스/호환 에러(status 404, 400+model 키워드, model_not_found 등) 시 자동 폴백
  - rate limit / content policy 등 비-액세스 에러는 즉시 throw (기존 동작 유지)
  - 폴백 발생 시 `[ImageGen] OpenAI 폴백 모델 사용` 경고 로깅
- **Storage 업로드 폴백**: 실패 시 `data:image/png;base64,...` URL 로 graceful fallback (`image-storage.ts` 공통 헬퍼). `generate` / `regenerate-image` / `prompts/test` 통일.
- `output_format: 'png'` 명시 (cookbook 권장).

## Test plan
- [x] 빌드 통과
- [ ] production 재배포 후 AI 글 생성 시 OpenAI 이미지가 본문에 정상 렌더링되는지 확인
- [ ] Vercel 로그에서 `[ImageGen] OpenAI 폴백 모델 사용` 경고 발생 여부 → 1순위 모델 액세스 상태 진단

🤖 Generated with [Claude Code](https://claude.com/claude-code)