### PR TITLE
feat(marketing): 텍스트 카드 자동 카피 기본값을 글 제목으로 변경

### DIFF
--- a/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
@@ -892,6 +892,7 @@ export default function NewMarketingPostPage() {
             <BrandImageSection
               clinicNameForCopy=""
               keyword={keyword}
+              topic={topic}
               value={brandImageOptions}
               onChange={setBrandImageOptions}
               disabled={isFormDisabled}

--- a/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
+++ b/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
@@ -1062,6 +1062,7 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
             <BrandImageSection
               clinicNameForCopy=""
               keyword={keyword}
+              topic={topic}
               value={brandImageOptions}
               onChange={setBrandImageOptions}
               disabled={isGenerating}

--- a/dental-clinic-manager/src/components/marketing/brand/BrandImageSection.tsx
+++ b/dental-clinic-manager/src/components/marketing/brand/BrandImageSection.tsx
@@ -7,6 +7,8 @@ import Link from 'next/link';
 interface Props {
   clinicNameForCopy: string;
   keyword: string;
+  /** 글 제목(주제) — 텍스트 카드 자동 카피의 기본값으로 사용 */
+  topic?: string;
   value: BrandImageOptions;
   onChange: (next: BrandImageOptions) => void;
   disabled?: boolean;
@@ -18,21 +20,22 @@ const POSITIONS: { key: 'top' | 'middle' | 'bottom'; label: string }[] = [
   { key: 'bottom', label: '끝' },
 ];
 
-export function BrandImageSection({ clinicNameForCopy, keyword, value, onChange, disabled }: Props) {
+export function BrandImageSection({ clinicNameForCopy, keyword, topic, value, onChange, disabled }: Props) {
   const { assets, photos } = useBrandAssets();
   const [copyTouched, setCopyTouched] = useState(false);
 
   useEffect(() => {
     if (copyTouched) return;
-    // 클리닉명과 키워드 중 채워진 값만 합쳐 자동 카피 생성.
-    // 둘 다 비어있으면 빈 문자열을 유지(서버에서 글 제목으로 자동 채움).
-    const parts = [clinicNameForCopy, keyword].map((s) => (s || '').trim()).filter(Boolean);
-    const auto = parts.join(' / ');
+    // 기본 카피는 글 제목(topic) 으로 자동 세팅.
+    // 제목이 비어있으면 키워드 → 클리닉명 순으로 폴백, 모두 비면 빈 문자열 유지(서버에서 글 제목으로 자동 채움).
+    const auto = (topic || '').trim()
+      || (keyword || '').trim()
+      || (clinicNameForCopy || '').trim();
     if (auto !== value.title.copy) {
       onChange({ ...value, title: { ...value.title, copy: auto } });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [clinicNameForCopy, keyword, copyTouched]);
+  }, [topic, keyword, clinicNameForCopy, copyTouched]);
 
   const togglePosition = (
     section: keyof BrandImageOptions,


### PR DESCRIPTION
## Summary
- BrandImageSection 의 텍스트 카드 자동 카피 기본값을 **글 제목(주제 / topic)** 으로 변경
- 우선순위: topic → keyword → clinicNameForCopy → '' (모두 비면 서버에서 글 제목으로 자동 채움)
- NewPostForm / posts/new/page.tsx 두 호출 위치에 topic prop 전달

## Why
기존에는 "(클리닉명) / (키워드)" 형태로 자동 합성되어 사용자가 매번 수정해야 했음.
텍스트 카드 이미지가 본문 주제와 즉시 일치하도록 글 제목을 기본값으로 사용.

## Test plan
- [x] 빌드 통과 (`npm run build` ✓ Compiled successfully)
- [ ] 새 글 작성 화면에서 주제 입력 시 텍스트 카드 카피가 자동으로 주제와 동일하게 채워지는지 확인
- [ ] 사용자가 직접 수정하면(`copyTouched`) 이후 주제 변경이 카피를 덮어쓰지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)