### PR TITLE
feat(regime): 내 종목 분석 — 종목 이름 검색 + 자동완성

### DIFF
--- a/dental-clinic-manager/.claude/WORK_LOG.md
+++ b/dental-clinic-manager/.claude/WORK_LOG.md
@@ -10,6 +10,35 @@
 
 ---
 
+## 2026-05-19 [기능 개선] 내 종목 분석 — 종목 이름 검색 + 자동완성
+
+**키워드:** #regime #ticker-search #autocomplete #korean-search #user-ticker
+
+### 📋 작업 내용
+- 신규 API `GET /api/investment/regime/search?q=`: KR/US ticker dict 검색 (한글 이름 / 영문 이름 / alias / 코드 모두 지원, KR 우선 정렬, 최대 10건)
+- `analyze` API 개선:
+  - 입력값을 ticker 형식 검증 → 통과하면 그대로, 실패하면 KR/US dict 검색으로 ticker 변환
+  - `resolved_name` 응답 필드 추가 (사용자에게 어떤 종목으로 매칭됐는지 노출)
+  - 매칭 실패 시 친절한 에러 메시지
+- `RegimeUserTickerTab` 자동완성 드롭다운:
+  - 입력 200ms debounce + AbortController 로 race condition 방지
+  - 결과 클릭 → 자동 큐 등록 (별도 버튼 클릭 불필요)
+  - placeholder/안내 문구 갱신: "005930 / AAPL / 삼성전자 / 애플"
+- 성공 메시지 포맷: `✅ AAPL (Apple Inc.) 분석 큐에 추가됨`
+
+### 🧪 검증
+- "삼성전자" 입력 → 자동완성 [005930 삼성전자 KR / 005935 삼성전자우 KR]
+- 자동완성 항목 클릭 → "✅ 005930 분석 큐에 추가됨" 즉시 등록
+- "애플" 직접 입력 + 분석 요청 버튼 → "✅ **AAPL (Apple Inc.)** 분석 큐에 추가됨" (resolved_name 표시)
+- 콘솔 에러 0, 빌드 PASS
+
+### 💡 배운 점
+- 기존 `searchTickerDict` 헬퍼 (점수 기반 매칭) 재사용 — UX 일관성 + 코드 중복 회피
+- onMouseDown + preventDefault 로 input onBlur 직전 자동완성 클릭 캡처 (setTimeout 150ms 도 보조)
+- resolved_name 응답 필드 1개 추가만으로 입력 안내 UX 크게 향상
+
+---
+
 ## 2026-05-19 [운영/기능] 시장 국면 시스템 launchd + GICS 섹터 22개
 
 **키워드:** #regime #sectors #gics #launchd #etf #yahoo-fallback

--- a/dental-clinic-manager/src/app/api/investment/regime/analyze/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/regime/analyze/route.ts
@@ -1,8 +1,31 @@
 import { NextResponse } from 'next/server'
 import { requireAuth } from '@/lib/auth/requireAuth'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { searchKRTicker } from '@/lib/krTickerDict'
+import { searchUSTicker } from '@/lib/usTickerDict'
 
 export const dynamic = 'force-dynamic'
