### PR TITLE
feat(marketing): AI 글쓰기 5종 개선 (로고 합성/이미지 순서/글 완결/자동저장/브랜드 마커)

### DIFF
--- a/dental-clinic-manager/src/app/api/marketing/generate/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/generate/route.ts
@@ -87,6 +87,7 @@ export async function POST(request: NextRequest) {
           schedule: body.schedule || { snsDelayMinutes: 30 },
           clinical: body.clinical,
           notice: body.notice,
+          brandImageOptions: body.brandImageOptions,
         };
 
         const useSeoAnalysis = body.useSeoAnalysis || false;
@@ -502,51 +503,75 @@ export async function POST(request: NextRequest) {
             console.error('[API] 자동 저장 업데이트 실패:', updateError);
           }
         } else {
-          // 신규 항목 자동 생성 (캘린더 + 항목)
+          // 신규 항목 자동 생성 (캘린더 + 항목) — 일시 statement timeout 대비 최대 3회 재시도
           const today = new Date().toISOString().split('T')[0];
-          const { data: calendar, error: calInsertError } = await saveClient
-            .from('content_calendars')
-            .insert({
-              clinic_id: userData.clinic_id,
-              period_start: today,
-              period_end: today,
-              status: 'approved',
-              created_by: user.id,
-              approved_by: user.id,
-              approved_at: new Date().toISOString(),
-            })
-            .select()
-            .single();
+          const insertWithRetry = async <T,>(
+            label: string,
+            fn: () => Promise<{ data: T | null; error: { message?: string; code?: string } | null }>
+          ): Promise<{ data: T | null; error: { message?: string; code?: string } | null }> => {
+            let lastErr: { message?: string; code?: string } | null = null;
+            for (let attempt = 1; attempt <= 3; attempt++) {
+              const r = await fn();
+              if (!r.error) return r;
+              lastErr = r.error;
+              const msg = (r.error.message || '').toLowerCase();
+              const transient = msg.includes('timeout') || msg.includes('canceling statement') || msg.includes('temporarily') || msg.includes('connection');
+              if (!transient) return r;
+              console.warn(`[API] ${label} 재시도 ${attempt}/3 - ${r.error.message}`);
+              await new Promise((res) => setTimeout(res, 1500 * attempt));
+            }
+            return { data: null, error: lastErr };
+          };
+
+          const { data: calendar, error: calInsertError } = await insertWithRetry<{ id: string }>('캘린더 생성', async () =>
+            await saveClient
+              .from('content_calendars')
+              .insert({
+                clinic_id: userData.clinic_id,
+                period_start: today,
+                period_end: today,
+                status: 'approved',
+                created_by: user.id,
+                approved_by: user.id,
+                approved_at: new Date().toISOString(),
+              })
+              .select()
+              .single()
+          );
 
           if (calInsertError) {
             console.error('[API] 캘린더 생성 실패:', calInsertError);
+            sendEvent(controller, { saveWarning: `자동 저장에 실패했습니다(캘린더): ${calInsertError.message || calInsertError.code || '알 수 없는 오류'}. 글관리에 노출되지 않을 수 있습니다.` });
           }
 
           if (calendar) {
-            const { data: item, error: itemInsertError } = await saveClient
-              .from('content_calendar_items')
-              .insert({
-                calendar_id: calendar.id,
-                publish_date: today,
-                publish_time: '09:00',
-                title: result.title,
-                topic: options.topic,
-                keyword: options.keyword,
-                post_type: options.postType,
-                tone: options.tone,
-                use_research: options.useResearch,
-                fact_check: options.factCheck,
-                platforms: options.platforms,
-                status: 'review',
-                generated_content: JSON.stringify(result),
-                generated_images: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (result as any).generatedImages || null,
-              })
-              .select('id')
-              .single();
+            const { data: item, error: itemInsertError } = await insertWithRetry<{ id: string }>('캘린더 항목 생성', async () =>
+              await saveClient
+                .from('content_calendar_items')
+                .insert({
+                  calendar_id: calendar.id,
+                  publish_date: today,
+                  publish_time: '09:00',
+                  title: result.title,
+                  topic: options.topic,
+                  keyword: options.keyword,
+                  post_type: options.postType,
+                  tone: options.tone,
+                  use_research: options.useResearch,
+                  fact_check: options.factCheck,
+                  platforms: options.platforms,
+                  status: 'review',
+                  generated_content: JSON.stringify(result),
+                  generated_images: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (result as any).generatedImages || null,
+                })
+                .select('id')
+                .single()
+            );
 
             if (itemInsertError) {
               console.error('[API] 캘린더 항목 생성 실패:', itemInsertError);
+              sendEvent(controller, { saveWarning: `자동 저장에 실패했습니다(항목): ${itemInsertError.message || itemInsertError.code || '알 수 없는 오류'}. 글관리에 노출되지 않을 수 있습니다.` });
             }
 
             if (item) {

--- a/dental-clinic-manager/src/contexts/AIGenerationContext.tsx
+++ b/dental-clinic-manager/src/contexts/AIGenerationContext.tsx
@@ -171,6 +171,10 @@ export function AIGenerationProvider({ children }: { children: ReactNode }) {
 
                 if (data.heartbeat) continue
                 if (data.error) throw new Error(data.error)
+                if (data.saveWarning) {
+                  // 글은 정상 생성되었지만 자동 저장 실패 — 에러로 표시(생성된 본문은 result로 들어옴)
+                  setGenerationError(String(data.saveWarning))
+                }
 
                 if (data.progress !== undefined) setGenerationProgress(data.progress)
                 if (data.step) setGenerationStep(data.step)

--- a/dental-clinic-manager/src/lib/marketing/brand/logo-overlay.ts
+++ b/dental-clinic-manager/src/lib/marketing/brand/logo-overlay.ts
@@ -1,0 +1,100 @@
+import sharp from 'sharp';
+import { getSupabaseAdmin } from '@/lib/supabase/admin';
+
+const LOGO_CACHE = new Map<string, { buffer: Buffer; fetchedAt: number }>();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * 클리닉 로고를 fetch 후 캐시. URL → PNG 버퍼.
+ */
+async function fetchLogoBuffer(logoUrl: string): Promise<Buffer | null> {
+  const cached = LOGO_CACHE.get(logoUrl);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) return cached.buffer;
+
+  try {
+    const res = await fetch(logoUrl);
+    if (!res.ok) return null;
+    const ab = await res.arrayBuffer();
+    const buf = Buffer.from(ab);
+    LOGO_CACHE.set(logoUrl, { buffer: buf, fetchedAt: Date.now() });
+    return buf;
+  } catch (err) {
+    console.error('[logo-overlay] fetch 실패:', err);
+    return null;
+  }
+}
+
+async function loadClinicLogoUrl(clinicId: string): Promise<string | null> {
+  const admin = getSupabaseAdmin();
+  if (!admin) return null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data } = await (admin as any)
+    .from('clinic_brand_assets')
+    .select('logo_url')
+    .eq('clinic_id', clinicId)
+    .maybeSingle();
+  const url = data?.logo_url as string | undefined;
+  return url && url.trim() ? url.trim() : null;
+}
+
+/**
+ * 생성된 이미지(base64 PNG)에 클리닉 로고를 우상단에 합성한다.
+ * - 로고가 없으면 원본 그대로 반환.
+ * - 로고 크기: 캔버스 짧은 변의 12% (가독성과 시각적 비중 균형).
+ * - 위치: 우상단, 패딩 = 짧은 변의 3%.
+ * - 반투명 흰 라운드 배경 박스로 다양한 배경에서도 식별성 확보.
+ */
+export async function overlayClinicLogo(
+  imageBase64: string,
+  clinicId: string | undefined
+): Promise<string> {
+  if (!clinicId) return imageBase64;
+  try {
+    const logoUrl = await loadClinicLogoUrl(clinicId);
+    if (!logoUrl) return imageBase64;
+    const logoBuf = await fetchLogoBuffer(logoUrl);
+    if (!logoBuf) return imageBase64;
+
+    const baseBuf = Buffer.from(imageBase64, 'base64');
+    const base = sharp(baseBuf);
+    const meta = await base.metadata();
+    const W = meta.width || 1024;
+    const H = meta.height || 1024;
+    const shortSide = Math.min(W, H);
+    const targetW = Math.round(shortSide * 0.12);
+    const pad = Math.round(shortSide * 0.03);
+
+    // 로고를 targetW 로 비례 리사이즈 (PNG/JPEG/SVG 모두 sharp 가 처리)
+    const logoResized = await sharp(logoBuf, { failOn: 'none' })
+      .resize({ width: targetW, withoutEnlargement: false, fit: 'inside' })
+      .png()
+      .toBuffer({ resolveWithObject: true });
+
+    const logoW = logoResized.info.width;
+    const logoH = logoResized.info.height;
+
+    // 라운드 사각형 배경 (반투명 흰색) - SVG 로 생성
+    const boxPad = Math.max(6, Math.round(targetW * 0.12));
+    const boxW = logoW + boxPad * 2;
+    const boxH = logoH + boxPad * 2;
+    const r = Math.max(8, Math.round(boxPad * 1.5));
+    const bgSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="${boxW}" height="${boxH}"><rect x="0" y="0" width="${boxW}" height="${boxH}" rx="${r}" ry="${r}" fill="white" fill-opacity="0.88"/></svg>`;
+    const bgBuf = await sharp(Buffer.from(bgSvg)).png().toBuffer();
+
+    const left = W - boxW - pad;
+    const top = pad;
+
+    const out = await base
+      .composite([
+        { input: bgBuf, left, top },
+        { input: logoResized.data, left: left + boxPad, top: top + boxPad },
+      ])
+      .png()
+      .toBuffer();
+
+    return out.toString('base64');
+  } catch (err) {
+    console.error('[logo-overlay] 합성 실패 — 원본 반환:', err);
+    return imageBase64;
+  }
+}

--- a/dental-clinic-manager/src/lib/marketing/brand/marker-resolver.ts
+++ b/dental-clinic-manager/src/lib/marketing/brand/marker-resolver.ts
@@ -46,7 +46,10 @@ export async function resolveBrandMarkers(body: string, ctx: ResolveContext): Pr
     .select('*')
     .eq('clinic_id', ctx.clinicId)
     .maybeSingle();
-  if (!assets) return body.replace(/\[BRAND_IMAGE:[^\]]+\]/g, '');
+  if (!assets) {
+    console.warn('[brand-resolve] assets 없음 — 마커 제거');
+    return body.replace(/\[BRAND_IMAGE:[^\]]+\]/g, '');
+  }
   const a = assets as BrandAssets;
 
   const { data: photoRows } = await (admin as any)
@@ -89,6 +92,7 @@ export async function resolveBrandMarkers(body: string, ctx: ResolveContext): Pr
         type: marker.type,
         params: marker.params,
         message: e?.message,
+        stack: e?.stack?.split('\n').slice(0, 4),
       });
     }
     const replacement = url ? `\n\n![](${url})\n\n` : '';

--- a/dental-clinic-manager/src/lib/marketing/content-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/content-generator.ts
@@ -187,7 +187,9 @@ export async function generateContent(
       `### 이미지 ${imgCount}장 ↔ 핵심 포인트 ${imgCount}개 매핑 (필수 절차)\n` +
       `1) 글을 쓰기 전에 환자에게 전달할 **핵심 포인트 ${imgCount}개**를 먼저 정하세요 ` +
       `(서로 중복되지 않는, 글의 주요 메시지).\n` +
-      `2) 각 핵심 포인트가 본문에 등장하는 위치 **바로 다음**에 [IMAGE: ...] 마커를 1개씩 배치하세요. ` +
+      `2) **이미지는 그 핵심 포인트를 설명하는 본문 단락의 바로 "앞"에 배치**하세요. ` +
+      `즉 [IMAGE: ...] 마커를 먼저 1줄 두고, 그 다음 줄부터 해당 포인트를 설명하는 본문이 시작되어야 합니다. ` +
+      `독자가 이미지(시각적 요약)를 먼저 보고 그 아래에서 자세한 설명을 읽는 자연스러운 흐름을 만드세요. ` +
       `한 곳에 몰지 말고 글 전체에 고르게 분포.\n` +
       `3) 마커의 내용은 "그 카드 이미지 안에 그대로 들어갈 한글 텍스트" 입니다. 그림 묘사가 아닙니다. ` +
       `다음 형식을 권장합니다:\n` +
@@ -347,9 +349,11 @@ export async function generateContent(
     userContent = `다음 주제로 블로그 글을 작성해주세요.\n\n주제: ${options.topic}\n키워드: ${options.keyword}`;
   }
 
+  // max_tokens: 본문이 짧은 글도 자주 4096 토큰을 초과해 잘리므로 8192로 상향
+  // (Claude Sonnet 4.6 은 충분히 지원, 비용은 출력 토큰 기준으로 과금되므로 실제 사용분만 청구됨)
   const response = await anthropic.messages.create({
     model: 'claude-sonnet-4-6',
-    max_tokens: 4096,
+    max_tokens: 8192,
     messages: [
       {
         role: 'user',
@@ -359,6 +363,52 @@ export async function generateContent(
     system: systemPrompt,
   });
   const callDurationMs = Date.now() - callStart;
+
+  // stop_reason 검사: max_tokens 로 잘렸으면 이어쓰기 호출로 글을 완결시킨다.
+  // 한 글이 max_tokens 두 번에도 안 끝나면 그대로 진행(이상치).
+  let assembledText = response.content[0].type === 'text' ? response.content[0].text : '';
+  let lastStopReason = response.stop_reason;
+  let continueIter = 0;
+  while (lastStopReason === 'max_tokens' && continueIter < 2) {
+    continueIter++;
+    const contStart = Date.now();
+    const contResponse = await anthropic.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 8192,
+      messages: [
+        { role: 'user', content: userContent },
+        { role: 'assistant', content: assembledText },
+        { role: 'user', content: '이어서 마저 작성해주세요. 끊긴 문장부터 자연스럽게 이어 쓰고, 글이 완전히 마무리될 때까지(결론·해시태그까지) 작성하세요. 새로 시작하지 말고 이어쓰기만 하세요. 기존 [IMAGE:] / [BRAND_IMAGE:] / [CLINICAL_PHOTO:] 마커는 중복 삽입하지 마세요.' },
+      ],
+      system: systemPrompt,
+    });
+    const contDurationMs = Date.now() - contStart;
+    const contText = contResponse.content[0].type === 'text' ? contResponse.content[0].text : '';
+    assembledText += contText;
+    lastStopReason = contResponse.stop_reason;
+
+    if (generationSessionId) {
+      logApiUsage({
+        clinicId,
+        generationSessionId,
+        apiProvider: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        callType: 'text_retry',
+        inputTokens: contResponse.usage.input_tokens,
+        outputTokens: contResponse.usage.output_tokens,
+        totalTokens: contResponse.usage.input_tokens + contResponse.usage.output_tokens,
+        generationOptions: {
+          topic: options.topic,
+          keyword: options.keyword,
+          tone: options.tone,
+          postType: options.postType,
+          imageCount: options.imageCount,
+        },
+        success: true,
+        durationMs: contDurationMs,
+      });
+    }
+  }
 
   if (generationSessionId) {
     logApiUsage({
@@ -382,7 +432,7 @@ export async function generateContent(
     });
   }
 
-  const rawText = response.content[0].type === 'text' ? response.content[0].text : '';
+  const rawText = assembledText;
 
   // 5. 결과 파싱
   const parsed = parseGeneratedContent(rawText, options.keyword);
@@ -407,7 +457,7 @@ export async function generateContent(
       : '1,000자 이상';
     const retryResponse = await anthropic.messages.create({
       model: 'claude-sonnet-4-6',
-      max_tokens: 4096,
+      max_tokens: 8192,
       messages: [
         {
           role: 'user',

--- a/dental-clinic-manager/src/lib/marketing/image-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/image-generator.ts
@@ -6,6 +6,7 @@ import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import { seedDefaultPromptsIfNeeded } from './seed-prompts';
 import { logApiUsage } from './api-usage-logger';
 import { getImageProvider, type ImageProvider } from './image-provider-setting';
+import { overlayClinicLogo } from './brand/logo-overlay';
 import type { GeneratedImageMeta, ImageMarker, ImageStyleOption, ImageVisualStyle } from '@/types/marketing';
 
 // ============================================
@@ -284,7 +285,9 @@ export async function generateBlogImage(
     });
   }
 
-  const imageBase64 = result.imageBase64;
+  // 로고 워터마크 합성: AI 가 생성한 가짜 로고 영역 위에 실제 클리닉 로고를 우상단에 오버레이.
+  // 실패해도 원본을 반환하므로 이미지 생성 전체 흐름은 보장됨.
+  const imageBase64 = await overlayClinicLogo(result.imageBase64, resolvedClinicId);
 
   // 2. 한글 파일명 생성
   const fileName = await generateImageFileName(prompt, generationSessionId, resolvedClinicId);
@@ -360,7 +363,10 @@ export async function generatePlatformImage(
 
   const fileName = await generateImageFileName(`${platform}_${prompt}`, generationSessionId, generationClinicId);
 
-  return { imageBase64: result.imageBase64, fileName };
+  // 플랫폼 이미지도 로고 워터마크 합성 (블로그 이미지와 일관성)
+  const imageBase64 = await overlayClinicLogo(result.imageBase64, generationClinicId);
+
+  return { imageBase64, fileName };
 }
 
 // ─── 기본 이미지 프롬프트 (DB 미조회 시 폴백) ───


### PR DESCRIPTION
## Summary
- **이슈 1 (로고 합성)**: 생성 이미지에 sharp 로 클리닉 로고를 우상단 자동 합성 (logo-overlay.ts 신규)
- **이슈 2 (이미지 순서)**: 이미지가 핵심 포인트를 설명하는 본문 단락 "앞"에 배치되도록 Claude 프롬프트 수정
- **이슈 3 (글 완결)**: max_tokens 4096→8192 + stop_reason='max_tokens' 시 최대 2회 자동 이어쓰기
- **이슈 4 (자동 저장)**: statement timeout 등 transient 에러 시 최대 3회 지수 백오프 재시도 + 실패 시 SSE saveWarning 알림
- **이슈 5 (브랜드 마커)**: /api/marketing/generate 에서 누락되어 있던 body.brandImageOptions 를 options 에 전달 → 의료법/텍스트 카드/병원 사진 마커가 본문 정상 삽입

## 검증
Chrome DevTools MCP + 실제 글 생성으로 다음을 확인:
- ✅ 생성 이미지 우상단에 하얀치과 캐릭터 로고 정상 합성 (sharp 로그 + 이미지 시각 검증)
- ✅ H2 섹션 직전에 이미지 배치
- ✅ 2,414자, FAQ 4개, 마무리, 해시태그까지 완벽히 마무리됨
- ✅ DB body 최상단에 텍스트 카드 + 의료법 이미지 URL 정상 삽입 (이미지 직접 렌더 확인)
- ✅ 글관리 페이지 API 200 + 40개 글 정상 노출

## Test plan
- [x] 빌드 통과 (`npm run build`)
- [x] 로그인 후 `/dashboard/marketing/posts/new` 에서 짧은 글 생성 → DB 본문에 brand 이미지 URL 2개 + AI 이미지 1개 확인
- [x] 생성된 인포그래픽 이미지 우상단에 실제 클리닉 로고 합성 확인
- [x] 텍스트 카드 / 의료법 이미지 자체를 직접 열어 정상 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)