### PR TITLE
feat(marketing): 끝맺음 브랜드 이미지 세트 (Layer 1+2)

### DIFF
--- a/dental-clinic-manager/src/app/api/marketing/brand/image-sets/[id]/cards/[cardId]/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/brand/image-sets/[id]/cards/[cardId]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getSupabaseAdmin } from '@/lib/supabase/admin';
+import { loadUserContext, hasPermission } from '@/lib/marketing/brand/server-permissions';
+
+async function authorize() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: NextResponse.json({ error: '인증 필요' }, { status: 401 }) };
+  const ctx = await loadUserContext(user.id);
+  if (!hasPermission(ctx, 'marketing_brand_manage')) {
+    return { error: NextResponse.json({ error: '권한 없음' }, { status: 403 }) };
+  }
+  if (!ctx?.clinicId) return { error: NextResponse.json({ error: '소속 클리닉 없음' }, { status: 403 }) };
+  return { clinicId: ctx.clinicId };
+}
+
+// PATCH — 카드 카피/정렬 수정
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string; cardId: string }> }) {
+  const auth = await authorize();
+  if ('error' in auth) return auth.error;
+  const { cardId } = await params;
+
+  const body = await request.json().catch(() => ({}));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const update: any = {};
+  if (typeof body.title_copy === 'string' || body.title_copy === null) update.title_copy = body.title_copy?.trim() || null;
+  if (typeof body.subtitle_copy === 'string' || body.subtitle_copy === null) update.subtitle_copy = body.subtitle_copy?.trim() || null;
+  if (typeof body.sort_order === 'number') update.sort_order = body.sort_order;
+  if (Object.keys(update).length === 0) return NextResponse.json({ error: '변경 사항 없음' }, { status: 400 });
+
+  const admin = getSupabaseAdmin();
+  if (!admin) return NextResponse.json({ error: 'admin 미가용' }, { status: 500 });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (admin as any)
+    .from('clinic_brand_image_set_cards')
+    .update(update)
+    .eq('id', cardId)
+    .eq('clinic_id', auth.clinicId)
+    .select('*')
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ card: data });
+}
+
+// DELETE — 카드 삭제 (Storage 원본 파일은 cleanup 작업에서 별도 처리)
+export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string; cardId: string }> }) {
+  const auth = await authorize();
+  if ('error' in auth) return auth.error;
+  const { cardId } = await params;
+
+  const admin = getSupabaseAdmin();
+  if (!admin) return NextResponse.json({ error: 'admin 미가용' }, { status: 500 });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (admin as any)
+    .from('clinic_brand_image_set_cards')
+    .delete()
+    .eq('id', cardId)
+    .eq('clinic_id', auth.clinicId);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/dental-clinic-manager/src/app/api/marketing/brand/image-sets/[id]/cards/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/brand/image-sets/[id]/cards/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getSupabaseAdmin } from '@/lib/supabase/admin';
+import { loadUserContext, hasPermission } from '@/lib/marketing/brand/server-permissions';
+import { randomUUID } from 'crypto';
+
+const BUCKET = 'marketing-brand';
+const MAX_BYTES = 10 * 1024 * 1024;
+
+// POST /api/marketing/brand/image-sets/[id]/cards — 카드(이미지 + 카피) 추가
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: '인증 필요' }, { status: 401 });
+
+  const ctx = await loadUserContext(user.id);
+  if (!hasPermission(ctx, 'marketing_brand_manage')) {
+    return NextResponse.json({ error: '권한 없음' }, { status: 403 });
+  }
+  if (!ctx?.clinicId) return NextResponse.json({ error: '소속 클리닉 없음' }, { status: 403 });
+
+  const { id: setId } = await params;
+
+  const formData = await request.formData();
+  const file = formData.get('file');
+  const titleCopy = (formData.get('title_copy') as string | null)?.trim() || null;
+  const subtitleCopy = (formData.get('subtitle_copy') as string | null)?.trim() || null;
+  if (!(file instanceof File)) return NextResponse.json({ error: '파일 누락' }, { status: 400 });
+  if (file.size > MAX_BYTES) return NextResponse.json({ error: '10MB 이하만 가능' }, { status: 413 });
+
+  const admin = getSupabaseAdmin();
+  if (!admin) return NextResponse.json({ error: 'admin 미가용' }, { status: 500 });
+
+  // 세트 소유 검증
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: setRow } = await (admin as any)
+    .from('clinic_brand_image_sets')
+    .select('id, clinic_id')
+    .eq('id', setId)
+    .eq('clinic_id', ctx.clinicId)
+    .maybeSingle();
+  if (!setRow) return NextResponse.json({ error: '세트 없음 또는 권한 없음' }, { status: 404 });
+
+  const cardId = randomUUID();
+  const ext = file.name.split('.').pop()?.toLowerCase() || 'jpg';
+  const objectPath = `clinics/${ctx.clinicId}/sets/${setId}/originals/${cardId}.${ext}`;
+  const arrBuf = await file.arrayBuffer();
+  const { error: upErr } = await admin.storage.from(BUCKET).upload(objectPath, Buffer.from(arrBuf), {
+    contentType: file.type || 'image/jpeg',
+    upsert: false,
+  });
+  if (upErr) return NextResponse.json({ error: upErr.message }, { status: 500 });
+  const { data: pub } = admin.storage.from(BUCKET).getPublicUrl(objectPath);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: row, error: insErr } = await (admin as any)
+    .from('clinic_brand_image_set_cards')
+    .insert({
+      id: cardId,
+      set_id: setId,
+      clinic_id: ctx.clinicId,
+      image_url: pub.publicUrl,
+      title_copy: titleCopy,
+      subtitle_copy: subtitleCopy,
+    })
+    .select('*')
+    .single();
+  if (insErr) return NextResponse.json({ error: insErr.message }, { status: 500 });
+
+  return NextResponse.json({ card: row });
+}

