### PR TITLE
fix(layout): 첫 접속 깜빡임(배경색 전환) 제거

### DIFF
--- a/dental-clinic-manager/src/app/dashboard/layout.tsx
+++ b/dental-clinic-manager/src/app/dashboard/layout.tsx
@@ -124,9 +124,11 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   }, [router])
 
   // 퇴사자/승인대기/거절된 사용자는 대시보드를 렌더링하지 않음
+  // 배경색은 본 콘텐츠와 동일하게 bg-at-surface 사용 — 로딩 → 본 콘텐츠 전환 시
+  // 배경 톤이 바뀌면서 화면 전체가 깜빡이는 것처럼 보였음 (시크릿 모드에서도 재현됨)
   if (loading) {
     return (
-      <div className="min-h-screen bg-at-surface-alt flex items-center justify-center">
+      <div className="min-h-screen bg-at-surface flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-at-accent"></div>
       </div>
     )
@@ -134,7 +136,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 
   if (!user || user.status === 'resigned') {
     return (
-      <div className="min-h-screen bg-at-surface-alt flex items-center justify-center">
+      <div className="min-h-screen bg-at-surface flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-at-accent"></div>
       </div>
     )
@@ -142,7 +144,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   // pending/rejected 사용자는 공개 모임 상세 페이지에 한해 본문 렌더 허용
   if ((user.status === 'pending' || user.status === 'rejected') && !isPublicTelegramGroupRoute) {
     return (
-      <div className="min-h-screen bg-at-surface-alt flex items-center justify-center">
+      <div className="min-h-screen bg-at-surface flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-at-accent"></div>
       </div>
     )


### PR DESCRIPTION
## Summary
- 로딩 스피너 배경(\`bg-at-surface-alt\` #f8fafc) → 본 콘텐츠 배경(\`bg-at-surface\` #ffffff) 전환이 첫 접속 시 회색→흰색 깜빡임으로 보였음
- 시크릿 모드에서도 동일하게 1회 발생 (SW/localStorage 아님 → 배경색 차이가 진짜 원인)
- 세 곳의 로딩 화면 배경을 \`bg-at-surface\`로 통일

## Test plan
- [ ] 일반/시크릿 모드 모두에서 첫 접속 시 깜빡임 없는지 확인