### PR TITLE
fix(mobile): 대시보드 진입 시 깜빡임 — useSupabaseData loading 토글 정정

### DIFF
--- a/dental-clinic-manager/src/hooks/useSupabaseData.ts
+++ b/dental-clinic-manager/src/hooks/useSupabaseData.ts
@@ -472,7 +472,7 @@ export const useSupabaseData = (clinicId?: string | null, options: UseSupabaseDa
   useEffect(() => {
     if (typeof window === 'undefined') {
       console.log('[useSupabaseData] Server-side rendering, skipping data fetch')
-      setLoading(false)
+      // SSR: loading 초기값(true) 유지 — 클라이언트 hydration 후 첫 fetch 까지 빈 화면 깜빡임 방지
       return
     }
 
@@ -483,7 +483,9 @@ export const useSupabaseData = (clinicId?: string | null, options: UseSupabaseDa
 
     if (!activeClinicId) {
       console.log('[useSupabaseData] Waiting for clinic_id before loading data')
-      setLoading(false)
+      // 인증/프로필 로딩이 끝나 clinic_id 가 도착할 때까지 loading=true 유지.
+      // 옛 동작은 여기서 setLoading(false) 호출 → 빈 데이터 + loading=false 상태로 한 번 렌더
+      // → 모바일에서 \"빈 화면 → 스피너 → 데이터\" 깜빡임의 원인이었음.
       return
     }
 


### PR DESCRIPTION
## Summary
모바일에서 대시보드 진입 시 \"빈 화면 → 스피너 → 실제 데이터\" 연쇄 깜빡임 보고.

## 근본 원인
- \`useSupabaseData\` hook 이 \`activeClinicId\` 가 아직 null 인 동안(인증/프로필 로딩 중) \`setLoading(false)\` 호출
- DashboardHome 이 \`dataLoading=false + dailyReports=[]\` 빈 상태로 한 번 렌더
- 이후 clinic_id 도착 → setLoading(true) → fetch → 데이터 도착 → setLoading(false) 추가 시퀀스
- 모바일에서 활성 탭 전환·인증 race 가 겹쳐 더 두드러짐

## 수정
- SSR 분기: \`setLoading(false)\` 제거 → loading 초기값(true) 유지
- \`!activeClinicId\` 분기: \`setLoading(false)\` 제거 → clinic_id 도착할 때까지 loading=true
- 결과: \"스피너 → 데이터\" 단일 전환만 발생

🤖 Generated with [Claude Code](https://claude.com/claude-code)