### PR TITLE
release: regime launchd + GICS 섹터 22개 (US 11 + KR 11)

### DIFF
--- a/dental-clinic-manager/.claude/WORK_LOG.md
+++ b/dental-clinic-manager/.claude/WORK_LOG.md
@@ -10,6 +10,46 @@
 
 ---
 
+## 2026-05-19 [운영/기능] 시장 국면 시스템 launchd + GICS 섹터 22개
+
+**키워드:** #regime #sectors #gics #launchd #etf #yahoo-fallback
+
+### 📋 작업 내용
+
+#### launchd 자동 일배치 (Mac mini)
+- `python-workers/regime/launchd/com.dental.regime.plist` 작성
+- 매일 KST 20:30 자동 실행 (시장 6 + 섹터 22 + 사용자 큐 + 알림)
+- 환경변수 단일 스레드 강제 (BLAS/joblib hang 방지)
+- 설치 + load 완료, 즉시 트리거 PASS
+
+#### GICS 섹터 22개 추가 (US 11 + KR 11)
+- `config.py.SECTORS`: US SPDR XL 시리즈(XLK/XLF/...) + KR KODEX 섹터 ETF
+- `train_worker.py`: `train_scope("sector", ...)` 루프 + `sectors` CLI 모드 추가
+- `price_fetcher.py`: cache miss 시 yahoo 직접 fallback (KR 6자리 → `.KS`/`.KQ` 시도)
+- API: `GET /api/investment/regime/sectors` (region=KR/US/ALL 필터)
+- UI: `RegimeSectorGrid.tsx` (4-column 그리드, 한국어 라벨 매핑, 카드 클릭 → Drawer 재사용)
+- `RegimeContent.tsx`: 3 탭 (시장 지수 / GICS 섹터 / 내 종목 분석)
+
+### 🐛 해결한 문제
+1. ETF 가격 데이터 stock_price_cache 부재 → yahoo_fetcher fallback 추가
+2. KR 6자리 ETF (091160 등) yfinance 인식 안 됨 → `.KS`/`.KQ` 접미사 자동 시도
+3. dev 서버 build 후 캐시 충돌 → rm -rf .next + 재기동 (패턴 재사용)
+
+### 🧪 검증 결과 (22 섹터 모두 학습 PASS)
+- 대부분 sideways (시장과 합치)
+- 특이 시그널:
+  - 🟢 **US Consumer Discretionary: bull 87%** (소비재 상승)
+  - 🔴 **KR 반도체: crisis 75%** (반도체 위기 경고, 5d 전환 98%)
+- US/KR/전체 필터 토글 정상
+- 카드 클릭 → 섹터 scope Drawer 정상 (history 200, 콘솔 에러 0)
+
+### 💡 배운 점
+- 섹터 ETF로 GICS 11개를 우회 매핑 — 시가총액 가중 자동 + 데이터 신뢰성 ↑
+- KR ETF는 .KS 접미사 자동 시도로 yfinance 호환 — 별도 KR 가격 캐시 작업 불필요
+- 동일 `RegimeDetailDrawer` 가 scope='market'/'sector'/'ticker' 3가지 모두 재사용 → 코드 100% 공유
+
+---
+
 ## 2026-05-19 [기능 개발] 시장 국면 시스템 Phase 3-E (국면 전환 알림)
 
 **키워드:** #regime #alerts #user_notifications #state-change

--- a/dental-clinic-manager/python-workers/regime/config.py
+++ b/dental-clinic-manager/python-workers/regime/config.py
@@ -22,10 +22,33 @@ MARKETS = {
     "RUSSELL2000": {"market": "US", "ticker": "^RUT"},
 }
 
