### PR TITLE
fix(marketing): OpenAI 빌링 한도 에러를 사용자 친화적 메시지로 변환

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778845462664'
+const SW_VERSION = 'v1778847622861'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/lib/marketing/image-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/image-generator.ts
@@ -612,6 +612,12 @@ async function generateImageWithOpenAI(
         type: err?.type,
         message: err?.message || err?.error?.message,
       });
+      // billing 한도 에러는 모든 모델에서 동일하게 발생하므로 폴백 의미 없음 → 즉시 친절한 메시지로 throw.
+      const code = (err?.code || '').toLowerCase();
+      const msgBlob = `${err?.message || ''} ${err?.error?.message || ''}`.toLowerCase();
+      if (code.includes('billing') || code.includes('insufficient_quota') || msgBlob.includes('billing') || msgBlob.includes('hard limit')) {
+        throw new Error('OpenAI 결제 한도에 도달했습니다. OpenAI 대시보드에서 사용 한도를 늘리거나 결제 정보를 확인해주세요.');
+      }
       // 모델 액세스/호환 문제면 다음 모델로 폴백. 그 외 에러(rate limit, content policy 등)는 즉시 throw.
       if (i < OPENAI_IMAGE_MODEL_CHAIN.length - 1 && isModelAccessIssue(err)) {
         continue;


### PR DESCRIPTION
## Summary

production에서 OpenAI 이미지 생성이 실패한 진짜 원인을 추적한 결과:

```
status: 400
code: billing_hard_limit_reached
type: billing_limit_user_error
message: Billing hard limit has been reached.
```

**OpenAI 계정의 사용량 한도(hard limit)에 도달**해서 모든 gpt-image-* 모델 (gpt-image-2 / 1.5 / 1 / 1-mini) 호출이 동일하게 거부되고 있었습니다. 모델 호환 문제가 아니라 결제 설정 문제.

## 변경

- `billing` / `insufficient_quota` / `hard limit` 키워드 매칭 시 사용자 친화적 한국어 메시지로 즉시 throw
- 모든 폴백 모델이 같은 빌링 에러로 실패하므로 폴백 시도 의미 없음 → 즉시 중단
- SSE 스트림을 통해 결과 카드 에러 영역에 노출

## 운영 조치 (사용자)
- OpenAI 대시보드 → Settings → Limits에서 monthly hard limit 증액
- 또는 결제 정보 갱신/확인

## Test plan
- [x] 직접 API 호출 테스트로 root cause 확인 (billing_hard_limit_reached)
- [x] 빌드 통과
- [ ] 빌링 한도 해소 후 production AI 글 생성 시 이미지 정상 렌더링 재검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)