### PR TITLE
fix(auction): 상세 페이지 모바일 가독성 개선

### DIFF
--- a/dental-clinic-manager/src/app/investment/auction/[itemId]/page.tsx
+++ b/dental-clinic-manager/src/app/investment/auction/[itemId]/page.tsx
@@ -41,19 +41,19 @@ export default function AuctionDetailPage({ params }: { params: Promise<{ itemId
   if (!data) return <div className="flex justify-center py-16"><Loader2 className="w-6 h-6 animate-spin text-at-accent" /></div>
 
   return (
-    <div className="max-w-5xl mx-auto">
-      <button onClick={() => router.back()} className="flex items-center gap-1 text-sm text-at-text-secondary mb-3">
+    <div className="max-w-5xl mx-auto px-3 sm:px-0">
+      <button onClick={() => router.back()} className="flex items-center gap-1 text-[14px] md:text-sm font-medium text-at-text-secondary hover:text-at-text mb-3">
         <ArrowLeft className="w-4 h-4" /> 뒤로
       </button>
 
       <AuctionDetailHeader item={data.item} market={data.market} />
 
-      <div className="flex gap-1 border-b border-at-border mb-4 overflow-x-auto">
+      <div className="flex gap-1 border-b border-at-border mb-4 overflow-x-auto -mx-3 sm:mx-0 px-3 sm:px-0">
         {TABS.map(t => (
           <button
             key={t.id}
             onClick={() => setTab(t.id)}
-            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            className={`px-4 py-2.5 text-[15px] md:text-sm font-semibold border-b-2 transition-colors whitespace-nowrap shrink-0 ${
               tab === t.id ? 'border-at-accent text-at-accent' : 'border-transparent text-at-text-secondary hover:text-at-text'
             }`}
           >

--- a/dental-clinic-manager/src/components/Investment/Auction/AuctionDetailHeader.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/AuctionDetailHeader.tsx
@@ -15,11 +15,11 @@ export function AuctionDetailHeader({ item, market }: Props) {
   const s = market ? calculateSecondary(item, market, { isMultiOwner: false }) : null
 
   return (
-    <div className="bg-at-surface rounded-2xl p-6 border border-at-border mb-4">
-      <div className="text-sm text-at-text-secondary mb-1">
+    <div className="bg-at-surface rounded-2xl p-5 md:p-6 border border-at-border mb-4">
+      <div className="text-[13px] md:text-sm text-at-text-secondary mb-1">
         {item.case_number} · {item.court_name}
       </div>
-      <h1 className="text-xl font-bold mb-4">
+      <h1 className="text-lg md:text-xl font-bold mb-4 text-at-text">
         {item.sido} {item.sigungu} {item.eupmyeondong}
       </h1>
 
@@ -46,8 +46,8 @@ function Field({ label, value, highlight, accent }: { label: string; value: stri
                 : 'text-at-text'
   return (
     <div>
-      <div className="text-xs text-at-text-secondary">{label}</div>
-      <div className={`text-base ${highlight ? 'font-bold' : 'font-medium'} ${colorCls}`}>{value}</div>
+      <div className="text-[13px] md:text-xs text-at-text-secondary">{label}</div>
+      <div className={`text-base md:text-base ${highlight ? 'font-bold' : 'font-semibold'} ${colorCls} tabular-nums`}>{value}</div>
     </div>
   )
 }

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/AttachmentsTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/AttachmentsTab.tsx
@@ -12,11 +12,11 @@ export function AttachmentsTab({ item }: Props) {
   ].filter(x => x.url)
 
   if (items.length === 0) {
-    return <p className="text-sm text-at-text-secondary py-8 text-center">첨부된 자료가 없습니다.</p>
+    return <p className="text-[14px] md:text-sm text-at-text-secondary py-8 text-center">첨부된 자료가 없습니다.</p>
   }
 
   return (
-    <div className="bg-at-surface rounded-2xl p-5 border border-at-border space-y-2">
+    <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border space-y-2">
       {items.map((it) => (
         <a
           key={it.label}
@@ -25,12 +25,12 @@ export function AttachmentsTab({ item }: Props) {
           rel="noopener noreferrer"
           className="flex items-center gap-3 px-3 py-2.5 rounded-xl hover:bg-at-surface-hover"
         >
-          <FileText className="w-5 h-5 text-at-accent" />
-          <span className="flex-1 text-sm font-medium">{it.label}</span>
+          <FileText className="w-5 h-5 text-at-accent shrink-0" />
+          <span className="flex-1 text-[15px] md:text-sm font-semibold text-at-text">{it.label}</span>
           <ExternalLink className="w-4 h-4 text-at-text-secondary" />
         </a>
       ))}
-      <p className="text-xs text-at-text-secondary mt-3">※ 외부 링크는 새 창으로 열립니다.</p>
+      <p className="text-[13px] md:text-xs text-at-text-secondary mt-3">※ 외부 링크는 새 창으로 열립니다.</p>
     </div>
   )
 }

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/HistoryTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/HistoryTab.tsx
@@ -41,10 +41,10 @@ export function HistoryTab({ itemId, history }: Props) {
 
   return (
     <div className="space-y-4">
-      <section className="bg-at-surface rounded-2xl p-5 border border-at-border">
-        <h3 className="font-semibold mb-3">회차별 변동</h3>
+      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+        <h3 className="text-base font-semibold mb-3 text-at-text">회차별 변동</h3>
         {history.length === 0 ? (
-          <p className="text-sm text-at-text-secondary">이력이 없습니다.</p>
+          <p className="text-[14px] md:text-sm text-at-text-secondary">이력이 없습니다.</p>
         ) : (
           <>
             <div className="h-48 mb-4">
@@ -57,53 +57,79 @@ export function HistoryTab({ itemId, history }: Props) {
                 </LineChart>
               </ResponsiveContainer>
             </div>
-            <table className="w-full text-sm">
-              <thead className="text-at-text-secondary text-left">
-                <tr>
-                  <th className="py-1">회차</th>
-                  <th>예정일</th>
-                  <th className="text-right">최저가</th>
-                  <th>결과</th>
-                  <th className="text-right">낙찰가</th>
-                  <th className="text-right">응찰자</th>
-                </tr>
-              </thead>
-              <tbody>
-                {history.map(h => (
-                  <tr key={h.round_no} className="border-t border-at-border">
-                    <td className="py-2">{h.round_no}차</td>
-                    <td>{h.scheduled_date}</td>
-                    <td className="text-right tabular-nums">{fmt(h.min_bid_price)}원</td>
-                    <td>{h.result ? RESULT_LABEL[h.result] ?? h.result : '-'}</td>
-                    <td className="text-right tabular-nums">{fmt(h.sold_price)}원</td>
-                    <td className="text-right tabular-nums">{h.bid_count ?? '-'}명</td>
+
+            {/* 모바일: 카드 리스트 */}
+            <ul className="md:hidden space-y-2">
+              {history.map(h => (
+                <li key={h.round_no} className="rounded-xl border border-at-border bg-at-surface-alt p-3">
+                  <div className="flex items-center justify-between mb-1.5">
+                    <span className="text-[15px] font-bold text-at-text">{h.round_no}차</span>
+                    <span className="text-[13px] text-at-text-secondary">{h.scheduled_date}</span>
+                  </div>
+                  <dl className="grid grid-cols-2 gap-x-3 gap-y-1 text-[14px]">
+                    <dt className="text-at-text-secondary">최저가</dt>
+                    <dd className="text-right font-semibold text-at-text tabular-nums">{fmt(h.min_bid_price)}원</dd>
+                    <dt className="text-at-text-secondary">결과</dt>
+                    <dd className="text-right font-semibold text-at-text">{h.result ? RESULT_LABEL[h.result] ?? h.result : '-'}</dd>
+                    <dt className="text-at-text-secondary">낙찰가</dt>
+                    <dd className="text-right font-semibold text-at-text tabular-nums">{fmt(h.sold_price)}원</dd>
+                    <dt className="text-at-text-secondary">응찰자</dt>
+                    <dd className="text-right font-semibold text-at-text tabular-nums">{h.bid_count ?? '-'}명</dd>
+                  </dl>
+                </li>
+              ))}
+            </ul>
+
+            {/* 데스크톱: 테이블 */}
+            <div className="hidden md:block overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="text-at-text-secondary text-left">
+                  <tr>
+                    <th className="py-1">회차</th>
+                    <th>예정일</th>
+                    <th className="text-right">최저가</th>
+                    <th>결과</th>
+                    <th className="text-right">낙찰가</th>
+                    <th className="text-right">응찰자</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {history.map(h => (
+                    <tr key={h.round_no} className="border-t border-at-border">
+                      <td className="py-2 font-semibold">{h.round_no}차</td>
+                      <td>{h.scheduled_date}</td>
+                      <td className="text-right tabular-nums font-medium">{fmt(h.min_bid_price)}원</td>
+                      <td>{h.result ? RESULT_LABEL[h.result] ?? h.result : '-'}</td>
+                      <td className="text-right tabular-nums font-medium">{fmt(h.sold_price)}원</td>
+                      <td className="text-right tabular-nums">{h.bid_count ?? '-'}명</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </>
         )}
       </section>
 
-      <section className="bg-at-surface rounded-2xl p-5 border border-at-border">
-        <h3 className="font-semibold mb-3">동일 동·용도 낙찰 통계 (최근 6개월)</h3>
+      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+        <h3 className="text-base font-semibold mb-3 text-at-text">동일 동·용도 낙찰 통계 (최근 6개월)</h3>
         {!stats ? (
-          <p className="text-sm text-at-text-secondary">로딩 중...</p>
+          <p className="text-[14px] md:text-sm text-at-text-secondary">로딩 중...</p>
         ) : stats.sample_count === 0 ? (
-          <p className="text-sm text-at-text-secondary">이 동·용도의 최근 낙찰 이력이 없습니다.</p>
+          <p className="text-[14px] md:text-sm text-at-text-secondary">이 동·용도의 최근 낙찰 이력이 없습니다.</p>
         ) : (
-          <dl className="grid grid-cols-3 gap-4 text-sm">
+          <dl className="grid grid-cols-3 gap-2 sm:gap-4 text-[14px] md:text-sm">
             <div>
-              <dt className="text-at-text-secondary">표본</dt>
-              <dd className="text-lg font-semibold">{stats.sample_count}건</dd>
+              <dt className="text-[13px] md:text-sm text-at-text-secondary">표본</dt>
+              <dd className="text-lg font-bold text-at-text tabular-nums">{stats.sample_count}건</dd>
             </div>
             <div>
-              <dt className="text-at-text-secondary">평균 낙찰가율</dt>
-              <dd className="text-lg font-semibold">{stats.avg_sold_to_appraisal_pct?.toFixed(1) ?? '-'}%</dd>
+              <dt className="text-[13px] md:text-sm text-at-text-secondary">평균 낙찰가율</dt>
+              <dd className="text-lg font-bold text-at-text tabular-nums">{stats.avg_sold_to_appraisal_pct?.toFixed(1) ?? '-'}%</dd>
             </div>
             <div>
-              <dt className="text-at-text-secondary">평균 응찰자</dt>
-              <dd className="text-lg font-semibold">{stats.avg_bid_count?.toFixed(1) ?? '-'}명</dd>
+              <dt className="text-[13px] md:text-sm text-at-text-secondary">평균 응찰자</dt>
+              <dd className="text-lg font-bold text-at-text tabular-nums">{stats.avg_bid_count?.toFixed(1) ?? '-'}명</dd>
             </div>
           </dl>
         )}

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/OverviewTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/OverviewTab.tsx
@@ -19,10 +19,10 @@ export function OverviewTab({ item, market }: Props) {
     : null
 
   return (
-    <div className="space-y-6">
-      <section className="bg-at-surface rounded-2xl p-5 border border-at-border">
-        <h3 className="font-semibold mb-3">물건 정보</h3>
-        <dl className="grid grid-cols-2 gap-y-2 text-sm">
+    <div className="space-y-4 md:space-y-6">
+      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+        <h3 className="text-base font-semibold mb-3 text-at-text">물건 정보</h3>
+        <dl className="grid grid-cols-2 gap-x-3 gap-y-2 text-[14px] md:text-sm">
           <Dt>용도</Dt><Dd>{PROPERTY_LABEL[item.property_type] ?? '기타'}</Dd>
           <Dt>주소(도로명)</Dt><Dd>{item.address_road ?? '-'}</Dd>
           <Dt>주소(지번)</Dt><Dd>{item.address_jibun ?? '-'}</Dd>
@@ -33,22 +33,22 @@ export function OverviewTab({ item, market }: Props) {
         </dl>
       </section>
 
-      <section className="bg-at-surface rounded-2xl p-5 border border-at-border">
-        <h3 className="font-semibold mb-3">시세 비교</h3>
+      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+        <h3 className="text-base font-semibold mb-3 text-at-text">시세 비교</h3>
         {market ? (
-          <div className="space-y-2">
+          <div className="space-y-3">
             <Bar label="감정가" value={item.appraisal_price} max={Math.max(item.appraisal_price, market.median_price_3m ?? 0)} />
             <Bar label="시세 (3개월 중위)" value={market.median_price_3m ?? 0} max={Math.max(item.appraisal_price, market.median_price_3m ?? 0)} accent="blue" />
             <Bar label="최저입찰가" value={item.min_bid_price} max={Math.max(item.appraisal_price, market.median_price_3m ?? 0)} accent="emerald" />
             {ratio !== null && (
-              <p className="text-sm text-at-text-secondary mt-3">
+              <p className="text-[14px] md:text-sm text-at-text mt-3 leading-relaxed">
                 최저입찰가는 시세의 <strong>{ratio}%</strong> 수준입니다.
                 매칭 신뢰도: <strong>{market.match_confidence}</strong> ({market.matched_complex ?? '-'}, 거래 {market.trade_count_3m ?? 0}건)
               </p>
             )}
           </div>
         ) : (
-          <p className="text-sm text-at-text-secondary">
+          <p className="text-[14px] md:text-sm text-at-text-secondary leading-relaxed">
             이 물건은 자동 시세 매칭이 불가능합니다 (토지/공장 등). 시뮬레이터 탭에서 직접 시세를 입력해 수익률을 계산해 보세요.
           </p>
         )}
@@ -66,7 +66,7 @@ export function OverviewTab({ item, market }: Props) {
         </section>
       )}
 
-      <p className="text-xs text-at-text-secondary px-1">
+      <p className="text-[13px] md:text-xs text-at-text-secondary px-1 leading-relaxed">
         ※ 본 정보는 투자 판단의 보조 자료이며, 최종 판단의 책임은 사용자에게 있습니다.
       </p>
     </div>
@@ -74,18 +74,18 @@ export function OverviewTab({ item, market }: Props) {
 }
 
 const Dt = (p: { children: React.ReactNode }) => <dt className="text-at-text-secondary">{p.children}</dt>
-const Dd = (p: { children: React.ReactNode }) => <dd className="font-medium">{p.children}</dd>
+const Dd = (p: { children: React.ReactNode }) => <dd className="font-semibold text-at-text break-words">{p.children}</dd>
 
 function Bar({ label, value, max, accent }: { label: string; value: number; max: number; accent?: 'blue'|'emerald' }) {
   const pct = max > 0 ? Math.round(value / max * 100) : 0
   const color = accent === 'emerald' ? 'bg-emerald-500'
               : accent === 'blue' ? 'bg-blue-500'
-              : 'bg-at-text'
+              : 'bg-slate-500'
   return (
     <div>
-      <div className="flex justify-between text-xs mb-1">
-        <span>{label}</span>
-        <span>{fmt(value)}원</span>
+      <div className="flex justify-between text-[13px] md:text-xs mb-1">
+        <span className="text-at-text font-medium">{label}</span>
+        <span className="text-at-text font-semibold tabular-nums">{fmt(value)}원</span>
       </div>
       <div className="h-3 rounded-full bg-at-surface-alt overflow-hidden">
         <div className={`h-full ${color}`} style={{ width: `${pct}%` }} />

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/RightsTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/RightsTab.tsx
@@ -54,14 +54,14 @@ export function RightsTab({ itemId, rights, initialAi }: Props) {
 
   return (
     <div className="space-y-4">
-      <section className="bg-at-surface rounded-2xl p-5 border border-at-border">
-        <h3 className="font-semibold mb-3">자동 추출 권리분석</h3>
+      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+        <h3 className="text-base font-semibold mb-3 text-at-text">자동 추출 권리분석</h3>
         {rights ? (
-          <dl className="grid grid-cols-2 gap-y-2 text-sm">
+          <dl className="grid grid-cols-2 gap-x-3 gap-y-2 text-[14px] md:text-sm">
             <Dt>말소기준권리</Dt>
             <Dd>{rights.base_right_type ?? '미확인'} {rights.base_right_date && `(${rights.base_right_date})`}</Dd>
             <Dt>대항력 임차인</Dt>
-            <Dd className={rights.has_senior_tenant ? 'text-rose-600 font-semibold' : ''}>
+            <Dd className={rights.has_senior_tenant ? 'text-rose-600 font-bold' : ''}>
               {rights.has_senior_tenant === null ? '미확인' : rights.has_senior_tenant ? '있음 (인수 위험)' : '없음'}
             </Dd>
             <Dt>임차인 수</Dt>
@@ -74,54 +74,54 @@ export function RightsTab({ itemId, rights, initialAi }: Props) {
             <Dd>{rights.parse_status ?? '-'}</Dd>
           </dl>
         ) : (
-          <p className="text-sm text-at-text-secondary">권리분석 데이터가 아직 수집되지 않았습니다.</p>
+          <p className="text-[14px] md:text-sm text-at-text-secondary">권리분석 데이터가 아직 수집되지 않았습니다.</p>
         )}
       </section>
 
-      <section className="bg-at-surface rounded-2xl p-5 border border-at-border">
-        <div className="flex justify-between items-center mb-3">
-          <h3 className="font-semibold">AI 권리분석 코멘트</h3>
+      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+        <div className="flex justify-between items-center mb-3 gap-2">
+          <h3 className="text-base font-semibold text-at-text">AI 권리분석 코멘트</h3>
           <button
             onClick={callAi}
             disabled={loading}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-at-accent-light text-at-accent text-sm font-medium disabled:opacity-50"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-at-accent-light text-at-accent text-sm font-semibold disabled:opacity-50 shrink-0"
           >
             {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Sparkles className="w-4 h-4" />}
             {ai ? '재생성' : 'AI 분석 실행'}
           </button>
         </div>
 
-        {err && <p className="text-sm text-rose-600 mb-2">{err}</p>}
+        {err && <p className="text-[14px] md:text-sm text-rose-600 mb-2 font-medium">{err}</p>}
 
         {ai ? (
           <div className="space-y-3">
             {ai.risk_score !== null && (
               <div className="flex items-center gap-2">
-                <span className="text-sm">위험도</span>
-                <div className="flex-1 h-2 bg-at-surface-alt rounded-full overflow-hidden">
+                <span className="text-[14px] md:text-sm text-at-text font-medium">위험도</span>
+                <div className="flex-1 h-2.5 bg-at-surface-alt rounded-full overflow-hidden">
                   <div
                     className={`h-full ${ai.risk_score >= 70 ? 'bg-rose-500' : ai.risk_score >= 40 ? 'bg-amber-500' : 'bg-emerald-500'}`}
                     style={{ width: `${ai.risk_score}%` }}
                   />
                 </div>
-                <span className="text-sm font-semibold tabular-nums">{ai.risk_score}/100</span>
+                <span className="text-[14px] md:text-sm font-bold tabular-nums text-at-text">{ai.risk_score}/100</span>
               </div>
             )}
-            <p className="text-sm leading-relaxed whitespace-pre-line">{ai.summary}</p>
+            <p className="text-[15px] md:text-sm leading-relaxed whitespace-pre-line text-at-text">{ai.summary}</p>
             {ai.bullet_points && ai.bullet_points.length > 0 && (
-              <ul className="text-sm space-y-1 list-disc list-inside text-at-text-secondary">
+              <ul className="text-[14px] md:text-sm space-y-1 list-disc list-inside text-at-text">
                 {ai.bullet_points.map((b, i) => <li key={i}>{b}</li>)}
               </ul>
             )}
-            <p className="text-xs text-at-text-secondary">
+            <p className="text-[13px] md:text-xs text-at-text-secondary">
               생성: {new Date(ai.generated_at).toLocaleString('ko-KR')} {ai.cached && '(캐시)'}
             </p>
           </div>
         ) : (
-          <p className="text-sm text-at-text-secondary">버튼을 눌러 AI 권리분석을 받아보세요. 결과는 24시간 캐싱됩니다.</p>
+          <p className="text-[14px] md:text-sm text-at-text-secondary">버튼을 눌러 AI 권리분석을 받아보세요. 결과는 24시간 캐싱됩니다.</p>
         )}
 
-        <p className="text-xs text-at-text-secondary mt-4">
+        <p className="text-[13px] md:text-xs text-at-text-secondary mt-4 leading-relaxed">
           ※ AI 코멘트는 보조 자료입니다. 최종 투자 판단의 책임은 사용자에게 있으며, 등기부등본 원본을 반드시 확인하세요.
         </p>
       </section>
@@ -130,4 +130,4 @@ export function RightsTab({ itemId, rights, initialAi }: Props) {
 }
 
 const Dt = (p: { children: React.ReactNode }) => <dt className="text-at-text-secondary">{p.children}</dt>
-const Dd = (p: { children: React.ReactNode; className?: string }) => <dd className={`font-medium ${p.className ?? ''}`}>{p.children}</dd>
+const Dd = (p: { children: React.ReactNode; className?: string }) => <dd className={`font-semibold text-at-text break-words ${p.className ?? ''}`}>{p.children}</dd>

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/SimulatorTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/SimulatorTab.tsx
@@ -40,8 +40,8 @@ export function SimulatorTab({ item, market, initialInput, onSave }: Props) {
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-      <div className="bg-at-surface rounded-2xl p-5 border border-at-border space-y-5">
-        <h3 className="font-semibold">입찰 시뮬레이션 입력</h3>
+      <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border space-y-5">
+        <h3 className="text-base font-semibold text-at-text">입찰 시뮬레이션 입력</h3>
 
         <Slider label="응찰가" value={input.bid_price} min={min} max={max} step={100_000} format={(n) => `${fmt(n)}원`} onChange={(v) => set('bid_price', v)} />
         <Slider label="예상 월세" value={input.monthly_rent} min={0} max={20_000_000} step={50_000} format={(n) => `${fmt(n)}원/월`} onChange={(v) => set('monthly_rent', v)} />
@@ -50,13 +50,13 @@ export function SimulatorTab({ item, market, initialInput, onSave }: Props) {
         <Slider label="수리비" value={input.repair_cost} min={0} max={200_000_000} step={1_000_000} format={(n) => `${fmt(n)}원`} onChange={(v) => set('repair_cost', v)} />
         <Slider label="체납 관리비/세금" value={input.unpaid_dues} min={0} max={50_000_000} step={100_000} format={(n) => `${fmt(n)}원`} onChange={(v) => set('unpaid_dues', v)} />
 
-        <label className="flex items-center gap-2 text-sm">
+        <label className="flex items-center gap-2 text-[14px] md:text-sm text-at-text">
           <input type="checkbox" checked={input.is_multi_owner} onChange={(e) => set('is_multi_owner', e.target.checked)} />
           다주택자 (취득세 12% 적용)
         </label>
 
         {onSave && (
-          <button onClick={() => onSave(input)} className="w-full py-2 rounded-xl bg-at-accent text-white font-medium">
+          <button onClick={() => onSave(input)} className="w-full py-2.5 rounded-xl bg-at-accent text-white font-semibold">
             관심물건에 저장
           </button>
         )}
@@ -64,17 +64,17 @@ export function SimulatorTab({ item, market, initialInput, onSave }: Props) {
 
       <div className="space-y-4">
         {secondary && (
-          <div className="bg-at-surface rounded-2xl p-5 border border-at-border">
-            <h3 className="font-semibold mb-3">매도 시뮬 (시세 기반)</h3>
+          <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+            <h3 className="text-base font-semibold mb-3 text-at-text">매도 시뮬 (시세 기반)</h3>
             <Result label="예상 시세" value={`${fmt(secondary.expected_market_price)}원`} />
             <Result label="예상 매도차익" value={`${fmt(secondary.expected_resale_profit)}원`} accent={secondary.expected_resale_profit > 0 ? 'emerald' : 'rose'} />
             <Result label="단순 수익률" value={`${secondary.simple_roi_pct.toFixed(2)}%`} accent={secondary.simple_roi_pct > 0 ? 'emerald' : 'rose'} />
-            <p className="text-xs text-at-text-secondary mt-2">시세 매칭 신뢰도: {secondary.match_confidence}</p>
+            <p className="text-[13px] md:text-xs text-at-text-secondary mt-2">시세 매칭 신뢰도: {secondary.match_confidence}</p>
           </div>
         )}
 
-        <div className="bg-at-surface rounded-2xl p-5 border border-at-border">
-          <h3 className="font-semibold mb-3">임대 시뮬</h3>
+        <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+          <h3 className="text-base font-semibold mb-3 text-at-text">임대 시뮬</h3>
           <Result label="총 투자비용" value={`${fmt(tertiary.total_investment)}원`} />
           <Result label="연 순임대수익" value={`${fmt(tertiary.annual_net_rent)}원`} />
           <Result label="임대수익률" value={`${tertiary.rental_yield_pct.toFixed(2)}%`} accent={tertiary.rental_yield_pct > 0 ? 'emerald' : 'rose'} />
@@ -103,9 +103,9 @@ interface SliderProps {
 function Slider({ label, value, min, max, step, format, onChange }: SliderProps) {
   return (
     <div>
-      <div className="flex justify-between items-baseline mb-1">
-        <label className="text-sm font-medium">{label}</label>
-        <span className="text-sm tabular-nums">{format(value)}</span>
+      <div className="flex justify-between items-baseline mb-1.5 gap-2">
+        <label className="text-[14px] md:text-sm font-semibold text-at-text">{label}</label>
+        <span className="text-[14px] md:text-sm tabular-nums font-semibold text-at-text">{format(value)}</span>
       </div>
       <input type="range" min={min} max={max} step={step} value={value} onChange={(e) => onChange(Number(e.target.value))} className="w-full" />
     </div>
@@ -113,12 +113,12 @@ function Slider({ label, value, min, max, step, format, onChange }: SliderProps)
 }
 
 function Result({ label, value, accent }: { label: string; value: string; accent?: 'emerald'|'rose' }) {
-  const cls = accent === 'emerald' ? 'text-emerald-600 font-semibold'
-            : accent === 'rose' ? 'text-rose-600 font-semibold'
-            : 'font-medium'
+  const cls = accent === 'emerald' ? 'text-emerald-600 font-bold'
+            : accent === 'rose' ? 'text-rose-600 font-bold'
+            : 'text-at-text font-semibold'
   return (
-    <div className="flex justify-between items-baseline py-1.5 border-b border-at-border last:border-b-0">
-      <span className="text-sm text-at-text-secondary">{label}</span>
+    <div className="flex justify-between items-baseline py-2 border-b border-at-border last:border-b-0 gap-2">
+      <span className="text-[14px] md:text-sm text-at-text-secondary">{label}</span>
       <span className={`text-base tabular-nums ${cls}`}>{value}</span>
     </div>
   )


### PR DESCRIPTION
## Summary
부동산 경매 상세 페이지(`/investment/auction/[itemId]`)에서 모바일에 글씨가 잘 안 보이던 문제를 해결.

## 변경
- 본문 글씨 12-14px → 14-15px (모바일만, md 이상은 기존 유지)
- 옅던 `text-at-text-secondary` 값들 → 진한 `text-at-text` + `font-semibold/bold`
- **HistoryTab**: 6컬럼 가로 테이블이 모바일에서 짜부라지던 문제 → 모바일은 카드 리스트, 데스크톱은 테이블 유지
- 탭 네비게이션 글씨 14→15px + `font-semibold`, 가로 스크롤 영역 확장
- 헤더 Field 값에 `font-semibold` + `tabular-nums` 일관 적용
- AI 위험도 바 두께 살짝 키움(2→2.5px), 점수 굵게

## Test plan
- [x] 빌드 통과
- [ ] 모바일에서 5개 탭(개요/시뮬레이터/권리분석/이력·통계/첨부) 모두 글씨 확실히 보이는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)