### PR TITLE
feat(auction): 부동산 경매를 독립 최상위 탭으로 분리

### DIFF
--- a/dental-clinic-manager/src/app/dashboard/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/page.tsx
@@ -33,6 +33,7 @@ import AIChat from '@/components/AIAnalysis/AIChat'
 import PremiumGate from '@/components/Premium/PremiumGate'
 import TaskChecklistManagement from '@/components/TaskChecklist/TaskChecklistManagement'
 import InvestmentTab from '@/components/Investment/InvestmentTab'
+import AuctionContent from '@/components/Investment/Auction/AuctionContent'
 import { useSupabaseData } from '@/hooks/useSupabaseData'
 import { useUserNotifications } from '@/hooks/useUserNotifications'
 import { dataService } from '@/lib/dataService'
@@ -943,6 +944,15 @@ export default function DashboardPage() {
           {activeTab === 'investment' && (
             <PremiumGate featureId="investment">
               <InvestmentTab />
+            </PremiumGate>
+          )}
+
+          {/* 부동산 경매 (독립 최상위 탭) */}
+          {activeTab === 'auction' && (
+            <PremiumGate featureId="auction">
+              <div className="p-4 sm:p-6 bg-white min-h-screen">
+                <AuctionContent />
+              </div>
             </PremiumGate>
           )}
 

--- a/dental-clinic-manager/src/app/investment/auction/[itemId]/page.tsx
+++ b/dental-clinic-manager/src/app/investment/auction/[itemId]/page.tsx
@@ -1,8 +1,8 @@
-// 경매 상세는 dashboard 내부(/dashboard?tab=investment&sub=auction&item=<id>)에서 통합 렌더되므로
+// 경매 상세는 dashboard 의 독립 최상위 탭(/dashboard?tab=auction&item=<id>)에서 렌더되므로
 // 이 라우트는 즐겨찾기 / 외부 링크 호환성을 위해 dashboard 로 redirect 한다.
 import { redirect } from 'next/navigation'
 
 export default async function AuctionDetailRedirect({ params }: { params: Promise<{ itemId: string }> }) {
   const { itemId } = await params
-  redirect(`/dashboard?tab=investment&sub=auction&item=${encodeURIComponent(itemId)}`)
+  redirect(`/dashboard?tab=auction&item=${encodeURIComponent(itemId)}`)
 }

--- a/dental-clinic-manager/src/app/investment/auction/page.tsx
+++ b/dental-clinic-manager/src/app/investment/auction/page.tsx
@@ -1,7 +1,7 @@
-// 경매 목록은 dashboard 내부(/dashboard?tab=investment&sub=auction)에서 통합 렌더되므로
+// 경매 목록은 dashboard 의 독립 최상위 탭(/dashboard?tab=auction)에서 렌더되므로
 // 이 라우트는 즐겨찾기 / 외부 링크 호환성을 위해 dashboard 로 redirect 한다.
 import { redirect } from 'next/navigation'
 
 export default function AuctionListRedirect() {
-  redirect('/dashboard?tab=investment&sub=auction')
+  redirect('/dashboard?tab=auction')
 }

--- a/dental-clinic-manager/src/app/investment/layout.tsx
+++ b/dental-clinic-manager/src/app/investment/layout.tsx
@@ -20,7 +20,6 @@ import {
   Search,
   Brain,
   Users,
-  Gavel,
   Trophy,
 } from 'lucide-react'
 import type { InvestmentTab } from '@/types/investment'
@@ -44,7 +43,6 @@ const NAV_ITEMS: NavItem[] = [
   { id: 'rankings', label: '전략 랭킹', icon: Trophy, href: '/dashboard?tab=investment&sub=rankings' },
   { id: 'screener', label: '종목 스크리너', icon: Search, href: '/dashboard?tab=investment&sub=screener' },
   { id: 'smart-money', label: '스마트머니 분석', icon: Brain, href: '/dashboard?tab=investment&sub=smart-money' },
-  { id: 'auction', label: '부동산 경매', icon: Gavel, href: '/dashboard?tab=investment&sub=auction' },
   { id: 'trading', label: '자동매매', icon: TrendingUp, href: '/dashboard?tab=investment&sub=trading' },
   { id: 'psychology', label: '└ 심리 분석', icon: Users, href: '/dashboard?tab=investment&sub=psychology' },
   { id: 'portfolio', label: '포트폴리오', icon: Briefcase, href: '/dashboard?tab=investment&sub=portfolio' },

--- a/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/InvestmentTab.tsx
@@ -8,7 +8,7 @@ import {
   LayoutDashboard, Link2, Target, TrendingUp, TrendingDown, Briefcase,
   Wallet, Activity, AlertCircle, OctagonX, Loader2,
   ArrowRight, Plus, Play, Pause, Trash2, BarChart3,
-  Zap, GitCompare, Search, Brain, Users, Trophy, Cpu, Gavel,
+  Zap, GitCompare, Search, Brain, Users, Trophy, Cpu,
 } from 'lucide-react'
 import ConnectContent from './ConnectContent'
 import TradingContent from './TradingContent'
@@ -23,12 +23,11 @@ import PsychologyContent from './Psychology/PsychologyContent'
 import RankingsContent from './RankingsContent'
 import RLModelsContent from './RLModelsContent'
 import StrategyBuilder from './StrategyBuilder/StrategyBuilder'
-import AuctionContent from './Auction/AuctionContent'
 import type { InvestmentStrategy } from '@/types/investment'
 
 type SubTab =
   | 'dashboard' | 'connect' | 'strategy' | 'daytrading' | 'compare' | 'screener'
-  | 'smart-money' | 'auction' | 'trading' | 'psychology' | 'rankings' | 'rl-models' | 'portfolio'
+  | 'smart-money' | 'trading' | 'psychology' | 'rankings' | 'rl-models' | 'portfolio'
 
 const SUB_TABS: { id: SubTab; label: string; icon: React.ElementType }[] = [
   { id: 'dashboard', label: '대시보드', icon: LayoutDashboard },
@@ -39,7 +38,6 @@ const SUB_TABS: { id: SubTab; label: string; icon: React.ElementType }[] = [
   { id: 'rankings', label: '전략 랭킹', icon: Trophy },
   { id: 'screener', label: '종목 스크리너', icon: Search },
   { id: 'smart-money', label: '스마트머니 분석', icon: Brain },
-  { id: 'auction', label: '부동산 경매', icon: Gavel },
   { id: 'trading', label: '자동매매', icon: TrendingUp },
   { id: 'psychology', label: '심리 분석', icon: Users },
   { id: 'rl-models', label: 'RL 모델', icon: Cpu },
@@ -48,7 +46,7 @@ const SUB_TABS: { id: SubTab; label: string; icon: React.ElementType }[] = [
 
 const SUB_TAB_IDS = new Set<SubTab>([
   'dashboard', 'connect', 'strategy', 'daytrading', 'compare', 'screener',
-  'smart-money', 'auction', 'trading', 'psychology', 'rankings', 'rl-models', 'portfolio',
+  'smart-money', 'trading', 'psychology', 'rankings', 'rl-models', 'portfolio',
 ])
 
 function isSubTab(v: string | null): v is SubTab {
@@ -283,9 +281,6 @@ export default function InvestmentTab() {
         )}
         {!inInlineView && subTab === 'smart-money' && (
           <SmartMoneyContent />
-        )}
-        {!inInlineView && subTab === 'auction' && (
-          <AuctionContent />
         )}
         {!inInlineView && subTab === 'trading' && (
           <TradingContent />

--- a/dental-clinic-manager/src/config/menuConfig.ts
+++ b/dental-clinic-manager/src/config/menuConfig.ts
@@ -408,7 +408,7 @@ export const MENU_CONFIG: MenuConfigItem[] = [
     id: 'auction',
     label: '부동산 경매',
     icon: 'Gavel',
-    route: '/dashboard?tab=investment&sub=auction',
+    route: '/dashboard?tab=auction',
     permissions: ['auction_view'],
     categoryId: 'investment',
     order: 16.6,


### PR DESCRIPTION
## 문제
사이드바의 "부동산 경매" 메뉴 클릭 시 InvestmentTab 내부의 SUB_TABS 탭바(전략 관리·계좌 연결·자동매매 등)가 함께 노출되어, **"주식 자동매매" 페이지의 서브 메뉴처럼** 보였음.

## 수정
- `menuConfig`: route `/dashboard?tab=investment&sub=auction` → **`/dashboard?tab=auction`**
- `dashboard/page.tsx`: `activeTab === 'auction'` 케이스 추가
  - `PremiumGate('auction')` + `AuctionContent` (이미 PREMIUM_FEATURE_IDS 에 등록되어 있어 게이팅 자동)
- `InvestmentTab`: SubTab/SUB_TABS/SUB_TAB_IDS 에서 `'auction'` 제거, 미사용 Gavel import 제거
- `investment/layout.tsx` NAV_ITEMS: auction 항목 제거
- `/investment/auction`, `/investment/auction/[itemId]` redirect: 새 라우트 `/dashboard?tab=auction(&item=…)` 로 갱신

## 결과
경매 클릭 → 사이드바 유지된 채 깔끔한 경매 화면만 렌더 (주식 자동매매 sub-tab 탭바 노출되지 않음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)