### PR TITLE
feat(protocol): 에디터에 글자 정렬 툴바 버튼 추가

### DIFF
--- a/dental-clinic-manager/src/components/Protocol/EnhancedTiptapEditor.tsx
+++ b/dental-clinic-manager/src/components/Protocol/EnhancedTiptapEditor.tsx
@@ -41,6 +41,7 @@ import {
   MinusIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline'
+import { AlignLeft, AlignCenter, AlignRight, AlignJustify } from 'lucide-react'
 import { appAlert, appPrompt } from '@/components/ui/AppDialog'
 
 // 커스텀 Video 노드 익스텐션
@@ -553,7 +554,7 @@ export default function EnhancedTiptapEditor({
       }),
       TextAlign.configure({
         types: ['heading', 'paragraph'],
-        alignments: ['left', 'center', 'right'],
+        alignments: ['left', 'center', 'right', 'justify'],
         defaultAlignment: 'left'
       }),
       Image.configure({
@@ -1011,6 +1012,30 @@ export default function EnhancedTiptapEditor({
               title={`제목 ${level}`}
             >
               H{level}
+            </button>
+          ))}
+        </div>
+
+        <div className="w-px h-8 bg-at-border" />
+
+        {/* 정렬 */}
+        <div className="flex gap-1">
+          {([
+            { align: 'left' as const, Icon: AlignLeft, title: '왼쪽 정렬' },
+            { align: 'center' as const, Icon: AlignCenter, title: '가운데 정렬' },
+            { align: 'right' as const, Icon: AlignRight, title: '오른쪽 정렬' },
+            { align: 'justify' as const, Icon: AlignJustify, title: '양쪽 정렬' },
+          ]).map(({ align, Icon, title }) => (
+            <button
+              key={align}
+              type="button"
+              onClick={() => editor.chain().focus().setTextAlign(align).run()}
+              className={`p-2 rounded hover:bg-at-border transition-colors ${
+                editor.isActive({ textAlign: align }) ? 'bg-at-border' : ''
+              }`}
+              title={title}
+            >
+              <Icon className="h-4 w-4" />
             </button>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- 프로토콜 에디터(EnhancedTiptapEditor) 툴바에 글자 정렬 버튼 4개 추가
- 지원 정렬: 왼쪽 / 가운데 / 오른쪽 / 양쪽(justify)
- TextAlign extension의 alignments에 'justify' 추가
- lucide-react의 AlignLeft/Center/Right/Justify 아이콘 사용
- 활성 정렬은 isActive({ textAlign }) 로 토글 강조

## Test plan
- [ ] 프로토콜 작성/편집 화면에서 정렬 버튼 4개가 제목과 리스트 사이에 노출되는지 확인
- [ ] 각 정렬 버튼 클릭 시 paragraph/heading의 정렬이 변경되는지 확인
- [ ] 현재 정렬 상태에 따라 버튼 강조(배경색) 표시되는지 확인
- [ ] 기존 기능(굵게/기울임/색상/줄간격/제목/리스트/미디어 삽입 등)이 영향 없이 정상 작동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)