--- a/dental-clinic-manager/src/app/api/marketing/brand/image-sets/[id]/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/brand/image-sets/[id]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getSupabaseAdmin } from '@/lib/supabase/admin';
+import { loadUserContext, hasPermission } from '@/lib/marketing/brand/server-permissions';
+
+async function authorize(): Promise<{ clinicId: string } | NextResponse> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: '인증 필요' }, { status: 401 });
+  const ctx = await loadUserContext(user.id);
+  if (!hasPermission(ctx, 'marketing_brand_manage')) {
+    return NextResponse.json({ error: '권한 없음' }, { status: 403 });
+  }
+  if (!ctx?.clinicId) return NextResponse.json({ error: '소속 클리닉 없음' }, { status: 403 });
+  return { clinicId: ctx.clinicId };
+}
+
+// PATCH — 세트 이름/설명 수정
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await authorize();
+  if (auth instanceof NextResponse) return auth;
+  const { id } = await params;
+
+  const body = await request.json().catch(() => ({}));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const update: any = {};
+  if (typeof body.name === 'string') update.name = body.name.trim();
+  if (typeof body.description === 'string' || body.description === null) update.description = body.description?.trim() || null;
+  if (typeof body.sort_order === 'number') update.sort_order = body.sort_order;
+  if (Object.keys(update).length === 0) return NextResponse.json({ error: '변경 사항 없음' }, { status: 400 });
+
+  const admin = getSupabaseAdmin();
+  if (!admin) return NextResponse.json({ error: 'admin 미가용' }, { status: 500 });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (admin as any)
+    .from('clinic_brand_image_sets')
+    .update(update)
+    .eq('id', id)
+    .eq('clinic_id', auth.clinicId)
+    .select('*')
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ set: data });
+}
+
+// DELETE — 세트 삭제 (카드는 cascade)
+export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await authorize();
+  if (auth instanceof NextResponse) return auth;
+  const { id } = await params;
+
+  const admin = getSupabaseAdmin();
+  if (!admin) return NextResponse.json({ error: 'admin 미가용' }, { status: 500 });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error } = await (admin as any)
+    .from('clinic_brand_image_sets')
+    .delete()
+    .eq('id', id)
+    .eq('clinic_id', auth.clinicId);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/dental-clinic-manager/src/app/api/marketing/brand/image-sets/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/brand/image-sets/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getSupabaseAdmin } from '@/lib/supabase/admin';
+import { loadUserContext, hasPermission } from '@/lib/marketing/brand/server-permissions';
+
+// GET /api/marketing/brand/image-sets — 클리닉의 세트 목록(+카드 포함)
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: '인증 필요' }, { status: 401 });
+
+  const ctx = await loadUserContext(user.id);
+  if (!hasPermission(ctx, 'marketing_brand_view')) {
+    return NextResponse.json({ error: '권한 없음' }, { status: 403 });
+  }
+  if (!ctx?.clinicId) return NextResponse.json({ error: '소속 클리닉 없음' }, { status: 403 });
+
+  const admin = getSupabaseAdmin();
+  if (!admin) return NextResponse.json({ error: 'admin 미가용' }, { status: 500 });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: sets } = await (admin as any)
+    .from('clinic_brand_image_sets')
+    .select('*')
+    .eq('clinic_id', ctx.clinicId)
+    .order('sort_order', { ascending: true })
+    .order('created_at', { ascending: true });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: cards } = await (admin as any)
+    .from('clinic_brand_image_set_cards')
+    .select('*')
+    .eq('clinic_id', ctx.clinicId)
+    .order('sort_order', { ascending: true });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const merged = (sets ?? []).map((s: any) => ({
+    ...s,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    cards: (cards ?? []).filter((c: any) => c.set_id === s.id),
+  }));
+
+  return NextResponse.json({ sets: merged });
+}
+
+// POST /api/marketing/brand/image-sets — 세트 생성
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: '인증 필요' }, { status: 401 });
+
+  const ctx = await loadUserContext(user.id);
+  if (!hasPermission(ctx, 'marketing_brand_manage')) {
+    return NextResponse.json({ error: '권한 없음' }, { status: 403 });
+  }
+  if (!ctx?.clinicId) return NextResponse.json({ error: '소속 클리닉 없음' }, { status: 403 });
+
+  const body = await request.json().catch(() => ({}));
+  const name = (body.name as string | undefined)?.trim();
+  if (!name) return NextResponse.json({ error: '세트 이름 누락' }, { status: 400 });
+  const description = (body.description as string | undefined)?.trim() || null;
+
+  const admin = getSupabaseAdmin();
+  if (!admin) return NextResponse.json({ error: 'admin 미가용' }, { status: 500 });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (admin as any)
+    .from('clinic_brand_image_sets')
+    .insert({ clinic_id: ctx.clinicId, name, description })
+    .select('*')
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ set: { ...data, cards: [] } });
+}

--- a/dental-clinic-manager/src/app/api/marketing/generate/route.ts
+++ b/dental-clinic-manager/src/app/api/marketing/generate/route.ts
@@ -243,7 +243,11 @@ export async function POST(request: NextRequest) {
         // 브랜드 이미지 마커를 합성된 이미지 URL로 치환
         // ([BRAND_IMAGE:...] 만 처리. AI 이미지용 [IMAGE: ...] 마커는 영향 없음)
         try {
-          result.body = await resolveBrandMarkers(result.body, { clinicId: userData.clinic_id });
+          result.body = await resolveBrandMarkers(result.body, {
+            clinicId: userData.clinic_id,
+            articleTitle: result.title,
+            keyword: body.keyword,
+          });
         } catch (brandErr) {
           console.error('[API] 브랜드 마커 리졸브 실패:', brandErr);
         }

--- a/dental-clinic-manager/src/app/dashboard/marketing/brand/BrandSettingsClient.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/brand/BrandSettingsClient.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/components/marketing/brand/BrandSettingsForm';
 import { BrandPhotoUploader } from '@/components/marketing/brand/BrandPhotoUploader';
 import { BrandPreview } from '@/components/marketing/brand/BrandPreview';
+import { BrandImageSetsManager } from '@/components/marketing/brand/BrandImageSetsManager';
 import type { DraftBrandAssets } from '@/types/brand';
 
 interface Props {
@@ -122,6 +123,12 @@ export function BrandSettingsClient({ canManage, embedded = false }: Props) {
             ) : (
               <p className="text-sm text-at-text-weak">조회만 가능합니다.</p>
             )}
+          </section>
+
+          <section className="bg-white rounded-xl border border-at-border p-5">
+            <h2 className="text-sm font-semibold text-at-text mb-1">끝맺음 브랜드 이미지 세트</h2>
+            <p className="text-xs text-at-text-weak mb-4">AI 글의 마지막 부분에 자동 첨가될 이미지 카드 묶음을 만들고 관리합니다.</p>
+            <BrandImageSetsManager canManage={canManage} />
           </section>
         </div>
 

--- a/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
+++ b/dental-clinic-manager/src/app/dashboard/marketing/posts/new/page.tsx
@@ -123,6 +123,7 @@ export default function NewMarketingPostPage() {
     medicalLaw: { enabled: true, positions: ['top'] },
     title:      { enabled: true, positions: ['top'], copy: '' },
     photo:      { enabled: true, positions: ['bottom'], mode: 'random' },
+    imageSet:   { enabled: false, positions: ['bottom'] },
   })
   const seoPreview = useSeoPreview()
   // 키워드 mismatch 가드: 입력 키워드와 분석된 키워드가 일치할 때만 결과 표시 (이전 분석 잔존 방지)

