### PR TITLE
feat(regime): 판단 근거 시각화 + 모델 용도 분리 (HMM 전이 + Reservoir N-step)

### DIFF
--- a/dental-clinic-manager/.claude/WORK_LOG.md
+++ b/dental-clinic-manager/.claude/WORK_LOG.md
@@ -10,6 +10,54 @@
 
 ---
 
+## 2026-05-19 [기능 개선] 국면 판단 근거 시각화 + 모델 용도 분리
+
+**키워드:** #regime #signals #transparency #reservoir-nstep #model-specialization
+
+### 📋 작업 내용
+
+#### 1) 판단 근거 시각화 (Transparency)
+- 마이그레이션: `regime_runs.signals` (JSONB) + `regime_runs.reservoir_predictions` (JSONB) 컬럼 추가
+- `labeling.py` 리팩터링:
+  - `THRESHOLDS` dict 단일 진실 원천 (Crisis VIX>30 / 수익률<-10%, Bull/Bear ±3% + 변동성 조건)
+  - 신규 `compute_current_signals(features)` — 마지막 시점 입력값 + 매칭된 규칙(✓/✗) 평가
+- `train_worker.train_scope`: 학습 후 `compute_current_signals` 호출 → signals upsert
+- 신규 컴포넌트 `RegimeSignals.tsx`:
+  - 3개 카드: 20일 수익률 / 60일 변동성 (중앙값 함께) / VIX
+  - 최종 판단 규칙 + 어떤 조건이 ✓/✗인지 명시
+  - "분류 규칙 전체 보기" 펼치기 (4-state 전체 규칙 참조)
+
+#### 2) 모델 용도 분리 (HMM = 현재+전이, Reservoir = 시계열 예측)
+- 신규 `reservoir_hypernet.predict_nstep_proba(bundle, features, horizons)`:
+  - 자기-반복(auto-regressive): 마지막 feature 를 N번 반복 입력
+  - 새 Reservoir 인스턴스(같은 seed)로 전체 시퀀스 한 번에 run (reservoirpy 0.3.x reset 미지원 우회)
+  - HyperReadout 으로 N-step ahead 4-state 분포 출력
+- `train_worker`: HMM transmat^n + Reservoir N-step 두 가지 모두 계산·저장
+- `RegimeTransitionTable` 재설계: 두 모델 분리 표시 + 비교 설명 + 셀 색상 (HMM 인디고 / Reservoir 에메랄드)
+
+### 🐛 해결한 문제
+1. `reservoirpy.Node.run(reset=False)` 미지원 → 새 인스턴스(같은 seed) + 전체 시퀀스 한 번에 run
+2. IDE 진단 (torch/reservoirpy 모듈 못 찾음) — venv 미참조로 발생, 실제 빌드/실행은 정상
+
+### 🧪 검증 (KOSPI 예시)
+- 판단 근거 카드: 수익률 +27.68%, 변동성 0.0364 (중앙값 0.0116), VIX 17.2
+- 매칭 규칙 표시: ✗ Crisis, ✗ Bull (수익률 OK 지만 변동성 > 중앙값×1.2 미충족), ✗ Bear → Sideways 정착 이유 명확
+- HMM Transition: 5d/10d/30d 모두 Sideways 100% (유지 시각)
+- Reservoir N-step: 5d Bear 95% / 10d Bear 92% / 30d Bear 91% (조정 신호) — **두 모델의 견해 차이가 명확히 사용자에게 노출**
+- 콘솔 에러 0, 빌드 PASS
+
+### 💡 배운 점
+- **HMM vs Reservoir 의 상호 보완**: 안정적 상태 유지(HMM) vs 단기 조정 시그널(Reservoir) 둘 다 함께 보여줄 때 의사결정 가치 ↑
+- 임계값(THRESHOLDS dict)을 단일 진실 원천으로 → labeling + signals 양쪽이 동일 규칙 사용
+- Auto-regressive simulation 은 단순 baseline 이지만 (마지막 feature 반복) 시각화로서 직관적, 실제 외부 입력 시뮬레이션은 차후 개선 여지
+
+### 🔮 다음 개선 여지
+- 임계값(THRESHOLDS)을 시장·자산별 동적 분위수로 (현재는 하드코딩)
+- KR 시장에 VKOSPI 추가 (현재 VIX 단일 의존)
+- Reservoir N-step 입력에 외부 시뮬레이션 (예: VIX shock 시나리오) 가능
+
+---
+
 ## 2026-05-19 [기능 개선] 내 종목 분석 — 종목 이름 검색 + 자동완성
 
 **키워드:** #regime #ticker-search #autocomplete #korean-search #user-ticker