+
+const TICKER_PATTERN = /^([0-9]{6}|[A-Z][A-Z0-9.\-]*)$/
+
+function resolveTicker(input: string): { ticker: string; resolved_name?: string } | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+
+  // 1. ticker 형식이면 그대로 사용
+  const upper = trimmed.toUpperCase()
+  if (TICKER_PATTERN.test(upper)) {
+    return { ticker: upper }
+  }
+
+  // 2. 종목 이름 → ticker dict 검색 (KR 우선, 그 다음 US)
+  const krMatch = searchKRTicker(trimmed, 1)[0]
+  if (krMatch) return { ticker: krMatch.ticker, resolved_name: krMatch.name }
+  const usMatch = searchUSTicker(trimmed, 1)[0]
+  if (usMatch) return { ticker: usMatch.ticker, resolved_name: usMatch.name }
+
+  return null
+}
 
 export async function POST(req: Request) {
   const auth = await requireAuth(['owner', 'vice_director', 'manager'])
@@ -11,14 +34,19 @@ export async function POST(req: Request) {
   }
 
   const body = (await req.json().catch(() => ({}))) as { ticker?: string }
-  const raw = (body.ticker ?? '').trim().toUpperCase()
-  if (!raw || raw.length > 12) {
-    return NextResponse.json({ error: 'ticker 는 1~12자 필수' }, { status: 400 })
+  const rawInput = (body.ticker ?? '').trim()
+  if (!rawInput || rawInput.length > 30) {
+    return NextResponse.json({ error: '종목 코드 또는 이름은 1~30자 필수' }, { status: 400 })
   }
-  // 6자리 숫자(KR) 또는 알파벳·점·하이픈(US) 만 허용
-  if (!/^([0-9]{6}|[A-Z][A-Z0-9.\-]*)$/.test(raw)) {
-    return NextResponse.json({ error: 'ticker 형식 오류 (예: 005930 또는 AAPL)' }, { status: 400 })
+
+  const resolved = resolveTicker(rawInput)
+  if (!resolved) {
+    return NextResponse.json({
+      error: `'${rawInput}' 을 찾을 수 없습니다. 종목 코드(예: 005930, AAPL) 또는 정확한 이름(예: 삼성전자, Apple)을 입력하세요`,
+    }, { status: 400 })
   }
+  const raw = resolved.ticker
+  const resolvedName = resolved.resolved_name
 
   const sb = getSupabaseAdmin()
   if (!sb) return NextResponse.json({ error: 'Server error' }, { status: 500 })
@@ -46,7 +74,7 @@ export async function POST(req: Request) {
 
   if (pending) {
     return NextResponse.json({
-      data: { job_id: pending.id, status: pending.status, ticker: raw, already_running: true },
+      data: { job_id: pending.id, status: pending.status, ticker: raw, resolved_name: resolvedName, already_running: true },
     })
   }
 
@@ -71,6 +99,7 @@ export async function POST(req: Request) {
       job_id: inserted.id,
       status: inserted.status,
       ticker: raw,
+      resolved_name: resolvedName,
       has_existing_result: !!existing,
     },
   })

--- a/dental-clinic-manager/src/app/api/investment/regime/search/route.ts
+++ b/dental-clinic-manager/src/app/api/investment/regime/search/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth/requireAuth'
+import { searchKRTicker } from '@/lib/krTickerDict'
+import { searchUSTicker } from '@/lib/usTickerDict'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: Request) {
+  const auth = await requireAuth(['owner', 'vice_director', 'manager'])
+  if (auth.error || !auth.user) {
+    return NextResponse.json({ error: auth.error ?? '인증 실패' }, { status: auth.status })
+  }
+
+  const url = new URL(req.url)
+  const q = (url.searchParams.get('q') ?? '').trim()
+  if (q.length < 1) {
+    return NextResponse.json({ data: [] })
+  }
+
+  const krResults = searchKRTicker(q, 5).map(e => ({
+    ticker: e.ticker, name: e.name, market: 'KR' as const,
+  }))
+  const usResults = searchUSTicker(q, 5).map(e => ({
+    ticker: e.ticker, name: e.name, market: 'US' as const,
+  }))
+
+  // KR 우선 (한글 검색 시 더 의미 있는 매칭)
+  return NextResponse.json({ data: [...krResults, ...usResults].slice(0, 10) })
+}

--- a/dental-clinic-manager/src/components/Investment/Regime/RegimeUserTickerTab.tsx
+++ b/dental-clinic-manager/src/components/Investment/Regime/RegimeUserTickerTab.tsx
@@ -1,11 +1,17 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   REGIME_LABEL, REGIME_LABEL_KO, REGIME_EMOJI, REGIME_COLOR,
   RegimeRun, RegimeState,
 } from './types'
 import RegimeDetailDrawer from './RegimeDetailDrawer'