-# GICS 11 섹터 (Phase 2)
-GICS_SECTORS_KR = ["TECH","COMM","FIN","INDUS","CONS_DISC","CONS_STAPLE",
-                   "HEALTH","ENERGY","UTIL","MATERIAL","REIT"]
-GICS_SECTORS_US = GICS_SECTORS_KR[:]
+# GICS 11 섹터 — US 는 SPDR XL 시리즈 정확 매핑, KR 은 KODEX 일부만 (정확 매핑 가능한 것)
+SECTORS = {
+    # US (SPDR Select Sector ETF — GICS 공식 매핑)
+    "US_TECH":          {"market": "US", "ticker": "XLK",  "label": "Technology"},
+    "US_FIN":           {"market": "US", "ticker": "XLF",  "label": "Financials"},
+    "US_HEALTH":        {"market": "US", "ticker": "XLV",  "label": "Health Care"},
+    "US_ENERGY":        {"market": "US", "ticker": "XLE",  "label": "Energy"},
+    "US_INDUS":         {"market": "US", "ticker": "XLI",  "label": "Industrials"},
+    "US_CONS_DISC":     {"market": "US", "ticker": "XLY",  "label": "Consumer Discretionary"},
+    "US_CONS_STAPLE":   {"market": "US", "ticker": "XLP",  "label": "Consumer Staples"},
+    "US_UTIL":          {"market": "US", "ticker": "XLU",  "label": "Utilities"},
+    "US_MATERIAL":      {"market": "US", "ticker": "XLB",  "label": "Materials"},
+    "US_REIT":          {"market": "US", "ticker": "XLRE", "label": "Real Estate"},
+    "US_COMM":          {"market": "US", "ticker": "XLC",  "label": "Communication Services"},
+    # KR (KODEX 섹터 ETF — GICS 매핑 가능한 것만)
+    "KR_SEMI":          {"market": "KR", "ticker": "091160", "label": "반도체 (KODEX)"},
+    "KR_BANK":          {"market": "KR", "ticker": "091170", "label": "은행 (KODEX)"},
+    "KR_AUTO":          {"market": "KR", "ticker": "091180", "label": "자동차 (KODEX)"},
+    "KR_BIO":           {"market": "KR", "ticker": "244580", "label": "바이오 (KODEX)"},
+    "KR_SECURITIES":    {"market": "KR", "ticker": "102970", "label": "증권 (KODEX)"},
+    "KR_BUILD":         {"market": "KR", "ticker": "117700", "label": "건설 (KODEX)"},
+    "KR_STEEL":         {"market": "KR", "ticker": "117680", "label": "철강 (KODEX)"},
+    "KR_ENERGY_CHEM":   {"market": "KR", "ticker": "117460", "label": "에너지화학 (KODEX)"},
+    "KR_IT":            {"market": "KR", "ticker": "157490", "label": "IT (KODEX)"},
+    "KR_CONS":          {"market": "KR", "ticker": "266390", "label": "필수소비재 (KODEX)"},
+    "KR_TRANSPORT":     {"market": "KR", "ticker": "140710", "label": "운송 (KODEX)"},
+}
 
 # FRED 매크로 지표 — US
 FRED_INDICATORS = [

--- a/dental-clinic-manager/python-workers/regime/fetchers/price_fetcher.py
+++ b/dental-clinic-manager/python-workers/regime/fetchers/price_fetcher.py
@@ -38,6 +38,18 @@ def fetch_prices(ticker: str, market: str, since: date) -> pd.DataFrame:
         offset += PAGE_SIZE
 
     if not rows:
+        # cache 에 없는 ticker (ETF 등) → yahoo 직접 fallback
+        # KR 6자리 숫자는 .KS 접미사 시도, 실패하면 .KQ (KOSDAQ)
+        candidates = [ticker]
+        if ticker.isdigit() and len(ticker) == 6:
+            candidates = [f"{ticker}.KS", f"{ticker}.KQ"]
+        for cand in candidates:
+            try:
+                df = fetch_index_prices(cand, since)
+                if not df.empty:
+                    return df
+            except Exception:
+                continue
         return pd.DataFrame()
 
     df = pd.DataFrame(rows)

--- a/dental-clinic-manager/python-workers/regime/train_worker.py
+++ b/dental-clinic-manager/python-workers/regime/train_worker.py
@@ -17,7 +17,7 @@ import sys
 from datetime import date, timedelta
 import numpy as np
 
-from regime.config import MARKETS, MODEL_VERSION, STATES
+from regime.config import MARKETS, SECTORS, MODEL_VERSION, STATES
 from regime.fetchers.fred_fetcher import fetch_all_fred
 from regime.fetchers.ecos_fetcher import fetch_all_ecos
 from regime.fetchers.price_fetcher import fetch_prices
@@ -304,13 +304,45 @@ def run_full_batch(scope_filter: str | None = None,
         except Exception as e:
             print(f"  ERROR {name}: {type(e).__name__}: {e}")
 
-    # 시장 학습 후 사용자 ticker 큐 처리
+    print("== sectors ==")
+    for name, cfg in SECTORS.items():
+        if scope_filter and scope_filter != name:
+            continue
+        try:
+            train_scope("sector", name, cfg["ticker"], cfg["market"])
+        except Exception as e:
+            print(f"  ERROR sector {name}: {type(e).__name__}: {e}")
+
+    # 시장·섹터 학습 후 사용자 ticker 큐 처리
     process_queued_jobs()
+
+
+def run_sectors_only(scope_filter: str | None = None,
+                     macro_backfill_days: int = 365 * 8) -> None:
+    """섹터만 학습 — 시장 학습 건너뛰고 섹터만 처리."""
+    today = date.today()
+    print(f"== macro fetch (since {macro_backfill_days}d ago) ==")
+    fetch_all_fred(since=today - timedelta(days=macro_backfill_days))
+    try:
+        fetch_all_ecos(since=today - timedelta(days=macro_backfill_days), until=today)
+    except Exception as e:
+        print(f"  ECOS warn (continuing): {e}")
+
+    print("== sectors ==")
+    for name, cfg in SECTORS.items():
+        if scope_filter and scope_filter != name:
+            continue
+        try:
+            train_scope("sector", name, cfg["ticker"], cfg["market"])
+        except Exception as e:
+            print(f"  ERROR sector {name}: {type(e).__name__}: {e}")
 
 
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == "jobs":
         process_queued_jobs(limit=int(sys.argv[2]) if len(sys.argv) > 2 else 20)
+    elif len(sys.argv) > 1 and sys.argv[1] == "sectors":
+        run_sectors_only(scope_filter=sys.argv[2] if len(sys.argv) > 2 else None)
     else:
         scope = sys.argv[1] if len(sys.argv) > 1 else None
         run_full_batch(scope_filter=scope)

--- a/dental-clinic-manager/src/app/api/investment/regime/sectors/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/regime/sectors/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+export const dynamic = 'force-dynamic'
+
+interface RunRow {
+  scope_id: string
+  current_state: string
+  current_confidence: number
+  state_probabilities: Record<string, number> | null
+  transition_probabilities: Record<string, Record<string, number>> | null
+  data_as_of: string
+  as_of_date: string
+}
+
+export async function GET(req: Request) {
+  const auth = await requireAuth(['owner', 'vice_director', 'manager'])
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 실패' }, { status: auth.status })
+  }
+
+  const url = new URL(req.url)
+  const region = url.searchParams.get('region')  // 'KR' | 'US' | null(all)
+
+  const sb = getSupabaseAdmin()
+  if (!sb) return NextResponse.json({ error: 'Server error' }, { status: 500 })
+
+  // 각 sector scope_id 별 최신 run 만 조회 (DISTINCT ON 대용으로 클라이언트 그룹화)
+  const { data, error } = await sb
+    .from('regime_runs')
+    .select('scope_id, current_state, current_confidence, state_probabilities, transition_probabilities, data_as_of, as_of_date')
+    .eq('scope_type', 'sector')
+    .order('as_of_date', { ascending: false })
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const latestByScope = new Map<string, RunRow>()
+  for (const r of (data ?? []) as RunRow[]) {
+    if (!latestByScope.has(r.scope_id)) {
+      // region 필터 (scope_id prefix 로 KR/US 판별)
+      if (region && !r.scope_id.startsWith(`${region}_`)) continue
+      latestByScope.set(r.scope_id, r)
+    }
+  }
+
+  return NextResponse.json({ data: Array.from(latestByScope.values()) })
+}

--- a/dental-clinic-manager/src/components/Investment/Regime/RegimeContent.tsx
+++ b/dental-clinic-manager/src/components/Investment/Regime/RegimeContent.tsx
@@ -4,12 +4,14 @@ import { useState } from 'react'
 import dynamic from 'next/dynamic'
 
 const RegimeMarketGrid = dynamic(() => import('./RegimeMarketGrid'), { ssr: false })
+const RegimeSectorGrid = dynamic(() => import('./RegimeSectorGrid'), { ssr: false })
 const RegimeUserTickerTab = dynamic(() => import('./RegimeUserTickerTab'), { ssr: false })
 
-type Tab = 'markets' | 'tickers'
+type Tab = 'markets' | 'sectors' | 'tickers'
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'markets', label: '시장 지수' },
+  { id: 'sectors', label: 'GICS 섹터' },
   { id: 'tickers', label: '내 종목 분석' },
 ]
 