--- a/dental-clinic-manager/python-workers/regime/labeling.py
+++ b/dental-clinic-manager/python-workers/regime/labeling.py
@@ -1,16 +1,27 @@
-"""4-state 휴리스틱 라벨링 (학습 초기 supervision)."""
+"""4-state 휴리스틱 라벨링 (학습 초기 supervision) + 현재 판단 근거 시그널."""
 import numpy as np
 import pandas as pd
+
+
+# 임계값 — 단일 진실 원천 (labeling 과 signals 양쪽에서 공유)
+THRESHOLDS = {
+    "crisis_vix": 30.0,           # VIX > 30 = crisis
+    "crisis_ret_20d": -0.10,      # 20일 수익률 < -10% = crisis
+    "bull_ret_20d": 0.03,         # 20일 수익률 > +3% = bull (보조: 변동성 조건)
+    "bear_ret_20d": -0.03,        # 20일 수익률 < -3% = bear (보조: 변동성 조건)
+    "bull_vol_ratio": 1.2,        # 60일 변동성 < median × 1.2 = 안정적 → bull
+    "bear_vol_ratio": 1.5,        # 60일 변동성 < median × 1.5 = bear (덜 엄격)
+}
 
 
 def heuristic_labels(features: pd.DataFrame) -> np.ndarray:
     """
     Returns: shape (T,) with 0=bull, 1=bear, 2=sideways, 3=crisis
 
-    규칙:
-      Bull:     20일 수익률 > +3%, 60일 변동성 < median × 1.2
-      Bear:     20일 수익률 < -3%, 60일 변동성 < median × 1.5
+    규칙 (우선순위: Crisis > Bull/Bear > Sideways):
       Crisis:   VIX > 30 OR 20일 수익률 < -10%
+      Bull:     20일 수익률 > +3% AND 60일 변동성 < median × 1.2
+      Bear:     20일 수익률 < -3% AND 60일 변동성 < median × 1.5
       Sideways: 나머지
     """
     ret_20d = features["ret_20d"]
@@ -21,12 +32,75 @@ def heuristic_labels(features: pd.DataFrame) -> np.ndarray:
 
     labels = np.full(len(features), 2)  # default sideways
 
-    bull = (ret_20d > 0.03) & (vol_60d < vol_median * 1.2)
-    bear = (ret_20d < -0.03) & (vol_60d < vol_median * 1.5)
-    crisis = (vix > 30) | (ret_20d < -0.10)
+    bull = (ret_20d > THRESHOLDS["bull_ret_20d"]) & (vol_60d < vol_median * THRESHOLDS["bull_vol_ratio"])
+    bear = (ret_20d < THRESHOLDS["bear_ret_20d"]) & (vol_60d < vol_median * THRESHOLDS["bear_vol_ratio"])
+    crisis = (vix > THRESHOLDS["crisis_vix"]) | (ret_20d < THRESHOLDS["crisis_ret_20d"])
 
     labels[bull.fillna(False).to_numpy()] = 0
     labels[bear.fillna(False).to_numpy()] = 1
-    labels[crisis.fillna(False).to_numpy()] = 3  # crisis 가 bear 보다 우선
+    labels[crisis.fillna(False).to_numpy()] = 3
 
     return labels
