### PR TITLE
fix(worker): 스키마 마이그레이션 자동 full sync + chunk 분할 전송

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/src/config-store.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/config-store.ts
@@ -37,6 +37,10 @@ interface StoreSchema {
   dentwebLastSyncDate: string;
   dentwebLastSyncStatus: string;
   dentwebLastSyncPatientCount: number;
+  // 덴트웹 → Supabase 매핑 스키마 버전.
+  // 새 컬럼 추가 시 이 값을 올리면 워커가 첫 실행 때 자동 full sync 1회 실행 후 갱신.
+  // 0 = legacy(메모 없음), 2 = next_appointment_memo 포함.
+  dentwebSchemaVersion: number;
 }
 
 export interface AppConfig {
@@ -59,6 +63,7 @@ export interface AppConfig {
   dentwebLastSyncDate: string;
   dentwebLastSyncStatus: string;
   dentwebLastSyncPatientCount: number;
+  dentwebSchemaVersion: number;
 }
 
 export interface UpdateMeta {
@@ -98,6 +103,7 @@ const storeDefaults: StoreSchema = {
   dentwebLastSyncDate: '',
   dentwebLastSyncStatus: '',
   dentwebLastSyncPatientCount: 0,
+  dentwebSchemaVersion: 0,
 };
 
 function createStore(): Store<StoreSchema> {
@@ -165,6 +171,7 @@ export function getConfig(): AppConfig {
     dentwebLastSyncDate: store.get('dentwebLastSyncDate'),
     dentwebLastSyncStatus: store.get('dentwebLastSyncStatus'),
     dentwebLastSyncPatientCount: store.get('dentwebLastSyncPatientCount'),
+    dentwebSchemaVersion: store.get('dentwebSchemaVersion') ?? 0,
   };
 }
 
@@ -191,6 +198,7 @@ export function setConfig(partial: Partial<AppConfig>): void {
   if (partial.dentwebLastSyncDate !== undefined) store.set('dentwebLastSyncDate', partial.dentwebLastSyncDate);
   if (partial.dentwebLastSyncStatus !== undefined) store.set('dentwebLastSyncStatus', partial.dentwebLastSyncStatus);
   if (partial.dentwebLastSyncPatientCount !== undefined) store.set('dentwebLastSyncPatientCount', partial.dentwebLastSyncPatientCount);
+  if (partial.dentwebSchemaVersion !== undefined) store.set('dentwebSchemaVersion', partial.dentwebSchemaVersion);
   store.set('isConfigured', true);
 }
 

--- a/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
@@ -268,20 +268,65 @@ async function syncPatientsToServer(patients: Record<string, unknown>[], syncTyp
   const cfg = getDentwebConfig();
   const { dashboardUrl } = getConfig();
   const url = `${dashboardUrl}/api/dentweb/sync`;
+  const CHUNK_SIZE = 500;
 
-  const response = await fetchWithRetry(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      clinic_id: cfg.clinicId,
-      api_key: cfg.apiKey,
-      sync_type: syncType,
-      patients,
-      agent_version: '2.0.0-electron',
-    }),
-  });
+  // 작은 페이로드는 기존 한 번에 전송 동작 유지 (호환성 + 단순성)
+  if (patients.length <= CHUNK_SIZE) {
+    const response = await fetchWithRetry(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        clinic_id: cfg.clinicId,
+        api_key: cfg.apiKey,
+        sync_type: syncType,
+        patients,
+        agent_version: '2.0.0-electron',
+      }),
+    });
+    return await response.json();
+  }
 
