### PR TITLE
feat(auction-worker): 수집 범위 5배 확장 — pageSize 10→50 + 윈도우 분할

### DIFF
--- a/dental-clinic-manager/scraping-worker/auction/src/scrapers/courtAuctionListScraper.ts
+++ b/dental-clinic-manager/scraping-worker/auction/src/scrapers/courtAuctionListScraper.ts
@@ -19,8 +19,16 @@ const SEARCH_API = '/pgj/pgjsearch/searchControllerMain.on'
 const COURT_LIST_API = '/pgj/pgj002/selectCortOfcLst.on'
 
 const THROTTLE_MS = Number(process.env.SCRAPE_THROTTLE_MS ?? 500)
-const PAGE_SIZE = 10  // 서버가 더 큰 값은 거부함 (보안/성능 제한)
-const MAX_PAGES = Number(process.env.SCRAPE_MAX_LIST_PAGES ?? 200)
+// 서버가 pageSize 100 이상은 400 에러로 거부. 50 까지는 안정적.
+// pageSize 10 시절에는 서버 페이지네이션이 1법원당 20페이지(=200건)에서 절단되었음 →
+// 50 으로 키우면 같은 20페이지 한도 안에서 최대 1000건을 가져올 수 있다.
+const PAGE_SIZE = 50
+// 안전상 페이지 상한 (서버가 1법원당 20페이지 정도에서 빈 결과를 반환함)
+const MAX_PAGES = Number(process.env.SCRAPE_MAX_LIST_PAGES ?? 40)
+// 매각기일 검색 윈도우 — 1법원·1윈도우당 최대 1000건 한도를 회피하기 위해
+// 60일을 더 작은 윈도우로 쪼개서 여러 번 호출하고 dailyScrape 의 dedupe 에 위임한다.
+const WINDOW_DAYS = Number(process.env.SCRAPE_WINDOW_DAYS ?? 20)
+const TOTAL_DAYS = Number(process.env.SCRAPE_TOTAL_DAYS ?? 60)
 
 interface CortOfc {
   code: string  // e.g. 'B000210'
@@ -126,12 +134,20 @@ function toScrapedListItem(it: ApiItem): ScrapedListItem | null {
   }
 }
 
