### PR TITLE
fix(marketing): AI 글 생성 첫 호출 network error 자동 해결

### DIFF
--- a/dental-clinic-manager/src/app/api/marketing/generate/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/generate/route.ts
@@ -36,6 +36,10 @@ export async function POST(request: NextRequest) {
 
   const stream = new ReadableStream({
     async start(controller) {
+      // 클라이언트가 즉시 첫 body chunk 를 받도록 보장 (Vercel cold start / dev 첫 컴파일 시
+      // 브라우저 fetch 가 응답 body 없이 timeout 되는 "network error" 방지)
+      sendEvent(controller, { heartbeat: true });
+
       let keepalive: ReturnType<typeof setInterval> | null = null;
       try {
         // 인증 확인

--- a/dental-clinic-manager/src/contexts/AIGenerationContext.tsx
+++ b/dental-clinic-manager/src/contexts/AIGenerationContext.tsx
@@ -98,33 +98,49 @@ export function AIGenerationProvider({ children }: { children: ReactNode }) {
     // SSE 스트리밍을 비동기로 실행
     ;(async () => {
       try {
-        const res = await fetch('/api/marketing/generate', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            topic: options.topic,
-            keyword: options.keyword,
-            postType: options.postType,
-            tone: options.tone,
-            useResearch: options.useResearch,
-            factCheck: options.factCheck,
-            useSeoAnalysis: options.useSeoAnalysis,
-            platforms: options.platforms,
-            imageStyle: options.imageStyle,
-            imageVisualStyle: options.imageVisualStyle,
-            imageCount: options.imageCount,
-            ...(options.imageStyleAllocation ? { imageStyleAllocation: options.imageStyleAllocation } : {}),
-            ...(options.targetWordCount ? { targetWordCount: options.targetWordCount } : {}),
-            ...((options.imageStyleAllocation?.use_own_image ?? 0) > 0 && options.referenceImageBase64
-              ? { referenceImageBase64: options.referenceImageBase64 }
-              : options.imageStyle === 'use_own_image' && options.referenceImageBase64
-              ? { referenceImageBase64: options.referenceImageBase64 }
-              : {}),
-            ...(options.clinical ? { clinical: options.clinical } : {}),
-            ...(options.brandImageOptions ? { brandImageOptions: options.brandImageOptions } : {}),
-          }),
-          signal: abortController.signal,
+        const requestBody = JSON.stringify({
+          topic: options.topic,
+          keyword: options.keyword,
+          postType: options.postType,
+          tone: options.tone,
+          useResearch: options.useResearch,
+          factCheck: options.factCheck,
+          useSeoAnalysis: options.useSeoAnalysis,
+          platforms: options.platforms,
+          imageStyle: options.imageStyle,
+          imageVisualStyle: options.imageVisualStyle,
+          imageCount: options.imageCount,
+          ...(options.imageStyleAllocation ? { imageStyleAllocation: options.imageStyleAllocation } : {}),
+          ...(options.targetWordCount ? { targetWordCount: options.targetWordCount } : {}),
+          ...((options.imageStyleAllocation?.use_own_image ?? 0) > 0 && options.referenceImageBase64
+            ? { referenceImageBase64: options.referenceImageBase64 }
+            : options.imageStyle === 'use_own_image' && options.referenceImageBase64
+            ? { referenceImageBase64: options.referenceImageBase64 }
+            : {}),
+          ...(options.clinical ? { clinical: options.clinical } : {}),
+          ...(options.brandImageOptions ? { brandImageOptions: options.brandImageOptions } : {}),
         })
+
+        // 첫 호출은 Vercel cold start / dev 첫 컴파일로 네트워크 오류가 날 수 있어
+        // 자동 1회 재시도 (사용자가 "두 번째는 된다"고 보고한 패턴 해결).
+        const doFetch = (): Promise<Response> =>
+          fetch('/api/marketing/generate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: requestBody,
+            signal: abortController.signal,
+          })
+
+        let res: Response
+        try {
+          res = await doFetch()
+        } catch (firstErr) {
+          if (firstErr instanceof Error && firstErr.name === 'AbortError') throw firstErr
+          // 첫 호출 실패(콜드 스타트 등) → 1.5초 대기 후 재시도
+          await new Promise((r) => setTimeout(r, 1500))
+          if (abortController.signal.aborted) throw new DOMException('Aborted', 'AbortError')
+          res = await doFetch()
+        }
 
         if (!res.ok || !res.body) {
           const text = await res.text()
@@ -142,9 +158,9 @@ export function AIGenerationProvider({ children }: { children: ReactNode }) {
         const decoder = new TextDecoder()
         let buffer = ''
 
-        // idle timeout: 서버가 90초간 어떤 chunk도 보내지 않으면 hang으로 판단하고 abort
-        // (서버는 5초 간격 heartbeat 송신; 90초는 단계 전환 사이 안전 마진)
-        const IDLE_TIMEOUT_MS = 90000
+        // idle timeout: 서버가 120초간 어떤 chunk도 보내지 않으면 hang으로 판단하고 abort
+        // (서버는 5초 간격 heartbeat 송신; 120초는 SEO 워커 polling·Vercel cold start 안전 마진)
+        const IDLE_TIMEOUT_MS = 120000
         let idleTimer: ReturnType<typeof setTimeout> | null = null
         const resetIdleTimer = () => {
           if (idleTimer) clearTimeout(idleTimer)


### PR DESCRIPTION
## Summary
- **원인**: 첫 호출 시 Vercel cold start / dev 서버 첫 컴파일로 SSE route 가 응답 body 첫 chunk 를 송신하기까지 시간이 걸려, 브라우저 fetch 가 그 사이 timeout 되어 "network error" 메시지가 표시되던 문제. 두 번째 호출은 warm 상태라 정상.
- **해결**:
  - `route.ts`: ReadableStream start() 가장 첫 줄에 `sendEvent(heartbeat)` 즉시 송신 → Next.js 가 응답 body 첫 chunk 와 함께 헤더를 즉시 흘려보냄 → fetch 즉시 resolve
  - `AIGenerationContext`: 첫 fetch 실패 시 1.5초 대기 후 1회 자동 재시도 (cold start 의 극단 케이스 대비)
  - idle timeout 90 → 120초 확대 (SEO 워커 polling·플랫폼 이미지 생성 안전 마진)

## 검증
- ✅ dev 서버 완전 재시작 후 첫 SSE 호출에서 fetch 1.1초 / 첫 chunk 1.1초 만에 수신 (`data: {"heartbeat":true}`)
- ✅ 빌드 통과 (`npm run build`)

## Test plan
- [x] dev clean restart 후 콜드 상태에서 첫 호출 즉시 응답 확인
- [x] 빌드 통과