### PR TITLE
feat(auction): 목록 카드에 대표 이미지 영역 + 스크래퍼 강건화

### DIFF
--- a/dental-clinic-manager/scraping-worker/auction/src/jobs/dailyScrape.ts
+++ b/dental-clinic-manager/scraping-worker/auction/src/jobs/dailyScrape.ts
@@ -1,4 +1,13 @@
 import 'dotenv/config'
+// undici fetch 의 일시적 실패가 supabase-js 내부 마이크로태스크에서 unhandled rejection 으로
+// 빠져나오는 케이스가 있어 메인 catch 까지 도달하지 못하고 process 가 죽는다. 전역 핸들러로 흡수.
+process.on('unhandledRejection', (reason) => {
+  // 라이브러리 내부 일시 rejection — 무시하고 진행
+  console.error(JSON.stringify({ ts: new Date().toISOString(), level: 'warn', msg: 'unhandled_rejection', reason: String(reason) }))
+})
+process.on('uncaughtException', (err) => {
+  console.error(JSON.stringify({ ts: new Date().toISOString(), level: 'warn', msg: 'uncaught_exception', error: String(err) }))
+})
 import { scrapeAllLists } from '../scrapers/courtAuctionListScraper.js'
 import { scrapeDetails } from '../scrapers/courtAuctionDetailScraper.js'
 import { downloadPdf } from '../scrapers/pdfDownloader.js'

