### PR TITLE
fix: 로그아웃 재발 + dentweb sync 속도 저하 근본 원인 수정

### DIFF
--- a/dental-clinic-manager/src/app/api/dentweb/sync/route.ts
+++ b/dental-clinic-manager/src/app/api/dentweb/sync/route.ts
@@ -43,9 +43,9 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const { clinic_id, api_key, sync_type, patients, agent_version } = body
 
-    if (!clinic_id || !api_key || !patients) {
+    if (!clinic_id || !api_key || !Array.isArray(patients)) {
       return NextResponse.json(
-        { success: false, error: '필수 파라미터가 누락되었습니다. (clinic_id, api_key, patients)' },
+        { success: false, error: '필수 파라미터가 누락되었거나 형식이 올바르지 않습니다. (clinic_id, api_key, patients[])' },
         { status: 400 }
       )
     }
@@ -91,101 +91,74 @@ export async function POST(request: NextRequest) {
       console.error('[dentweb/sync] Failed to create sync log:', logError)
     }
 
-    // 환자 데이터 동기화 (upsert)
-    let newRecords = 0
-    let updatedRecords = 0
     const totalRecords = patients.length
-    const batchSize = 100
 
     try {
-      for (let i = 0; i < patients.length; i += batchSize) {
-        const batch = patients.slice(i, i + batchSize) as PatientSyncData[]
+      const syncedAt = new Date().toISOString()
+      const normalizedPatients = (patients as PatientSyncData[]).map((p: PatientSyncData) => ({
+        dentweb_patient_id: p.dentweb_patient_id,
+        chart_number: p.chart_number || null,
+        patient_name: p.patient_name,
+        phone_number: p.phone_number || null,
+        birth_date: sanitizeDate(p.birth_date),
+        gender: p.gender || null,
+        last_visit_date: sanitizeDate(p.last_visit_date),
+        last_treatment_type: p.last_treatment_type || null,
+        next_appointment_date: sanitizeDate(p.next_appointment_date),
+        next_appointment_memo: typeof p.next_appointment_memo === 'string' && p.next_appointment_memo.trim()
+          ? p.next_appointment_memo.trim().slice(0, 500)
+          : null,
+        registration_date: sanitizeDate(p.registration_date),
+        acquisition_channel: p.acquisition_channel ?? null,
+        customer_type: p.customer_type ?? null,
+        is_active: p.is_active !== false,
+        raw_data: p.raw_data || null,
+      }))
 
-        const upsertData = batch.map((p: PatientSyncData) => ({
-          clinic_id,
-          dentweb_patient_id: p.dentweb_patient_id,
-          chart_number: p.chart_number || null,
-          patient_name: p.patient_name,
-          phone_number: p.phone_number || null,
-          birth_date: sanitizeDate(p.birth_date),
-          gender: p.gender || null,
-          last_visit_date: sanitizeDate(p.last_visit_date),
-          last_treatment_type: p.last_treatment_type || null,
-          next_appointment_date: sanitizeDate(p.next_appointment_date),
-          next_appointment_memo: typeof p.next_appointment_memo === 'string' && p.next_appointment_memo.trim()
-            ? p.next_appointment_memo.trim().slice(0, 500)
-            : null,
-          registration_date: sanitizeDate(p.registration_date),
-          acquisition_channel: p.acquisition_channel ?? null,
-          customer_type: p.customer_type ?? null,
-          is_active: p.is_active !== false,
-          raw_data: p.raw_data || null,
-          synced_at: new Date().toISOString(),
-          updated_at: new Date().toISOString()
-        }))
+      const { data: syncSummaryRows, error: syncError } = await supabase.rpc('sync_dentweb_patients_batch', {
+        p_clinic_id: clinic_id,
+        p_patients: normalizedPatients,
+        p_synced_at: syncedAt,
+      })
 
-        // 기존 데이터 확인 (신규/업데이트 구분용)
-        const dentwebIds = batch.map(p => p.dentweb_patient_id)
-        const { data: existingPatients } = await supabase
-          .from('dentweb_patients')
-          .select('dentweb_patient_id')
-          .eq('clinic_id', clinic_id)
-          .in('dentweb_patient_id', dentwebIds)
-
-        const existingIdSet = new Set(
-          (existingPatients || []).map(p => p.dentweb_patient_id)
-        )
-
-        for (const p of batch) {
-          if (existingIdSet.has(p.dentweb_patient_id)) {
-            updatedRecords++
-          } else {
-            newRecords++
-          }
-        }
-
-        // Upsert 실행
-        const { error: upsertError } = await supabase
-          .from('dentweb_patients')
-          .upsert(upsertData, {
-            onConflict: 'clinic_id,dentweb_patient_id'
-          })
-
-        if (upsertError) {
-          throw new Error(`Batch upsert failed: ${upsertError.message}`)
-        }
+      if (syncError) {
+        throw new Error(`Batch upsert failed: ${syncError.message}`)
       }
+
+      const syncSummary = Array.isArray(syncSummaryRows) ? syncSummaryRows[0] : syncSummaryRows
+      const newRecords = syncSummary?.new_records ?? 0
+      const updatedRecords = syncSummary?.updated_records ?? 0
 
       // 동기화 성공 - 설정 업데이트
       const completedAt = new Date().toISOString()
       const durationMs = new Date(completedAt).getTime() - new Date(startedAt).getTime()
 
-      await supabase
-        .from('dentweb_sync_config')
-        .update({
-          last_sync_at: completedAt,
-          last_sync_status: 'success',
-          last_sync_error: null,
-          last_sync_patient_count: totalRecords,
-          agent_version: agent_version || null,
-          updated_at: completedAt
-        })
-        .eq('clinic_id', clinic_id)
-
-      // 동기화 로그 업데이트
-      if (syncLog) {
-        await supabase
-          .from('dentweb_sync_logs')
+      await Promise.all([
+        supabase
+          .from('dentweb_sync_config')
           .update({
-            status: 'success',
-            total_records: totalRecords,
-            new_records: newRecords,
-            updated_records: updatedRecords,
-            completed_at: completedAt,
-            duration_ms: durationMs
+            last_sync_at: completedAt,
+            last_sync_status: 'success',
+            last_sync_error: null,
+            last_sync_patient_count: totalRecords,
+            agent_version: agent_version || null,
+            updated_at: completedAt
           })
-          .eq('id', syncLog.id)
-      }
+          .eq('clinic_id', clinic_id),
+        syncLog
+          ? supabase
+              .from('dentweb_sync_logs')
+              .update({
+                status: 'success',
+                total_records: totalRecords,
+                new_records: newRecords,
+                updated_records: updatedRecords,
+                completed_at: completedAt,
+                duration_ms: durationMs
+              })
+              .eq('id', syncLog.id)
+          : Promise.resolve(null)
+      ])
 
       return NextResponse.json({
         success: true,
@@ -201,30 +174,31 @@ export async function POST(request: NextRequest) {
       const completedAt = new Date().toISOString()
       const durationMs = new Date(completedAt).getTime() - new Date(startedAt).getTime()
 
-      await supabase
-        .from('dentweb_sync_config')
-        .update({
-          last_sync_at: completedAt,
-          last_sync_status: 'error',
-          last_sync_error: errorMessage,
-          updated_at: completedAt
-        })
-        .eq('clinic_id', clinic_id)
-
-      if (syncLog) {
-        await supabase
-          .from('dentweb_sync_logs')
+      await Promise.all([
+        supabase
+          .from('dentweb_sync_config')
           .update({
-            status: 'error',
-            error_message: errorMessage,
-            total_records: totalRecords,
-            new_records: newRecords,
-            updated_records: updatedRecords,
-            completed_at: completedAt,
-            duration_ms: durationMs
+            last_sync_at: completedAt,
+            last_sync_status: 'error',
+            last_sync_error: errorMessage,
+            updated_at: completedAt
           })
-          .eq('id', syncLog.id)
-      }
+          .eq('clinic_id', clinic_id),
+        syncLog
+          ? supabase
+              .from('dentweb_sync_logs')
+              .update({
+                status: 'error',
+                error_message: errorMessage,
+                total_records: totalRecords,
+                new_records: 0,
+                updated_records: 0,
+                completed_at: completedAt,
+                duration_ms: durationMs
+              })
+              .eq('id', syncLog.id)
+          : Promise.resolve(null)
+      ])
 
       return NextResponse.json(
         { success: false, error: errorMessage },

--- a/dental-clinic-manager/src/app/dashboard/marketing/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/page.tsx
@@ -22,18 +22,21 @@ import type {
   PostType,
   GeneratedContent,
 } from '@/types/marketing'
-import PremiumGate from '@/components/Premium/PremiumGate'
-import NewPostForm from '@/components/marketing/NewPostForm'
-import ScheduleModal from '@/components/marketing/ScheduleModal'
-import WorkerStatusBanner from '@/components/marketing/WorkerStatusBanner'
-import { BrandSettingsClient } from '@/app/dashboard/marketing/brand/BrandSettingsClient'
 import { usePermissions } from '@/hooks/usePermissions'
 import dynamic from 'next/dynamic'
 
+const PremiumGate = dynamic(() => import('@/components/Premium/PremiumGate'), { ssr: false })
+const NewPostForm = dynamic(() => import('@/components/marketing/NewPostForm'), { ssr: false })
+const ScheduleModal = dynamic(() => import('@/components/marketing/ScheduleModal'), { ssr: false })
+const WorkerStatusBanner = dynamic(() => import('@/components/marketing/WorkerStatusBanner'), { ssr: false })
+const BrandSettingsClient = dynamic(
+  () => import('@/app/dashboard/marketing/brand/BrandSettingsClient').then((mod) => mod.BrandSettingsClient),
+  { ssr: false }
+)
 const ContentEditor = dynamic(() => import('@/components/marketing/ContentEditor'), { ssr: false })
 const ClinicalPhotoEditor = dynamic(() => import('@/components/marketing/clinical/ClinicalPhotoEditor'), { ssr: false })
 const ContentCalendarView = dynamic(() => import('@/components/marketing/ContentCalendarView'), { ssr: false })
-import ImageEditModal from '@/components/marketing/ImageEditModal'
+const ImageEditModal = dynamic(() => import('@/components/marketing/ImageEditModal'), { ssr: false })
 
 type MarketingTab = 'newpost' | 'dashboard' | 'posts' | 'calendar' | 'settings'
 

--- a/dental-clinic-manager/src/contexts/AuthContext.tsx
+++ b/dental-clinic-manager/src/contexts/AuthContext.tsx
@@ -1,15 +1,14 @@
 'use client'
 
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+import React, { createContext, useContext, useState, useEffect, ReactNode, useRef } from 'react'
 import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
 import { createClient } from '@/lib/supabase/client'
 import { dataService } from '@/lib/dataService'
 import type { Permission } from '@/types/permissions'
 import { useActivityTracker } from '@/hooks/useActivityTracker'
 import { SESSION_CHECK_TIMEOUT, safeLocalStorage, isIOSDevice } from '@/lib/sessionUtils'
-import { TIMEOUTS } from '@/lib/constants/timeouts'
 import { useRouter } from 'next/navigation'
-import { clearAllSupabaseCookies, refreshSessionCookies } from '@/lib/cookieStorageAdapter'
+import { clearAllSupabaseCookies } from '@/lib/cookieStorageAdapter'
 import { appAlert } from '@/components/ui/AppDialog'
 
 export interface UserProfile {
@@ -34,12 +33,141 @@ export interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
+const PROFILE_FETCH_MAX_ATTEMPTS = 3
+const PROFILE_FETCH_RETRY_DELAY_MS = 700
+const SIGNED_OUT_RECHECK_DELAY_MS = 400
+const SESSION_RECHECK_MAX_ATTEMPTS = 2
+
+type ProfileResolution =
+  | { status: 'success'; profile: UserProfile }
+  | { status: 'missing' }
+  | { status: 'transient'; error?: string }
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+const DEFINITIVE_SESSION_ERROR_PATTERNS = [
+  'refresh token',
+  'invalid refresh token',
+  'refresh token not found',
+  'jwt',
+  'session missing',
+  'auth session missing',
+]
+
+function isDefinitiveSessionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : ''
+  const normalized = message.toLowerCase()
+  return DEFINITIVE_SESSION_ERROR_PATTERNS.some(pattern => normalized.includes(pattern))
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const router = useRouter()
   const [user, setUser] = useState<UserProfile | null>(null)
   const [loading, setLoading] = useState(true)
   const [isLoggingOut, setIsLoggingOut] = useState(false)
   const [showInactivityModal, setShowInactivityModal] = useState(false)
+  const isLoggingOutRef = useRef(false)
+
+  const persistUser = (profile: UserProfile) => {
+    setUser(profile)
+    safeLocalStorage.setItem('dental_auth', 'true')
+    safeLocalStorage.setItem('dental_user', JSON.stringify(profile))
+    if (profile.clinic_id) {
+      dataService.setCachedClinicId(profile.clinic_id)
+    } else {
+      dataService.clearCachedClinicId()
+    }
+  }
+
+  const clearPersistedUser = () => {
+    setUser(null)
+    safeLocalStorage.removeItem('dental_auth')
+    safeLocalStorage.removeItem('dental_user')
+    dataService.clearCachedClinicId()
+  }
+
+  const restoreCachedUser = (userId: string) => {
+    const cachedUserRaw = safeLocalStorage.getItem('dental_user')
+    if (!cachedUserRaw) {
+      return false
+    }
+
+    try {
+      const cachedUser = JSON.parse(cachedUserRaw)
+      if (cachedUser?.id !== userId) {
+        return false
+      }
+
+      console.log('AuthContext: 캐시된 프로필로 폴백')
+      setUser(cachedUser)
+      if (cachedUser.clinic_id) {
+        dataService.setCachedClinicId(cachedUser.clinic_id)
+      }
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  const resolveUserProfile = async (userId: string): Promise<ProfileResolution> => {
+    let lastTransientError: string | undefined
+
+    for (let attempt = 1; attempt <= PROFILE_FETCH_MAX_ATTEMPTS; attempt++) {
+      const result = await dataService.getUserProfileById(userId)
+
+      if (result.success && result.data) {
+        return { status: 'success', profile: result.data }
+      }
+
+      if (result.success === true && !result.data) {
+        if (attempt < PROFILE_FETCH_MAX_ATTEMPTS) {
+          console.warn(`[AuthContext] User profile missing, retrying... (${attempt}/${PROFILE_FETCH_MAX_ATTEMPTS})`)
+          await delay(PROFILE_FETCH_RETRY_DELAY_MS)
+          continue
+        }
+        return { status: 'missing' }
+      }
+
+      lastTransientError = (result as { error?: string }).error
+
+      if (attempt < PROFILE_FETCH_MAX_ATTEMPTS) {
+        console.warn(`[AuthContext] User profile fetch failed, retrying... (${attempt}/${PROFILE_FETCH_MAX_ATTEMPTS})`, lastTransientError)
+        await delay(PROFILE_FETCH_RETRY_DELAY_MS)
+      }
+    }
+
+    return {
+      status: 'transient',
+      error: lastTransientError,
+    }
+  }
+
+  const confirmSignedOutState = async (supabase: ReturnType<typeof createClient>) => {
+    for (let attempt = 1; attempt <= SESSION_RECHECK_MAX_ATTEMPTS; attempt++) {
+      try {
+        const { data, error } = await supabase.auth.getSession()
+        if (data.session?.user) {
+          console.warn('[AuthContext] Ignoring transient SIGNED_OUT event because session still exists')
+          return false
+        }
+
+        if (error && isDefinitiveSessionError(error)) {
+          return true
+        }
+      } catch (error) {
+        if (isDefinitiveSessionError(error)) {
+          return true
+        }
+        console.warn(`[AuthContext] SIGNED_OUT recheck failed (${attempt}/${SESSION_RECHECK_MAX_ATTEMPTS})`, error)
+      }
+
+      if (attempt < SESSION_RECHECK_MAX_ATTEMPTS) {
+        await delay(SIGNED_OUT_RECHECK_DELAY_MS)
+      }
+    }
+
+    return true
+  }
 
   useEffect(() => {
     let subscription: any = null
@@ -212,37 +340,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                   return
                 }
 
-                setUser(result.data)
-                // storage에도 저장하여 bulletinService 등에서 접근 가능하게 함
-                safeLocalStorage.setItem('dental_auth', 'true')
-                safeLocalStorage.setItem('dental_user', JSON.stringify(result.data))
-                if (result.data.clinic_id) {
-                  dataService.setCachedClinicId(result.data.clinic_id)
-                }
+                persistUser(result.data)
               } else if (result.success === true && !result.data) {
                 // 프로필이 DB에 실제로 존재하지 않을 때만 로그아웃 (예: 탈퇴 후 잔존 세션)
-                console.warn('AuthContext: 프로필이 DB에 존재하지 않음 - 로그아웃')
-                await supabase.auth.signOut()
+                const profileResolution = await resolveUserProfile(session.user.id)
+
+                if (profileResolution.status === 'success') {
+                  persistUser(profileResolution.profile)
+                } else if (profileResolution.status === 'missing') {
+                  console.warn('AuthContext: 프로필이 재시도 후에도 존재하지 않음 - 로그아웃')
+                  await supabase.auth.signOut()
+                } else {
+                  console.warn('AuthContext: 프로필 확인 실패 (transient) - 세션 유지:', profileResolution.error)
+                  restoreCachedUser(session.user.id)
+                }
               } else {
                 // ⚠️ 일시적 로드 실패 (네트워크, 배포 직후 cold-start, RLS 일시 오류 등)
                 // 세션은 유지하고 캐시된 프로필로 폴백. 다음 요청에서 자동 재시도됨.
                 // 과거에는 무조건 signOut을 호출해 배포 후 간헐적 강제 로그아웃의 원인이었음.
                 console.warn('AuthContext: 프로필 로드 실패 (transient) - 세션 유지:', (result as { error?: string }).error)
-                const cachedUserRaw = safeLocalStorage.getItem('dental_user')
-                if (cachedUserRaw) {
-                  try {
-                    const cachedUser = JSON.parse(cachedUserRaw)
-                    if (cachedUser?.id === session.user.id) {
-                      console.log('AuthContext: 캐시된 프로필로 폴백')
-                      setUser(cachedUser)
-                      if (cachedUser.clinic_id) {
-                        dataService.setCachedClinicId(cachedUser.clinic_id)
-                      }
-                    }
-                  } catch {
-                    // 캐시 파싱 실패 — 세션은 그대로 유지
-                  }
-                }
+                restoreCachedUser(session.user.id)
               }
             } else {
               // Supabase 세션이 없으면 storage 확인 (기존 방식 호환)
@@ -299,54 +416,67 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 // 데드락이 발생합니다.
                 // setTimeout(0)으로 다음 이벤트 루프에서 실행하여 잠금 해제 후
                 // 프로필을 안전하게 조회합니다.
-                if (!isLoggingOut) {
+                if (!isLoggingOutRef.current) {
                   const userId = session.user.id
                   setTimeout(async () => {
                     try {
-                      const result = await dataService.getUserProfileById(userId)
-                      if (result.success && result.data) {
-                        if (result.data.status === 'pending' || result.data.status === 'rejected') {
-                          console.warn('[AuthContext] SIGNED_IN event - User status:', result.data.status)
-                          setUser(result.data)
+                      const profileResolution = await resolveUserProfile(userId)
+
+                      if (profileResolution.status === 'success') {
+                        if (profileResolution.profile.status === 'pending' || profileResolution.profile.status === 'rejected') {
+                          console.warn('[AuthContext] SIGNED_IN event - User status:', profileResolution.profile.status)
+                          setUser(profileResolution.profile)
                           if (window.location.pathname !== '/pending-approval') {
                             router.push('/pending-approval')
                           }
                           return
                         }
 
-                        if (result.data.status === 'resigned') {
+                        if (profileResolution.profile.status === 'resigned') {
                           console.warn('[AuthContext] SIGNED_IN event - User has resigned')
-                          setUser(result.data)
+                          setUser(profileResolution.profile)
                           if (window.location.pathname !== '/resigned') {
                             router.push('/resigned')
                           }
                           return
                         }
 
-                        if (result.data.clinic?.status === 'suspended') {
+                        if (profileResolution.profile.clinic?.status === 'suspended') {
                           await appAlert('소속 병원이 중지되었습니다. 관리자에게 문의해주세요.')
                           await supabase.auth.signOut()
                           window.location.href = '/'
                           return
                         }
 
-                        setUser(result.data)
-                        safeLocalStorage.setItem('dental_auth', 'true')
-                        safeLocalStorage.setItem('dental_user', JSON.stringify(result.data))
-                        if (result.data.clinic_id) {
-                          dataService.setCachedClinicId(result.data.clinic_id)
-                        }
+                        persistUser(profileResolution.profile)
+                        return
                       }
+
+                      if (profileResolution.status === 'missing') {
+                        console.warn('[AuthContext] SIGNED_IN event - user profile missing after retry, keeping session for follow-up recovery')
+                        restoreCachedUser(userId)
+                        return
+                      }
+
+                      console.warn('[AuthContext] Failed to load user profile on SIGNED_IN, keeping session:', profileResolution.error)
+                      restoreCachedUser(userId)
                     } catch (err) {
                       console.warn('[AuthContext] Failed to load user profile on SIGNED_IN:', err)
                     }
                   }, 0)
                 }
               } else if (event === 'SIGNED_OUT') {
-                setUser(null)
-                safeLocalStorage.removeItem('dental_auth')
-                safeLocalStorage.removeItem('dental_user')
-                dataService.clearCachedClinicId()
+                setTimeout(async () => {
+                  if (isLoggingOutRef.current || safeLocalStorage.getItem('dental_logging_out') === 'true') {
+                    clearPersistedUser()
+                    return
+                  }
+
+                  const confirmedSignedOut = await confirmSignedOutState(supabase)
+                  if (confirmedSignedOut) {
+                    clearPersistedUser()
+                  }
+                }, 0)
               } else if (event === 'TOKEN_REFRESHED') {
                 console.log('[AuthContext] Token refreshed successfully')
                 // 토큰 갱신 시 세션 유지 확인을 위해 프로필 다시 로드
@@ -449,15 +579,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       userId: userId, // 로그인 시 사용한 ID는 별도로 저장
     };
 
-    setUser(userData)
-    safeLocalStorage.setItem('dental_auth', 'true')
-    safeLocalStorage.setItem('dental_user', JSON.stringify(userData))
-    if (userData.clinic_id) {
-      dataService.setCachedClinicId(userData.clinic_id)
-    } else {
-      // clinic_id가 없는 경우 (마스터 관리자 등) 캐시 클리어
-      dataService.clearCachedClinicId()
-    }
+    persistUser(userData)
   }
 
   const updateUser = (updatedUserData: any) => {
@@ -467,16 +589,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = async () => {
     try {
+      isLoggingOutRef.current = true
       setIsLoggingOut(true)
       safeLocalStorage.setItem('dental_logging_out', 'true')
 
       const supabase = createClient()
       await supabase.auth.signOut()
 
-      setUser(null)
-      safeLocalStorage.removeItem('dental_auth')
-      safeLocalStorage.removeItem('dental_user')
-      dataService.clearCachedClinicId()
+      clearPersistedUser()
 
       // iOS Safari 호환: 쿠키 기반 스토리지 클리어
       clearAllSupabaseCookies()
@@ -487,9 +607,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } catch (error) {
       console.error('Logout error:', error)
       // Force logout even if error
-      setUser(null)
-      safeLocalStorage.removeItem('dental_auth')
-      safeLocalStorage.removeItem('dental_user')
+      clearPersistedUser()
       // iOS Safari 호환: 쿠키 기반 스토리지 클리어
       clearAllSupabaseCookies()
       window.location.href = '/'
@@ -511,40 +629,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }).catch(() => {}) // 실패해도 무시
     }
   }, [user?.id])
-
-  // iOS Safari 호환: 사용자 활동 시 세션 쿠키 갱신
-  // 사용자가 사이트와 상호작용하면 쿠키 수명이 연장됨
-  useEffect(() => {
-    if (!isAuthenticated || typeof window === 'undefined') return
-
-    // 사용자 활동 감지 시 쿠키 갱신
-    const handleUserActivity = () => {
-      // 너무 자주 갱신하지 않도록 debounce (5분에 한 번)
-      const lastRefresh = sessionStorage.getItem('lastCookieRefresh')
-      const now = Date.now()
-
-      if (!lastRefresh || now - parseInt(lastRefresh) > 5 * 60 * 1000) {
-        refreshSessionCookies()
-        sessionStorage.setItem('lastCookieRefresh', now.toString())
-      }
-    }
-
-    // 사용자 활동 이벤트 리스너 등록
-    const events = ['click', 'scroll', 'keypress', 'touchstart']
-    events.forEach(event => {
-      window.addEventListener(event, handleUserActivity, { passive: true })
-    })
-
-    // 초기 갱신 (페이지 로드 시)
-    handleUserActivity()
-
-    return () => {
-      events.forEach(event => {
-        window.removeEventListener(event, handleUserActivity)
-      })
-    }
-  }, [isAuthenticated])
-
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-at-surface-alt">

--- a/dental-clinic-manager/src/lib/supabase/client.ts
+++ b/dental-clinic-manager/src/lib/supabase/client.ts
@@ -1,7 +1,6 @@
 import { createBrowserClient } from '@supabase/ssr'
 import type { Database } from '@/types/supabase'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { createCookieStorageAdapter } from '../cookieStorageAdapter'
 
 /**
  * 싱글톤 Supabase 클라이언트 인스턴스
@@ -76,24 +75,26 @@ export function createClient() {
     console.log('[Supabase Browser Client] iOS device detected - using cookie-based storage for session persistence')
   }
 
-  // 쿠키 기반 스토리지 어댑터 생성
-  // iOS Safari에서 앱 종료 후에도 세션 유지를 위해 쿠키 사용
-  const cookieStorage = createCookieStorageAdapter()
+  const isSecure = window.location.protocol === 'https:'
 
   // 싱글톤 인스턴스 생성 (iOS 호환 설정 포함)
-  // 주의: storageKey는 미들웨어와 일관성을 위해 기본값 사용
-  // 커스텀 storageKey 사용 시 미들웨어와 쿠키 이름이 불일치하여 iOS Chrome에서 세션 유지 문제 발생
+  // @supabase/ssr의 브라우저/미들웨어 쿠키 구현을 함께 사용해
+  // 세션 쿠키 포맷과 갱신 책임을 하나의 경로로 통일합니다.
   supabaseInstance = createBrowserClient<Database>(
     supabaseUrl,
     supabaseAnonKey,
     {
+      cookieOptions: {
+        path: '/',
+        sameSite: 'lax',
+        secure: isSecure,
+        maxAge: 60 * 60 * 24 * 30,
+      },
       auth: {
         autoRefreshToken: true,  // 자동 토큰 갱신 활성화
         persistSession: true,    // 세션 유지
         detectSessionInUrl: true, // URL에서 세션 감지
         flowType: 'pkce',        // PKCE flow 명시적 사용 (보안 강화)
-        storage: cookieStorage,  // 쿠키 기반 스토리지 (iOS Safari 호환)
-        // storageKey 제거: 기본값 사용하여 미들웨어와 일관성 유지
       },
       global: {
         headers: {

--- a/dental-clinic-manager/src/lib/supabase/connectionCheck.ts
+++ b/dental-clinic-manager/src/lib/supabase/connectionCheck.ts
@@ -1,5 +1,35 @@
 import { createClient } from './client'
 
+const DEFINITIVE_SESSION_ERROR_PATTERNS = [
+  'refresh token',
+  'invalid refresh token',
+  'refresh token not found',
+  'jwt',
+  'session missing',
+  'auth session missing',
+]
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+function isDefinitiveSessionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : ''
+  const normalized = message.toLowerCase()
+  return DEFINITIVE_SESSION_ERROR_PATTERNS.some(pattern => normalized.includes(pattern))
+}
+
+function isTransientSessionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : ''
+  const normalized = message.toLowerCase()
+
+  return (
+    normalized.includes('timeout') ||
+    normalized.includes('network') ||
+    normalized.includes('failed to fetch') ||
+    normalized.includes('fetch failed') ||
+    normalized.includes('connection')
+  )
+}
+
 /**
  * DB 연결 확인 및 자동 재연결 유틸리티
  *
@@ -28,26 +58,52 @@ export async function ensureConnection() {
   }
 
   try {
-    // 1. 세션 확인 (타임아웃 3초 - 공격적 최적화)
-    const sessionPromise = supabase.auth.getSession()
-    const timeoutPromise = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error('Session check timeout')), 3000)
-    )
+    // 1. 세션 확인 (재시도 포함)
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      try {
+        const sessionPromise = supabase.auth.getSession()
+        const timeoutPromise = new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Session check timeout')), 3000)
+        )
 
-    const { data: { session }, error: sessionError } = await Promise.race([
-      sessionPromise,
-      timeoutPromise
-    ]) as any
+        const { data: { session }, error: sessionError } = await Promise.race([
+          sessionPromise,
+          timeoutPromise
+        ]) as any
 
-    if (sessionError) {
-      console.error('[ensureConnection] Session check error:', sessionError)
-      throw sessionError
-    }
+        if (sessionError) {
+          if (isDefinitiveSessionError(sessionError)) {
+            console.error('[ensureConnection] Definitive session check error:', sessionError)
+            throw sessionError
+          }
 
-    // 2. 세션이 유효한 경우 - 바로 반환
-    if (session) {
-      console.log('[ensureConnection] Session valid')
-      return supabase
+          if (attempt === 2) {
+            throw sessionError
+          }
+
+          console.warn(`[ensureConnection] Transient session check error, retrying... (${attempt}/2)`, sessionError)
+          await delay(500)
+          continue
+        }
+
+        if (session) {
+          console.log('[ensureConnection] Session valid')
+          return supabase
+        }
+
+        break
+      } catch (error) {
+        if (isDefinitiveSessionError(error)) {
+          throw error
+        }
+
+        if (attempt === 2) {
+          throw error
+        }
+
+        console.warn(`[ensureConnection] Session check attempt ${attempt}/2 failed, retrying...`, error)
+        await delay(500)
+      }
     }
 
     // 3. 세션이 없는 경우 - 갱신 시도 (재시도 로직 포함)
@@ -83,6 +139,10 @@ export async function ensureConnection() {
         // 실패한 경우
         console.warn(`[ensureConnection] Refresh attempt ${attempt} failed:`, refreshError)
 
+        if (isDefinitiveSessionError(refreshError)) {
+          break
+        }
+
         // 마지막 시도가 아니면 백오프 후 재시도
         if (attempt < 2) {
           const backoffMs = attempt * 1000 // 1초
@@ -94,6 +154,10 @@ export async function ensureConnection() {
         console.error(`[ensureConnection] Refresh attempt ${attempt} exception:`, error)
         refreshError = error
 
+        if (isDefinitiveSessionError(error)) {
+          break
+        }
+
         // 마지막 시도가 아니면 백오프 후 재시도
         if (attempt < 2) {
           const backoffMs = attempt * 1000
@@ -102,8 +166,13 @@ export async function ensureConnection() {
       }
     }
 
-    // 4. 모든 재시도 실패 - 로그아웃 및 리다이렉트
+    // 4. 모든 재시도 실패
     console.error('[ensureConnection] All refresh attempts failed')
+
+    if (!isDefinitiveSessionError(refreshError)) {
+      throw new Error('세션 확인 중 일시적인 연결 문제가 발생했습니다. 잠시 후 다시 시도해주세요.')
+    }
+
     await supabase.auth.signOut()
 
     if (typeof window !== 'undefined') {
@@ -120,7 +189,7 @@ export async function ensureConnection() {
     console.error('[ensureConnection] Error:', error)
 
     // 타임아웃 또는 네트워크 에러인 경우
-    if (error.message?.includes('timeout') || error.message?.includes('network')) {
+    if (isTransientSessionError(error)) {
       throw new Error('데이터베이스 연결에 실패했습니다. 네트워크를 확인해주세요.')
     }
 

--- a/dental-clinic-manager/supabase/migrations/20260516_optimize_dentweb_sync.sql
+++ b/dental-clinic-manager/supabase/migrations/20260516_optimize_dentweb_sync.sql
@@ -1,0 +1,138 @@
+-- ============================================
+-- DentWeb sync path optimization
+-- Created: 2026-05-16
+-- ============================================
+
+CREATE INDEX IF NOT EXISTS idx_dentweb_sync_config_clinic_api_key
+  ON dentweb_sync_config(clinic_id, api_key);
+
+CREATE OR REPLACE FUNCTION sync_dentweb_patients_batch(
+  p_clinic_id UUID,
+  p_patients JSONB,
+  p_synced_at TIMESTAMPTZ DEFAULT NOW()
+)
+RETURNS TABLE (
+  total_records INTEGER,
+  new_records INTEGER,
+  updated_records INTEGER
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH payload AS (
+    SELECT
+      p_clinic_id AS clinic_id,
+      dentweb_patient_id,
+      NULLIF(chart_number, '') AS chart_number,
+      patient_name,
+      NULLIF(phone_number, '') AS phone_number,
+      birth_date,
+      NULLIF(gender, '') AS gender,
+      last_visit_date,
+      NULLIF(last_treatment_type, '') AS last_treatment_type,
+      next_appointment_date,
+      NULLIF(next_appointment_memo, '') AS next_appointment_memo,
+      registration_date,
+      NULLIF(acquisition_channel, '') AS acquisition_channel,
+      NULLIF(customer_type, '') AS customer_type,
+      COALESCE(is_active, true) AS is_active,
+      raw_data
+    FROM jsonb_to_recordset(COALESCE(p_patients, '[]'::jsonb)) AS incoming(
+      dentweb_patient_id TEXT,
+      chart_number TEXT,
+      patient_name TEXT,
+      phone_number TEXT,
+      birth_date DATE,
+      gender TEXT,
+      last_visit_date DATE,
+      last_treatment_type TEXT,
+      next_appointment_date DATE,
+      next_appointment_memo TEXT,
+      registration_date DATE,
+      acquisition_channel TEXT,
+      customer_type TEXT,
+      is_active BOOLEAN,
+      raw_data JSONB
+    )
+  ),
+  counts AS (
+    SELECT
+      COUNT(*)::INTEGER AS total_records,
+      COUNT(*) FILTER (WHERE existing.dentweb_patient_id IS NULL)::INTEGER AS new_records,
+      COUNT(*) FILTER (WHERE existing.dentweb_patient_id IS NOT NULL)::INTEGER AS updated_records
+    FROM payload
+    LEFT JOIN dentweb_patients AS existing
+      ON existing.clinic_id = p_clinic_id
+     AND existing.dentweb_patient_id = payload.dentweb_patient_id
+  ),
+  upserted AS (
+    INSERT INTO dentweb_patients (
+      clinic_id,
+      dentweb_patient_id,
+      chart_number,
+      patient_name,
+      phone_number,
+      birth_date,
+      gender,
+      last_visit_date,
+      last_treatment_type,
+      next_appointment_date,
+      next_appointment_memo,
+      registration_date,
+      acquisition_channel,
+      customer_type,
+      is_active,
+      raw_data,
+      synced_at,
+      updated_at
+    )
+    SELECT
+      clinic_id,
+      dentweb_patient_id,
+      chart_number,
+      patient_name,
+      phone_number,
+      birth_date,
+      gender,
+      last_visit_date,
+      last_treatment_type,
+      next_appointment_date,
+      next_appointment_memo,
+      registration_date,
+      acquisition_channel,
+      customer_type,
+      is_active,
+      raw_data,
+      p_synced_at,
+      p_synced_at
+    FROM payload
+    ON CONFLICT (clinic_id, dentweb_patient_id) DO UPDATE
+    SET
+      chart_number = EXCLUDED.chart_number,
+      patient_name = EXCLUDED.patient_name,
+      phone_number = EXCLUDED.phone_number,
+      birth_date = EXCLUDED.birth_date,
+      gender = EXCLUDED.gender,
+      last_visit_date = EXCLUDED.last_visit_date,
+      last_treatment_type = EXCLUDED.last_treatment_type,
+      next_appointment_date = EXCLUDED.next_appointment_date,
+      next_appointment_memo = EXCLUDED.next_appointment_memo,
+      registration_date = EXCLUDED.registration_date,
+      acquisition_channel = EXCLUDED.acquisition_channel,
+      customer_type = EXCLUDED.customer_type,
+      is_active = EXCLUDED.is_active,
+      raw_data = EXCLUDED.raw_data,
+      synced_at = EXCLUDED.synced_at,
+      updated_at = EXCLUDED.updated_at
+    RETURNING 1
+  ),
+  applied AS (
+    SELECT COUNT(*) FROM upserted
+  )
+  SELECT counts.total_records, counts.new_records, counts.updated_records
+  FROM counts, applied;
+END;
+$$;


### PR DESCRIPTION
## 🚨 Critical
오늘 보고된 3가지 문제 중 2건(로그아웃, 속도) 동시 처리 — 현금 손실은 PR #654 별도 머지 완료.

## 1) 로그아웃 재발 (Codex 진단)
- \`ensureConnection()\` 이 일시적 타임아웃·네트워크 실패에도 signOut 트리거 → false-positive 로그아웃 다발
- \`SIGNED_OUT\` 이벤트 수신 시 세션 재확인 없이 즉시 로컬 상태 초기화
- 브라우저 클라이언트가 cookieStorageAdapter 로 \`sb-*\` 쿠키 직접 쓰기 + middleware @supabase/ssr 이 같은 키 덮어쓰기 race

**수정**:
- \`resolveUserProfile()\` 실패 시 3회 재시도 후에만 signOut
- \`ensureConnection()\`: 확정적 auth 오류만 signOut, 타임아웃 제외
- \`SIGNED_OUT\` 이벤트: 세션 재확인 + debounce
- 브라우저 클라이언트 → @supabase/ssr 내장 쿠키 스토리지로 전환 (cookie 단일 소유권)

## 2) /api/dentweb/sync 속도 저하 (12명 처리 5~16초 → 목표 <2초)
- 원인: per-row read→write loop (N+1) + \`(clinic_id, api_key)\` 인덱스 없음

**수정**:
- batch RPC \`sync_dentweb_patients_batch\` 위임 → O(1) 라운드트립 (적용 완료)
- config + log update 병렬 (\`Promise.all\`)
- 신규 복합 인덱스 (적용 완료)
- 신규 migration \`20260516_optimize_dentweb_sync.sql\` **Supabase 적용 완료**

## 3) 부가
- \`/dashboard/marketing\` prerender 실패 해결 (\`dynamic({ ssr: false })\`)

## Test plan
- [x] DB 마이그레이션 적용 확인 (RPC + 인덱스 존재)
- [ ] Vercel 배포 후 dentweb sync duration < 2초 확인
- [ ] 운영 환경에서 로그아웃 재발 모니터링

🤖 Generated with Codex GPT-5.4 + Claude Code