-function defaultBidRange(): { bgn: string; end: string } {
+const fmtYmd = (d: Date) =>
+  `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`
+
+// TOTAL_DAYS 를 WINDOW_DAYS 단위로 쪼갠 검색 윈도우들.
+// 사이트가 (법원, 검색조건) 조합당 최대 1000건만 응답하므로 큰 법원을 위해 필요.
+function buildBidWindows(): Array<{ bgn: string; end: string }> {
   const today = new Date()
-  const end = new Date(today)
-  end.setDate(today.getDate() + 60)
-  const fmt = (d: Date) => `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`
-  return { bgn: fmt(today), end: fmt(end) }
+  const windows: Array<{ bgn: string; end: string }> = []
+  for (let off = 0; off < TOTAL_DAYS; off += WINDOW_DAYS) {
+    const bgn = new Date(today); bgn.setDate(today.getDate() + off)
+    const end = new Date(today); end.setDate(today.getDate() + Math.min(off + WINDOW_DAYS - 1, TOTAL_DAYS))
+    windows.push({ bgn: fmtYmd(bgn), end: fmtYmd(end) })
+  }
+  return windows
 }
 
 function buildSearchPayload(opts: { cortOfcCd: string; bidBgngYmd: string; bidEndYmd: string; pageNo: number; pageSize: number }) {
@@ -206,8 +222,8 @@ function extractItems(j: SearchResp): ApiItem[] {
 function sleep(ms: number) { return new Promise((r) => setTimeout(r, ms)) }
 
 export async function scrapeAllLists(): Promise<ScrapedListItem[]> {
-  const range = defaultBidRange()
-  log.info('list_scrape_begin', { bidBgngYmd: range.bgn, bidEndYmd: range.end })
+  const windows = buildBidWindows()
+  log.info('list_scrape_begin', { windowCount: windows.length, windows })
 
   const browser = await chromium.launch({ headless: process.env.PLAYWRIGHT_HEADLESS !== 'false' })
   const ctx = await browser.newContext({
@@ -227,39 +243,43 @@ export async function scrapeAllLists(): Promise<ScrapedListItem[]> {
     log.info('court_list_fetched', { count: courts.length })
 
     for (const c of courts) {
-      let pageNo = 1
       const beforeCount = all.length
-      while (pageNo <= MAX_PAGES) {
-        let resp: SearchResp
-        try {
-          resp = await callApi<SearchResp>(page, SEARCH_API, buildSearchPayload({
-            cortOfcCd: c.code,
-            bidBgngYmd: range.bgn,
-            bidEndYmd: range.end,
-            pageNo,
-            pageSize: PAGE_SIZE,
-          }), SUBMISSION_ID_SEARCH)
-        } catch (e) {
-          log.warn('court_page_failed', { court: c.name, pageNo, error: String(e) })
-          break
+      for (const w of windows) {
+        let pageNo = 1
+        const windowStart = all.length
+        while (pageNo <= MAX_PAGES) {
+          let resp: SearchResp
+          try {
+            resp = await callApi<SearchResp>(page, SEARCH_API, buildSearchPayload({
+              cortOfcCd: c.code,
+              bidBgngYmd: w.bgn,
+              bidEndYmd: w.end,
+              pageNo,
+              pageSize: PAGE_SIZE,
+            }), SUBMISSION_ID_SEARCH)
+          } catch (e) {
+            log.warn('court_page_failed', { court: c.name, window: w, pageNo, error: String(e) })
+            break
+          }
+
+          const items = extractItems(resp)
+          if (items.length === 0) break
+
+          for (const it of items) {
+            const m = toScrapedListItem(it)
+            if (m) all.push(m)
+          }
+
+          const total = Number(resp?.data?.dma_pageInfo?.totalCnt ?? 0)
+          // 이번 윈도우에서 모은 raw item 수 ≥ totalCnt 이거나 한 페이지가 PAGE_SIZE 미만이면 종료
+          if (items.length < PAGE_SIZE || (total > 0 && all.length - windowStart >= total)) break
+
+          pageNo++
+          await sleep(THROTTLE_MS)
         }
-
-        const items = extractItems(resp)
-        if (items.length === 0) break
-
-        for (const it of items) {
-          const m = toScrapedListItem(it)
-          if (m) all.push(m)
-        }
-
-        const total = Number(resp?.data?.dma_pageInfo?.totalCnt ?? 0)
-        if (items.length < PAGE_SIZE || (total > 0 && all.length - beforeCount >= total)) break
-
-        pageNo++
         await sleep(THROTTLE_MS)
       }
       log.info('court_scraped', { court: c.name, count: all.length - beforeCount })
-      await sleep(THROTTLE_MS)
     }
   } finally {
     await browser.close()


### PR DESCRIPTION
## 문제
- courtauction.go.kr 가 (법원, 검색조건)당 **최대 1000건** 만 응답.
- 기존 PAGE_SIZE=10 + 20페이지 = 200건에서 절단되어, **서울중앙(454건), 서울남부(896건) 등 큰 법원 매물 대부분 누락**.
- 결과: 서울 5개 법원 합쳐 DB에 129건만 적재되어 있었음.

## 수정
- **PAGE_SIZE 10 → 50**: 동일 20페이지 한도 안에서 최대 1000건 수집 가능 (사이트 검증: pageSize 100 이상은 400 에러, 50까지 안정)
- **MAX_PAGES 200 → 40**: 실제 한도(50×20=1000)에 맞춤
- **매각기일 윈도우 분할**: 60일 단일 → 20일 × 3 윈도우 순회. 한 법원이 1000건 넘는 경우의 안전망. dailyScrape 의 기존 dedupe 가 중복 자동 제거
- 환경변수로 조정 가능: `SCRAPE_WINDOW_DAYS`(기본 20), `SCRAPE_TOTAL_DAYS`(기본 60)

## 검증
- 서울 5개 법원 시험 결과: **129건 → 2,410건** (약 19배)
- 서울남부 첫 윈도우 totalCnt=896 / 가져온 매물 896 — 한도 내 전부 수집 확인

## 적용
- 워커 코드만 변경 (Vercel 무관)
- 다음 03:00 KST cron 실행부터 적용. Mac mini 에서 `npm run build && npm run dev:daily` 수동 실행도 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)