### PR TITLE
fix(marketing): SEO 평균에서 추출 실패 글 제외 + 워커 iframe 본문 race 해소

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/package.json
+++ b/dental-clinic-manager/marketing-worker/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hayan-marketing-worker",
-  "version": "1.1.104",
+  "version": "1.1.105",
   "description": "하얀치과 마케팅 워커 - Electron 데스크탑 앱",
   "productName": "클리닉 매니저 워커",
   "private": true,

--- a/dental-clinic-manager/marketing-worker/electron/src/seo-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/seo-bridge.ts
@@ -421,15 +421,34 @@ async function scrapeAndAnalyzePost(page: any, url: string, keyword: string, ran
   await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
   await page.waitForTimeout(2000);
 
-  // iframe 내부 콘텐츠 접근 (네이버 블로그는 iframe 사용)
-  let contentFrame = page;
+  // iframe 내부 콘텐츠 접근 (네이버 블로그는 iframe 사용).
+  // 일부 글은 top-level 에 본문이 노출되지 않고 iframe#mainFrame 내부에만 .se-main-container 가 있어,
+  // 단순 waitForTimeout 만으로는 본문 로드 전에 evaluate 가 실행되어 body_length === 0 으로 잘못 표시됨.
+  // → iframe contentFrame 안 본문 selector 가 실제로 나타날 때까지 명시적으로 대기 (최대 10초).
+  let contentFrame: any = page;
   try {
     const iframe = await page.waitForSelector('#mainFrame', { timeout: 5000 });
     if (iframe) {
-      contentFrame = await iframe.contentFrame();
-      await contentFrame.waitForTimeout(1000);
+      const cf = await iframe.contentFrame();
+      if (cf) {
+        contentFrame = cf;
+        try {
+          await cf.waitForSelector('.se-main-container, #postViewArea', { timeout: 10000 });
+        } catch { /* 본문 selector 못 찾음 — 다음 단계에서 top-level fallback */ }
+      }
     }
   } catch { /* iframe 없는 경우 */ }
+
+  // iframe 안에서 본문을 못 찾았으면 top-level 에서 한 번 더 시도 (보강 fallback).
+  if (contentFrame !== page) {
+    const found = await contentFrame.evaluate(() => !!document.querySelector('.se-main-container, #postViewArea'));
+    if (!found) {
+      try {
+        await page.waitForSelector('.se-main-container, #postViewArea', { timeout: 5000 });
+        contentFrame = page;
+      } catch { /* 정말 본문 selector 없음 — body_length=0 로 진행 */ }
+    }
+  }
 
   // 정량 데이터 추출
   const quantitative = await contentFrame.evaluate((kw: string) => {

--- a/dental-clinic-manager/public/sw.js
+++ b/dental-clinic-manager/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for PWA install & auto-update support
 // 배포마다 이 파일의 내용이 변경되어야 브라우저가 업데이트를 감지함
 // SW_VERSION은 빌드 스크립트(prebuild)에서 자동 갱신됨
-const SW_VERSION = 'v1778896653601'
+const SW_VERSION = 'v1778897077454'
 
 // 캐시 이름 (버전별)
 const CACHE_NAME = `clinic-manager-${SW_VERSION}`

--- a/dental-clinic-manager/src/app/api/marketing/seo/preview/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/seo/preview/route.ts
@@ -82,12 +82,22 @@ async function buildResultFromAnalysis(admin: ReturnType<typeof getSupabaseAdmin
     });
   }
 
+  // 본문 추출 실패(bodyLength === 0) 글은 평균 계산에서 제외 — 캐시된 textMining 결과까지 일관 보정.
+  // (워커가 분석에 실패한 글이 평균에 들어가면 실제값 대비 평균이 낮게 잡혀 사용자가 글자수/이미지 목표를 과소 설정하게 됨)
+  const analyzed = referencedPosts.filter((p) => p.bodyLength > 0);
+  const n = analyzed.length;
+  const recomputedAverages = n > 0 ? {
+    avgBodyLength: Math.round(analyzed.reduce((s, p) => s + p.bodyLength, 0) / n),
+    avgImageCount: Math.round((analyzed.reduce((s, p) => s + p.imageCount, 0) / n) * 10) / 10,
+    avgHeadingCount: Math.round((analyzed.reduce((s, p) => s + p.headingCount, 0) / n) * 10) / 10,
+  } : null;
+
   if (analysis.summary?.textMining) {
-    return { ...analysis.summary.textMining, referencedPosts };
+    return { ...analysis.summary.textMining, ...(recomputedAverages || {}), referencedPosts };
   }
   if (!postRows || postRows.length === 0) return null;
   const mined = extractKeywordsFromPosts(postRows, keyword);
-  return { ...mined, referencedPosts };
+  return { ...mined, ...(recomputedAverages || {}), referencedPosts };
 }
 
 /** 키워드의 현재 상태 조사 — POST/GET 공용 핵심 로직 */