--- a/dental-clinic-manager/src/components/Investment/Auction/AuctionCard.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/AuctionCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 import Link from 'next/link'
-import { Star } from 'lucide-react'
-import type { AuctionItem, MarketPrice } from '@/types/auction'
+import { Star, Building2, Building, Home, Store, Mountain, Factory, Trees, MapPin } from 'lucide-react'
+import type { AuctionItem, MarketPrice, PropertyType } from '@/types/auction'
 import { calculatePrimary } from '@/lib/auction/roiCalculator'
 
 interface Props {
@@ -17,6 +17,19 @@ const PROPERTY_LABEL: Record<string, string> = {
   commercial: '상가', land: '토지', factory: '공장', forest: '임야', other: '기타'
 }
 
+// 용도별 placeholder 아이콘 + 그라데이션 — 실제 사진이 없을 때 시각적 차별화 제공
+const PROPERTY_VISUAL: Record<PropertyType, { icon: React.ElementType; gradient: string; iconColor: string }> = {
+  apt:        { icon: Building2, gradient: 'from-sky-100 to-sky-50',         iconColor: 'text-sky-600' },
+  officetel:  { icon: Building,  gradient: 'from-indigo-100 to-indigo-50',   iconColor: 'text-indigo-600' },
+  villa:      { icon: Home,      gradient: 'from-emerald-100 to-emerald-50', iconColor: 'text-emerald-600' },
+  house:      { icon: Home,      gradient: 'from-amber-100 to-amber-50',     iconColor: 'text-amber-700' },
+  commercial: { icon: Store,     gradient: 'from-rose-100 to-rose-50',       iconColor: 'text-rose-600' },
+  land:       { icon: Mountain,  gradient: 'from-lime-100 to-lime-50',       iconColor: 'text-lime-700' },
+  factory:    { icon: Factory,   gradient: 'from-slate-200 to-slate-100',    iconColor: 'text-slate-600' },
+  forest:     { icon: Trees,     gradient: 'from-green-100 to-green-50',     iconColor: 'text-green-700' },
+  other:      { icon: MapPin,    gradient: 'from-stone-200 to-stone-100',    iconColor: 'text-stone-600' },
+}
+
 const fmt = (n: number | null) => n === null ? '-' : new Intl.NumberFormat('ko-KR').format(n)
 
 export function AuctionCard({ item, isFavorite, onToggleFavorite, onClick }: Props) {
@@ -24,50 +37,83 @@ export function AuctionCard({ item, isFavorite, onToggleFavorite, onClick }: Pro
   const primary = calculatePrimary(item, today)
   const m = item.market
 
-  const innerClassName = 'block bg-at-surface border border-at-border rounded-2xl p-4 hover:bg-at-surface-hover transition-colors cursor-pointer'
+  const innerClassName = 'block bg-at-surface border border-at-border rounded-2xl overflow-hidden hover:bg-at-surface-hover transition-colors cursor-pointer'
+  const photoUrl = item.photos && item.photos.length > 0 ? item.photos[0] : null
+  const visual = PROPERTY_VISUAL[item.property_type] ?? PROPERTY_VISUAL.other
+  const PlaceholderIcon = visual.icon
 
   const innerContent = (
     <>
-      <div className="flex justify-between items-start mb-2">
-        <div className="text-sm text-at-text-secondary">
-          {PROPERTY_LABEL[item.property_type] ?? '기타'} · {item.sido} {item.sigungu} {item.eupmyeondong}
-          {item.building_area_m2 ? ` · ${item.building_area_m2}㎡` : ''}
-        </div>
+      {/* 대표 이미지 영역 — 실제 사진이 있으면 표시, 없으면 용도별 placeholder */}
+      <div className="relative w-full aspect-[16/9] bg-at-surface-alt">
+        {photoUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={photoUrl}
+            alt={`${PROPERTY_LABEL[item.property_type] ?? '경매물건'} ${item.sigungu ?? ''}`}
+            loading="lazy"
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className={`w-full h-full bg-gradient-to-br ${visual.gradient} flex flex-col items-center justify-center`}>
+            <PlaceholderIcon className={`w-12 h-12 ${visual.iconColor} mb-2`} strokeWidth={1.5} />
+            <span className={`text-xs font-medium ${visual.iconColor}`}>
+              {PROPERTY_LABEL[item.property_type] ?? '기타'}
+            </span>
+          </div>
+        )}
+        {/* 우상단 좋아요 — 이미지 위에 띄움 */}
         <button
           onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleFavorite(item.id) }}
           aria-label="관심물건 토글"
-          className="p-1.5 rounded-lg hover:bg-at-accent-light"
+          className="absolute top-2 right-2 p-1.5 rounded-full bg-white/90 backdrop-blur-sm shadow hover:bg-white"
         >
           <Star className={`w-4 h-4 ${isFavorite ? 'fill-yellow-400 text-yellow-400' : 'text-at-text-secondary'}`} />
         </button>
-      </div>
-
-      <div className="text-xs text-at-text-secondary mb-3">
-        {item.case_number} · {item.court_name}
-      </div>
-
-      <div className="grid grid-cols-2 gap-y-1 text-sm">
-        <div>감정가</div>
-        <div className="text-right">{fmt(item.appraisal_price)}원</div>
-        <div>최저가</div>
-        <div className="text-right font-medium">{fmt(item.min_bid_price)}원</div>
-        <div>할인율</div>
-        <div className="text-right text-emerald-600">-{primary.discount_rate_pct.toFixed(1)}%</div>
-      </div>
-
-      <div className="flex items-center gap-2 mt-3 flex-wrap text-xs">
-        {m?.match_confidence === 'high' && m.median_price_3m && (
-          <span className="px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700">
-            시세 대비 -{Math.round((m.median_price_3m - item.min_bid_price) / m.median_price_3m * 100)}%
+        {/* 좌상단 용도 배지 (사진이 있을 때만 — placeholder 에는 이미 라벨 있음) */}
+        {photoUrl && (
+          <span className="absolute top-2 left-2 px-2 py-0.5 rounded-full bg-white/90 backdrop-blur-sm text-[11px] font-semibold text-at-text">
+            {PROPERTY_LABEL[item.property_type] ?? '기타'}
           </span>
         )}
-        <span className="px-2 py-0.5 rounded-full bg-at-surface-alt">유찰 {primary.failure_count}회</span>
+        {/* 좌하단 D-day */}
         {primary.d_day !== null && (
-          <span className="px-2 py-0.5 rounded-full bg-amber-50 text-amber-700">D-{primary.d_day}</span>
+          <span className="absolute bottom-2 left-2 px-2 py-0.5 rounded-full bg-amber-500 text-white text-[11px] font-bold shadow">
+            D-{primary.d_day}
+          </span>
         )}
-        {primary.price_per_m2 && (
-          <span className="px-2 py-0.5 rounded-full bg-at-surface-alt">㎡당 {fmt(primary.price_per_m2)}원</span>
-        )}
+      </div>
+
+      <div className="p-4">
+        <div className="text-sm text-at-text-secondary mb-1">
+          {item.sido} {item.sigungu} {item.eupmyeondong}
+          {item.building_area_m2 ? ` · ${item.building_area_m2}㎡` : ''}
+        </div>
+
+        <div className="text-xs text-at-text-secondary mb-3">
+          {item.case_number} · {item.court_name}
+        </div>
+
+        <div className="grid grid-cols-2 gap-y-1 text-sm">
+          <div>감정가</div>
+          <div className="text-right">{fmt(item.appraisal_price)}원</div>
+          <div>최저가</div>
+          <div className="text-right font-medium">{fmt(item.min_bid_price)}원</div>
+          <div>할인율</div>
+          <div className="text-right text-emerald-600 font-semibold">-{primary.discount_rate_pct.toFixed(1)}%</div>
+        </div>
+
+        <div className="flex items-center gap-2 mt-3 flex-wrap text-xs">
+          {m?.match_confidence === 'high' && m.median_price_3m && (
+            <span className="px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700">
+              시세 대비 -{Math.round((m.median_price_3m - item.min_bid_price) / m.median_price_3m * 100)}%
+            </span>
+          )}
+          <span className="px-2 py-0.5 rounded-full bg-at-surface-alt">유찰 {primary.failure_count}회</span>
+          {primary.price_per_m2 && (
+            <span className="px-2 py-0.5 rounded-full bg-at-surface-alt">㎡당 {fmt(primary.price_per_m2)}원</span>
+          )}
+        </div>
       </div>
     </>
   )


### PR DESCRIPTION
## UI 변경 (AuctionCard)
- 카드 상단에 16:9 이미지 영역 추가
  - `photos[0]` 가 있으면 실제 사진 표시 (`loading="lazy"`, `object-cover`)
  - 없으면 **용도별 그라데이션 placeholder** + lucide 아이콘 (아파트→sky/Building2, 토지→lime/Mountain, 상가→rose/Store, 임야→green/Trees 등)
- 좋아요 버튼을 이미지 우상단으로 이동 (`white/90 backdrop-blur`)
- D-day 배지를 이미지 좌하단으로 이동 (`amber-500` 강조)
- 본문에서 중복 용도 prefix 와 D-day 배지 제거

## 스크래퍼 강건화
- 전역 `unhandledRejection`/`uncaughtException` 핸들러 추가
- undici fetch 일시 실패가 supabase-js 마이크로태스크로 빠져나가 메인 catch 에 도달 못 하던 케이스를 흡수해 프로세스가 안 죽음

## 후속 작업
- 실제 사진(`photos`) backfill 은 별개. courtauction.go.kr SPA 의 detail API 호출이 필요하며, 추후 스크래퍼 확장 PR 에서 진행.
- 그때까지는 placeholder 가 노출되어 시각적 차별화 + 카드 톤 통일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)