### PR TITLE
fix(auction): 상세 페이지 5개 탭 기능 결함 정리

### DIFF
--- a/dental-clinic-manager/src/components/Investment/Auction/AuctionContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/AuctionContent.tsx
@@ -59,7 +59,8 @@ export default function AuctionContent() {
     setSelectedItemId(id)
     const params = new URLSearchParams(Array.from(sp.entries()))
     params.set('item', id)
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+    const qs = params.toString()
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
     // 상세 진입 시 스크롤 상단으로
     if (typeof window !== 'undefined') window.scrollTo({ top: 0, behavior: 'instant' })
   }, [pathname, router, sp])
@@ -68,7 +69,8 @@ export default function AuctionContent() {
     setSelectedItemId(null)
     const params = new URLSearchParams(Array.from(sp.entries()))
     params.delete('item')
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+    const qs = params.toString()
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
   }, [pathname, router, sp])
 
   if (selectedItemId) {
@@ -264,7 +266,7 @@ function AuctionDetailView({ itemId, onBack }: { itemId: string; onBack: () => v
             item={data.item}
             market={data.market}
             onSave={async (input: SimulatorInput) => {
-              await fetch('/api/auction/favorites', {
+              const r = await fetch('/api/auction/favorites', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -274,7 +276,10 @@ function AuctionDetailView({ itemId, onBack }: { itemId: string; onBack: () => v
                   expected_monthly_rent: input.monthly_rent,
                 }),
               })
-              alert('관심물건에 저장되었습니다.')
+              if (!r.ok) {
+                const j = await r.json().catch(() => ({}))
+                throw new Error(j?.error ?? `HTTP ${r.status}`)
+              }
             }}
           />
         )}

--- a/dental-clinic-manager/src/components/Investment/Auction/AuctionDetailHeader.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/AuctionDetailHeader.tsx
@@ -9,6 +9,13 @@ interface Props {
 
 const fmt = (n: number | null) => n === null ? '-' : new Intl.NumberFormat('ko-KR').format(n)
 
+// 양수면 "−x%" (싸짐, 호재), 음수면 "+x%" (비쌈), 0은 "0%".
+function signedPct(pct: number): string {
+  if (pct === 0) return '0%'
+  if (pct > 0) return `−${pct.toFixed(1)}%`
+  return `+${Math.abs(pct).toFixed(1)}%`
+}
+
 export function AuctionDetailHeader({ item, market }: Props) {
   const today = new Date().toISOString().slice(0, 10)
   const p = calculatePrimary(item, today)
@@ -35,9 +42,17 @@ export function AuctionDetailHeader({ item, market }: Props) {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 pt-4 border-t border-at-border">
         <Field label="감정가" value={`${fmt(item.appraisal_price)}원`} />
         <Field label="최저입찰가" value={`${fmt(item.min_bid_price)}원`} highlight />
-        <Field label="할인율" value={`−${p.discount_rate_pct.toFixed(1)}%`} accent="success" />
+        <Field
+          label="할인율"
+          value={signedPct(p.discount_rate_pct)}
+          accent={p.discount_rate_pct > 0 ? 'success' : p.discount_rate_pct < 0 ? 'warning' : undefined}
+        />
         {s && (
-          <Field label="시세 대비" value={`−${s.market_discount_rate_pct.toFixed(1)}%`} accent="accent" />
+          <Field
+            label="시세 대비"
+            value={signedPct(s.market_discount_rate_pct)}
+            accent={s.market_discount_rate_pct > 0 ? 'accent' : s.market_discount_rate_pct < 0 ? 'warning' : undefined}
+          />
         )}
         <Field label="유찰" value={`${p.failure_count}회 (${p.round_no}차)`} />
         <Field label="매각기일" value={item.next_auction_date ?? '미정'} />
@@ -47,9 +62,10 @@ export function AuctionDetailHeader({ item, market }: Props) {
   )
 }
 
-function Field({ label, value, highlight, accent }: { label: string; value: string; highlight?: boolean; accent?: 'success'|'accent' }) {
+function Field({ label, value, highlight, accent }: { label: string; value: string; highlight?: boolean; accent?: 'success'|'accent'|'warning' }) {
   const colorCls = accent === 'success' ? 'text-[var(--at-success)]'
                 : accent === 'accent'  ? 'text-at-accent'
+                : accent === 'warning' ? 'text-[var(--at-warning)]'
                 : 'text-at-text'
   return (
     <div>

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/HistoryTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/HistoryTab.tsx
@@ -30,8 +30,20 @@ const RESULT_LABEL: Record<string, string> = {
 
 export function HistoryTab({ itemId, history }: Props) {
   const [stats, setStats] = useState<ComplexStats | null>(null)
+  const [statsErr, setStatsErr] = useState<string | null>(null)
   useEffect(() => {
-    fetch(`/api/auction/items/${itemId}/complex-stats`).then(r => r.json()).then(setStats).catch(() => {})
+    setStats(null)
+    setStatsErr(null)
+    fetch(`/api/auction/items/${itemId}/complex-stats`)
+      .then(async r => {
+        const j = await r.json().catch(() => ({}))
+        if (!r.ok || typeof j?.sample_count !== 'number') {
+          setStatsErr(j?.error ?? `통계를 불러오지 못했습니다 (HTTP ${r.status})`)
+          return
+        }
+        setStats(j)
+      })
+      .catch(e => setStatsErr(`통계를 불러오지 못했습니다: ${e?.message ?? e}`))
   }, [itemId])
 
   const chartData = history.map(h => ({
@@ -44,7 +56,11 @@ export function HistoryTab({ itemId, history }: Props) {
       <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
         <h3 className="text-base font-semibold mb-3 text-at-text">회차별 변동</h3>
         {history.length === 0 ? (
-          <p className="text-[14px] md:text-sm text-at-text-secondary">이력이 없습니다.</p>
+          <p className="text-[14px] md:text-sm text-at-text-secondary leading-relaxed">
+            이 물건의 회차별 가격 변동·낙찰 이력이 아직 수집되지 않았습니다.
+            <br />
+            <span className="text-[13px] md:text-xs text-at-text-weak">법원경매정보의 사건 상세에서 직접 확인하실 수 있습니다 (첨부 탭의 &quot;법원경매정보 원문&quot; 링크).</span>
+          </p>
         ) : (
           <>
             <div className="h-48 mb-4">
@@ -113,10 +129,16 @@ export function HistoryTab({ itemId, history }: Props) {
 
       <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
         <h3 className="text-base font-semibold mb-3 text-at-text">동일 동·용도 낙찰 통계 (최근 6개월)</h3>
-        {!stats ? (
+        {statsErr ? (
+          <p className="text-[14px] md:text-sm text-rose-600">{statsErr}</p>
+        ) : !stats ? (
           <p className="text-[14px] md:text-sm text-at-text-secondary">로딩 중...</p>
         ) : stats.sample_count === 0 ? (
-          <p className="text-[14px] md:text-sm text-at-text-secondary">이 동·용도의 최근 낙찰 이력이 없습니다.</p>
+          <p className="text-[14px] md:text-sm text-at-text-secondary leading-relaxed">
+            동일 동·용도의 최근 6개월 낙찰 표본이 없습니다.
+            <br />
+            <span className="text-[13px] md:text-xs text-at-text-weak">표본은 낙찰 이력이 수집된 매물에서 자동 집계됩니다.</span>
+          </p>
         ) : (
           <dl className="grid grid-cols-3 gap-2 sm:gap-4 text-[14px] md:text-sm">
             <div>

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/OverviewTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/OverviewTab.tsx
@@ -54,18 +54,6 @@ export function OverviewTab({ item, market }: Props) {
         )}
       </section>
 
-      {item.photos.length > 0 && (
-        <section className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
-          <h3 className="text-base font-bold mb-3 text-at-text">사진</h3>
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-            {item.photos.map((url, i) => (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img key={i} src={url} alt={`사진 ${i+1}`} className="rounded-xl w-full h-40 object-cover border border-at-border" />
-            ))}
-          </div>
-        </section>
-      )}
-
       <p className="text-[13px] md:text-xs text-at-text-secondary px-1 leading-relaxed">
         ※ 본 정보는 투자 판단의 보조 자료이며, 최종 판단의 책임은 사용자에게 있습니다.
       </p>

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/RightsTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/RightsTab.tsx
@@ -74,7 +74,11 @@ export function RightsTab({ itemId, rights, initialAi }: Props) {
             <Dd>{rights.parse_status ?? '-'}</Dd>
           </dl>
         ) : (
-          <p className="text-[14px] md:text-sm text-at-text-secondary">권리분석 데이터가 아직 수집되지 않았습니다.</p>
+          <p className="text-[14px] md:text-sm text-at-text-secondary leading-relaxed">
+            매각물건명세서 자동 파싱 결과가 아직 수집되지 않았습니다.
+            <br />
+            <span className="text-[13px] md:text-xs text-at-text-weak">아래 &quot;AI 분석 실행&quot; 버튼으로 매물 메타데이터 기반의 위험도 코멘트를 받을 수 있습니다.</span>
+          </p>
         )}
       </section>
 

--- a/dental-clinic-manager/src/components/Investment/Auction/tabs/SimulatorTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Auction/tabs/SimulatorTab.tsx
@@ -7,7 +7,7 @@ interface Props {
   item: AuctionItem
   market: MarketPrice | null
   initialInput?: Partial<SimulatorInput>
-  onSave?: (input: SimulatorInput) => void
+  onSave?: (input: SimulatorInput) => Promise<void> | void
 }
 
 const fmt = (n: number | null) => n === null ? '-' : new Intl.NumberFormat('ko-KR').format(n)
@@ -23,27 +23,66 @@ export function SimulatorTab({ item, market, initialInput, onSave }: Props) {
     is_multi_owner: initialInput?.is_multi_owner ?? false,
   })
 
-  const tertiary = useMemo(() => calculateTertiary(item, input), [item, input])
+  // 시세 매칭이 없거나 사용자가 직접 입력하고 싶을 때 수동 시세를 받는다.
+  const matchedPrice = market?.median_price_3m ?? market?.median_price_12m ?? null
+  const [marketPriceInput, setMarketPriceInput] = useState<number | null>(matchedPrice)
+
   const secondary = useMemo(() => {
-    if (!market) return null
-    return calculateSecondary(item, market, {
+    if (!marketPriceInput || marketPriceInput <= 0) return null
+    const effectiveMarket: MarketPrice = market
+      ? { ...market, median_price_3m: marketPriceInput }
+      : {
+          source: 'manual',
+          matched_complex: null,
+          median_price_3m: marketPriceInput,
+          trade_count_3m: null,
+          median_price_12m: null,
+          last_trade_date: null,
+          match_confidence: 'low',
+        }
+    return calculateSecondary(item, effectiveMarket, {
       isMultiOwner: input.is_multi_owner,
       repairCost: input.repair_cost,
       unpaidDues: input.unpaid_dues,
     })
-  }, [item, market, input])
+  }, [item, market, marketPriceInput, input.is_multi_owner, input.repair_cost, input.unpaid_dues])
+
+  const tertiary = useMemo(() => calculateTertiary(item, input), [item, input])
 
   const set = <K extends keyof SimulatorInput>(k: K, v: SimulatorInput[K]) => setInput(p => ({ ...p, [k]: v }))
 
-  const min = item.min_bid_price
-  const max = Math.round(item.appraisal_price * 1.1)
+  // min_bid_price > appraisal_price * 1.1 인 비정상 케이스에서 슬라이더가 무너지지 않도록 가드.
+  const bidSliderMin = item.min_bid_price
+  const bidSliderMax = Math.max(bidSliderMin, Math.round(item.appraisal_price * 1.1))
+
+  const [saving, setSaving] = useState(false)
+  const [saveMsg, setSaveMsg] = useState<{ type: 'ok' | 'err'; text: string } | null>(null)
+  const handleSave = async () => {
+    if (!onSave) return
+    setSaving(true)
+    setSaveMsg(null)
+    try {
+      await onSave(input)
+      setSaveMsg({ type: 'ok', text: '관심물건에 저장되었습니다.' })
+    } catch (e: any) {
+      setSaveMsg({ type: 'err', text: `저장 실패: ${e?.message ?? '알 수 없는 오류'}` })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const marketSourceLabel = marketPriceInput === null
+    ? null
+    : market && marketPriceInput === matchedPrice
+      ? `자동 매칭 (${market.match_confidence}${market.matched_complex ? ', ' + market.matched_complex : ''})`
+      : '직접 입력'
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
       <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card space-y-5">
         <h3 className="text-base font-semibold text-at-text">입찰 시뮬레이션 입력</h3>
 
-        <Slider label="응찰가" value={input.bid_price} min={min} max={max} step={100_000} format={(n) => `${fmt(n)}원`} onChange={(v) => set('bid_price', v)} />
+        <Slider label="응찰가" value={input.bid_price} min={bidSliderMin} max={bidSliderMax} step={100_000} format={(n) => `${fmt(n)}원`} onChange={(v) => set('bid_price', v)} />
         <Slider label="예상 월세" value={input.monthly_rent} min={0} max={20_000_000} step={50_000} format={(n) => `${fmt(n)}원/월`} onChange={(v) => set('monthly_rent', v)} />
         <Slider label="월 관리비" value={input.monthly_management_cost} min={0} max={2_000_000} step={10_000} format={(n) => `${fmt(n)}원/월`} onChange={(v) => set('monthly_management_cost', v)} />
         <Slider label="연 재산세" value={input.annual_property_tax} min={0} max={50_000_000} step={100_000} format={(n) => `${fmt(n)}원/년`} onChange={(v) => set('annual_property_tax', v)} />
@@ -56,22 +95,48 @@ export function SimulatorTab({ item, market, initialInput, onSave }: Props) {
         </label>
 
         {onSave && (
-          <button onClick={() => onSave(input)} className="w-full py-2.5 rounded-xl bg-at-accent text-white font-semibold">
-            관심물건에 저장
-          </button>
+          <div>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="w-full py-2.5 rounded-xl bg-at-accent text-white font-semibold disabled:opacity-50"
+            >
+              {saving ? '저장 중...' : '관심물건에 저장'}
+            </button>
+            {saveMsg && (
+              <p className={`mt-2 text-[13px] md:text-xs font-medium ${saveMsg.type === 'ok' ? 'text-[var(--at-success)]' : 'text-rose-600'}`}>
+                {saveMsg.text}
+              </p>
+            )}
+          </div>
         )}
       </div>
 
       <div className="space-y-4">
-        {secondary && (
-          <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
-            <h3 className="text-base font-semibold mb-3 text-at-text">매도 시뮬 (시세 기반)</h3>
-            <Result label="예상 시세" value={`${fmt(secondary.expected_market_price)}원`} />
-            <Result label="예상 매도차익" value={`${fmt(secondary.expected_resale_profit)}원`} accent={secondary.expected_resale_profit > 0 ? 'emerald' : 'rose'} />
-            <Result label="단순 수익률" value={`${secondary.simple_roi_pct.toFixed(2)}%`} accent={secondary.simple_roi_pct > 0 ? 'emerald' : 'rose'} />
-            <p className="text-[13px] md:text-xs text-at-text-secondary mt-2">시세 매칭 신뢰도: {secondary.match_confidence}</p>
-          </div>
-        )}
+        <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card space-y-3">
+          <h3 className="text-base font-semibold text-at-text">매도 시뮬</h3>
+          <ManualMarketPriceInput
+            value={marketPriceInput}
+            onChange={setMarketPriceInput}
+            placeholder={matchedPrice}
+            hasMatchedMarket={!!market}
+          />
+
+          {secondary ? (
+            <div>
+              <Result label="예상 시세" value={`${fmt(secondary.expected_market_price)}원`} />
+              <Result label="예상 매도차익" value={`${fmt(secondary.expected_resale_profit)}원`} accent={secondary.expected_resale_profit > 0 ? 'emerald' : 'rose'} />
+              <Result label="단순 수익률" value={`${secondary.simple_roi_pct.toFixed(2)}%`} accent={secondary.simple_roi_pct > 0 ? 'emerald' : 'rose'} />
+              {marketSourceLabel && (
+                <p className="text-[13px] md:text-xs text-at-text-secondary mt-2">출처: {marketSourceLabel}</p>
+              )}
+            </div>
+          ) : (
+            <p className="text-[14px] md:text-sm text-at-text-secondary py-2 leading-relaxed">
+              예상 시세를 입력하면 취득세·등기비 등 부대비용을 반영한 매도 수익을 계산합니다.
+            </p>
+          )}
+        </div>
 
         <div className="bg-at-surface rounded-2xl p-4 md:p-5 border border-at-border shadow-at-card">
           <h3 className="text-base font-semibold mb-3 text-at-text">임대 시뮬</h3>
@@ -101,13 +166,59 @@ interface SliderProps {
 }
 
 function Slider({ label, value, min, max, step, format, onChange }: SliderProps) {
+  const safeMax = Math.max(min, max)
+  const safeValue = Math.min(Math.max(value, min), safeMax)
+  const disabled = safeMax === min
   return (
     <div>
       <div className="flex justify-between items-baseline mb-1.5 gap-2">
         <label className="text-[14px] md:text-sm font-semibold text-at-text">{label}</label>
-        <span className="text-[14px] md:text-sm tabular-nums font-semibold text-at-text">{format(value)}</span>
+        <span className="text-[14px] md:text-sm tabular-nums font-semibold text-at-text">{format(safeValue)}</span>
       </div>
-      <input type="range" min={min} max={max} step={step} value={value} onChange={(e) => onChange(Number(e.target.value))} className="w-full" />
+      <input
+        type="range"
+        min={min}
+        max={safeMax}
+        step={step}
+        value={safeValue}
+        onChange={(e) => onChange(Number(e.target.value))}
+        disabled={disabled}
+        className="w-full disabled:opacity-50"
+      />
+    </div>
+  )
+}
+
+function ManualMarketPriceInput({
+  value, onChange, placeholder, hasMatchedMarket,
+}: {
+  value: number | null
+  onChange: (v: number | null) => void
+  placeholder: number | null
+  hasMatchedMarket: boolean
+}) {
+  const [raw, setRaw] = useState(value !== null ? value.toString() : '')
+  return (
+    <div>
+      <label className="block text-[14px] md:text-sm font-semibold text-at-text mb-1.5">
+        예상 시세 {hasMatchedMarket ? '(자동 매칭값 수정 가능)' : '(직접 입력)'}
+      </label>
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          inputMode="numeric"
+          value={raw}
+          placeholder={placeholder !== null ? new Intl.NumberFormat('ko-KR').format(placeholder) : '예) 350000000'}
+          onChange={(e) => {
+            const cleaned = e.target.value.replace(/[^\d]/g, '')
+            setRaw(cleaned)
+            const n = cleaned === '' ? null : Number(cleaned)
+            onChange(n === null || Number.isNaN(n) ? null : n)
+          }}
+          className="flex-1 h-10 px-3 rounded-lg border border-at-border bg-at-surface-alt text-[14px] md:text-sm text-at-text tabular-nums focus:outline-none focus:ring-2 focus:ring-at-accent"
+        />
+        <span className="text-[13px] md:text-xs text-at-text-secondary shrink-0">원</span>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- 사진 갤러리 중복, 음수 할인율 표기 버그, 매도 시뮬 불가, 빈 상태 안내 빈약 등 상세 페이지 5개 탭의 사용성 결함을 정리

## 변경
- **OverviewTab**: AuctionContent 갤러리와 중복되던 사진 섹션 제거
- **AuctionDetailHeader**: 음수 할인율·시세대비가 \"−-15%\" 이중 마이너스로 표기되던 버그 수정. \`signedPct\` 헬퍼로 양수 \"−x%\" / 음수 \"+x%\" / 0 \"0%\" 일관 표기. 시세보다 비싼 매물은 warning 컬러로 강조
- **SimulatorTab**: 매도 시뮬 섹션에 \"예상 시세 직접 입력\" 필드 추가 — 시세 매칭이 없던 토지/공장 매물도 매도 수익 계산이 가능해짐. Slider min/max 가드(min_bid > 감정가×1.1 비정상 케이스 대응), 관심물건 저장 실패 시 사용자에게 에러 메시지 노출
- **HistoryTab**: 회차별 변동·낙찰 통계 빈 상태 안내를 \"왜 없는지 + 대안\"으로 명확화, complex-stats fetch 실패 가드 추가
- **RightsTab**: 권리분석 자동 추출이 없는 매물에서 \"AI 분석 실행 버튼을 누르라\"는 안내 추가
- **AuctionContent**: 상세 진입/이탈 URL에서 빈 query string(\`?\`)이 남지 않도록 정리, Simulator onSave가 실패 시 throw하여 SimulatorTab 안에서 사용자 메시지로 처리

## Test plan
- [x] \`npm run build\` 통과
- [ ] 상세 페이지 진입 시 사진이 한 번만 표시되는지
- [ ] 시세 대비가 시세보다 싼 매물에서 \`−x%\`, 비싼 매물에서 \`+x%\`로 표기되는지
- [ ] 시뮬레이터 매도 시뮬에 시세 입력하면 매도 수익이 계산되는지
- [ ] 이력·통계 / 권리분석 탭의 빈 상태 안내가 명확한지

🤖 Generated with [Claude Code](https://claude.com/claude-code)