### PR TITLE
refactor(auction): 페이지 전체 디자인 시스템 토큰 재정돈

### DIFF
--- a/dental-clinic-manager/src/components/Investment/Auction/AuctionCard.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/AuctionCard.tsx
@@ -37,14 +37,14 @@ export function AuctionCard({ item, isFavorite, onToggleFavorite, onClick }: Pro
   const primary = calculatePrimary(item, today)
   const m = item.market
 
-  const innerClassName = 'block bg-at-surface border border-at-border rounded-2xl overflow-hidden hover:bg-at-surface-hover transition-colors cursor-pointer'
+  const innerClassName = 'group block bg-at-surface border border-at-border rounded-2xl overflow-hidden shadow-at-card hover:-translate-y-0.5 hover:border-at-accent/40 transition-all cursor-pointer'
   const photoUrl = item.photos && item.photos.length > 0 ? item.photos[0] : null
   const visual = PROPERTY_VISUAL[item.property_type] ?? PROPERTY_VISUAL.other
   const PlaceholderIcon = visual.icon
 
   const innerContent = (
     <>
-      {/* 대표 이미지 영역 — 실제 사진이 있으면 표시, 없으면 용도별 placeholder */}
+      {/* 대표 이미지 영역 */}
       <div className="relative w-full aspect-[16/9] bg-at-surface-alt">
         {photoUrl ? (
           // eslint-disable-next-line @next/next/no-img-element
@@ -57,61 +57,71 @@ export function AuctionCard({ item, isFavorite, onToggleFavorite, onClick }: Pro
         ) : (
           <div className={`w-full h-full bg-gradient-to-br ${visual.gradient} flex flex-col items-center justify-center`}>
             <PlaceholderIcon className={`w-12 h-12 ${visual.iconColor} mb-2`} strokeWidth={1.5} />
-            <span className={`text-xs font-medium ${visual.iconColor}`}>
+            <span className={`text-xs font-semibold ${visual.iconColor}`}>
               {PROPERTY_LABEL[item.property_type] ?? '기타'}
             </span>
           </div>
         )}
-        {/* 우상단 좋아요 — 이미지 위에 띄움 */}
         <button
           onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleFavorite(item.id) }}
           aria-label="관심물건 토글"
-          className="absolute top-2 right-2 p-1.5 rounded-full bg-white/90 backdrop-blur-sm shadow hover:bg-white"
+          className="absolute top-2 right-2 p-1.5 rounded-full bg-at-surface/95 backdrop-blur-sm shadow-at-card hover:bg-at-surface"
         >
-          <Star className={`w-4 h-4 ${isFavorite ? 'fill-yellow-400 text-yellow-400' : 'text-at-text-secondary'}`} />
+          <Star className={`w-4 h-4 ${isFavorite ? 'fill-amber-400 text-amber-400' : 'text-at-text-secondary'}`} />
         </button>
-        {/* 좌상단 용도 배지 (사진이 있을 때만 — placeholder 에는 이미 라벨 있음) */}
         {photoUrl && (
-          <span className="absolute top-2 left-2 px-2 py-0.5 rounded-full bg-white/90 backdrop-blur-sm text-[11px] font-semibold text-at-text">
+          <span className="absolute top-2 left-2 px-2 py-0.5 rounded-full bg-at-surface/95 backdrop-blur-sm text-[11px] font-semibold text-at-text">
             {PROPERTY_LABEL[item.property_type] ?? '기타'}
           </span>
         )}
-        {/* 좌하단 D-day */}
         {primary.d_day !== null && (
-          <span className="absolute bottom-2 left-2 px-2 py-0.5 rounded-full bg-amber-500 text-white text-[11px] font-bold shadow">
+          <span className="absolute bottom-2 left-2 px-2 py-1 rounded-md bg-[var(--at-warning)] text-white text-[11px] font-bold shadow">
             D-{primary.d_day}
           </span>
         )}
       </div>
 
-      <div className="p-4">
-        <div className="text-[15px] md:text-sm font-semibold text-slate-900 mb-1">
-          {item.sido} {item.sigungu} {item.eupmyeondong}
-          {item.building_area_m2 ? ` · ${item.building_area_m2}㎡` : ''}
+      <div className="p-4 space-y-3">
+        {/* 주소 (강조) */}
+        <div>
+          <div className="text-[15px] md:text-sm font-bold text-at-text leading-snug">
+            {item.sido} {item.sigungu} {item.eupmyeondong}
+          </div>
+          <div className="text-[12px] md:text-xs text-at-text-weak mt-0.5 font-medium">
+            {item.case_number} · {item.court_name}{item.building_area_m2 ? ` · ${item.building_area_m2}㎡` : ''}
+          </div>
         </div>
 
-        <div className="text-[13px] md:text-xs text-slate-500 mb-3 font-medium">
-          {item.case_number} · {item.court_name}
+        {/* 핵심 지표 — 최저가 강조 */}
+        <div className="grid grid-cols-3 gap-2 pt-1">
+          <div>
+            <div className="text-[11px] text-at-text-weak font-medium">감정가</div>
+            <div className="text-[13px] md:text-sm font-semibold text-at-text-secondary tabular-nums line-through decoration-at-text-weak/40">{fmt(item.appraisal_price)}원</div>
+          </div>
+          <div>
+            <div className="text-[11px] text-at-text-weak font-medium">최저가</div>
+            <div className="text-[15px] md:text-base font-extrabold text-at-text tabular-nums">{fmt(item.min_bid_price)}원</div>
+          </div>
+          <div className="text-right">
+            <div className="text-[11px] text-at-text-weak font-medium">할인율</div>
+            <div className="text-[15px] md:text-base font-extrabold text-emerald-600 tabular-nums">−{primary.discount_rate_pct.toFixed(1)}%</div>
+          </div>
         </div>
 
-        <dl className="grid grid-cols-2 gap-y-1.5 text-[14px] md:text-sm">
-          <dt className="text-slate-600 font-medium">감정가</dt>
-          <dd className="text-right text-slate-900 font-semibold tabular-nums">{fmt(item.appraisal_price)}원</dd>
-          <dt className="text-slate-600 font-medium">최저가</dt>
-          <dd className="text-right text-slate-900 font-bold tabular-nums">{fmt(item.min_bid_price)}원</dd>
-          <dt className="text-slate-600 font-medium">할인율</dt>
-          <dd className="text-right text-emerald-600 font-bold tabular-nums">-{primary.discount_rate_pct.toFixed(1)}%</dd>
-        </dl>
-
-        <div className="flex items-center gap-2 mt-3 flex-wrap text-[12px] md:text-xs font-semibold">
+        {/* 보조 배지 */}
+        <div className="flex items-center gap-1.5 flex-wrap text-[11px] font-semibold pt-1">
           {m?.match_confidence === 'high' && m.median_price_3m && (
-            <span className="px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700">
-              시세 대비 -{Math.round((m.median_price_3m - item.min_bid_price) / m.median_price_3m * 100)}%
+            <span className="px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700 border border-emerald-100">
+              시세 −{Math.round((m.median_price_3m - item.min_bid_price) / m.median_price_3m * 100)}%
             </span>
           )}
-          <span className="px-2 py-0.5 rounded-full bg-slate-100 text-slate-700">유찰 {primary.failure_count}회</span>
+          <span className="px-2 py-0.5 rounded-full bg-at-surface-alt text-at-text-secondary border border-at-border">
+            유찰 {primary.failure_count}회
+          </span>
           {primary.price_per_m2 && (
-            <span className="px-2 py-0.5 rounded-full bg-slate-100 text-slate-700">㎡당 {fmt(primary.price_per_m2)}원</span>
+            <span className="px-2 py-0.5 rounded-full bg-at-surface-alt text-at-text-secondary border border-at-border">
+              ㎡당 {fmt(primary.price_per_m2)}원
+            </span>
           )}
         </div>
       </div>

--- a/dental-clinic-manager/src/components/Investment/Auction/AuctionContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/AuctionContent.tsx
@@ -133,18 +133,28 @@ function AuctionListView({ onOpen }: { onOpen: (id: string) => void }) {
 
   return (
     <div className="max-w-6xl mx-auto">
-      <div className="flex items-center justify-between mb-4">
-        <h1 className="text-xl font-bold">부동산 경매 ({new Intl.NumberFormat('ko-KR').format(total)}건)</h1>
-      </div>
+      {/* 페이지 헤더 */}
+      <header className="mb-5">
+        <h1 className="text-2xl font-bold text-at-text">부동산 경매</h1>
+        <p className="text-[13px] text-at-text-secondary mt-1">
+          전국 법원에 등록된 매물 <span className="font-semibold text-at-text">{new Intl.NumberFormat('ko-KR').format(total)}건</span> · 매일 새벽 자동 갱신
+        </p>
+      </header>
 
       <AuctionFilters />
 
       {loading && items.length === 0 ? (
-        <div className="flex justify-center py-16">
-          <Loader2 className="w-6 h-6 animate-spin text-at-accent" />
+        <div className="flex flex-col items-center justify-center py-24 bg-at-surface border border-at-border rounded-2xl">
+          <Loader2 className="w-7 h-7 animate-spin text-at-accent mb-3" />
+          <p className="text-sm text-at-text-secondary">매물을 불러오는 중...</p>
+        </div>
+      ) : items.length === 0 ? (
+        <div className="bg-at-surface border border-at-border rounded-2xl px-6 py-16 text-center">
+          <p className="text-base font-semibold text-at-text">조건에 맞는 매물이 없습니다</p>
+          <p className="text-sm text-at-text-secondary mt-1">필터를 완화하거나 초기화해 보세요.</p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 sm:gap-4">
           {items.map(item => (
             <AuctionCard
               key={item.id}
@@ -158,10 +168,10 @@ function AuctionListView({ onOpen }: { onOpen: (id: string) => void }) {
       )}
 
       {cursor !== null && !loading && items.length > 0 && (
-        <div className="text-center mt-6">
+        <div className="flex justify-center mt-8">
           <button
             onClick={() => load(cursor)}
-            className="px-4 py-2 rounded-xl bg-at-surface hover:bg-at-surface-hover border border-at-border"
+            className="h-10 px-6 rounded-xl bg-at-surface hover:bg-at-surface-hover border border-at-border text-[14px] font-semibold text-at-text transition-colors shadow-at-card"
           >
             더 보기
           </button>

--- a/dental-clinic-manager/src/components/Investment/Auction/AuctionDetailHeader.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/AuctionDetailHeader.tsx
@@ -15,39 +15,48 @@ export function AuctionDetailHeader({ item, market }: Props) {
   const s = market ? calculateSecondary(item, market, { isMultiOwner: false }) : null
 
   return (
-    <div className="bg-at-surface rounded-2xl p-5 md:p-6 border border-at-border mb-4">
-      <div className="text-[13px] md:text-sm text-at-text-secondary mb-1">
-        {item.case_number} · {item.court_name}
+    <div className="bg-at-surface rounded-2xl border border-at-border shadow-at-card p-5 md:p-6 mb-4">
+      <div className="flex items-start justify-between gap-3 mb-4">
+        <div className="min-w-0">
+          <div className="text-[13px] md:text-sm font-medium text-at-text-secondary mb-1">
+            {item.case_number} · {item.court_name}
+          </div>
+          <h1 className="text-xl md:text-2xl font-bold text-at-text leading-tight">
+            {item.sido} {item.sigungu} {item.eupmyeondong}
+          </h1>
+        </div>
+        {p.d_day !== null && (
+          <span className="shrink-0 px-3 py-1.5 rounded-full bg-[var(--at-warning-bg)] text-[var(--at-warning)] text-sm font-bold">
+            D-{p.d_day}
+          </span>
+        )}
       </div>
-      <h1 className="text-lg md:text-xl font-bold mb-4 text-at-text">
-        {item.sido} {item.sigungu} {item.eupmyeondong}
-      </h1>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 pt-4 border-t border-at-border">
         <Field label="감정가" value={`${fmt(item.appraisal_price)}원`} />
         <Field label="최저입찰가" value={`${fmt(item.min_bid_price)}원`} highlight />
-        <Field label="할인율" value={`-${p.discount_rate_pct.toFixed(1)}%`} accent="emerald" />
+        <Field label="할인율" value={`−${p.discount_rate_pct.toFixed(1)}%`} accent="success" />
         {s && (
-          <Field label="시세 대비" value={`-${s.market_discount_rate_pct.toFixed(1)}%`} accent="blue" />
+          <Field label="시세 대비" value={`−${s.market_discount_rate_pct.toFixed(1)}%`} accent="accent" />
         )}
         <Field label="유찰" value={`${p.failure_count}회 (${p.round_no}차)`} />
         <Field label="매각기일" value={item.next_auction_date ?? '미정'} />
-        {p.d_day !== null && <Field label="D-day" value={`D-${p.d_day}`} accent="amber" />}
         <Field label="입찰보증금" value={`${fmt(p.bid_deposit)}원`} />
       </div>
     </div>
   )
 }
 
-function Field({ label, value, highlight, accent }: { label: string; value: string; highlight?: boolean; accent?: 'emerald'|'blue'|'amber' }) {
-  const colorCls = accent === 'emerald' ? 'text-emerald-600'
-                : accent === 'blue'    ? 'text-blue-600'
-                : accent === 'amber'   ? 'text-amber-600'
+function Field({ label, value, highlight, accent }: { label: string; value: string; highlight?: boolean; accent?: 'success'|'accent' }) {
+  const colorCls = accent === 'success' ? 'text-[var(--at-success)]'
+                : accent === 'accent'  ? 'text-at-accent'
                 : 'text-at-text'
   return (
     <div>
-      <div className="text-[13px] md:text-xs text-at-text-secondary">{label}</div>
-      <div className={`text-base md:text-base ${highlight ? 'font-bold' : 'font-semibold'} ${colorCls} tabular-nums`}>{value}</div>
+      <div className="text-[12px] md:text-xs text-at-text-weak font-medium mb-0.5">{label}</div>
+      <div className={`text-[15px] md:text-base ${highlight ? 'font-extrabold' : 'font-bold'} ${colorCls} tabular-nums`}>
+        {value}
+      </div>
     </div>
   )
 }

--- a/dental-clinic-manager/src/components/Investment/Auction/AuctionFilters.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/AuctionFilters.tsx
@@ -38,7 +38,7 @@ const SORT_OPTS = [
   { value: 'failure_desc',  label: '유찰 ↓' },
 ]
 
-const SELECT_CLS = "px-3 py-1.5 text-sm bg-at-surface border border-at-border rounded-lg"
+const SELECT_CLS = "h-9 px-3 text-[13px] font-medium text-at-text bg-at-surface border border-at-border rounded-lg hover:border-at-accent/50 focus:outline-none focus:border-at-accent focus:ring-2 focus:ring-at-accent/15 transition-colors cursor-pointer"
 
 export function AuctionFilters() {
   const router = useRouter()
@@ -52,42 +52,69 @@ export function AuctionFilters() {
     router.replace(`${pathname}?${next.toString()}`)
   }
 
+  const hasFilters = ['sido', 'propertyType', 'minDiscountPct', 'minFailureCount', 'maxDDay', 'minAppraisalPrice', 'maxAppraisalPrice']
+    .some(k => sp.get(k))
+
+  const reset = () => {
+    const next = new URLSearchParams()
+    // 정렬은 보존
+    const sort = sp.get('sort')
+    if (sort) next.set('sort', sort)
+    // 외부 컨텍스트 파라미터 보존
+    const tab = sp.get('tab'); if (tab) next.set('tab', tab)
+    const sub = sp.get('sub'); if (sub) next.set('sub', sub)
+    router.replace(`${pathname}?${next.toString()}`)
+  }
+
   return (
-    <div className="flex flex-wrap gap-2 items-center mb-4">
-      <select className={SELECT_CLS} value={sp.get('sido') ?? ''} onChange={e => update('sido', e.target.value)}>
-        {SIDO_OPTS.map(s => <option key={s} value={s}>{s || '전체 지역'}</option>)}
-      </select>
-      <select className={SELECT_CLS} value={sp.get('propertyType') ?? ''} onChange={e => update('propertyType', e.target.value)}>
-        {PROPERTY_OPTS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-      </select>
-      <select className={SELECT_CLS} value={sp.get('minDiscountPct') ?? ''} onChange={e => update('minDiscountPct', e.target.value)}>
-        <option value="">할인율 무관</option>
-        {DISCOUNT_OPTS.map(d => <option key={d} value={d}>{d}% 이상</option>)}
-      </select>
-      <select className={SELECT_CLS} value={sp.get('minFailureCount') ?? ''} onChange={e => update('minFailureCount', e.target.value)}>
-        <option value="">유찰 무관</option>
-        {FAILURE_OPTS.map(d => <option key={d} value={d}>{d}회 이상</option>)}
-      </select>
-      <select className={SELECT_CLS} value={sp.get('maxDDay') ?? ''} onChange={e => update('maxDDay', e.target.value)}>
-        <option value="">기일 무관</option>
-        {DDAY_OPTS.map(d => <option key={d} value={d}>{d === 0 ? '오늘' : `D-${d} 이내`}</option>)}
-      </select>
+    <div className="bg-at-surface border border-at-border rounded-2xl shadow-at-card p-3 sm:p-4 mb-4">
+      <div className="flex flex-wrap gap-2 items-center">
+        <select className={SELECT_CLS} value={sp.get('sido') ?? ''} onChange={e => update('sido', e.target.value)}>
+          {SIDO_OPTS.map(s => <option key={s} value={s}>{s || '전체 지역'}</option>)}
+        </select>
+        <select className={SELECT_CLS} value={sp.get('propertyType') ?? ''} onChange={e => update('propertyType', e.target.value)}>
+          {PROPERTY_OPTS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+        </select>
+        <select className={SELECT_CLS} value={sp.get('minDiscountPct') ?? ''} onChange={e => update('minDiscountPct', e.target.value)}>
+          <option value="">할인율 무관</option>
+          {DISCOUNT_OPTS.map(d => <option key={d} value={d}>{d}% 이상</option>)}
+        </select>
+        <select className={SELECT_CLS} value={sp.get('minFailureCount') ?? ''} onChange={e => update('minFailureCount', e.target.value)}>
+          <option value="">유찰 무관</option>
+          {FAILURE_OPTS.map(d => <option key={d} value={d}>{d}회 이상</option>)}
+        </select>
+        <select className={SELECT_CLS} value={sp.get('maxDDay') ?? ''} onChange={e => update('maxDDay', e.target.value)}>
+          <option value="">기일 무관</option>
+          {DDAY_OPTS.map(d => <option key={d} value={d}>{d === 0 ? '오늘' : `D-${d} 이내`}</option>)}
+        </select>
+        <select className={SELECT_CLS} value={sp.get('minAppraisalPrice') ?? ''} onChange={e => update('minAppraisalPrice', e.target.value)}>
+          <option value="">감정가 하한 무관</option>
+          {APPRAISAL_OPTS.map(o => <option key={o.value} value={o.value}>{o.label} 이상</option>)}
+        </select>
+        <select className={SELECT_CLS} value={sp.get('maxAppraisalPrice') ?? ''} onChange={e => update('maxAppraisalPrice', e.target.value)}>
+          <option value="">감정가 상한 무관</option>
+          {APPRAISAL_OPTS.map(o => <option key={o.value} value={o.value}>{o.label} 이하</option>)}
+        </select>
 
-      <select className={SELECT_CLS} value={sp.get('minAppraisalPrice') ?? ''} onChange={e => update('minAppraisalPrice', e.target.value)}>
-        <option value="">감정가 하한 무관</option>
-        {APPRAISAL_OPTS.map(o => <option key={o.value} value={o.value}>{o.label} 이상</option>)}
-      </select>
-      <select className={SELECT_CLS} value={sp.get('maxAppraisalPrice') ?? ''} onChange={e => update('maxAppraisalPrice', e.target.value)}>
-        <option value="">감정가 상한 무관</option>
-        {APPRAISAL_OPTS.map(o => <option key={o.value} value={o.value}>{o.label} 이하</option>)}
-      </select>
+        {hasFilters && (
+          <button
+            type="button"
+            onClick={reset}
+            className="h-9 px-3 text-[13px] font-semibold text-at-text-secondary hover:text-at-text border border-at-border rounded-lg hover:bg-at-surface-alt transition-colors"
+          >
+            필터 초기화
+          </button>
+        )}
 
-      <div className="flex-1" />
+        <div className="flex-1" />
 
-      <label className="text-sm text-at-text-secondary">정렬</label>
-      <select className={SELECT_CLS} value={sp.get('sort') ?? 'discount_desc'} onChange={e => update('sort', e.target.value)}>
-        {SORT_OPTS.map(s => <option key={s.value} value={s.value}>{s.label}</option>)}
-      </select>
+        <div className="flex items-center gap-2 ml-auto">
+          <span className="text-[12px] font-semibold text-at-text-weak">정렬</span>
+          <select className={SELECT_CLS} value={sp.get('sort') ?? 'discount_desc'} onChange={e => update('sort', e.target.value)}>
+            {SORT_OPTS.map(s => <option key={s.value} value={s.value}>{s.label}</option>)}
+          </select>
+        </div>
+      </div>
     </div>
   )
 }

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/AttachmentsTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/AttachmentsTab.tsx
@@ -16,7 +16,7 @@ export function AttachmentsTab({ item }: Props) {
   }
 
   return (
-    <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border space-y-2">
+    <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card space-y-2">
       {items.map((it) => (
         <a
           key={it.label}

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/HistoryTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/HistoryTab.tsx
@@ -41,7 +41,7 @@ export function HistoryTab({ itemId, history }: Props) {
 
   return (
     <div className="space-y-4">
-      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
         <h3 className="text-base font-semibold mb-3 text-at-text">회차별 변동</h3>
         {history.length === 0 ? (
           <p className="text-[14px] md:text-sm text-at-text-secondary">이력이 없습니다.</p>
@@ -111,7 +111,7 @@ export function HistoryTab({ itemId, history }: Props) {
         )}
       </section>
 
-      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
         <h3 className="text-base font-semibold mb-3 text-at-text">동일 동·용도 낙찰 통계 (최근 6개월)</h3>
         {!stats ? (
           <p className="text-[14px] md:text-sm text-at-text-secondary">로딩 중...</p>

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/OverviewTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/OverviewTab.tsx
@@ -19,10 +19,10 @@ export function OverviewTab({ item, market }: Props) {
     : null
 
   return (
-    <div className="space-y-4 md:space-y-6">
-      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
-        <h3 className="text-base font-semibold mb-3 text-at-text">물건 정보</h3>
-        <dl className="grid grid-cols-2 gap-x-3 gap-y-2 text-[14px] md:text-sm">
+    <div className="space-y-4 md:space-y-5">
+      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
+        <h3 className="text-base font-bold mb-3 text-at-text">물건 정보</h3>
+        <dl className="grid grid-cols-2 gap-x-3 gap-y-2.5 text-[14px] md:text-sm">
           <Dt>용도</Dt><Dd>{PROPERTY_LABEL[item.property_type] ?? '기타'}</Dd>
           <Dt>주소(도로명)</Dt><Dd>{item.address_road ?? '-'}</Dd>
           <Dt>주소(지번)</Dt><Dd>{item.address_jibun ?? '-'}</Dd>
@@ -33,8 +33,8 @@ export function OverviewTab({ item, market }: Props) {
         </dl>
       </section>
 
-      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
-        <h3 className="text-base font-semibold mb-3 text-at-text">시세 비교</h3>
+      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
+        <h3 className="text-base font-bold mb-3 text-at-text">시세 비교</h3>
         {market ? (
           <div className="space-y-3">
             <Bar label="감정가" value={item.appraisal_price} max={Math.max(item.appraisal_price, market.median_price_3m ?? 0)} />
@@ -55,12 +55,12 @@ export function OverviewTab({ item, market }: Props) {
       </section>
 
       {item.photos.length > 0 && (
-        <section className="bg-at-surface rounded-2xl p-5 border border-at-border">
-          <h3 className="font-semibold mb-3">사진</h3>
+        <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
+          <h3 className="text-base font-bold mb-3 text-at-text">사진</h3>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
             {item.photos.map((url, i) => (
               // eslint-disable-next-line @next/next/no-img-element
-              <img key={i} src={url} alt={`사진 ${i+1}`} className="rounded-lg w-full h-40 object-cover" />
+              <img key={i} src={url} alt={`사진 ${i+1}`} className="rounded-xl w-full h-40 object-cover border border-at-border" />
             ))}
           </div>
         </section>
@@ -73,22 +73,22 @@ export function OverviewTab({ item, market }: Props) {
   )
 }
 
-const Dt = (p: { children: React.ReactNode }) => <dt className="text-at-text-secondary">{p.children}</dt>
+const Dt = (p: { children: React.ReactNode }) => <dt className="text-at-text-weak font-medium">{p.children}</dt>
 const Dd = (p: { children: React.ReactNode }) => <dd className="font-semibold text-at-text break-words">{p.children}</dd>
 
 function Bar({ label, value, max, accent }: { label: string; value: number; max: number; accent?: 'blue'|'emerald' }) {
   const pct = max > 0 ? Math.round(value / max * 100) : 0
-  const color = accent === 'emerald' ? 'bg-emerald-500'
-              : accent === 'blue' ? 'bg-blue-500'
-              : 'bg-slate-500'
+  const color = accent === 'emerald' ? 'bg-[var(--at-success)]'
+              : accent === 'blue'    ? 'bg-at-accent'
+              :                        'bg-at-text-weak'
   return (
     <div>
-      <div className="flex justify-between text-[13px] md:text-xs mb-1">
+      <div className="flex justify-between text-[13px] md:text-xs mb-1.5">
         <span className="text-at-text font-medium">{label}</span>
-        <span className="text-at-text font-semibold tabular-nums">{fmt(value)}원</span>
+        <span className="text-at-text font-bold tabular-nums">{fmt(value)}원</span>
       </div>
-      <div className="h-3 rounded-full bg-at-surface-alt overflow-hidden">
-        <div className={`h-full ${color}`} style={{ width: `${pct}%` }} />
+      <div className="h-2.5 rounded-full bg-at-surface-alt overflow-hidden">
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
       </div>
     </div>
   )

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/RightsTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/RightsTab.tsx
@@ -54,7 +54,7 @@ export function RightsTab({ itemId, rights, initialAi }: Props) {
 
   return (
     <div className="space-y-4">
-      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
         <h3 className="text-base font-semibold mb-3 text-at-text">자동 추출 권리분석</h3>
         {rights ? (
           <dl className="grid grid-cols-2 gap-x-3 gap-y-2 text-[14px] md:text-sm">
@@ -78,7 +78,7 @@ export function RightsTab({ itemId, rights, initialAi }: Props) {
         )}
       </section>
 
-      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+      <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
         <div className="flex justify-between items-center mb-3 gap-2">
           <h3 className="text-base font-semibold text-at-text">AI 권리분석 코멘트</h3>
           <button

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/SimulatorTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/SimulatorTab.tsx
@@ -40,7 +40,7 @@ export function SimulatorTab({ item, market, initialInput, onSave }: Props) {
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-      <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border space-y-5">
+      <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card space-y-5">
         <h3 className="text-base font-semibold text-at-text">입찰 시뮬레이션 입력</h3>
 
         <Slider label="응찰가" value={input.bid_price} min={min} max={max} step={100_000} format={(n) => `${fmt(n)}원`} onChange={(v) => set('bid_price', v)} />
@@ -64,7 +64,7 @@ export function SimulatorTab({ item, market, initialInput, onSave }: Props) {
 
       <div className="space-y-4">
         {secondary && (
-          <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+          <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
             <h3 className="text-base font-semibold mb-3 text-at-text">매도 시뮬 (시세 기반)</h3>
             <Result label="예상 시세" value={`${fmt(secondary.expected_market_price)}원`} />
             <Result label="예상 매도차익" value={`${fmt(secondary.expected_resale_profit)}원`} accent={secondary.expected_resale_profit > 0 ? 'emerald' : 'rose'} />
@@ -73,7 +73,7 @@ export function SimulatorTab({ item, market, initialInput, onSave }: Props) {
           </div>
         )}
 
-        <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border">
+        <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
           <h3 className="text-base font-semibold mb-3 text-at-text">임대 시뮬</h3>
           <Result label="총 투자비용" value={`${fmt(tertiary.total_investment)}원`} />
           <Result label="연 순임대수익" value={`${fmt(tertiary.annual_net_rent)}원`} />


### PR DESCRIPTION
## 목표
부동산 경매 페이지의 색상·간격·위계·인터랙션을 프로젝트 디자인 시스템(\`--at-*\` 토큰, \`shadow-at-card\`)으로 통일.

## 변경 사항

### AuctionCard
- 슬레이트 직접 사용 → \`at-text/at-text-secondary/at-text-weak/at-surface\` 토큰
- hover 시 \`-translate-y-0.5\` + accent 보더로 살짝 떠오르는 인터랙션
- 핵심 지표를 3-그리드(감정가 line-through / 최저가 강조 / 할인율) 재배치
- D-day 배지 amber → \`var(--at-warning)\`

### AuctionFilters
- 카드 컨테이너로 시각적 그룹화 (bg-at-surface + border + shadow-at-card)
- focus ring + accent 보더 마이크로 인터랙션
- 필터 적용 시 "필터 초기화" 버튼

### AuctionContent (목록·상세 공통)
- 페이지 헤더: 2xl 타이틀 + 보조 설명(총 건수 강조)
- 빈/로딩 상태 분리, 정돈된 placeholder
- 그리드: 1 → 2 → 3 columns 반응형

### AuctionDetailHeader
- 상단 주소(타이틀) + 사건번호 분리, D-day 우상단 캡슐
- KPI 그리드를 구분선으로 분리하여 위계 명확
- 색상: emerald → \`var(--at-success)\`, blue → at-accent

### 5개 탭
- Overview/Simulator/Rights/History/Attachments 모든 섹션 카드에 \`shadow-at-card\` 적용
- OverviewTab Bar 컬러: slate-500 → \`bg-[var(--at-success)]\` / \`bg-at-accent\` 의미 토큰

## 빌드
- \`npm run build\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)