+
+
+def compute_current_signals(features: pd.DataFrame) -> dict:
+    """현재 시점(features 마지막 행) 판단 근거 시그널 + 규칙 매칭 결과.
+
+    UI 의 '판단 근거' 섹션 표시용으로 regime_runs.signals 에 저장.
+    """
+    if len(features) == 0:
+        return {}
+
+    last = features.iloc[-1]
+    ret_20d = float(last["ret_20d"]) if "ret_20d" in features.columns else None
+    vol_60d = float(last["vol_60d"]) if "vol_60d" in features.columns else None
+    vol_median = float(features["vol_60d"].median()) if "vol_60d" in features.columns else None
+    vix = float(last["VIXCLS"]) if "VIXCLS" in features.columns else None
+
+    # 규칙 매칭 평가
+    rules = []
+    if vix is not None and ret_20d is not None:
+        rule_crisis_vix = vix > THRESHOLDS["crisis_vix"]
+        rule_crisis_ret = ret_20d < THRESHOLDS["crisis_ret_20d"]
+        rule_bull_ret = ret_20d > THRESHOLDS["bull_ret_20d"]
+        rule_bull_vol = vol_60d is not None and vol_median is not None and vol_60d < vol_median * THRESHOLDS["bull_vol_ratio"]
+        rule_bear_ret = ret_20d < THRESHOLDS["bear_ret_20d"]
+        rule_bear_vol = vol_60d is not None and vol_median is not None and vol_60d < vol_median * THRESHOLDS["bear_vol_ratio"]
+
+        is_crisis = rule_crisis_vix or rule_crisis_ret
+        is_bull = rule_bull_ret and rule_bull_vol
+        is_bear = rule_bear_ret and rule_bear_vol
+
+        # 우선순위: Crisis > Bull/Bear > Sideways
+        if is_crisis:
+            matched_rule = "crisis"
+            if rule_crisis_vix:
+                rules.append({"name": "VIX 위기 임계 초과", "ok": True, "actual": f"VIX {vix:.1f}", "threshold": f"> {THRESHOLDS['crisis_vix']}"})
+            if rule_crisis_ret:
+                rules.append({"name": "20일 수익률 폭락", "ok": True, "actual": f"{ret_20d*100:.2f}%", "threshold": f"< {THRESHOLDS['crisis_ret_20d']*100:.0f}%"})
+        elif is_bull:
+            matched_rule = "bull"
+            rules.append({"name": "20일 수익률 상승", "ok": True, "actual": f"{ret_20d*100:.2f}%", "threshold": f"> +{THRESHOLDS['bull_ret_20d']*100:.0f}%"})
+            rules.append({"name": "60일 변동성 안정", "ok": True, "actual": f"{vol_60d:.4f}", "threshold": f"< 중앙값×{THRESHOLDS['bull_vol_ratio']} ({(vol_median or 0)*THRESHOLDS['bull_vol_ratio']:.4f})"})
+        elif is_bear:
+            matched_rule = "bear"
+            rules.append({"name": "20일 수익률 하락", "ok": True, "actual": f"{ret_20d*100:.2f}%", "threshold": f"< {THRESHOLDS['bear_ret_20d']*100:.0f}%"})
+            rules.append({"name": "60일 변동성 (덜 엄격)", "ok": True, "actual": f"{vol_60d:.4f}", "threshold": f"< 중앙값×{THRESHOLDS['bear_vol_ratio']} ({(vol_median or 0)*THRESHOLDS['bear_vol_ratio']:.4f})"})
+        else:
+            matched_rule = "sideways"
+            # 왜 다른 규칙에 해당 안 됐는지 설명
+            rules.append({"name": "Crisis 규칙 미해당", "ok": False, "actual": f"VIX {vix:.1f}, 20일 {ret_20d*100:.2f}%", "threshold": f"VIX>{THRESHOLDS['crisis_vix']} OR 수익률<{THRESHOLDS['crisis_ret_20d']*100:.0f}%"})
+            rules.append({"name": "Bull 규칙 미해당", "ok": False, "actual": f"수익률 {ret_20d*100:.2f}%, 변동성 {vol_60d:.4f}" if vol_60d else "변동성 없음", "threshold": f"수익률>+{THRESHOLDS['bull_ret_20d']*100:.0f}% AND 안정"})
+            rules.append({"name": "Bear 규칙 미해당", "ok": False, "actual": f"수익률 {ret_20d*100:.2f}%", "threshold": f"수익률<{THRESHOLDS['bear_ret_20d']*100:.0f}% AND 변동성 조건"})
+    else:
+        matched_rule = "unknown"
+
+    return {
+        "ret_20d": ret_20d,
+        "vol_60d": vol_60d,
+        "vol_median": vol_median,
+        "vix": vix,
+        "thresholds": THRESHOLDS,
+        "matched_rule": matched_rule,
+        "rules": rules,
+    }

--- a/dental-clinic-manager/python-workers/regime/models/reservoir_hypernet.py
+++ b/dental-clinic-manager/python-workers/regime/models/reservoir_hypernet.py
@@ -137,3 +137,48 @@ def predict_proba(bundle: dict, features: np.ndarray) -> np.ndarray:
         c = torch.from_numpy(ctx)
         proba = torch.softmax(model(h, c), dim=1).numpy()
     return proba
