### PR TITLE
fix(marketing): 텍스트 카드(title) 이미지 항상 글 최상단에 생성

### DIFF
--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778853472690'
+const SW_VERSION = 'v1778896653601'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
@@ -118,8 +118,10 @@ export default function NewMarketingPostPage() {
   useEffect(() => { setTargetWordCountInput(String(targetWordCount)) }, [targetWordCount])
   const [useSeoAnalysis, setUseSeoAnalysis] = useState(true)
   const [brandImageOptions, setBrandImageOptions] = useState<BrandImageOptions>({
+    // 텍스트 카드(title) 를 네이버 검색 노출 첫 이미지로 보이도록 'top' 우선 배치.
+    // insertBrandMarkers 가 top 슬롯 안에서도 title 을 최상위로 정렬.
     medicalLaw: { enabled: true, positions: ['top'] },
-    title:      { enabled: true, positions: ['middle'], copy: '' },
+    title:      { enabled: true, positions: ['top'], copy: '' },
     photo:      { enabled: true, positions: ['bottom'], mode: 'random' },
   })
   const seoPreview = useSeoPreview()
@@ -313,7 +315,7 @@ export default function NewMarketingPostPage() {
     setTargetWordCount(1500)
     setBrandImageOptions({
       medicalLaw: { enabled: true, positions: ['top'] },
-      title: { enabled: true, positions: ['middle'], copy: '' },
+      title: { enabled: true, positions: ['top'], copy: '' },
       photo: { enabled: true, positions: ['bottom'], mode: 'random' },
     })
     setReferenceImageBase64('')

--- a/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
+++ b/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
@@ -131,8 +131,10 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
   const [referenceImagePreview, setReferenceImagePreview] = useState<string>('')
   const [clinicalData, setClinicalData] = useState<ClinicalFormData | null>(null)
   const [brandImageOptions, setBrandImageOptions] = useState<BrandImageOptions>({
+    // 텍스트 카드(title) 를 네이버 검색 노출 첫 이미지로 보이도록 'top' 우선 배치.
+    // insertBrandMarkers 가 top 슬롯 안에서도 title 을 최상위로 정렬.
     medicalLaw: { enabled: true, positions: ['top'] },
-    title:      { enabled: true, positions: ['middle'], copy: '' },
+    title:      { enabled: true, positions: ['top'], copy: '' },
     photo:      { enabled: true, positions: ['bottom'], mode: 'random' },
   })
 
@@ -329,7 +331,7 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
     setTargetWordCount(1500)
     setBrandImageOptions({
       medicalLaw: { enabled: true, positions: ['top'] },
-      title: { enabled: true, positions: ['middle'], copy: '' },
+      title: { enabled: true, positions: ['top'], copy: '' },
       photo: { enabled: true, positions: ['bottom'], mode: 'random' },
     })
     setReferenceImageBase64('')

--- a/dental-clinic-manager/src/lib/marketing/brand/marker-resolver.ts
+++ b/dental-clinic-manager/src/lib/marketing/brand/marker-resolver.ts
@@ -66,7 +66,11 @@ export async function resolveBrandMarkers(body: string, ctx: ResolveContext): Pr
       if (marker.type === 'medical_law') {
         url = await renderBrandImage({ type: 'medical_law', assets: a });
       } else if (marker.type === 'title') {
-        const copy = marker.params.copy || `${a.name_ko ?? ''} / `.trim();
+        // copy 가 비었거나 placeholder('/' 만) 면 의미 없는 카드가 생성되므로 폼/상위에서 articleTitle 자동 채움이 우선.
+        // 여기는 최후 fallback — 클리닉명만이라도 노출.
+        const rawCopy = (marker.params.copy || '').trim();
+        const looksEmpty = rawCopy.length === 0 || /^\/+\s*$/.test(rawCopy);
+        const copy = looksEmpty ? (a.name_ko ?? a.name_en ?? '').trim() : rawCopy;
         url = await renderBrandImage({ type: 'title', assets: a, copy });
       } else if (marker.type === 'photo') {
         let chosen: BrandPhoto | undefined;
@@ -80,7 +84,12 @@ export async function resolveBrandMarkers(body: string, ctx: ResolveContext): Pr
         if (chosen) url = await renderBrandImage({ type: 'photo', assets: a, photo: chosen });
       }
     } catch (err) {
-      console.error('[brand marker resolve] error:', err);
+      const e = err as { message?: string; stack?: string };
+      console.error('[brand marker resolve] error:', {
+        type: marker.type,
+        params: marker.params,
+        message: e?.message,
+      });
     }
     const replacement = url ? `\n\n![](${url})\n\n` : '';
     out = out.slice(0, marker.index) + replacement + out.slice(marker.index + marker.raw.length);

--- a/dental-clinic-manager/src/lib/marketing/content-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/content-generator.ts
@@ -60,8 +60,10 @@ function applyParagraphIndent(body: string): string {
 }
 
 // ─── 브랜드 이미지 마커 삽입 ───
-// options.brandImageOptions에 따라 [BRAND_IMAGE:...] 마커를 본문 위치(top/middle/bottom)에 삽입
-function insertBrandMarkers(body: string, opts?: BrandImageOptions): string {
+// options.brandImageOptions에 따라 [BRAND_IMAGE:...] 마커를 본문 위치(top/middle/bottom)에 삽입.
+// title(텍스트 카드) 의 copy 가 비어있거나 placeholder('/' 만) 면 글 제목을 자동 적용 — 네이버 검색
+// 노출 시 첫 이미지가 글 주제를 그대로 보여주도록.
+function insertBrandMarkers(body: string, opts?: BrandImageOptions, articleTitle?: string): string {
   if (!opts) return body;
 
   type Spot = 'top' | 'middle' | 'bottom';
@@ -71,8 +73,14 @@ function insertBrandMarkers(body: string, opts?: BrandImageOptions): string {
     for (const pos of opts.medicalLaw.positions) buckets[pos].push('[BRAND_IMAGE:medical_law]');
   }
   if (opts.title.enabled) {
-    const copy = opts.title.copy.replace(/\]/g, '');
-    for (const pos of opts.title.positions) buckets[pos].push(`[BRAND_IMAGE:title|copy=${copy}]`);
+    // copy 자동 채움: 사용자 입력이 비었거나 placeholder('/' 만) 면 articleTitle 사용.
+    // marker 형식 보존을 위해 `]` 및 `|` 는 그대로 두면 파서가 깨짐 → 제거.
+    const userCopy = (opts.title.copy || '').replace(/\]/g, '').replace(/\|/g, '').trim();
+    const looksEmpty = userCopy.length === 0 || /^\/+\s*$/.test(userCopy);
+    const finalCopy = looksEmpty
+      ? (articleTitle || '').replace(/\]/g, '').replace(/\|/g, '').trim()
+      : userCopy;
+    for (const pos of opts.title.positions) buckets[pos].push(`[BRAND_IMAGE:title|copy=${finalCopy}]`);
   }
   if (opts.photo.enabled) {
     const tail = opts.photo.mode === 'manual' && opts.photo.photoId
@@ -81,8 +89,9 @@ function insertBrandMarkers(body: string, opts?: BrandImageOptions): string {
     for (const pos of opts.photo.positions) buckets[pos].push(`[BRAND_IMAGE:photo|${tail}]`);
   }
 
-  // 우선순위 정렬: medical_law → title → photo
-  const order = (m: string) => m.includes('medical_law') ? 0 : m.includes(':title') ? 1 : 2;
+  // 우선순위 정렬: title → medical_law → photo
+  // (네이버 검색 첫 이미지 = 글 최상단 이미지. 텍스트 카드가 글 주제를 보여주도록 title 을 최상위로)
+  const order = (m: string) => m.includes(':title') ? 0 : m.includes('medical_law') ? 1 : 2;
   for (const k of ['top', 'middle', 'bottom'] as const) {
     buckets[k].sort((a, b) => order(a) - order(b));
   }
@@ -441,12 +450,13 @@ export async function generateContent(
 
     const retryText = retryResponse.content[0].type === 'text' ? retryResponse.content[0].text : '';
     const retryParsed = parseGeneratedContent(retryText, options.keyword);
-    // 단락 들여쓰기 후 브랜드 마커 삽입 (마커 줄은 들여쓰기 대상이 아니므로 순서 중요)
-    retryParsed.body = insertBrandMarkers(applyParagraphIndent(retryParsed.body), options.brandImageOptions);
+    // 단락 들여쓰기 후 브랜드 마커 삽입 (마커 줄은 들여쓰기 대상이 아니므로 순서 중요).
+    // title 카드 copy 자동 채움을 위해 글 제목 전달.
+    retryParsed.body = insertBrandMarkers(applyParagraphIndent(retryParsed.body), options.brandImageOptions, retryParsed.title);
     return retryParsed;
   }
 
-  parsed.body = insertBrandMarkers(applyParagraphIndent(parsed.body), options.brandImageOptions);
+  parsed.body = insertBrandMarkers(applyParagraphIndent(parsed.body), options.brandImageOptions, parsed.title);
   return parsed;
 }
 


