### PR TITLE
fix(marketing): 목표 글자수 숫자 직접 입력 가능하도록 수정

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778847622861'
+const SW_VERSION = 'v1778851331739'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
@@ -112,6 +112,10 @@ export default function NewMarketingPostPage() {
   })
   const [imageCount, setImageCount] = useState(3)
   const [targetWordCount, setTargetWordCount] = useState<number>(1500)
+  // 숫자 input 의 raw 입력 버퍼 — typing 중에는 clamp 하지 않고 string 그대로 유지하다 blur 시 검증·clamp.
+  // (이전: onChange 에서 즉시 clamp 되어 사용자가 "2500" 타이핑 시 첫 키 "2" 가 강제 변환되어 입력 불가)
+  const [targetWordCountInput, setTargetWordCountInput] = useState<string>('1500')
+  useEffect(() => { setTargetWordCountInput(String(targetWordCount)) }, [targetWordCount])
   const [useSeoAnalysis, setUseSeoAnalysis] = useState(true)
   const [brandImageOptions, setBrandImageOptions] = useState<BrandImageOptions>({
     medicalLaw: { enabled: true, positions: ['top'] },
@@ -725,11 +729,18 @@ export default function NewMarketingPostPage() {
                 min={1000}
                 max={dynamicWordMax}
                 step={100}
-                value={targetWordCount}
-                onChange={(e) => {
-                  const v = Number(e.target.value)
-                  if (Number.isFinite(v)) setTargetWordCount(Math.max(500, Math.min(dynamicWordMax, v)))
+                value={targetWordCountInput}
+                onChange={(e) => setTargetWordCountInput(e.target.value)}
+                onBlur={() => {
+                  const v = Number(targetWordCountInput)
+                  if (!Number.isFinite(v) || v <= 0) {
+                    setTargetWordCountInput(String(targetWordCount))
+                    return
+                  }
+                  const clamped = Math.max(1000, Math.min(dynamicWordMax, Math.round(v / 100) * 100))
+                  setTargetWordCount(clamped)
                 }}
+                onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
                 disabled={isFormDisabled}
                 className="w-24 px-2 py-1.5 border border-at-border rounded-lg text-sm focus:ring-2 focus:ring-at-accent focus:border-at-accent disabled:bg-at-surface-alt"
               />

--- a/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
+++ b/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
@@ -115,6 +115,10 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
   const [imageVisualStyle, setImageVisualStyle] = useState<ImageVisualStyle>('realistic')
   const [imageCount, setImageCount] = useState(3)
   const [targetWordCount, setTargetWordCount] = useState<number>(1500)
+  // 숫자 input 의 raw 입력 버퍼 — typing 중에는 clamp 하지 않고 string 그대로 유지하다 blur 시 검증·clamp.
+  // (이전: onChange 에서 즉시 Math.max(500, ...) clamp 가 적용되어 사용자가 "2500" 타이핑 시 첫 키 "2" 가 500 으로 강제되어 입력 불가)
+  const [targetWordCountInput, setTargetWordCountInput] = useState<string>('1500')
+  useEffect(() => { setTargetWordCountInput(String(targetWordCount)) }, [targetWordCount])
   // ── SEO 분석 미리보기 ──
   const seoPreview = useSeoPreview()
   // 키워드 mismatch 가드: 입력 키워드와 분석된 키워드가 일치할 때만 결과 표시 (이전 분석 잔존 방지)
@@ -904,11 +908,18 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
                   min={1000}
                   max={dynamicWordMax}
                   step={100}
-                  value={targetWordCount}
-                  onChange={(e) => {
-                    const v = Number(e.target.value)
-                    if (Number.isFinite(v)) setTargetWordCount(Math.max(500, Math.min(dynamicWordMax, v)))
+                  value={targetWordCountInput}
+                  onChange={(e) => setTargetWordCountInput(e.target.value)}
+                  onBlur={() => {
+                    const v = Number(targetWordCountInput)
+                    if (!Number.isFinite(v) || v <= 0) {
+                      setTargetWordCountInput(String(targetWordCount))
+                      return
+                    }
+                    const clamped = Math.max(1000, Math.min(dynamicWordMax, Math.round(v / 100) * 100))
+                    setTargetWordCount(clamped)
                   }}
+                  onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
                   className="w-24 px-2 py-1.5 border border-at-border rounded-lg text-sm focus:ring-2 focus:ring-at-accent focus:border-at-accent"
                 />
                 <span className="text-xs text-at-text-weak">자</span>


### PR DESCRIPTION
## Summary

AI 글쓰기 폼의 목표 글자수가 슬라이더로만 조정 가능하고 숫자 input 직접 입력이 막히던 문제 수정.

### 원인
`number` input 의 `onChange` 가 매 키스트로크마다 `Math.max(500, Math.min(dynamicWordMax, v))` 로 즉시 clamp. 사용자가 "2500" 타이핑 시 첫 키 "2" → `max(500, 2) = 500` 으로 강제 → state 가 500 에 고정되어 더 이상 타이핑 불가.

### 해결
typing 중에는 raw string 버퍼(`targetWordCountInput`)에만 보관, blur 또는 Enter 시 검증·clamp 후 number state 에 반영. slider 는 number state 를 그대로 사용하므로 영향 없음.

### 영향 범위
- `src/components/marketing/NewPostForm.tsx` (마케팅 자동화 → AI 글쓰기 탭)
- `src/app/dashboard/marketing/posts/new/page.tsx` (새 글 작성 페이지)

## Test plan
- [x] 빌드 통과
- [ ] AI 글쓰기 탭에서 글자수 input 에 "2500" 직접 입력 가능 확인
- [ ] 범위 밖 값(예: 50, 99999) 입력 후 blur 시 1000~dynamicMax 로 clamp 확인
- [ ] Enter 키로도 blur 동작 확인
- [ ] 슬라이더 조작은 이전과 동일하게 정상 작동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)