+
+
+def predict_nstep_proba(bundle: dict, features: np.ndarray, horizons: list[int]) -> dict[int, np.ndarray]:
+    """N-step ahead 라벨 확률 — Sun 2025 의 핵심 강점인 시계열 다음 시점 예측.
+
+    구현: 입력 시계열 끝점부터 reservoir state 를 자기-반복(auto-regressive)으로
+    propagate 하여 t+1, t+5, ... t+N 시점의 4-state 분포를 얻는다.
+    - 새 입력이 없으므로 마지막 feature 를 반복 입력 (단순 baseline)
+    - context vector 도 동일하게 마지막 윈도우 mean 사용
+
+    Returns: {horizon: (4,) probability array}
+    """
+    if not _AVAILABLE:
+        raise RuntimeError(f"reservoir_hypernet unavailable: {_IMPORT_ERROR}")
+
+    if len(features) == 0:
+        return {h: np.array([0.25] * N_LABELS) for h in horizons}
+
+    Xs = bundle["scaler"].transform(features).astype(np.float32)
+    ctx_full = _make_context(Xs).astype(np.float32)
+    last_x = Xs[-1]
+    last_ctx = ctx_full[-1]
+    max_h = max(horizons)
+
+    # 자기-반복(auto-regressive): 마지막 feature 를 max_h 번 반복 입력하여 미래 state 시뮬레이션
+    # reservoirpy 0.3.x 의 Node.run() 은 reset 인자 미지원 → 새 인스턴스(같은 seed)로 전체 한 번에 run
+    X_extended = np.vstack([Xs, np.tile(last_x, (max_h, 1))]).astype(np.float32)
+    res_fresh = Reservoir(units=RESERVOIR_UNITS, lr=0.3, sr=0.9, seed=42)
+    H_extended = res_fresh.run(X_extended)
+    H_ahead = H_extended[-max_h:].astype(np.float32)
+    ctx_ahead = np.tile(last_ctx, (max_h, 1)).astype(np.float32)
+
+    dims = bundle["model_dims"]
+    model = HyperReadout(reservoir_dim=dims["reservoir"], context_dim=dims["context"])
+    model.load_state_dict(bundle["model_state"])
+    _set_inference(model)
+    with torch.no_grad():
+        h = torch.from_numpy(H_ahead)
+        c = torch.from_numpy(ctx_ahead)
+        proba_all = torch.softmax(model(h, c), dim=1).numpy()  # (max_h, 4)
+
+    out = {}
+    for hz in horizons:
+        out[hz] = proba_all[hz - 1]
+    return out

--- a/dental-clinic-manager/python-workers/regime/train_worker.py
+++ b/dental-clinic-manager/python-workers/regime/train_worker.py
@@ -22,7 +22,7 @@ from regime.fetchers.fred_fetcher import fetch_all_fred
 from regime.fetchers.ecos_fetcher import fetch_all_ecos
 from regime.fetchers.price_fetcher import fetch_prices
 from regime.features.feature_engineer import compute_features
-from regime.labeling import heuristic_labels
+from regime.labeling import heuristic_labels, compute_current_signals
 from regime.macro_loader import load_macro
 from regime.models import hmm_voting, kernel_markov, reservoir_hypernet
 from regime.storage import upload_model
@@ -187,7 +187,8 @@ def train_scope(scope_type: str, scope_id: str, ticker: str, market: str) -> dic
             "probs": {s: float(v) for s, v in zip(STATES, last)},
         }
 
-    # 전환 확률 (HMM transmat 기반 — hmm_voting 의 HMM 사용)
+    # ── 국면 전환 예측 ── 두 가지 모델 분리 활용
+    # 1) HMM transition matrix (P^n) — 통계적 마르코프 전이
     transitions = {}
     if "hmm_voting" in trained:
         m_hmm = trained["hmm_voting"][0]
@@ -195,6 +196,22 @@ def train_scope(scope_type: str, scope_id: str, ticker: str, market: str) -> dic
         transitions = {f"{h}d": _n_step_transition(m_hmm["hmm"], m_hmm["state_map"],
                                                     current_hidden, h)
                        for h in [5, 10, 30]}
+
+    # 2) Reservoir Hypernet N-step ahead (Sun 2025 강점: 시계열 next-step 예측)
+    reservoir_predictions = {}
+    if "reservoir_hypernet" in trained:
+        try:
+            m_res = trained["reservoir_hypernet"][0]
+            nstep = reservoir_hypernet.predict_nstep_proba(m_res, X, [5, 10, 30])
+            reservoir_predictions = {
+                f"{h}d": {s: float(p) for s, p in zip(STATES, nstep[h])}
+                for h in [5, 10, 30]
+            }
+        except Exception as e:
+            print(f"  WARN reservoir n-step skipped: {e}")
+
+    # 판단 근거 시그널 (ret_20d, vol_60d, VIX + 규칙 매칭)
+    signals = compute_current_signals(feat)
 
     today = feat.index[-1].date()
     sb = get_supabase()
