### PR TITLE
fix(auction-worker): list 후 supabase 클라이언트 재생성 — fetch failed 근본 해결

### DIFF
--- a/dental-clinic-manager/scraping-worker/auction/src/jobs/dailyScrape.ts
+++ b/dental-clinic-manager/scraping-worker/auction/src/jobs/dailyScrape.ts
@@ -15,7 +15,8 @@ import { extractRightsFromPdf } from '../parsers/rightsExtractor.js'
 import { fetchTrades, type MolitKind } from '../matchers/molitTradeClient.js'
 import { matchMarketPrice } from '../matchers/marketPriceMatcher.js'
 import { resolveLawdCdFromMap } from '../matchers/lawdCdMap.js'
-import { supabase } from '../lib/supabase.js'
+import { createSupabaseClient } from '../lib/supabase.js'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { log } from '../lib/logger.js'
 import { runDdayAlerts } from './ddayAlerts.js'
 import { runFilterMatchAlerts } from './filterMatchAlerts.js'
@@ -27,11 +28,13 @@ const KIND_MAP: Record<string, MolitKind | null> = {
 
 // Supabase 호출이 일시적 네트워크 오류(fetch failed, 502 등)로 throw 하는 경우에 대비해
 // 지수 backoff 재시도. 메인 루프가 1건 실패로 죽지 않도록 보호.
-async function retry<T>(fn: () => Promise<T>, label: string, attempts = 4): Promise<T | { __failed: true; error: string }> {
+async function retry<T>(fn: () => Promise<T> | PromiseLike<T>, label: string, attempts = 4): Promise<T | { __failed: true; error: string }> {
   let lastErr: unknown = null
   for (let i = 0; i < attempts; i++) {
     try {
-      return await fn()
+      // Promise.resolve 로 한번 더 wrap 하여 PostgrestBuilder thenable 의
+      // 마이크로태스크 분기가 unhandled rejection 으로 빠지는 경로를 막는다.
+      return await Promise.resolve(fn())
     } catch (e) {
       lastErr = e
       const wait = 500 * Math.pow(2, i)  // 500, 1000, 2000, 4000 ms
@@ -45,6 +48,8 @@ async function retry<T>(fn: () => Promise<T>, label: string, attempts = 4): Prom
 async function main() {
   const startedAt = new Date()
   log.info('daily_scrape_start', { startedAt: startedAt.toISOString() })
+
+  let supabase: SupabaseClient = createSupabaseClient()
 
   const listItems = await scrapeAllLists()
   if (listItems.length === 0) {
@@ -63,6 +68,11 @@ async function main() {
   }
   const details = Array.from(dedupeMap.values())
   log.info('dedupe_done', { before: detailsRaw.length, after: details.length })
+
+  // 8 분간 idle 한 HTTP keep-alive 가 죽어 첫 upsert 가 fetch failed 로 throw 되는 문제 해결:
+  // list/dedupe 직후에 클라이언트를 새로 생성하여 fresh connection pool 로 적재 시작.
+  supabase = createSupabaseClient()
+  log.info('supabase_client_refreshed')
 
   let okCount = 0
   let failCount = 0

--- a/dental-clinic-manager/scraping-worker/auction/src/lib/supabase.ts
+++ b/dental-clinic-manager/scraping-worker/auction/src/lib/supabase.ts
@@ -1,10 +1,14 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import 'dotenv/config'
 
 const url = process.env.SUPABASE_URL
 const key = process.env.SUPABASE_SERVICE_ROLE_KEY
 if (!url || !key) throw new Error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY missing')
 
-export const supabase = createClient(url, key, {
-  auth: { persistSession: false },
-})
+// HTTP keep-alive 연결이 장시간 idle 후 죽는 문제가 있어
+// 클라이언트를 재생성할 수 있도록 builder 를 export.
+export function createSupabaseClient(): SupabaseClient {
+  return createClient(url!, key!, { auth: { persistSession: false } })
+}
+
+export const supabase = createSupabaseClient()


### PR DESCRIPTION
## 원인 (확정)
- 8분간 list 스크래핑 중 idle 상태였던 supabase 클라이언트의 HTTP keep-alive 가 끊겨 첫 upsert 가 `TypeError: fetch failed` 로 throw
- PostgrestBuilder 의 thenable 체인이 마이크로태스크 분기를 만들어 retry 의 try/catch 가 잡지 못한 채 main().catch 로 빠짐
- 이전 PR 들에서 retry/전역 핸들러를 추가했으나 효과 없었던 이유: rejection 의 분기가 retry catch 범위 밖에서 발생

## 수정
- `lib/supabase.ts`: `createSupabaseClient()` 빌더 export (재생성 가능)
- `dailyScrape.ts`: list/dedupe 직후 supabase 클라이언트를 새로 생성 → fresh connection pool 로 적재 시작
- `retry`: `fn()` 결과를 `Promise.resolve` 로 감싸 PostgrestBuilder thenable 분기를 단일 Promise 로 정렬 → catch 로 잡히도록

🤖 Generated with [Claude Code](https://claude.com/claude-code)