@@ -47,6 +49,7 @@ export default function RegimeContent() {
       </div>
 
       {tab === 'markets' && <RegimeMarketGrid />}
+      {tab === 'sectors' && <RegimeSectorGrid />}
       {tab === 'tickers' && <RegimeUserTickerTab />}
     </div>
   )

--- a/dental-clinic-manager/src/components/Investment/Regime/RegimeSectorGrid.tsx
+++ b/dental-clinic-manager/src/components/Investment/Regime/RegimeSectorGrid.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  REGIME_LABEL, REGIME_LABEL_KO, REGIME_EMOJI, REGIME_COLOR,
+  RegimeRun, RegimeState,
+} from './types'
+import RegimeDetailDrawer from './RegimeDetailDrawer'
+
+// scope_id (US_TECH, KR_SEMI 등) → label / region 라벨링
+const SECTOR_LABEL: Record<string, string> = {
+  US_TECH: 'Technology',
+  US_FIN: 'Financials',
+  US_HEALTH: 'Health Care',
+  US_ENERGY: 'Energy',
+  US_INDUS: 'Industrials',
+  US_CONS_DISC: 'Consumer Discretionary',
+  US_CONS_STAPLE: 'Consumer Staples',
+  US_UTIL: 'Utilities',
+  US_MATERIAL: 'Materials',
+  US_REIT: 'Real Estate',
+  US_COMM: 'Communication Services',
+  KR_SEMI: '반도체',
+  KR_BANK: '은행',
+  KR_AUTO: '자동차',
+  KR_BIO: '바이오',
+  KR_SECURITIES: '증권',
+  KR_BUILD: '건설',
+  KR_STEEL: '철강',
+  KR_ENERGY_CHEM: '에너지화학',
+  KR_IT: 'IT',
+  KR_CONS: '필수소비재',
+  KR_TRANSPORT: '운송',
+}
+
+type Region = 'ALL' | 'US' | 'KR'
+
+interface SectorRow {
+  scope_id: string
+  current_state: RegimeState
+  current_confidence: number
+  state_probabilities: Record<string, number> | null
+  transition_probabilities: Record<string, Record<string, number>> | null
+  data_as_of: string
+  as_of_date: string
+}
+
+export default function RegimeSectorGrid() {
+  const [region, setRegion] = useState<Region>('ALL')
+  const [rows, setRows] = useState<SectorRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [selected, setSelected] = useState<{ id: string; label: string } | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    setLoading(true)
+    const params = region === 'ALL' ? '' : `?region=${region}`
+    fetch(`/api/investment/regime/sectors${params}`)
+      .then(async r => {
+        const j = await r.json()
+        if (!alive) return
+        if (!r.ok) {
+          setError(j.error ?? '조회 실패')
+          setRows([])
+        } else {
+          setRows((j.data ?? []) as SectorRow[])
+          setError(null)
+        }
+      })
+      .catch(e => { if (alive) setError(String(e)) })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [region])
+
+  const sorted = useMemo(() => {
+    return [...rows].sort((a, b) => a.scope_id.localeCompare(b.scope_id))
+  }, [rows])
+
+  const selectedRun = selected
+    ? (rows.find(r => r.scope_id === selected.id) as RegimeRun | undefined) ?? null
+    : null
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-1 text-xs">
+        {(['ALL', 'US', 'KR'] as Region[]).map(r => (
+          <button
+            key={r}
+            onClick={() => setRegion(r)}
+            className={`rounded px-2.5 py-1 ${region === r ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}
+          >
+            {r === 'ALL' ? '전체' : r}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <div className="py-12 text-center text-sm text-gray-500">로딩 중...</div>
+      ) : error ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">오류: {error}</div>
+      ) : sorted.length === 0 ? (
+        <div className="rounded border border-dashed border-gray-200 py-12 text-center text-sm text-gray-400">
+          섹터 학습 대기 — Mac mini 워커가 처리 중 (KST 20:30 일배치)
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+          {sorted.map(r => {
+            const state = r.current_state as RegimeState
+            const label = SECTOR_LABEL[r.scope_id] ?? r.scope_id
+            const isUS = r.scope_id.startsWith('US_')
+            const trans5d = (r.transition_probabilities?.['5d'] ?? {}) as Partial<Record<RegimeState, number>>
+            const transOther = Math.round((1 - (trans5d[state] ?? 0)) * 100)
+            return (
+              <button
+                key={r.scope_id}
+                type="button"
+                onClick={() => setSelected({ id: r.scope_id, label })}
+                className="rounded-md border bg-white p-3 text-left transition hover:shadow focus:outline-none focus:ring-2 focus:ring-indigo-300"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="text-sm text-gray-700 font-medium truncate">{label}</div>
+                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-500">{isUS ? 'US' : 'KR'}</span>
+                </div>
+                <div className="mt-1 flex items-center gap-1.5">
+                  <span>{REGIME_EMOJI[state]}</span>
+                  <span className="text-base font-semibold" style={{ color: REGIME_COLOR[state] }}>
+                    {REGIME_LABEL[state]}
+                  </span>
+                  <span className="text-xs text-gray-500">({REGIME_LABEL_KO[state]})</span>
+                </div>
+                <div className="text-xs text-gray-500 mt-0.5">확신도 {(r.current_confidence * 100).toFixed(0)}%</div>
+                <div className="mt-2 h-1.5 w-full bg-gray-200 rounded overflow-hidden">
+                  <div className="h-full" style={{
+                    width: `${r.current_confidence * 100}%`,
+                    background: REGIME_COLOR[state],
+                  }} />
+                </div>
+                <div className="mt-2 text-xs text-gray-500 flex justify-between">
+                  <span>5d 전환</span>
+                  <span className="font-medium">{transOther}%</span>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      {selected && selectedRun && (
+        <RegimeDetailDrawer
+          scope="sector"
+          scopeId={selected.id}
+          scopeLabel={selected.label}
+          run={selectedRun}
+          onClose={() => setSelected(null)}
+        />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **launchd plist** (\`26604f01\`): Mac mini 매일 KST 20:30 자동 일배치 (시장 6 + 섹터 22 + 사용자 큐 + 알림)
- **GICS 섹터 22개** (\`a3db8aff\`): US 11 SPDR + KR 11 KODEX ETF 학습 + 섹터 그리드 UI

### 특이 시그널
- 🟢 US Consumer Discretionary: **bull 87%** (소비재 상승)
- 🔴 KR 반도체 (KODEX 091160): **crisis 75%** (위기 경고, 5d 전환 98%)
- 나머지 대부분 sideways (시장 지수와 합치)

### UI 추가
- RegimeContent 탭 3개: 시장 지수 / GICS 섹터 / 내 종목 분석
- RegimeSectorGrid: 4-column 그리드 + US/KR/ALL 필터 + 카드 클릭 → Drawer 재사용
- 동일 RegimeDetailDrawer 가 scope='market'/'sector'/'ticker' 3종 모두 재사용

## Test plan
- [x] 22/22 섹터 학습 PASS (3-모델 앙상블)
- [x] sectors API 200, region 필터 정상
- [x] 섹터 카드 클릭 → Drawer 정상 (history API 200)
- [x] US 필터로 11개만 표시 확인
- [x] 콘솔 에러 0
- [x] launchctl load + start 실행 검증 (out.log 진입 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)