### PR TITLE
feat(bulk-sms): 생일 필터를 선택형(3옵션) + 기본 사용 안 함

### DIFF
--- a/dental-clinic-manager/src/components/BulkSms/SendTab/PatientFilterPanel.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/PatientFilterPanel.tsx
@@ -26,10 +26,26 @@ function daysAgo(d: number): string {
   return date.toISOString().slice(0, 10)
 }
 
+type BirthMode = 'none' | 'today' | 'months'
+
+function deriveBirthMode(value: BulkSmsFilter): BirthMode {
+  if (value.birthToday) return 'today'
+  if ((value.birthMonths ?? []).length > 0) return 'months'
+  return 'none'
+}
+
 export default function PatientFilterPanel({ value, onChange, onApply, loading }: Props) {
   const [keyword, setKeyword] = useState(value.searchKeyword ?? '')
+  const [birthMode, setBirthMode] = useState<BirthMode>(() => deriveBirthMode(value))
 
   const update = (patch: Partial<BulkSmsFilter>) => onChange({ ...value, ...patch })
+
+  const setBirthModeAndApply = (mode: BirthMode) => {
+    setBirthMode(mode)
+    if (mode === 'none') update({ birthToday: false, birthMonths: [] })
+    else if (mode === 'today') update({ birthToday: true, birthMonths: [] })
+    else update({ birthToday: false })
+  }
 
   const applyPreset = (preset: typeof LAST_VISIT_PRESETS[number]) => {
     if (preset.from === null && preset.to === null && !('daysFrom' in preset)) {
@@ -159,16 +175,17 @@ export default function PatientFilterPanel({ value, onChange, onApply, loading }
         <div>
           <label className="block text-sm font-medium text-[var(--at-text-primary)] mb-1.5">생일</label>
           <div className="flex gap-2 mb-2">
-            {[
-              { label: '🎂 오늘 생일자만', value: true },
-              { label: '월별 선택', value: false },
-            ].map(opt => (
+            {([
+              { mode: 'none', label: '사용 안 함' },
+              { mode: 'today', label: '🎂 오늘' },
+              { mode: 'months', label: '월별 선택' },
+            ] as const).map(opt => (
               <button
-                key={String(opt.value)}
+                key={opt.mode}
                 type="button"
-                onClick={() => update({ birthToday: opt.value, ...(opt.value ? { birthMonths: [] } : {}) })}
+                onClick={() => setBirthModeAndApply(opt.mode)}
                 className={`flex-1 px-3 py-1.5 text-sm rounded-lg border ${
-                  (value.birthToday ?? false) === opt.value
+                  birthMode === opt.mode
                     ? 'bg-[var(--at-accent-tag)] border-[var(--at-accent)] text-[var(--at-accent)]'
                     : 'bg-white border-[var(--at-border)] text-[var(--at-text-primary)] hover:bg-[var(--at-surface-alt)]'
                 }`}
@@ -177,7 +194,7 @@ export default function PatientFilterPanel({ value, onChange, onApply, loading }
               </button>
             ))}
           </div>
-          {!value.birthToday && (
+          {birthMode === 'months' && (
             <div className="grid grid-cols-6 gap-1.5">
               {Array.from({ length: 12 }, (_, i) => i + 1).map(m => {
                 const active = (value.birthMonths ?? []).includes(m)

--- a/dental-clinic-manager/src/components/BulkSms/SendTab/SendTab.tsx
+++ b/dental-clinic-manager/src/components/BulkSms/SendTab/SendTab.tsx
@@ -9,12 +9,12 @@ import SendActionBar from './SendActionBar'
 import SendConfirmDialog from './SendConfirmDialog'
 import type { BulkSmsFilter, BulkSmsEligiblePatient } from '@/types/bulkSms'
 
-// 진입 시 기본값: "오늘 생일자" 자동 조회 — 데스크의 주요 use case
+// 진입 시 기본값: 생일 필터 없음 — 사용자가 필요할 때 명시적으로 선택
 const INITIAL_FILTER: BulkSmsFilter = {
   gender: 'all', ageMin: null, ageMax: null,
   lastVisitFrom: null, lastVisitTo: null,
   lastTreatmentTypes: [], hasNextAppointment: null,
-  birthMonths: [], birthToday: true, searchKeyword: '', activeOnly: true,
+  birthMonths: [], birthToday: false, searchKeyword: '', activeOnly: true,
 }
 
 export default function SendTab() {


### PR DESCRIPTION
## Summary
- 단체 문자 환자 필터의 생일 옵션을 '사용 안 함 / 🎂 오늘 / 월별 선택' 3가지로 변경
- 페이지 진입 시 기본은 '사용 안 함' — 필요할 때만 사용자가 명시적으로 선택
- 월별 선택 모드일 때만 1~12월 그리드 노출 (사용 안 함/오늘 모드에선 숨김)
- 모드는 local state로 추적해 '월별 선택' 후 아무 달도 안 고르더라도 그리드가 사라지지 않음

## Test plan
- [ ] 단체 문자 발송 페이지 진입 시 생일 필터가 '사용 안 함' 활성 상태인지
- [ ] 진입 시 자동 조회되는 환자 목록이 생일 조건 없이 전체 활성 환자인지
- [ ] '🎂 오늘' 클릭 → 오늘 생일자만 조회되는지
- [ ] '월별 선택' 클릭 → 월 그리드 노출, 달 선택 시 해당 월 생일자만 조회되는지
- [ ] 다시 '사용 안 함' 클릭 → 생일 조건이 깔끔히 제거되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)