+
+interface SearchSuggestion {
+  ticker: string
+  name: string
+  market: 'KR' | 'US'
+}
 
 interface JobRow {
   job_id: number
@@ -53,6 +59,9 @@ export default function RegimeUserTickerTab() {
   const [message, setMessage] = useState<string | null>(null)
   const [selectedTicker, setSelectedTicker] = useState<string | null>(null)
   const [selectedRun, setSelectedRun] = useState<RegimeRun | null>(null)
+  const [suggestions, setSuggestions] = useState<SearchSuggestion[]>([])
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const suggestionAbortRef = useRef<AbortController | null>(null)
 
   const fetchJobs = useCallback(async () => {
     try {
@@ -84,12 +93,33 @@ export default function RegimeUserTickerTab() {
     return () => clearInterval(id)
   }, [fetchJobs])
 
-  const submit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    const t = ticker.trim().toUpperCase()
+  // 입력 변경 시 자동완성 검색 (debounce 200ms, 한글/영문 모두)
+  useEffect(() => {
+    const q = ticker.trim()
+    if (q.length < 1) {
+      setSuggestions([])
+      return
+    }
+    const handle = setTimeout(() => {
+      suggestionAbortRef.current?.abort()
+      const ctrl = new AbortController()
+      suggestionAbortRef.current = ctrl
+      fetch(`/api/investment/regime/search?q=${encodeURIComponent(q)}`, { signal: ctrl.signal })
+        .then(r => r.json())
+        .then(j => {
+          if (!ctrl.signal.aborted) setSuggestions(j.data ?? [])
+        })
+        .catch(() => {})
+    }, 200)
+    return () => clearTimeout(handle)
+  }, [ticker])
+
+  const submitWith = async (rawInput: string) => {
+    const t = rawInput.trim()
     if (!t) return
     setSubmitting(true)
     setMessage(null)
+    setShowSuggestions(false)
     try {
       const r = await fetch('/api/investment/regime/analyze', {
         method: 'POST',
@@ -99,18 +129,29 @@ export default function RegimeUserTickerTab() {
       const j = await r.json()
       if (!r.ok) {
         setMessage(`❌ ${j.error ?? '요청 실패'}`)
-      } else if (j.data?.already_running) {
-        setMessage(`⏳ ${t} 분석이 이미 진행 중입니다`)
       } else {
-        setMessage(`✅ ${t} 분석 큐에 추가됨 (Mac mini 워커가 처리)`)
-        setTicker('')
-        fetchJobs()
+        const display = j.data?.resolved_name
+          ? `${j.data.ticker} (${j.data.resolved_name})`
+          : j.data?.ticker ?? t
+        if (j.data?.already_running) {
+          setMessage(`⏳ ${display} 분석이 이미 진행 중입니다`)
+        } else {
+          setMessage(`✅ ${display} 분석 큐에 추가됨 (Mac mini 워커가 처리)`)
+          setTicker('')
+          setSuggestions([])
+          fetchJobs()
+        }
       }
     } catch (err) {
       setMessage(`❌ ${String(err)}`)
     } finally {
       setSubmitting(false)
     }
+  }
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault()
+    submitWith(ticker)
   }
 
   const openDetail = async (t: string) => {
@@ -128,17 +169,40 @@ export default function RegimeUserTickerTab() {
       <form onSubmit={submit} className="rounded-md border bg-white p-3">
         <div className="text-sm font-medium text-gray-800">종목 분석 요청</div>
         <div className="mt-1 text-xs text-gray-500">
-          KR 종목 6자리 코드(예: 005930) 또는 US 티커(예: AAPL, MSFT) 입력. Mac mini 워커가 학습(약 30~60초)
+          종목 코드(예: 005930, AAPL) 또는 이름(예: 삼성전자, 애플, Apple) 입력. Mac mini 워커가 학습(약 30~60초)
         </div>
         <div className="mt-2 flex gap-2">
-          <input
-            value={ticker}
-            onChange={e => setTicker(e.target.value)}
-            placeholder="005930 / AAPL"
-            maxLength={12}
-            className="flex-1 rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-indigo-500 focus:outline-none"
-            disabled={submitting}
-          />
+          <div className="relative flex-1">
+            <input
+              value={ticker}
+              onChange={e => { setTicker(e.target.value); setShowSuggestions(true) }}
+              onFocus={() => setShowSuggestions(true)}
+              onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+              placeholder="005930 / AAPL / 삼성전자 / 애플"
+              maxLength={30}
+              className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-indigo-500 focus:outline-none"
+              disabled={submitting}
+            />
+            {showSuggestions && suggestions.length > 0 && (
+              <ul className="absolute left-0 right-0 top-full z-10 mt-1 max-h-64 overflow-y-auto rounded-md border border-gray-200 bg-white shadow-lg">
+                {suggestions.map(s => (
+                  <li key={`${s.market}-${s.ticker}`}>
+                    <button
+                      type="button"
+                      onMouseDown={e => { e.preventDefault(); submitWith(s.ticker) }}
+                      className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-sm hover:bg-indigo-50"
+                    >
+                      <span className="flex items-center gap-2">
+                        <span className="font-mono text-xs text-gray-500">{s.ticker}</span>
+                        <span className="text-gray-800">{s.name}</span>
+                      </span>
+                      <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-500">{s.market}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
           <button
             type="submit"
             disabled={submitting || !ticker.trim()}


### PR DESCRIPTION
## Summary

내 종목 분석 탭에서 **종목 코드뿐 아니라 이름(한글/영문)으로도 검색 가능**하게 개선.

## 변경 사항

- 신규 API `GET /api/investment/regime/search?q=`: KR/US ticker dict 통합 검색 (점수 기반 매칭, KR 우선)
- `analyze` API: ticker 형식 아니면 dict 검색으로 자동 변환 + `resolved_name` 응답 추가
- `RegimeUserTickerTab`: 200ms debounce 자동완성 드롭다운 + 결과 클릭 즉시 큐 등록
- placeholder/안내 문구 갱신
- 성공 메시지에 매칭된 종목 이름 함께 노출

## Test plan

- [x] "삼성전자" 입력 → 자동완성 [005930 삼성전자 / 005935 삼성전자우]
- [x] 자동완성 클릭 → "✅ 005930 분석 큐에 추가됨"
- [x] "애플" 직접 입력 + 분석 요청 → "✅ AAPL (Apple Inc.) 분석 큐에 추가됨"
- [x] 빌드 PASS (EXIT=0)
- [x] 콘솔 에러 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)