--- a/dental-clinic-manager/src/lib/marketing/seo-text-miner.ts
+++ b/dental-clinic-manager/src/lib/marketing/seo-text-miner.ts
@@ -151,12 +151,15 @@ export function extractKeywordsFromPosts(
 
   const top15 = competitorKeywords.slice(0, 15);
 
-  // Aggregate stats
-  const totalPosts = posts.length || 1;
-  const avgBodyLength = posts.reduce((sum, p) => sum + p.body_length, 0) / totalPosts;
-  const avgImageCount = posts.reduce((sum, p) => sum + p.image_count, 0) / totalPosts;
-  const avgHeadingCount = posts.reduce((sum, p) => sum + p.heading_count, 0) / totalPosts;
-  const avgKeywordCount = posts.reduce((sum, p) => sum + p.keyword_count, 0) / totalPosts;
+  // Aggregate stats — 본문 추출 실패 글(body_length == 0)은 평균 계산에서 제외.
+  // (선택자 변경/iframe 차단 등으로 분석 실패한 글까지 평균에 포함되면 실제값보다 평균이 낮게 잡혀
+  //  사용자가 글자수/이미지 목표를 과소 설정하게 됨)
+  const analyzedPosts = posts.filter((p) => p.body_length > 0);
+  const totalAnalyzed = analyzedPosts.length || 1;
+  const avgBodyLength = analyzedPosts.reduce((sum, p) => sum + p.body_length, 0) / totalAnalyzed;
+  const avgImageCount = analyzedPosts.reduce((sum, p) => sum + p.image_count, 0) / totalAnalyzed;
+  const avgHeadingCount = analyzedPosts.reduce((sum, p) => sum + p.heading_count, 0) / totalAnalyzed;
+  const avgKeywordCount = analyzedPosts.reduce((sum, p) => sum + p.keyword_count, 0) / totalAnalyzed;
 
   // Collect common tags
   const tagCounts = new Map<string, number>();


### PR DESCRIPTION
## Summary

두 가지 누적 이슈 동시 수정.

### [1] 평균 계산 보정 — 본문 추출 실패 글 제외
경쟁 글 분석 미리보기의 평균 글자수/이미지 수/소제목 수가 실제 상위 노출 글 대비 낮게 표시되던 문제.

원인: 본문 추출에 실패한 글(`body_length === 0`)이 평균 계산에 포함되어 평균이 끌어내림. 사용자가 글자수/이미지 목표를 과소 설정하게 됨.

해결:
- `src/lib/marketing/seo-text-miner.ts`: `body_length > 0` 필터 후 평균 계산
- `src/app/api/marketing/seo/preview/route.ts`: 캐시된 `textMining` 결과까지 `referencedPosts` 기준으로 재계산해 덮어씀 → **기존 분석된 키워드 결과도 즉시 보정**

### [2] "천호역 치과" 4·5위 본문 추출 실패 — iframe race
원인: 네이버 블로그는 두 가지 페이지 구조 혼재.
- A) top-level 에 `.se-main-container` 직접 노출
- B) top-level 은 `iframe#mainFrame` 만, 본문은 iframe 내부 (`PostView.naver` 로드)

워커가 iframe 처리 후 `waitForTimeout(1000)` 만 했는데, B 구조에서 본문 로드 전에 `evaluate` 가 실행되어 `body_length=0` 으로 잘못 표시. 실측 4위(roundgreen87/224096787668), 5위(seoulnopain/224219661176) 모두 B 구조이고 iframe 안에는 정상적으로 `.se-main-container` + `img.se-image-resource` 22~9 장이 존재.

해결: `marketing-worker/electron/src/seo-bridge.ts`
- iframe contentFrame 안 `.se-main-container` / `#postViewArea` 가 실제로 나타날 때까지 `waitForSelector({ timeout: 10000 })` 명시적 대기
- iframe contentFrame `null` / 본문 없음 케이스에서 top-level fallback 시도

worker version: 1.1.104 → 1.1.105

## Test plan
- [x] 빌드 통과
- [ ] "천호역 치과" 재분석 → 4·5위 정상 분석 (body_length > 0) 확인
- [ ] 평균 글자수·이미지·소제목이 분석된 글 기준으로만 계산되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)