--- a/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
+++ b/dental-clinic-manager/src/components/marketing/NewPostForm.tsx
@@ -136,6 +136,7 @@ export default function NewPostForm({ onClose, onComplete }: NewPostFormProps) {
     medicalLaw: { enabled: true, positions: ['top'] },
     title:      { enabled: true, positions: ['top'], copy: '' },
     photo:      { enabled: true, positions: ['bottom'], mode: 'random' },
+    imageSet:   { enabled: false, positions: ['bottom'] },
   })
 
   // ── 생성 / 저장 상태 (컨텍스트에서 가져옴) ──

--- a/dental-clinic-manager/src/components/marketing/brand/BrandImageSection.tsx
+++ b/dental-clinic-manager/src/components/marketing/brand/BrandImageSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useBrandAssets } from '@/hooks/useBrandAssets';
+import { useBrandImageSets } from '@/hooks/useBrandImageSets';
 import type { BrandImageOptions } from '@/types/brand';
 import Link from 'next/link';
 
@@ -22,6 +23,7 @@ const POSITIONS: { key: 'top' | 'middle' | 'bottom'; label: string }[] = [
 
 export function BrandImageSection({ clinicNameForCopy, keyword, topic, value, onChange, disabled }: Props) {
   const { assets, photos } = useBrandAssets();
+  const { sets } = useBrandImageSets();
   const [copyTouched, setCopyTouched] = useState(false);
 
   useEffect(() => {
@@ -41,12 +43,23 @@ export function BrandImageSection({ clinicNameForCopy, keyword, topic, value, on
     section: keyof BrandImageOptions,
     pos: 'top' | 'middle' | 'bottom',
   ) => {
-    const cur = value[section].positions;
+    const cur = value[section]?.positions ?? [];
     const next = cur.includes(pos) ? cur.filter(p => p !== pos) : [...cur, pos];
+    // imageSet 은 optional 이라 기본 구조를 채워서 안전하게 전개
+    if (section === 'imageSet') {
+      const base = value.imageSet ?? { enabled: false, positions: [], setId: undefined };
+      onChange({ ...value, imageSet: { ...base, positions: next } });
+      return;
+    }
     onChange({ ...value, [section]: { ...value[section], positions: next } });
   };
 
   const setEnabled = (section: keyof BrandImageOptions, enabled: boolean) => {
+    if (section === 'imageSet') {
+      const base = value.imageSet ?? { enabled: false, positions: ['bottom'] as ('top'|'middle'|'bottom')[], setId: undefined };
+      onChange({ ...value, imageSet: { ...base, enabled } });
+      return;
+    }
     onChange({ ...value, [section]: { ...value[section], enabled } });
   };
 
@@ -87,6 +100,54 @@ export function BrandImageSection({ clinicNameForCopy, keyword, topic, value, on
           placeholder="중앙 큰 글씨 (자동 채움 — 수정 가능)"
           className="mt-2 w-full px-2 py-1.5 border border-at-border rounded text-xs"
         />
+      </Row>
+
+      <Row
+        label="끝맺음 이미지 세트 (LRU 순환 + 동적 변형)"
+        enabled={value.imageSet?.enabled ?? false}
+        onEnabledChange={(v) => setEnabled('imageSet', v)}
+        disabled={disabled || sets.length === 0}
+      >
+        {sets.length === 0 ? (
+          <p className="text-xs text-at-text-weak">
+            세트가 없습니다 —{' '}
+            <Link href="/dashboard/marketing/brand" className="text-at-accent underline">설정 페이지</Link>
+            에서 먼저 세트를 만들어주세요.
+          </p>
+        ) : (
+          <>
+            <div className="mt-2">
+              <label className="block text-xs text-at-text-secondary mb-1">사용할 세트</label>
+              <select
+                value={value.imageSet?.setId ?? ''}
+                onChange={(e) => {
+                  const base = value.imageSet ?? { enabled: false, positions: ['bottom' as const] };
+                  onChange({ ...value, imageSet: { ...base, setId: e.target.value || undefined } });
+                }}
+                disabled={disabled || !(value.imageSet?.enabled)}
+                className="w-full px-2 py-1.5 border border-at-border rounded text-xs disabled:bg-at-surface-alt"
+              >
+                <option value="">선택하세요…</option>
+                {sets.map(s => (
+                  <option key={s.id} value={s.id}>
+                    {s.name} ({s.cards.length}장)
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="mt-2">
+              <PositionPicker
+                positions={value.imageSet?.positions ?? []}
+                onToggle={(p) => togglePosition('imageSet', p)}
+                disabled={disabled || !(value.imageSet?.enabled)}
+              />
+            </div>
+            <p className="mt-1.5 text-[11px] text-at-text-weak leading-relaxed">
+              매번 다른 카드가 LRU 순서로 자동 선택되며, 발행 시점에 크롭·색조·텍스트 오버레이를 미세 변형해
+              네이버 유사이미지 판독을 회피합니다.
+            </p>
+          </>
+        )}
       </Row>
 
       <Row

--- a/dental-clinic-manager/src/components/marketing/brand/BrandImageSetsManager.tsx
+++ b/dental-clinic-manager/src/components/marketing/brand/BrandImageSetsManager.tsx
@@ -1,0 +1,304 @@
+'use client';
+import { useRef, useState } from 'react';
+import { useBrandImageSets } from '@/hooks/useBrandImageSets';
+import type { BrandImageSetCard, BrandImageSetWithCards } from '@/types/brand';
+
+interface Props {
+  canManage: boolean;
+}
+
+export function BrandImageSetsManager({ canManage }: Props) {
+  const { sets, loading, createSet, updateSet, deleteSet, addCard, updateCard, deleteCard } = useBrandImageSets();
+  const [newName, setNewName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [busyMsg, setBusyMsg] = useState<string>('');
+
+  const handleCreate = async () => {
+    const name = newName.trim();
+    if (!name) return;
+    setCreating(true);
+    try {
+      await createSet(name);
+      setNewName('');
+    } catch (e) {
+      alert(e instanceof Error ? e.message : '세트 생성 실패');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  if (loading) return <p className="text-sm text-at-text-weak">불러오는 중…</p>;
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-at-text-secondary leading-relaxed">
+        AI 글의 끝부분에 자동 첨가할 이미지 카드를 묶어 두는 공간입니다. 같은 세트의 카드는 LRU 순환으로
+        매번 다른 카드가 사용되며, 발행 시점에 sharp 로 미세 변형(크롭·색조·텍스트 오버레이)을 적용해
+        네이버 유사이미지 판독을 회피합니다.
+      </p>
+
+      {canManage && (
+        <div className="flex items-end gap-2">
+          <div className="flex-1">
+            <label className="block text-xs font-medium text-at-text-secondary mb-1">새 세트 이름</label>
+            <input
+              type="text"
+              value={newName}
+              onChange={e => setNewName(e.target.value)}
+              placeholder="예: 병원 소개, 진료시간, 오시는 길"
+              className="w-full px-3 py-2 border border-at-border rounded text-sm"
+              onKeyDown={e => { if (e.key === 'Enter') handleCreate(); }}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={handleCreate}
+            disabled={creating || !newName.trim()}
+            className="px-3 py-2 bg-at-accent text-white text-sm rounded disabled:bg-gray-300"
+          >
+            세트 추가
+          </button>
+        </div>
+      )}
+
+      {busyMsg && <p className="text-xs text-at-text-secondary">{busyMsg}</p>}
+
+      {sets.length === 0 ? (
+        <p className="text-sm text-at-text-weak">아직 세트가 없습니다 — 위에서 첫 세트를 만들어보세요.</p>
+      ) : (
+        <ul className="space-y-3">
+          {sets.map(set => (
+            <SetCard
+              key={set.id}
+              set={set}
+              canManage={canManage}
+              onRename={(name) => updateSet(set.id, { name })}
+              onDelete={async () => {
+                if (!confirm(`'${set.name}' 세트와 카드 ${set.cards.length}개를 모두 삭제할까요?`)) return;
+                try { await deleteSet(set.id); } catch (e) { alert(e instanceof Error ? e.message : '삭제 실패'); }
+              }}
+              onAddCard={async (file, t, s) => {
+                setBusyMsg(`${set.name}: 카드 업로드 중...`);
+                try { await addCard(set.id, file, t, s); } finally { setBusyMsg(''); }
+              }}
+              onUpdateCard={(cardId, update) => updateCard(set.id, cardId, update)}
+              onDeleteCard={(cardId) => deleteCard(set.id, cardId)}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+interface SetCardProps {
+  set: BrandImageSetWithCards;
+  canManage: boolean;
+  onRename: (name: string) => Promise<void>;
+  onDelete: () => Promise<void>;
+  onAddCard: (file: File, titleCopy?: string, subtitleCopy?: string) => Promise<void>;
+  onUpdateCard: (cardId: string, update: { title_copy?: string | null; subtitle_copy?: string | null }) => Promise<void>;
+  onDeleteCard: (cardId: string) => Promise<void>;
+}
+
+function SetCard({ set, canManage, onRename, onDelete, onAddCard, onUpdateCard, onDeleteCard }: SetCardProps) {
+  const [editingName, setEditingName] = useState(false);
+  const [nameDraft, setNameDraft] = useState(set.name);
+  const [cardTitleCopy, setCardTitleCopy] = useState('');
+  const [cardSubtitleCopy, setCardSubtitleCopy] = useState('');
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  const handleFile = async (file: File) => {
+    try {
+      await onAddCard(file, cardTitleCopy || undefined, cardSubtitleCopy || undefined);
+      setCardTitleCopy('');
+      setCardSubtitleCopy('');
+    } catch (e) {
+      alert(e instanceof Error ? e.message : '업로드 실패');
+    }
+  };
+
+  return (
+    <li className="border border-at-border rounded-lg p-3 bg-white">
+      <header className="flex items-center justify-between gap-2 mb-3">
+        {editingName ? (
+          <div className="flex items-center gap-1 flex-1">
+            <input
+              type="text"
+              value={nameDraft}
+              onChange={e => setNameDraft(e.target.value)}
+              className="flex-1 px-2 py-1 border border-at-border rounded text-sm"
+            />
+            <button
+              type="button"
+              onClick={async () => {
+                const n = nameDraft.trim();
+                if (n) await onRename(n);
+                setEditingName(false);
+              }}
+              className="px-2 py-1 text-xs bg-at-accent text-white rounded"
+            >저장</button>
+            <button
+              type="button"
+              onClick={() => { setNameDraft(set.name); setEditingName(false); }}
+              className="px-2 py-1 text-xs text-at-text-secondary border border-at-border rounded"
+            >취소</button>
+          </div>
+        ) : (
+          <h3 className="text-sm font-semibold text-at-text flex-1">
+            {set.name}
+            <span className="ml-2 text-xs text-at-text-secondary">({set.cards.length}장)</span>
+          </h3>
+        )}
+        {canManage && !editingName && (
+          <div className="flex gap-1">
+            <button
+              type="button"
+              onClick={() => setEditingName(true)}
+              className="text-xs text-at-text-secondary hover:text-at-text"
+            >이름 수정</button>
+            <button
+              type="button"
+              onClick={onDelete}
+              className="text-xs text-red-600 hover:text-red-700"
+            >세트 삭제</button>
+          </div>
+        )}
+      </header>
+
+      {set.cards.length > 0 && (
+        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3 mb-3">
+          {set.cards.map(card => (
+            <CardItem
+              key={card.id}
+              card={card}
+              canManage={canManage}
+              onUpdate={(update) => onUpdateCard(card.id, update)}
+              onDelete={async () => {
+                if (!confirm('이 카드를 삭제할까요?')) return;
+                try { await onDeleteCard(card.id); } catch (e) { alert(e instanceof Error ? e.message : '삭제 실패'); }
+              }}
+            />
+          ))}
+        </ul>
+      )}
+
+      {canManage && (
+        <div className="border-t border-at-border pt-3 space-y-2">
+          <p className="text-xs font-medium text-at-text-secondary">카드 추가</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <input
+              type="text"
+              value={cardTitleCopy}
+              onChange={e => setCardTitleCopy(e.target.value)}
+              placeholder="상단 카피 (선택) — 예: 진료시간 안내"
+              className="px-2 py-1.5 border border-at-border rounded text-xs"
+            />
+            <input
+              type="text"
+              value={cardSubtitleCopy}
+              onChange={e => setCardSubtitleCopy(e.target.value)}
+              placeholder="하단 카피 (선택) — 예: 평일 10:00~19:00"
+              className="px-2 py-1.5 border border-at-border rounded text-xs"
+            />
+          </div>
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={e => {
+              const f = e.target.files?.[0];
+              if (f) handleFile(f);
+              if (fileRef.current) fileRef.current.value = '';
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            className="w-full px-3 py-2 border-2 border-dashed border-at-border rounded text-xs text-at-text-secondary hover:bg-at-surface-alt"
+          >
+            이미지 파일 선택 (10MB 이하)
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}
+
+interface CardItemProps {
+  card: BrandImageSetCard;
+  canManage: boolean;
+  onUpdate: (update: { title_copy?: string | null; subtitle_copy?: string | null }) => Promise<void>;
+  onDelete: () => Promise<void>;
+}
+
+function CardItem({ card, canManage, onUpdate, onDelete }: CardItemProps) {
+  const [editing, setEditing] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(card.title_copy || '');
+  const [subtitleDraft, setSubtitleDraft] = useState(card.subtitle_copy || '');
+
+  return (
+    <li className="border border-at-border rounded overflow-hidden bg-at-surface-alt/40">
+      <div className="aspect-video bg-white">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={card.image_url} alt={card.title_copy || ''} className="w-full h-full object-cover" />
+      </div>
+      <div className="p-2 space-y-1.5">
+        {editing ? (
+          <>
+            <input
+              type="text"
+              value={titleDraft}
+              onChange={e => setTitleDraft(e.target.value)}
+              placeholder="상단 카피"
+              className="w-full px-1.5 py-1 border border-at-border rounded text-xs"
+            />
+            <input
+              type="text"
+              value={subtitleDraft}
+              onChange={e => setSubtitleDraft(e.target.value)}
+              placeholder="하단 카피"
+              className="w-full px-1.5 py-1 border border-at-border rounded text-xs"
+            />
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={async () => {
+                  await onUpdate({ title_copy: titleDraft || null, subtitle_copy: subtitleDraft || null });
+                  setEditing(false);
+                }}
+                className="flex-1 px-2 py-1 bg-at-accent text-white text-xs rounded"
+              >저장</button>
+              <button
+                type="button"
+                onClick={() => { setTitleDraft(card.title_copy || ''); setSubtitleDraft(card.subtitle_copy || ''); setEditing(false); }}
+                className="px-2 py-1 border border-at-border text-xs rounded"
+              >취소</button>
+            </div>
+          </>
+        ) : (
+          <>
+            {card.title_copy && <p className="text-xs font-semibold text-at-text leading-tight">{card.title_copy}</p>}
+            {card.subtitle_copy && <p className="text-[11px] text-at-text-secondary leading-tight">{card.subtitle_copy}</p>}
+            <p className="text-[10px] text-at-text-weak">사용 {card.use_count}회{card.last_used_at && ` · 마지막 ${new Date(card.last_used_at).toLocaleDateString('ko-KR')}`}</p>
+            {canManage && (
+              <div className="flex gap-1 pt-1">
+                <button
+                  type="button"
+                  onClick={() => setEditing(true)}
+                  className="flex-1 px-1.5 py-0.5 border border-at-border text-[11px] rounded"
+                >카피 수정</button>
+                <button
+                  type="button"
+                  onClick={onDelete}
+                  className="px-1.5 py-0.5 border border-red-300 text-red-600 text-[11px] rounded"
+                >삭제</button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/dental-clinic-manager/src/hooks/useBrandImageSets.ts
+++ b/dental-clinic-manager/src/hooks/useBrandImageSets.ts
@@ -1,0 +1,94 @@
+'use client';
+import { useCallback, useEffect, useState } from 'react';
+import type { BrandImageSetCard, BrandImageSetWithCards } from '@/types/brand';
+
+export function useBrandImageSets() {
+  const [sets, setSets] = useState<BrandImageSetWithCards[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await fetch('/api/marketing/brand/image-sets').then(r => r.json());
+      setSets(r.sets ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '조회 실패');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const createSet = useCallback(async (name: string, description?: string) => {
+    const res = await fetch('/api/marketing/brand/image-sets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, description }),
+    });
+    const json = await res.json();
+    if (!res.ok) throw new Error(json.error || '세트 생성 실패');
+    setSets(prev => [...prev, json.set]);
+    return json.set as BrandImageSetWithCards;
+  }, []);
+
+  const updateSet = useCallback(async (id: string, update: { name?: string; description?: string | null; sort_order?: number }) => {
+    const res = await fetch(`/api/marketing/brand/image-sets/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(update),
+    });
+    const json = await res.json();
+    if (!res.ok) throw new Error(json.error || '세트 수정 실패');
+    setSets(prev => prev.map(s => s.id === id ? { ...s, ...json.set } : s));
+  }, []);
+
+  const deleteSet = useCallback(async (id: string) => {
+    const res = await fetch(`/api/marketing/brand/image-sets/${id}`, { method: 'DELETE' });
+    if (!res.ok) {
+      const json = await res.json();
+      throw new Error(json.error || '세트 삭제 실패');
+    }
+    setSets(prev => prev.filter(s => s.id !== id));
+  }, []);
+
+  const addCard = useCallback(async (setId: string, file: File, titleCopy?: string, subtitleCopy?: string) => {
+    const fd = new FormData();
+    fd.append('file', file);
+    if (titleCopy) fd.append('title_copy', titleCopy);
+    if (subtitleCopy) fd.append('subtitle_copy', subtitleCopy);
+    const res = await fetch(`/api/marketing/brand/image-sets/${setId}/cards`, { method: 'POST', body: fd });
+    const json = await res.json();
+    if (!res.ok) throw new Error(json.error || '카드 추가 실패');
+    setSets(prev => prev.map(s => s.id === setId ? { ...s, cards: [...s.cards, json.card] } : s));
+    return json.card as BrandImageSetCard;
+  }, []);
+
+  const updateCard = useCallback(async (setId: string, cardId: string, update: { title_copy?: string | null; subtitle_copy?: string | null; sort_order?: number }) => {
+    const res = await fetch(`/api/marketing/brand/image-sets/${setId}/cards/${cardId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(update),
+    });
+    const json = await res.json();
+    if (!res.ok) throw new Error(json.error || '카드 수정 실패');
+    setSets(prev => prev.map(s => s.id === setId
+      ? { ...s, cards: s.cards.map(c => c.id === cardId ? json.card : c) }
+      : s));
+  }, []);
+
+  const deleteCard = useCallback(async (setId: string, cardId: string) => {
+    const res = await fetch(`/api/marketing/brand/image-sets/${setId}/cards/${cardId}`, { method: 'DELETE' });
+    if (!res.ok) {
+      const json = await res.json();
+      throw new Error(json.error || '카드 삭제 실패');
+    }
+    setSets(prev => prev.map(s => s.id === setId
+      ? { ...s, cards: s.cards.filter(c => c.id !== cardId) }
+      : s));
+  }, []);
+
+  return { sets, loading, error, refresh, createSet, updateSet, deleteSet, addCard, updateCard, deleteCard };
+}

--- a/dental-clinic-manager/src/lib/marketing/brand/image-set-variant.ts
+++ b/dental-clinic-manager/src/lib/marketing/brand/image-set-variant.ts
@@ -1,0 +1,185 @@
+import sharp from 'sharp';
+import satori from 'satori';
+import React from 'react';
+import { readFile } from 'fs/promises';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { getSupabaseAdmin } from '@/lib/supabase/admin';
+import type { BrandImageSetCard } from '@/types/brand';
+
+const BUCKET = 'marketing-brand';
+const FETCH_CACHE = new Map<string, { buffer: Buffer; fetchedAt: number }>();
+const CACHE_TTL_MS = 30 * 60 * 1000;
+
+let cachedFonts: { name: 'Pretendard'; data: Buffer; weight: 400 | 700 | 900; style: 'normal' }[] | null = null;
+
+async function loadFonts() {
+  if (cachedFonts) return cachedFonts;
+  const root = process.cwd();
+  const [regular, bold, black] = await Promise.all([
+    readFile(path.join(root, 'public/fonts/Pretendard-Regular.ttf')),
+    readFile(path.join(root, 'public/fonts/Pretendard-Bold.ttf')),
+    readFile(path.join(root, 'public/fonts/Pretendard-Black.ttf')),
+  ]);
+  cachedFonts = [
+    { name: 'Pretendard', data: regular, weight: 400, style: 'normal' },
+    { name: 'Pretendard', data: bold, weight: 700, style: 'normal' },
+    { name: 'Pretendard', data: black, weight: 900, style: 'normal' },
+  ];
+  return cachedFonts;
+}
+
+async function fetchBuffer(url: string): Promise<Buffer> {
+  const cached = FETCH_CACHE.get(url);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) return cached.buffer;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`fetch ${url} failed: ${res.status}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  FETCH_CACHE.set(url, { buffer: buf, fetchedAt: Date.now() });
+  return buf;
+}
+
+function randInRange(min: number, max: number): number {
+  return Math.random() * (max - min) + min;
+}
+
+interface VariantOptions {
+  /** 글 제목 — 텍스트 오버레이 상단에 사용 (없으면 card.title_copy 만 표시) */
+  articleTitle?: string;
+  /** 글 키워드 — alt 텍스트/파일명에 활용 */
+  keyword?: string;
+}
+
+/**
+ * 브랜드 이미지 세트의 카드를 발행 시점마다 미세 변형해서 새 PNG 로 합성·업로드한다.
+ *
+ * Layer 2 변형 (네이버 유사이미지 판독 회피):
+ *  1. 크롭 ±5% 랜덤 (perceptual hash window 어긋남 유발)
+ *  2. 색조(hue) ±3°, 채도 ±5%, 밝기 ±3% 랜덤
+ *  3. 글 제목·세트 카피를 텍스트 오버레이로 합성 (가장 강한 차별화 요소)
+ *  4. EXIF 완전 제거 (sharp 기본 동작 — withMetadata 생략)
+ *  5. 파일명을 발행 시점/카드/글 제목 기반 해시로 매번 다르게
+ */
+export async function renderImageSetVariant(
+  card: BrandImageSetCard,
+  opts: VariantOptions = {},
+): Promise<string> {
+  const admin = getSupabaseAdmin();
+  if (!admin) throw new Error('admin 미가용');
+
+  const baseBuf = await fetchBuffer(card.image_url);
+  const meta = await sharp(baseBuf).metadata();
+  const srcW = meta.width || 1024;
+  const srcH = meta.height || 1024;
+
+  // 1) 크롭 ±5%: 가장자리에서 0~5% 잘라내며 위치도 약간 시프트
+  const cropPct = randInRange(0.0, 0.05);
+  const cropX = Math.round(srcW * cropPct * randInRange(0, 1));
+  const cropY = Math.round(srcH * cropPct * randInRange(0, 1));
+  const cropW = Math.max(1, Math.round(srcW * (1 - cropPct)));
+  const cropH = Math.max(1, Math.round(srcH * (1 - cropPct)));
+
+  // 2) HSL 미세 변형
+  const hueShift = Math.round(randInRange(-3, 3));
+  const satMult = randInRange(0.95, 1.05);
+  const briMult = randInRange(0.97, 1.03);
+
+  // 텍스트 오버레이 영역: 하단 18% 띠 (반투명 어두운 배경 + 흰 텍스트)
+  // → 픽셀 분포 자체가 바뀌어 perceptual hash 회피에 가장 효과적
+  const W = cropW;
+  const H = cropH;
+  const overlayH = Math.round(H * 0.18);
+  const titleText = (opts.articleTitle || card.title_copy || '').trim();
+  const subtitleText = (card.subtitle_copy || '').trim();
+
+  const fonts = await loadFonts();
+  const titleFontSize = Math.max(18, Math.round(overlayH * 0.32));
+  const subtitleFontSize = Math.max(14, Math.round(overlayH * 0.22));
+
+  const overlayElement = React.createElement(
+    'div',
+    {
+      style: {
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        background: 'linear-gradient(to bottom, rgba(0,0,0,0) 0%, rgba(0,0,0,0.55) 30%, rgba(0,0,0,0.75) 100%)',
+        padding: `${Math.round(overlayH * 0.12)}px ${Math.round(W * 0.04)}px`,
+        gap: `${Math.round(overlayH * 0.06)}px`,
+      },
+    },
+    titleText
+      ? React.createElement(
+          'span',
+          {
+            style: {
+              color: 'white',
+              fontFamily: 'Pretendard',
+              fontWeight: 900,
+              fontSize: `${titleFontSize}px`,
+              letterSpacing: '-0.02em',
+              textAlign: 'center',
+              lineHeight: 1.2,
+            },
+          },
+          titleText,
+        )
+      : null,
+    subtitleText
+      ? React.createElement(
+          'span',
+          {
+            style: {
+              color: 'rgba(255,255,255,0.92)',
+              fontFamily: 'Pretendard',
+              fontWeight: 400,
+              fontSize: `${subtitleFontSize}px`,
+              letterSpacing: '-0.01em',
+              textAlign: 'center',
+              lineHeight: 1.3,
+            },
+          },
+          subtitleText,
+        )
+      : null,
+  );
+
+  let overlayPng: Buffer | null = null;
+  try {
+    const overlaySvg = await satori(overlayElement, { width: W, height: overlayH, fonts });
+    overlayPng = await sharp(Buffer.from(overlaySvg)).png().toBuffer();
+  } catch (err) {
+    console.warn('[image-set-variant] overlay 렌더 실패 — 오버레이 없이 진행:', err);
+  }
+
+  // sharp 파이프라인: 크롭 → modulate → 오버레이 합성 → PNG
+  let pipeline = sharp(baseBuf)
+    .extract({ left: cropX, top: cropY, width: cropW, height: cropH })
+    .modulate({ brightness: briMult, saturation: satMult, hue: hueShift });
+
+  if (overlayPng) {
+    pipeline = pipeline.composite([
+      { input: overlayPng, left: 0, top: H - overlayH },
+    ]);
+  }
+
+  // EXIF 자동 제거 (sharp 기본 동작; withMetadata 호출하지 않음)
+  const out = await pipeline.png({ compressionLevel: 8 }).toBuffer();
+
+  // 매번 다른 파일명 (perceptual hash 우회와 무관하지만 CDN 캐시 분리용)
+  const variantId = randomUUID();
+  const altSlug = (opts.keyword || titleText || 'image').replace(/[^a-zA-Z0-9가-힣]/g, '_').slice(0, 40);
+  const objectPath = `clinics/${card.clinic_id}/sets/${card.set_id}/${card.id}/${variantId}-${altSlug}.png`;
+
+  const { error: upErr } = await admin.storage.from(BUCKET).upload(objectPath, out, {
+    contentType: 'image/png',
+    upsert: false,
+  });
+  if (upErr) throw new Error(`variant upload 실패: ${upErr.message}`);
+
+  const { data: pub } = admin.storage.from(BUCKET).getPublicUrl(objectPath);
+  return pub.publicUrl;
+}

--- a/dental-clinic-manager/src/lib/marketing/brand/marker-resolver.ts
+++ b/dental-clinic-manager/src/lib/marketing/brand/marker-resolver.ts
@@ -1,6 +1,7 @@
 import { renderBrandImage } from './render-engine';
+import { renderImageSetVariant } from './image-set-variant';
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
-import type { BrandAssets, BrandImageType, BrandPhoto } from '@/types/brand';
+import type { BrandAssets, BrandImageType, BrandImageSetCard, BrandPhoto } from '@/types/brand';
 
 export interface BrandMarker {
   raw: string;
@@ -15,7 +16,7 @@ export function parseBrandMarkers(body: string): BrandMarker[] {
   const out: BrandMarker[] = [];
   for (const m of body.matchAll(MARKER_RE)) {
     const type = m[1] as BrandImageType;
-    if (type !== 'medical_law' && type !== 'title' && type !== 'photo') continue;
+    if (type !== 'medical_law' && type !== 'title' && type !== 'photo' && type !== 'image_set') continue;
     const params: Record<string, string> = {};
     if (m[2]) {
       for (const pair of m[2].split('|')) {
@@ -32,6 +33,10 @@ export function parseBrandMarkers(body: string): BrandMarker[] {
 interface ResolveContext {
   clinicId: string;
   rotateCounter?: number;
+  /** 글 제목 — image_set 변형의 텍스트 오버레이에 사용 */
+  articleTitle?: string;
+  /** 글 키워드 — image_set 변형의 alt/파일명 슬러그에 사용 */
+  keyword?: string;
 }
 
 export async function resolveBrandMarkers(body: string, ctx: ResolveContext): Promise<string> {
@@ -85,6 +90,21 @@ export async function resolveBrandMarkers(body: string, ctx: ResolveContext): Pr
           if (photos.length > 0) chosen = photos[Math.floor(Math.random() * photos.length)];
         }
         if (chosen) url = await renderBrandImage({ type: 'photo', assets: a, photo: chosen });
+      } else if (marker.type === 'image_set') {
+        // 끝맺음 이미지 세트: LRU 로 카드 한 장 pick + Layer 2 동적 변형 합성
+        const setId = (marker.params.set_id || '').trim();
+        if (setId) {
+          const { data: picked } = await (admin as any).rpc('pick_brand_image_set_card_lru', { p_set_id: setId });
+          const card = Array.isArray(picked) && picked.length > 0 ? (picked[0] as BrandImageSetCard) : null;
+          if (card) {
+            url = await renderImageSetVariant(card, {
+              articleTitle: ctx.articleTitle,
+              keyword: ctx.keyword,
+            });
+          } else {
+            console.warn('[brand-resolve] image_set 카드 없음 — set_id:', setId);
+          }
+        }
       }
     } catch (err) {
       const e = err as { message?: string; stack?: string };

--- a/dental-clinic-manager/src/lib/marketing/content-generator.ts
+++ b/dental-clinic-manager/src/lib/marketing/content-generator.ts
@@ -88,6 +88,12 @@ function insertBrandMarkers(body: string, opts?: BrandImageOptions, articleTitle
       : `mode=${opts.photo.mode}`;
     for (const pos of opts.photo.positions) buckets[pos].push(`[BRAND_IMAGE:photo|${tail}]`);
   }
+  if (opts.imageSet?.enabled && opts.imageSet.setId) {
+    // 끝맺음 브랜드 이미지 세트 — LRU 순환 + sharp 동적 변형
+    for (const pos of opts.imageSet.positions) {
+      buckets[pos].push(`[BRAND_IMAGE:image_set|set_id=${opts.imageSet.setId}]`);
+    }
+  }
 
   // 우선순위 정렬: title → medical_law → photo
   // (네이버 검색 첫 이미지 = 글 최상단 이미지. 텍스트 카드가 글 주제를 보여주도록 title 을 최상위로)

--- a/dental-clinic-manager/src/types/brand.ts
+++ b/dental-clinic-manager/src/types/brand.ts
@@ -1,4 +1,33 @@
-export type BrandImageType = 'medical_law' | 'title' | 'photo';
+export type BrandImageType = 'medical_law' | 'title' | 'photo' | 'image_set';
+
+// ─── 브랜드 이미지 세트 (반복 사용 가능한 끝맺음 이미지 묶음) ───
+export interface BrandImageSet {
+  id: string;
+  clinic_id: string;
+  name: string;
+  description: string | null;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BrandImageSetCard {
+  id: string;
+  set_id: string;
+  clinic_id: string;
+  image_url: string;
+  title_copy: string | null;
+  subtitle_copy: string | null;
+  sort_order: number;
+  last_used_at: string | null;
+  use_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BrandImageSetWithCards extends BrandImageSet {
+  cards: BrandImageSetCard[];
+}
 
 export type MedicalLawPresetKey =
   | 'yellow_black'
@@ -86,4 +115,6 @@ export interface BrandImageOptions {
   medicalLaw: { enabled: boolean; positions: ('top' | 'middle' | 'bottom')[] };
   title:       { enabled: boolean; positions: ('top' | 'middle' | 'bottom')[]; copy: string };
   photo:       { enabled: boolean; positions: ('top' | 'middle' | 'bottom')[]; mode: 'random' | 'manual' | 'rotate'; photoId?: string };
+  /** 끝맺음 브랜드 이미지 세트 — LRU 순환 + sharp 동적 변형 적용 (네이버 유사이미지 회피) */
+  imageSet?:   { enabled: boolean; setId?: string; positions: ('top' | 'middle' | 'bottom')[] };
 }

--- a/dental-clinic-manager/supabase/migrations/20260518_clinic_brand_image_sets.sql
+++ b/dental-clinic-manager/supabase/migrations/20260518_clinic_brand_image_sets.sql
@@ -1,0 +1,132 @@
+-- 클리닉 브랜드 이미지 세트 (반복 사용 가능한 끝맺음 이미지 묶음)
+-- 2026-05-18
+--
+-- 목적: 직원 사진/대표 진료/위치/진료시간 등 글 마지막에 반복 첨가할 수 있는 카드 묶음을 미리 등록.
+-- LRU 순환으로 같은 카드가 짧은 기간 반복되지 않도록 하고, sharp 동적 변형으로 매 발행마다
+-- 미세하게 다른 이미지를 생성 → 네이버 유사이미지 판독 회피 + 보존된 originals 캐싱.
+
+-- 1. 세트 (클리닉당 N개)
+CREATE TABLE IF NOT EXISTS clinic_brand_image_sets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,                              -- 예: "병원 소개", "진료시간", "오시는 길"
+  description TEXT,                                -- 관리자 메모 (글 작성자에게는 미노출)
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_clinic_brand_image_sets_clinic_id
+  ON clinic_brand_image_sets(clinic_id);
+
+-- 2. 카드 (세트당 N장)
+CREATE TABLE IF NOT EXISTS clinic_brand_image_set_cards (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  set_id UUID NOT NULL REFERENCES clinic_brand_image_sets(id) ON DELETE CASCADE,
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  image_url TEXT NOT NULL,                          -- 원본 (Storage public URL)
+  title_copy TEXT,                                  -- 텍스트 오버레이 상단 (예: "진료시간 안내")
+  subtitle_copy TEXT,                               -- 텍스트 오버레이 하단 (예: "평일 10:00~19:00")
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  last_used_at TIMESTAMPTZ,                         -- LRU 순환용 (NULL = 한 번도 안 씀)
+  use_count INTEGER NOT NULL DEFAULT 0,             -- 통계용
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_clinic_brand_image_set_cards_set_id
+  ON clinic_brand_image_set_cards(set_id);
+CREATE INDEX IF NOT EXISTS idx_clinic_brand_image_set_cards_clinic_id
+  ON clinic_brand_image_set_cards(clinic_id);
+CREATE INDEX IF NOT EXISTS idx_clinic_brand_image_set_cards_lru
+  ON clinic_brand_image_set_cards(set_id, last_used_at NULLS FIRST, sort_order);
+
+-- 3. updated_at 자동 갱신
+CREATE OR REPLACE FUNCTION set_updated_at_brand_image_sets()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_clinic_brand_image_sets_updated_at ON clinic_brand_image_sets;
+CREATE TRIGGER trg_clinic_brand_image_sets_updated_at
+  BEFORE UPDATE ON clinic_brand_image_sets
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at_brand_image_sets();
+
+DROP TRIGGER IF EXISTS trg_clinic_brand_image_set_cards_updated_at ON clinic_brand_image_set_cards;
+CREATE TRIGGER trg_clinic_brand_image_set_cards_updated_at
+  BEFORE UPDATE ON clinic_brand_image_set_cards
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at_brand_image_sets();
+
+-- 4. RLS
+ALTER TABLE clinic_brand_image_sets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE clinic_brand_image_set_cards ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "brand_image_sets_select" ON clinic_brand_image_sets;
+CREATE POLICY "brand_image_sets_select" ON clinic_brand_image_sets
+  FOR SELECT USING (
+    clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "brand_image_sets_modify" ON clinic_brand_image_sets;
+CREATE POLICY "brand_image_sets_modify" ON clinic_brand_image_sets
+  FOR ALL USING (
+    clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "brand_image_set_cards_select" ON clinic_brand_image_set_cards;
+CREATE POLICY "brand_image_set_cards_select" ON clinic_brand_image_set_cards
+  FOR SELECT USING (
+    clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "brand_image_set_cards_modify" ON clinic_brand_image_set_cards;
+CREATE POLICY "brand_image_set_cards_modify" ON clinic_brand_image_set_cards
+  FOR ALL USING (
+    clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())
+  );
+
+-- 5. LRU pick + 사용 마킹을 한 번에 수행하는 함수 (race 안전)
+-- 가장 오래 안 쓴 카드(=last_used_at 가장 오래 전 또는 NULL) 를 pick 하고 last_used_at/use_count 갱신.
+CREATE OR REPLACE FUNCTION pick_brand_image_set_card_lru(p_set_id UUID)
+RETURNS TABLE (
+  id UUID,
+  set_id UUID,
+  clinic_id UUID,
+  image_url TEXT,
+  title_copy TEXT,
+  subtitle_copy TEXT,
+  sort_order INTEGER,
+  last_used_at TIMESTAMPTZ,
+  use_count INTEGER
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_card_id UUID;
+BEGIN
+  SELECT c.id INTO v_card_id
+  FROM clinic_brand_image_set_cards c
+  WHERE c.set_id = p_set_id
+  ORDER BY c.last_used_at ASC NULLS FIRST, c.sort_order ASC, c.created_at ASC
+  LIMIT 1
+  FOR UPDATE SKIP LOCKED;
+
+  IF v_card_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  UPDATE clinic_brand_image_set_cards c
+  SET last_used_at = NOW(),
+      use_count = c.use_count + 1
+  WHERE c.id = v_card_id;
+
+  RETURN QUERY
+  SELECT c.id, c.set_id, c.clinic_id, c.image_url, c.title_copy, c.subtitle_copy,
+         c.sort_order, c.last_used_at, c.use_count
+  FROM clinic_brand_image_set_cards c
+  WHERE c.id = v_card_id;
+END;
+$$;


### PR DESCRIPTION
## Summary
AI 글 끝부분에 자동 첨가할 브랜드 이미지 세트 기능. 같은 이미지를 반복 노출해도 네이버 유사이미지 판독에 잡히지 않도록 LRU 순환(Layer 1) + sharp 동적 변형(Layer 2) 적용.

## Layer 1 — 자산 다양화
- 세트(예: "병원 소개", "진료시간", "오시는 길") 단위로 카드 묶음 등록
- 카드: 이미지 + 상단·하단 카피 + LRU 메타(`last_used_at`, `use_count`)
- RPC `pick_brand_image_set_card_lru` — 가장 오래 안 쓴 카드 pick + 사용 마킹 (FOR UPDATE SKIP LOCKED)
- 관리 UI: 브랜드 설정 페이지의 신규 섹션

## Layer 2 — 발행 시점 동적 변형
- 크롭 ±5% (perceptual hash 윈도우 시프트)
- 색조 ±3° / 채도 ±5% / 밝기 ±3% 랜덤
- 글 제목·카피를 텍스트 오버레이로 합성 (가장 강한 차별화 요소)
- EXIF 완전 제거 + 매번 다른 파일명 (랜덤 UUID + 키워드 슬러그)

## 통합
- 마커: `[BRAND_IMAGE:image_set|set_id=XXX]` (기존 `[BRAND_IMAGE:...]` 파서 재사용)
- `BrandImageOptions.imageSet?: { enabled, setId, positions }` 추가
- 글 작성 폼의 "브랜드 이미지" 섹션에 4번째 행으로 노출 (위치 토글)

## SQL
- `clinic_brand_image_sets`, `clinic_brand_image_set_cards` (+ LRU 인덱스)
- RPC `pick_brand_image_set_card_lru`
- RLS: clinic_id 기준 정책

## Test plan
- [x] 빌드 통과 (`npm run build`)
- [x] 세트 생성 / 카드 업로드 (POST 200)
- [x] LRU RPC: use_count 증가, last_used_at 갱신 확인
- [x] 폼에 세트 옵션 정상 노출
- [ ] 실제 글 발행 end-to-end (사용자가 production 에서 검증 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)