@@ -215,6 +232,8 @@ def train_scope(scope_type: str, scope_id: str, ticker: str, market: str) -> dic
         "state_probabilities": state_probs,
         "model_votes": model_votes,
         "transition_probabilities": transitions,
+        "reservoir_predictions": reservoir_predictions,
+        "signals": signals,
         "data_as_of": today.isoformat(),
     }, on_conflict="scope_type,scope_id,as_of_date,trigger_type").execute()
 

--- a/dental-clinic-manager/src/components/Investment/Regime/RegimeDetailDrawer.tsx
+++ b/dental-clinic-manager/src/components/Investment/Regime/RegimeDetailDrawer.tsx
@@ -9,6 +9,7 @@ import RegimeTimelineChart from './RegimeTimelineChart'
 import RegimeTransitionTable from './RegimeTransitionTable'
 import RegimeModelVotes from './RegimeModelVotes'
 import RegimeBestStrategies from './RegimeBestStrategies'
+import RegimeSignals from './RegimeSignals'
 
 const KR_MARKETS = new Set(['KOSPI', 'KOSDAQ'])
 
@@ -132,9 +133,15 @@ export default function RegimeDetailDrawer({ scope, scopeId, scopeLabel, run, on
           </section>
 
           <section>
-            <h3 className="mb-2 text-sm font-semibold text-gray-800">N일 후 국면 전환 확률</h3>
+            <h3 className="mb-2 text-sm font-semibold text-gray-800">현재 국면 판단 근거</h3>
+            <RegimeSignals signals={run.signals} currentState={state} />
+          </section>
+
+          <section>
+            <h3 className="mb-2 text-sm font-semibold text-gray-800">N일 후 국면 전환 예측</h3>
             <RegimeTransitionTable
               transitions={run.transition_probabilities ?? {}}
+              reservoirPredictions={run.reservoir_predictions}
               currentState={state}
             />
           </section>

--- a/dental-clinic-manager/src/components/Investment/Regime/RegimeSignals.tsx
+++ b/dental-clinic-manager/src/components/Investment/Regime/RegimeSignals.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { REGIME_COLOR, REGIME_EMOJI, REGIME_LABEL, REGIME_LABEL_KO, RegimeState } from './types'
+
+interface Rule {
+  name: string
+  ok: boolean
+  actual: string
+  threshold: string
+}
+
+interface Thresholds {
+  crisis_vix: number
+  crisis_ret_20d: number
+  bull_ret_20d: number
+  bear_ret_20d: number
+  bull_vol_ratio: number
+  bear_vol_ratio: number
+}
+
+interface Signals {
+  ret_20d: number | null
+  vol_60d: number | null
+  vol_median: number | null
+  vix: number | null
+  thresholds?: Thresholds
+  matched_rule?: RegimeState
+  rules?: Rule[]
+}
+
+interface Props {
+  signals: Signals | null | undefined
+  currentState: RegimeState
+}
+
+function fmtPct(v: number | null | undefined) {
+  if (v == null || !isFinite(v)) return '—'
+  return `${v >= 0 ? '+' : ''}${(v * 100).toFixed(2)}%`
+}
+
+function fmtNum(v: number | null | undefined, digits = 4) {
+  if (v == null || !isFinite(v)) return '—'
+  return v.toFixed(digits)
+}
+
+export default function RegimeSignals({ signals, currentState }: Props) {
+  if (!signals || signals.ret_20d == null) {
+    return (
+      <div className="rounded border border-dashed border-gray-200 py-4 text-center text-xs text-gray-400">
+        판단 근거 시그널은 다음 학습 이후 표시됩니다
+      </div>
+    )
+  }
+
+  const matched = (signals.matched_rule ?? currentState) as RegimeState
+
+  return (
+    <div className="space-y-3">
+      {/* 입력 지표 카드 3개 */}
+      <div className="grid grid-cols-3 gap-2">
+        <div className="rounded-md border bg-gray-50 p-2">
+          <div className="text-[10px] text-gray-500">20일 수익률</div>
+          <div className={`text-base font-semibold ${(signals.ret_20d ?? 0) >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+            {fmtPct(signals.ret_20d)}
+          </div>
+        </div>
+        <div className="rounded-md border bg-gray-50 p-2">
+          <div className="text-[10px] text-gray-500">60일 변동성</div>
+          <div className="text-base font-semibold text-gray-800">
+            {fmtNum(signals.vol_60d)}
+          </div>
+          <div className="text-[10px] text-gray-400">중앙값 {fmtNum(signals.vol_median)}</div>
+        </div>
+        <div className="rounded-md border bg-gray-50 p-2">
+          <div className="text-[10px] text-gray-500">VIX (공포 지수)</div>
+          <div className={`text-base font-semibold ${(signals.vix ?? 0) > 30 ? 'text-red-600' : 'text-gray-800'}`}>
+            {signals.vix?.toFixed(1) ?? '—'}
+          </div>
+        </div>
+      </div>
+
+      {/* 매칭된 규칙 표시 */}
+      <div className="rounded-md border border-indigo-200 bg-indigo-50/40 p-3">
+        <div className="mb-2 flex items-center gap-1.5 text-xs">
+          <span className="text-gray-600">최종 판단 규칙:</span>
+          <span>{REGIME_EMOJI[matched]}</span>
+          <span className="font-semibold" style={{ color: REGIME_COLOR[matched] }}>
+            {REGIME_LABEL[matched]} ({REGIME_LABEL_KO[matched]})
+          </span>
+        </div>
+        {signals.rules && signals.rules.length > 0 && (
+          <ul className="space-y-1">
+            {signals.rules.map((r, i) => (
+              <li key={i} className="flex items-start gap-2 text-[11px]">
+                <span className={r.ok ? 'text-emerald-600' : 'text-gray-400'}>
+                  {r.ok ? '✓' : '✗'}
+                </span>
+                <span className="flex-1">
+                  <span className={r.ok ? 'font-medium text-gray-800' : 'text-gray-500'}>{r.name}</span>
+                  <span className="text-gray-400"> — 실제 {r.actual} / 기준 {r.threshold}</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* 임계값 reference */}
+      {signals.thresholds && (
+        <details className="text-[11px] text-gray-500">
+          <summary className="cursor-pointer hover:text-gray-700">국면 분류 규칙 전체 보기</summary>
+          <div className="mt-1.5 space-y-0.5 pl-3">
+            <div>🔴 <b>Crisis</b>: VIX &gt; {signals.thresholds.crisis_vix} <b>OR</b> 20일 수익률 &lt; {(signals.thresholds.crisis_ret_20d * 100).toFixed(0)}%</div>
+            <div>🟢 <b>Bull</b>: 20일 수익률 &gt; +{(signals.thresholds.bull_ret_20d * 100).toFixed(0)}% <b>AND</b> 60일 변동성 &lt; 중앙값×{signals.thresholds.bull_vol_ratio}</div>
+            <div>🔵 <b>Bear</b>: 20일 수익률 &lt; {(signals.thresholds.bear_ret_20d * 100).toFixed(0)}% <b>AND</b> 60일 변동성 &lt; 중앙값×{signals.thresholds.bear_vol_ratio}</div>
+            <div>🟡 <b>Sideways</b>: 위 3개 모두 미해당</div>
+            <div className="mt-1 text-[10px] text-gray-400">우선순위: Crisis &gt; Bull/Bear &gt; Sideways</div>
+          </div>
+        </details>
+      )}
+    </div>
+  )
+}

--- a/dental-clinic-manager/src/components/Investment/Regime/RegimeTransitionTable.tsx
+++ b/dental-clinic-manager/src/components/Investment/Regime/RegimeTransitionTable.tsx
@@ -5,12 +5,15 @@ import { REGIME_COLOR, REGIME_EMOJI, REGIME_LABEL, REGIME_LABEL_KO, RegimeState 
 const STATES: RegimeState[] = ['bull', 'sideways', 'bear', 'crisis']
 const HORIZONS = ['5d', '10d', '30d'] as const
 
+type TransitionMap = {
+  '5d'?: Record<string, number>
+  '10d'?: Record<string, number>
+  '30d'?: Record<string, number>
+}
+
 interface Props {
-  transitions: {
-    '5d'?: Record<string, number>
-    '10d'?: Record<string, number>
-    '30d'?: Record<string, number>
-  }
+  transitions: TransitionMap
+  reservoirPredictions?: TransitionMap | null
   currentState: RegimeState
 }
 
@@ -19,44 +22,57 @@ function pct(v: number | undefined) {
   return `${(v * 100).toFixed(0)}%`
 }
 
-function cellBg(v: number | undefined) {
+function cellBg(v: number | undefined, color: string) {
   if (v == null || !isFinite(v)) return 'transparent'
   const alpha = Math.min(0.6, Math.max(0.05, v))
-  return `rgba(99, 102, 241, ${alpha})`
+  return color.replace('rgb(', 'rgba(').replace(')', `, ${alpha})`)
 }
 
-export default function RegimeTransitionTable({ transitions, currentState }: Props) {
+function MatrixTable({
+  title,
+  description,
+  rows,
+  currentState,
+  cellColor,
+}: {
+  title: string
+  description: string
+  rows: TransitionMap
+  currentState: RegimeState
+  cellColor: string
+}) {
   return (
-    <div className="overflow-x-auto">
+    <div className="rounded-md border p-2">
+      <div className="mb-1 text-xs font-semibold text-gray-800">{title}</div>
+      <div className="mb-2 text-[10px] text-gray-500">{description}</div>
       <table className="min-w-full text-xs">
         <thead>
           <tr className="text-gray-500">
             <th className="px-2 py-1 text-left font-medium">기간</th>
             {STATES.map(s => (
               <th key={s} className="px-2 py-1 text-center font-medium">
-                <span className="inline-flex items-center gap-1">
+                <span className="inline-flex items-center gap-0.5">
                   <span>{REGIME_EMOJI[s]}</span>
                   <span style={{ color: REGIME_COLOR[s] }}>{REGIME_LABEL[s]}</span>
                 </span>
-                <div className="text-[10px] text-gray-400">({REGIME_LABEL_KO[s]})</div>
               </th>
             ))}
           </tr>
         </thead>
         <tbody>
           {HORIZONS.map(h => {
-            const row = (transitions[h] ?? {}) as Record<string, number>
+            const row = (rows[h] ?? {}) as Record<string, number>
             return (
               <tr key={h} className="border-t">
-                <td className="px-2 py-1.5 text-gray-700 font-medium">{h}</td>
+                <td className="px-2 py-1 text-gray-700 font-medium">{h}</td>
                 {STATES.map(s => {
                   const v = row[s]
                   const isCurrent = s === currentState
                   return (
                     <td
                       key={s}
-                      className={`px-2 py-1.5 text-center ${isCurrent ? 'font-semibold' : ''}`}
-                      style={{ background: cellBg(v) }}
+                      className={`px-2 py-1 text-center ${isCurrent ? 'font-semibold' : ''}`}
+                      style={{ background: cellBg(v, cellColor) }}
                     >
                       {pct(v)}
                     </td>
@@ -67,9 +83,45 @@ export default function RegimeTransitionTable({ transitions, currentState }: Pro
           })}
         </tbody>
       </table>
-      <p className="mt-2 text-[11px] text-gray-500">
-        HMM 전이행렬 P^n 기반 — 현재 상태({REGIME_LABEL[currentState]})에서 n일 후 도달 확률
-      </p>
+    </div>
+  )
+}
+
+export default function RegimeTransitionTable({ transitions, reservoirPredictions, currentState }: Props) {
+  const hasReservoir = reservoirPredictions && Object.keys(reservoirPredictions).length > 0
+  const hasHmm = transitions && Object.keys(transitions).length > 0
+
+  return (
+    <div className="space-y-2">
+      {hasHmm && (
+        <MatrixTable
+          title="① HMM Transition Matrix (P^n)"
+          description={`현재 상태(${REGIME_LABEL[currentState]})에서 N일 후 도달 확률 — 통계적 마르코프 전이`}
+          rows={transitions}
+          currentState={currentState}
+          cellColor="rgb(99, 102, 241)"
+        />
+      )}
+      {hasReservoir && (
+        <MatrixTable
+          title="② Reservoir Hypernet N-step 예측 (Sun 2025)"
+          description="시계열 동학 기반 N일 후 라벨 분포 — auto-regressive next-step"
+          rows={reservoirPredictions!}
+          currentState={currentState}
+          cellColor="rgb(16, 185, 129)"
+        />
+      )}
+      {!hasHmm && !hasReservoir && (
+        <div className="rounded border border-dashed border-gray-200 py-4 text-center text-xs text-gray-400">
+          전환 예측 데이터 없음
+        </div>
+      )}
+      {(hasHmm || hasReservoir) && (
+        <p className="text-[10px] text-gray-500">
+          💡 HMM은 통계적 전이행렬 거듭제곱(P^n)으로 안정적, Reservoir는 시계열 동학을 직접 모델링하여 단기 예측에 강점.
+          두 결과가 일치할수록 신뢰도 높음.
+        </p>
+      )}
     </div>
   )
 }

--- a/dental-clinic-manager/src/components/Investment/Regime/types.ts
+++ b/dental-clinic-manager/src/components/Investment/Regime/types.ts
@@ -34,6 +34,23 @@ export interface ModelVote {
   probs: Record<RegimeState, number>
 }
 
+export interface RegimeSignals {
+  ret_20d: number | null
+  vol_60d: number | null
+  vol_median: number | null
+  vix: number | null
+  thresholds?: {
+    crisis_vix: number
+    crisis_ret_20d: number
+    bull_ret_20d: number
+    bear_ret_20d: number
+    bull_vol_ratio: number
+    bear_vol_ratio: number
+  }
+  matched_rule?: RegimeState
+  rules?: { name: string; ok: boolean; actual: string; threshold: string }[]
+}
+
 export interface RegimeRun {
   scope_type: 'market' | 'sector' | 'ticker'
   scope_id: string
@@ -47,5 +64,11 @@ export interface RegimeRun {
     '10d'?: Record<RegimeState, number>
     '30d'?: Record<RegimeState, number>
   }
+  reservoir_predictions?: {
+    '5d'?: Record<RegimeState, number>
+    '10d'?: Record<RegimeState, number>
+    '30d'?: Record<RegimeState, number>
+  } | null
+  signals?: RegimeSignals | null
   data_as_of: string
 }

--- a/dental-clinic-manager/supabase/migrations/20260519_regime_runs_signals_columns.sql
+++ b/dental-clinic-manager/supabase/migrations/20260519_regime_runs_signals_columns.sql
@@ -1,0 +1,14 @@
+-- ============================================
+-- regime_runs.signals + reservoir_predictions 컬럼 추가
+-- Created: 2026-05-19
+--
+-- Part 1 (판단 근거 시각화) + Part 2 (모델 용도 분리) 지원
+--   signals: ret_20d, vol_60d, vix, vol_median, thresholds, matched_rule, rules[]
+--   reservoir_predictions: Reservoir Hypernet N-step ahead label 분포 (5d/10d/30d)
+-- ============================================
+
+ALTER TABLE regime_runs ADD COLUMN IF NOT EXISTS signals JSONB;
+ALTER TABLE regime_runs ADD COLUMN IF NOT EXISTS reservoir_predictions JSONB;
+
+COMMENT ON COLUMN regime_runs.signals IS '국면 판단 근거 (ret_20d, vol_60d, vix, vol_median, 임계값, 매칭된 규칙)';
+COMMENT ON COLUMN regime_runs.reservoir_predictions IS 'Reservoir Hypernet N-step ahead 예측 (5d/10d/30d, label-wise 확률)';


### PR DESCRIPTION
## Summary

사용자 질문에서 출발한 두 가지 개선:

> **\"현재 국면 판단의 기준이 있어?\"** → Part 1: 판단 근거 시각화
> **\"모델 용도별로 구분해서 사용하고 있어?\"** → Part 2: HMM = 전이행렬 / Reservoir = 시계열 예측

## Part 1: 판단 근거 시각화

- \`regime_runs.signals\` (JSONB) 추가: 매 학습 시 마지막 시점 입력값(ret_20d, vol_60d, VIX, vol_median) + 임계값 + 매칭된 규칙 저장
- \`labeling.THRESHOLDS\` 단일 진실 원천 (Crisis VIX>30/수익률<-10%, Bull/Bear ±3% + 변동성 조건)
- \`RegimeSignals\` 컴포넌트: 3개 카드 + 매칭 규칙(✓/✗) + \"분류 규칙 전체 보기\" 펼치기

## Part 2: 모델 용도 분리

| 모델 | 강점 | 현재 활용 |
|---|---|---|
| HMM Voting | 통계적 전이행렬 (P^n) | ✅ 현재 판단 + ✅ 전이행렬 |
| Reservoir Hypernet | **시계열 next-step 예측** | ✅ 현재 판단 + ✅ **N-step ahead 추가** |
| Kernel Markov | 비선형 표현 | ✅ 현재 판단 voting |

- \`predict_nstep_proba()\` auto-regressive 시뮬레이션
- \`RegimeTransitionTable\` 재설계: 두 모델 분리 표시 (HMM 인디고 / Reservoir 에메랄드) + 비교 설명

## Test plan

- [x] KOSPI 검증: 판단 근거 표시 (수익률 +27.68%, 변동성 0.0364 vs 중앙값 0.0116 → bull 미충족)
- [x] 두 모델 견해 차이 명확 (HMM Sideways 100% vs Reservoir Bear 95%)
- [x] 콘솔 에러 0, 빌드 PASS
- [ ] 6 시장 + 22 섹터 다음 일배치 (KST 20:30 launchd) 시 자동 채워짐

🤖 Generated with [Claude Code](https://claude.com/claude-code)