### PR TITLE
feat(marketing): AI 글 본문 구조화 — TOC·콜아웃·FAQ·단계·짧은 문단

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778851331739'
+const SW_VERSION = 'v1778853472690'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/components/marketing/ContentEditor.tsx
+++ b/dental-clinic-manager/src/components/marketing/ContentEditor.tsx
@@ -129,8 +129,13 @@ function markdownToHtml(
   const formatInline = (text: string) =>
     escapeHtml(text).replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
 
-  for (const line of lines) {
+  let skipUntilIndex: number | null = null
+  for (let li = 0; li < lines.length; li++) {
+    const line = lines[li]
     const trimmed = line.trim()
+
+    if (skipUntilIndex !== null && li < skipUntilIndex) continue
+    if (skipUntilIndex !== null && li >= skipUntilIndex) skipUntilIndex = null
 
     if (!trimmed) {
       closeList()
@@ -175,6 +180,32 @@ function markdownToHtml(
     if (trimmed.startsWith('## ')) {
       closeList()
       htmlParts.push(`<h2>${formatInline(trimmed.slice(3))}</h2>`)
+      continue
+    }
+
+    // blockquote 콜아웃 (TIP / 주의 / 핵심)
+    if (trimmed.startsWith('> ')) {
+      closeList()
+      const calloutLines: string[] = [trimmed.replace(/^>\s+/, '')]
+      let k = li + 1
+      while (k < lines.length && lines[k].trim().startsWith('> ')) {
+        calloutLines.push(lines[k].trim().replace(/^>\s+/, ''))
+        k++
+      }
+      const first = calloutLines[0] || ''
+      const isWarn = first.includes('⚠️') || first.includes('주의')
+      const isTip = first.includes('💡')
+      const bg = isWarn ? '#fff7ed' : isTip ? '#ecfdf5' : '#eff6ff'
+      const border = isWarn ? '#f59e0b' : isTip ? '#10b981' : '#3b82f6'
+      const inner = calloutLines.map((q) => {
+        const isBullet = /^[-*]\s+/.test(q)
+        const text = isBullet ? q.replace(/^[-*]\s+/, '• ') : q
+        return `<p style="margin:4px 0;line-height:1.7;">${formatInline(text)}</p>`
+      }).join('')
+      htmlParts.push(
+        `<blockquote style="border-left:4px solid ${border};background:${bg};padding:12px 16px;margin:16px 0;border-radius:8px;">${inner}</blockquote>`
+      )
+      li = k - 1 // 다음 반복에서 quote 잔여 줄 모두 건너뜀
       continue
     }
 

--- a/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
+++ b/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
@@ -1532,6 +1532,40 @@ function RenderedBody({
       continue
     }
 
+    // blockquote 콜아웃 — 연속된 `> ...` 줄을 모아서 한 박스로 렌더
+    if (trimmed.startsWith('> ')) {
+      flushParagraph()
+      const calloutLines: string[] = []
+      let j = i
+      while (j < lines.length && lines[j].trim().startsWith('> ')) {
+        calloutLines.push(lines[j].trim().replace(/^>\s+/, ''))
+        j++
+      }
+      i = j - 1 // for-loop 가 다음 j 로 이동
+      // 첫 줄에 emoji 단서로 톤 결정 (TIP/주의/핵심)
+      const firstLine = calloutLines[0] || ''
+      const tone = firstLine.includes('⚠️') || firstLine.includes('주의')
+        ? { border: 'border-amber-300', bg: 'bg-amber-50', text: 'text-amber-900' }
+        : firstLine.includes('💡')
+          ? { border: 'border-emerald-300', bg: 'bg-emerald-50', text: 'text-emerald-900' }
+          : { border: 'border-blue-300', bg: 'bg-blue-50', text: 'text-blue-900' }
+      elements.push(
+        <div key={key++} className={`my-4 rounded-xl border ${tone.border} ${tone.bg} px-4 py-3`}>
+          {calloutLines.map((cl, idx) => {
+            const isBullet = /^[-*]\s+/.test(cl)
+            const content = isBullet ? cl.replace(/^[-*]\s+/, '') : cl
+            return (
+              <div key={idx} className={`text-sm leading-6 ${tone.text} ${isBullet ? 'flex gap-2 ml-1' : ''}`}>
+                {isBullet && <span className="mt-1 text-xs">•</span>}
+                <span className="flex-1">{renderInlineFormatting(content)}</span>
+              </div>
+            )
+          })}
+        </div>
+      )
+      continue
+    }
+
     if (trimmed.startsWith('## ')) {
       flushParagraph()
       elements.push(

--- a/dental-clinic-manager/src/lib/marketing/content-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/content-generator.ts
@@ -236,6 +236,37 @@ export async function generateContent(
     seoSection = `\n\n## SEO 키워드 분석 결과 (경쟁 글 기반)\n\n상위 노출 경쟁 글에서 추출된 핵심 키워드입니다. 아래 키워드들을 자연스럽게 본문에 포함해주세요.\n\n### 필수 포함 키워드 (본문에 각 2-3회 자연스럽게 배치):\n${top5.map(k => `- ${k.keyword} (경쟁 글에서 총 ${k.frequency}회, ${k.postCount}/5개 글에서 사용)`).join('\n')}\n\n${rest.length > 0 ? `### 권장 포함 키워드 (1-2회 자연스럽게 언급):\n${rest.map(k => `- ${k.keyword} (총 ${k.frequency}회, ${k.postCount}/5개 글)`).join('\n')}\n\n` : ''}### 경쟁 글 통계 (참고용):\n- 평균 본문 길이: ${seoKeywordData.avgBodyLength}자\n- 평균 이미지 수: ${seoKeywordData.avgImageCount}개\n- 평균 소제목 수: ${seoKeywordData.avgHeadingCount}개\n${seoKeywordData.commonTags.length > 0 ? `- 자주 사용되는 태그: ${seoKeywordData.commonTags.slice(0, 10).join(', ')}\n` : ''}\n### 키워드 배치 주의사항:\n- 키워드를 억지로 나열하지 말고 문맥에 맞게 자연스럽게 녹여주세요\n- 하나의 문단에 키워드를 몰아넣지 말고 글 전체에 고르게 분포시켜주세요\n- 키워드 밀도가 과도하면 스팸으로 분류될 수 있으니 주의하세요`;
   }
 
+  // 2-1. 글 구조 지침 (독자 가독성 ↑) — TOC, 핵심 요약, 콜아웃, 단계, FAQ, 짧은 문단
+  // 임상글은 환자 사례 흐름이 우선이라 일부 항목(FAQ 등)을 권장 수준으로 약화.
+  const isClinical = options.postType === 'clinical';
+  const structureInstruction = `\n\n## 글 구조 지침 (필수, 독자 가독성 ↑)\n` +
+    `독자가 모바일에서 빠르게 스캔하며 읽을 수 있는 구조로 작성하세요. 다음 6개 규칙을 모두 적용:\n\n` +
+    `### 1) 핵심 요약 콜아웃 (글 가장 처음)\n` +
+    `인사 문장(1문단) 직후, 본문 시작 전에 다음 blockquote 형식으로 "이 글의 핵심" 박스를 삽입:\n` +
+    `\`\`\`\n> 💡 **이 글의 핵심**\n> - 핵심 1 한 줄 요약\n> - 핵심 2 한 줄 요약\n> - 핵심 3 한 줄 요약\n\`\`\`\n` +
+    `핵심은 3~4개, 각 줄 30자 이내.\n\n` +
+    `### 2) 목차(TOC)\n` +
+    `핵심 요약 박스 직후에 다음 H2 섹션을 삽입:\n` +
+    `\`\`\`\n## 📋 이 글의 목차\n- (H2 소제목 1)\n- (H2 소제목 2)\n- (H2 소제목 3)\n...\n\`\`\`\n` +
+    `목차 항목은 본문 H2 소제목과 정확히 일치해야 합니다.\n\n` +
+    `### 3) 본문 중 TIP / 주의 콜아웃\n` +
+    `각 H2 섹션마다 최소 1개 콜아웃 권장. 다음 blockquote 형식 사용:\n` +
+    `\`\`\`\n> 💡 **TIP**: 한 문장 팁\n> ⚠️ **주의**: 한 문장 경고\n\`\`\`\n` +
+    `\n` +
+    `### 4) 단계별 절차 분리\n` +
+    `"방법", "절차", "순서", "단계" 류 설명은 반드시 번호 리스트로 분리:\n` +
+    `\`\`\`\n1. **1단계 — 액션 제목**: 짧은 액션 설명 (1문장)\n2. **2단계 — 액션 제목**: 짧은 액션 설명 (1문장)\n3. **3단계 — 액션 제목**: 짧은 액션 설명 (1문장)\n\`\`\`\n` +
+    `\n` +
+    `### 5) FAQ 섹션 (${isClinical ? '권장' : '필수'}, 글 마지막)\n` +
+    `글 마무리 직전에 다음 H2 섹션을 추가하고 3~5개의 Q&A 형식으로:\n` +
+    `\`\`\`\n## ❓ 자주 묻는 질문\n\n**Q1. (자주 받는 질문 한 줄)**\nA. (간결한 답변 2~3문장)\n\n**Q2. ...**\nA. ...\n\`\`\`\n` +
+    `\n` +
+    `### 6) 문단 길이 강제\n` +
+    `- 한 문단 최대 3문장. 한 문장이 길어지면 둘로 쪼개세요.\n` +
+    `- 한 문단 길이 200자 이내 권장.\n` +
+    `- 모바일 한 화면 가독성을 우선합니다.\n\n` +
+    `위 6가지 규칙을 모두 본문에 반영하세요. 단, [IMAGE:] 마커는 이미지 마커 지침을 따르고, 위 구조 요소(콜아웃·목차·FAQ)와 별개로 배치하세요.`;
+
   // 3. 변수 치환
   const systemPrompt = substituteVariables(promptTemplate, {
     keyword: options.keyword,
@@ -256,7 +287,7 @@ export async function generateContent(
       : '',
     // 공지글 변수
     ...options.notice?.templateData,
-  }) + imageStyleInstruction + seoSection + buildLengthInstruction(options.targetWordCount);
+  }) + imageStyleInstruction + seoSection + structureInstruction + buildLengthInstruction(options.targetWordCount);
 
   // 4. Claude API 호출 (임상 사진이 있으면 멀티모달)
   const callStart = Date.now();

--- a/dental-clinic-manager/src/lib/marketing/platform-adapters/naver-blog.ts
+++ b/dental-clinic-manager/src/lib/marketing/platform-adapters/naver-blog.ts
@@ -48,18 +48,54 @@ function plainToBlogHtml(body: string, images: GeneratedImageMeta[]): string {
   const lines = body.split('\n').map((l) => l.trim());
   const out: string[] = [];
   let bullets: string[] = [];
+  let quotes: string[] = [];
   let imageIdx = 0;
+
+  const renderInline = (s: string): string => {
+    // ** 굵게 ** 처리 + escape
+    const escaped = escapeHtml(s);
+    return escaped.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  };
 
   const flushBullets = () => {
     if (bullets.length === 0) return;
-    out.push(`<ul>${bullets.map((b) => `<li>${escapeHtml(b.replace(/^[-•*]\s*/, ''))}</li>`).join('')}</ul>`);
+    out.push(`<ul>${bullets.map((b) => `<li>${renderInline(b.replace(/^[-•*]\s*/, ''))}</li>`).join('')}</ul>`);
     bullets = [];
+  };
+
+  const flushQuotes = () => {
+    if (quotes.length === 0) return;
+    // 첫 줄 keyword 로 콜아웃 톤 결정 (TIP/주의/핵심)
+    const first = quotes[0] || '';
+    const isWarn = first.includes('⚠️') || first.includes('주의');
+    const isTip = first.includes('💡');
+    const bg = isWarn ? '#fff7ed' : isTip ? '#ecfdf5' : '#eff6ff';
+    const border = isWarn ? '#f59e0b' : isTip ? '#10b981' : '#3b82f6';
+    const inner = quotes.map((q) => {
+      const isBullet = /^[-*]\s+/.test(q);
+      const text = isBullet ? q.replace(/^[-*]\s+/, '• ') : q;
+      return `<p style="margin:4px 0;line-height:1.7;">${renderInline(text)}</p>`;
+    }).join('');
+    out.push(
+      `<blockquote style="border-left:4px solid ${border};background:${bg};padding:12px 16px;margin:16px 0;border-radius:8px;">${inner}</blockquote>`
+    );
+    quotes = [];
   };
 
   for (const line of lines) {
     if (!line) {
       flushBullets();
+      flushQuotes();
       continue;
+    }
+
+    // blockquote 콜아웃 — `> ` 로 시작하는 연속 줄
+    if (line.startsWith('> ')) {
+      flushBullets();
+      quotes.push(line.replace(/^>\s+/, ''));
+      continue;
+    } else if (quotes.length > 0) {
+      flushQuotes();
     }
 
     // 이미지 마커 (예: [IMAGE] 또는 ![...])
@@ -88,9 +124,10 @@ function plainToBlogHtml(body: string, images: GeneratedImageMeta[]): string {
     }
 
     flushBullets();
-    out.push(`<p>${escapeHtml(line)}</p>`);
+    out.push(`<p>${renderInline(line)}</p>`);
   }
   flushBullets();
+  flushQuotes();
 
   // 남은 이미지가 있다면 본문 뒤에 첨부
   while (imageIdx < images.length) {


### PR DESCRIPTION
## Summary

독자가 모바일에서 빠르게 스캔하며 읽을 수 있도록 AI 글 본문 구조를 6가지 규칙으로 강제합니다.

## LLM 프롬프트 강화 (`content-generator.ts`)

1. **핵심 요약 콜아웃** — 글 가장 처음에 `> 💡 **이 글의 핵심**` blockquote 박스 (3~4줄)
2. **목차(TOC)** — 핵심 요약 직후 `## 📋 이 글의 목차` H2 + H2 소제목 목록
3. **TIP / 주의 콜아웃** — 각 H2 섹션마다 `> 💡 **TIP**: …` 또는 `> ⚠️ **주의**: …` 권장
4. **단계별 절차** — 절차류는 번호 리스트로 `1. **1단계 — 액션 제목**: 설명` 형식
5. **FAQ 섹션** — 글 마지막에 `## ❓ 자주 묻는 질문` H2 + 3~5개 Q&A (임상글은 권장)
6. **문단 길이 강제** — 한 문단 최대 3문장 / 200자 이내 (모바일 가독성)

## 렌더링 (`NewPostForm.tsx`, `ContentEditor.tsx`, `naver-blog.ts`)

- blockquote(`> `) 연속 줄을 한 콜아웃 박스로 통합
- 첫 줄 이모지(💡 / ⚠️) 기반 톤 자동 결정 — 💡 emerald, ⚠️ amber, 그 외 blue
- 콜아웃 내 `-` / `*` 불릿 처리
- naver-blog 어댑터: inline style 직접 박힌 `<blockquote>` 로 네이버 에디터에 발행

## Test plan
- [x] 빌드 통과
- [ ] production AI 글 생성 → 본문에 콜아웃 박스(이 글의 핵심·TIP·FAQ), TOC, 단계 리스트 정상 렌더링 확인
- [ ] 짧은 문단 강제(3문장 이내)가 LLM 출력에 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)