### PR DESCRIPTION
## Summary

텍스트 카드 이미지가 네이버 검색 노출 첫 이미지(글 주제를 그대로 보여주는 카드) 역할을 하도록 정합성 강화.

## 원인
1. **copy 자동 채움 없음** — 사용자가 폼에서 copy 를 빈 채로 두면 marker-resolver fallback 이 `${name_ko} / ` 같은 의미 없는 텍스트로 카드 생성.
2. **위치 default 가 middle** — 폼 default 가 `title.positions: ['middle']` 이라 본문 중간에 배치.
3. **순서 정렬에서 title 이 뒤** — insertBrandMarkers 가 top 슬롯 안에서 `medical_law(0) → title(1)` 순으로 정렬해 텍스트 카드가 의료법 카드 아래로.

## 해결
- **content-generator `insertBrandMarkers`**: `articleTitle` 인자 추가. 사용자 copy 가 빈 문자열 또는 placeholder(`/` 만) 이면 글 제목으로 자동 채움.
- **buckets order**: `title(0) → medical_law(1) → photo(2)` — top 슬롯에서도 텍스트 카드가 가장 위로.
- **default position**: `title.positions: ['middle']` → `['top']` (`NewPostForm`, `posts/new/page`, `resetInputsToDefaults` 모두 동일).
- **marker-resolver fallback**: copy 비면 클리닉명(`name_ko ?? name_en`) 사용.
- **에러 로깅 보강**: 마커 resolve 실패 시 `type/params/message` 분리 출력.

## 영향
- 네이버 검색에 노출되는 첫 이미지가 글 제목 텍스트 카드로 통일됨.
- 사용자가 copy 입력 안 해도 자동으로 글 제목이 카드에 들어감.

## Test plan
- [x] 빌드 통과
- [ ] production AI 글 생성 → 본문 최상단에 텍스트 카드 이미지(글 제목 텍스트) 정상 생성 확인
- [ ] 텍스트 카드 위치가 의료법 안내 카드보다 위에 오는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)