-  return await response.json();
+  // 500명 초과: chunk 분할 전송 (Vercel 함수 타임아웃·payload 크기 방지)
+  let totalNew = 0;
+  let totalUpdated = 0;
+  const totalChunks = Math.ceil(patients.length / CHUNK_SIZE);
+  for (let i = 0; i < patients.length; i += CHUNK_SIZE) {
+    const chunk = patients.slice(i, i + CHUNK_SIZE);
+    const chunkNum = Math.floor(i / CHUNK_SIZE) + 1;
+    log('info', `[DentWeb] chunk ${chunkNum}/${totalChunks} 전송 (${chunk.length}명)`);
+    const response = await fetchWithRetry(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        clinic_id: cfg.clinicId,
+        api_key: cfg.apiKey,
+        // 첫 chunk 만 원래 sync_type — 나머지는 incremental 로 로그 분리 (서버 측 upsert 동작은 동일)
+        sync_type: i === 0 ? syncType : 'incremental',
+        patients: chunk,
+        agent_version: '2.0.0-electron',
+      }),
+    });
+    const result = await response.json();
+    if (!result.success) {
+      log('error', `[DentWeb] chunk ${chunkNum}/${totalChunks} 실패: ${result.error}`);
+      return {
+        success: false,
+        total_records: patients.length,
+        new_records: totalNew,
+        updated_records: totalUpdated,
+        error: result.error || 'chunk sync failed',
+      };
+    }
+    totalNew += result.new_records || 0;
+    totalUpdated += result.updated_records || 0;
+  }
+
+  return {
+    success: true,
+    total_records: patients.length,
+    new_records: totalNew,
+    updated_records: totalUpdated,
+  };
 }
 
 /* ------------------------------------------------------------------ */
@@ -1238,10 +1283,18 @@ async function runSync(): Promise<void> {
       log('info', '[DentWeb] SQL Server 연결 성공');
     }
 
+    // Schema migration: 매핑 컬럼 추가 후 한 번 full sync 강제 (next_appointment_memo 등 옛 환자 일괄 갱신)
+    const REQUIRED_DENTWEB_SCHEMA_VERSION = 2;
+    const currentSchemaVersion = (getConfig() as unknown as { dentwebSchemaVersion?: number }).dentwebSchemaVersion ?? 0;
+    const needsSchemaFullSync = currentSchemaVersion < REQUIRED_DENTWEB_SCHEMA_VERSION;
+    if (needsSchemaFullSync) {
+      log('info', `[DentWeb] 스키마 v${currentSchemaVersion} → v${REQUIRED_DENTWEB_SCHEMA_VERSION} 마이그레이션: 전체 동기화 1회 강제`);
+    }
+
     // Determine sync type
     let patients;
     let syncType: 'full' | 'incremental';
-    const lastSync = cfg.lastSyncDate ? new Date(cfg.lastSyncDate) : null;
+    const lastSync = (!needsSchemaFullSync && cfg.lastSyncDate) ? new Date(cfg.lastSyncDate) : null;
 
     if (!lastSync) {
       syncType = 'full';
@@ -1283,6 +1336,8 @@ async function runSync(): Promise<void> {
         dentwebLastSyncDate: new Date().toISOString(),
         dentwebLastSyncStatus: 'success',
         dentwebLastSyncPatientCount: result.total_records || 0,
+        // 마이그레이션 full sync 성공 시 스키마 버전 갱신 (이후엔 incremental 로 돌아감)
+        ...(needsSchemaFullSync ? { dentwebSchemaVersion: REQUIRED_DENTWEB_SCHEMA_VERSION } : {}),
       });
       lastSyncError = null;
 


### PR DESCRIPTION
## Summary
- v1.1.104 (next_appointment_memo) 적용 후에도 워커가 incremental sync 만 돌아 \`9107/9119\` 환자의 memo 가 NULL 로 남아있던 문제 해결
- 동기화 직전 \`dentwebSchemaVersion\` 검사 → 낮으면 1회 full sync 강제 후 v2 로 갱신 (영구 1회 마이그레이션)
- \`syncPatientsToServer\` 를 **500명 단위 chunk 분할 POST** 로 변경 (Vercel 함수 타임아웃·payload 크기 안전화)

## Test plan
- [x] 워커 \`tsc --noEmit\` 통과
- [x] 웹 \`npm run build\` 통과
- [ ] GitHub Actions 자동 빌드 + GitHub Release 발행
- [ ] 덴트웹 서버 PC 워커 자동 업데이트 + 재시작
- [ ] 다음 동기화 로그에 \"스키마 v0 → v2 마이그레이션\" 출력 확인
- [ ] DB 통계: \`COUNT(next_appointment_memo IS NOT NULL)\` 가 12 → 수백+ 로 증가

🤖 Generated with [Claude Code](https://claude.com/claude-code)