### PR TITLE
refactor(workers): 사이드바 워커별 버전 제거 + 덴트웹 agent_version 동적화

### DIFF
--- a/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
+++ b/dental-clinic-manager/marketing-worker/electron/src/dentweb-bridge.ts
@@ -1,8 +1,22 @@
 import sql from 'mssql';
+import { app } from 'electron';
 import { createClient, RealtimeChannel } from '@supabase/supabase-js';
 import { getConfig, setConfig, getDentwebConfig } from './config-store';
 import { log } from './logger';
 import { DentwebApiClient } from './dentweb-api-client';
+
+/**
+ * 워커 패키지 버전 — sync/heartbeat 의 agent_version 으로 전송되어
+ * `dentweb_sync_config.agent_version` 에 저장되고 대시보드 사이드바에 표시됨.
+ * Electron 메인 프로세스에서만 호출 (app.getVersion() 은 패키지 시점에만 의미있음).
+ */
+function getAgentVersion(): string {
+  try {
+    return app.getVersion();
+  } catch {
+    return 'unknown';
+  }
+}
 
 /* ------------------------------------------------------------------ */
 /*  Status management                                                  */
@@ -280,7 +294,7 @@ async function syncPatientsToServer(patients: Record<string, unknown>[], syncTyp
         api_key: cfg.apiKey,
         sync_type: syncType,
         patients,
-        agent_version: '2.0.0-electron',
+        agent_version: getAgentVersion(),
       }),
     });
     return await response.json();
@@ -303,7 +317,7 @@ async function syncPatientsToServer(patients: Record<string, unknown>[], syncTyp
         // 첫 chunk 만 원래 sync_type — 나머지는 incremental 로 로그 분리 (서버 측 upsert 동작은 동일)
         sync_type: i === 0 ? syncType : 'incremental',
         patients: chunk,
-        agent_version: '2.0.0-electron',
+        agent_version: getAgentVersion(),
       }),
     });
     const result = await response.json();
@@ -1251,7 +1265,7 @@ async function sendHeartbeat(): Promise<void> {
       body: JSON.stringify({
         clinic_id: cfg.clinicId,
         api_key: cfg.apiKey,
-        agent_version: '2.0.0-electron',
+        agent_version: getAgentVersion(),
         db_connected: dbConnected,
         last_error: lastSyncError,
       }),

--- a/dental-clinic-manager/src/components/Layout/WorkerStatusMenuItem.tsx
+++ b/dental-clinic-manager/src/components/Layout/WorkerStatusMenuItem.tsx
@@ -64,8 +64,6 @@ interface WorkerDef {
   premiumId: string
   /** 온라인 시 부가 정보 (예: workerCount) */
   getExtra?: (status: WorkerStatusResponse) => string
-  /** 워커 버전 추출 (있을 때만 표시) */
-  getVersion?: (status: WorkerStatusResponse) => string | null
 }
 
 const WORKER_DEFS: WorkerDef[] = [
@@ -73,7 +71,6 @@ const WORKER_DEFS: WorkerDef[] = [
     key: 'marketing',
     label: '마케팅 (발행)',
     premiumId: 'marketing',
-    getVersion: (s) => s.marketing?.currentVersion ?? null,
   },
   {
     key: 'seo',
@@ -85,8 +82,6 @@ const WORKER_DEFS: WorkerDef[] = [
     key: 'email',
     label: '이메일 모니터',
     premiumId: 'financial',
-    // 이메일 모니터는 마케팅 워커 서브 모듈 — 마케팅 워커 버전을 그대로 표시
-    getVersion: (s) => s.marketing?.currentVersion ?? null,
   },
   {
     key: 'scraping',
@@ -98,11 +93,10 @@ const WORKER_DEFS: WorkerDef[] = [
     key: 'dentweb',
     label: '덴트웹 동기화',
     premiumId: 'marketing',
-    getVersion: (s) => s.dentweb?.agentVersion ?? null,
   },
 ]
 
-/** v 접두사 정규화: "1.1.106" → "v1.1.106", "v1.1.106" 유지, "2.0.0-electron" → "2.0.0-electron" */
+/** v 접두사 정규화: "1.1.106" → "v1.1.106", "v1.1.106" 유지 */
 function formatVersion(v: string | null | undefined): string | null {
   if (!v) return null
   const trimmed = v.trim()
@@ -231,24 +225,18 @@ export default function WorkerStatusMenuItem() {
 
       {expanded && (
         <div className="ml-3 mr-1 mt-1 mb-2 space-y-1.5 px-3 py-2 rounded-lg bg-at-surface-alt border border-at-border">
-          {workerStatuses.map((w) => {
-            const version = w.getVersion ? formatVersion(w.getVersion(status)) : null
-            return (
-              <div key={w.key} className="flex items-center justify-between text-xs gap-2">
-                <span className="text-at-text-secondary truncate">{w.label}</span>
-                <div className="flex items-center space-x-1.5 flex-shrink-0">
-                  {version && w.status !== 'not-installed' && (
-                    <span className="text-[10px] text-at-text-weak font-mono">{version}</span>
-                  )}
-                  <span className={`w-2 h-2 rounded-full ${STATUS_COLOR[w.status]}`} />
-                  <span className="text-at-text-secondary">
-                    {STATUS_LABEL[w.status]}
-                    {w.status === 'online' && w.getExtra ? w.getExtra(status) : ''}
-                  </span>
-                </div>
+          {workerStatuses.map((w) => (
+            <div key={w.key} className="flex items-center justify-between text-xs">
+              <span className="text-at-text-secondary">{w.label}</span>
+              <div className="flex items-center space-x-1.5">
+                <span className={`w-2 h-2 rounded-full ${STATUS_COLOR[w.status]}`} />
+                <span className="text-at-text-secondary">
+                  {STATUS_LABEL[w.status]}
+                  {w.status === 'online' && w.getExtra ? w.getExtra(status) : ''}
+                </span>
               </div>
-            )
-          })}
+            </div>
+          ))}
           {overallStatus !== 'online' && overallStatus !== 'loading' && (
             <div className="pt-1 mt-1 border-t border-at-border text-[11px] text-at-text-weak leading-snug">
               워커에 문제가 있습니다. 관리자에게 설치/실행을 요청하세요.


### PR DESCRIPTION
## Summary
- 사이드바 확장 보기의 워커별 버전 표시 제거 (마케팅·이메일·덴트웹이 모두 동일 Electron 앱이라 v1.1.x 가 3번 반복되어 중복)
- 통합 라벨 한 줄에만 메인 워커 버전 유지 (\"워커 정상 · v1.1.106\")
- 워커 \`dentweb-bridge.ts\` 의 hardcoded \`'2.0.0-electron'\` 을 \`app.getVersion()\` 으로 대체 → \`dentweb_sync_config.agent_version\` 이 실제 패키지 버전으로 갱신

## Test plan
- [x] 워커 tsc, 웹 build 통과
- [ ] 워커 자동 업데이트 후 dentweb agent_version = v1.1.x 로 갱신 확인
- [ ] 사이드바 확장 보기에서 버전 중복 없이 깔끔하게 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)