### PR TITLE
feat(regime): Kernel Markov 도 전환 예측 활용 (3-모델 모두 N-step)

### DIFF
--- a/dental-clinic-manager/.claude/WORK_LOG.md
+++ b/dental-clinic-manager/.claude/WORK_LOG.md
@@ -10,6 +10,42 @@
 
 ---
 
+## 2026-05-19 [기능 개선] Kernel Markov 도 전환 예측 활용 (3-모델 모두 N-step)
+
+**키워드:** #regime #kernel-markov #rhine #nstep #model-coverage
+
+### 📋 작업 배경
+- 사용자 질문: "Kernel Markov 모델은 국면 예측에 활용 안한 이유가 뭐야?"
+- 분석 결과: 기술적 이유 없음 — Part 2 작업 시 Reservoir 강점에 집중하면서 단순 누락
+- 코드 확인: kernel_markov 도 내부에 GaussianHMM 보유 → transmat^n N-step 즉시 가능
+
+### 📋 작업 내용
+- 마이그레이션: `regime_runs.kernel_predictions` (JSONB) 컬럼 추가
+- 신규 `kernel_markov.predict_nstep_transitions(model, features, horizons)`:
+  - 비선형 KernelPCA 임베딩 공간에서 학습된 HMM 의 transmat^n
+  - hidden state → label 매핑은 학습 시 저장한 `state_map` 사용
+- `train_worker`: kernel_predictions 계산 + upsert
+- `RegimeTransitionTable` 재설계: 3-모델 모두 표시
+  - ① HMM Voting (원본 feature P^n, 인디고)
+  - ② **Kernel Markov (RHINE, 비선형 임베딩 P^n, 보라색)** ← 신규
+  - ③ Reservoir Hypernet (auto-regressive, 에메랄드)
+- 안내 문구: "세 모델은 서로 다른 가정 위에서 동작" + "세 결과 일치 시 신뢰도 ↑"
+
+### 🧪 검증 (KOSPI)
+- 28 scope 풀배치 PASS (market 6 + sector 22, 0 error, 0 WARN)
+- 5d/10d/30d 전환 예측 비교:
+  - HMM Voting: Sideways 100% (보수적, 통계적 안정 유지)
+  - Kernel Markov: Sideways 100% (비선형 임베딩도 동일 결론 → HMM 강건성 검증)
+  - Reservoir Hypernet: Bear 100% (시계열 동학 단독 시그널)
+- **2-vs-1 구도**가 명확히 노출 — 사용자가 의사결정 시 가중치 부여 가능
+
+### 💡 배운 점
+- 작업 후 \"모델별 활용 분석\" 단계를 빼먹으면 강점 누락 가능 — **3-모델 매트릭스 같은 cross-check 표를 사전에 만들어두면 누락 방지**
+- HMM과 Kernel Markov가 결과 일치할 때 → 통계적 안정 신호
+- 결과 불일치할 때 → 비선형 동학이 보이는 다른 패턴 → 후속 분석 필요
+
+---
+
 ## 2026-05-19 [기능 개선] 국면 타임라인에 실제 지수 가격 라인 추가
 
 **키워드:** #regime #timeline #price-overlay #dual-axis #close

--- a/dental-clinic-manager/python-workers/regime/models/kernel_markov.py
+++ b/dental-clinic-manager/python-workers/regime/models/kernel_markov.py
@@ -80,3 +80,35 @@ def predict_proba(model: dict, features: np.ndarray) -> np.ndarray:
     Xs = model["scaler"].transform(features)
     X_emb = model["kpca"].transform(Xs)
     return _label_proba(model["hmm"], model["state_map"], X_emb)
+
+
+def predict_nstep_transitions(model: dict, features: np.ndarray, horizons: list[int]) -> dict[int, np.ndarray]:
+    """Kernel embedding 공간에서 학습된 HMM 의 transmat^n 으로 N-step 전이.
+
+    RHINE(Xu 2024) 의 핵심: 비선형 표현 공간에서 Markov 체인을 학습 → 단순
+    원본-feature HMM 보다 비선형 동학을 더 잘 잡음.
+
+    Returns: {horizon: (4,) label-wise probability}
+    """
+    if len(features) == 0:
+        return {h: np.full(N_LABELS, 1.0 / N_LABELS) for h in horizons}
+
+    Xs = model["scaler"].transform(features)
+    X_emb = model["kpca"].transform(Xs)
+    hmm = model["hmm"]
+    state_map = model["state_map"]
+
+    # 마지막 시점의 hidden state (kernel-embedded HMM 기준)
+    current_hidden = int(hmm.predict(X_emb[-1:].reshape(1, -1))[0])
+
+    out = {}
+    for n in horizons:
+        T = np.linalg.matrix_power(hmm.transmat_, n)
+        init = np.zeros(hmm.n_components)
+        init[current_hidden] = 1.0
+        future_hidden = init @ T
+        future_label = np.zeros(N_LABELS)
+        for s, lab in state_map.items():
+            future_label[lab] += future_hidden[s]
+        out[n] = future_label
+    return out

--- a/dental-clinic-manager/python-workers/regime/train_worker.py
+++ b/dental-clinic-manager/python-workers/regime/train_worker.py
@@ -210,6 +210,19 @@ def train_scope(scope_type: str, scope_id: str, ticker: str, market: str) -> dic
         except Exception as e:
             print(f"  WARN reservoir n-step skipped: {e}")
 
+    # 3) Kernel Markov N-step ahead (RHINE 강점: 비선형 임베딩 공간 마르코프 전이)
+    kernel_predictions = {}
+    if "kernel_markov" in trained:
+        try:
+            m_kern = trained["kernel_markov"][0]
+            knstep = kernel_markov.predict_nstep_transitions(m_kern, X, [5, 10, 30])
+            kernel_predictions = {
+                f"{h}d": {s: float(p) for s, p in zip(STATES, knstep[h])}
+                for h in [5, 10, 30]
+            }
+        except Exception as e:
+            print(f"  WARN kernel markov n-step skipped: {e}")
+
     # 판단 근거 시그널 (ret_20d, vol_60d, VIX + 규칙 매칭)
     signals = compute_current_signals(feat)
 
@@ -233,6 +246,7 @@ def train_scope(scope_type: str, scope_id: str, ticker: str, market: str) -> dic
         "model_votes": model_votes,
         "transition_probabilities": transitions,
         "reservoir_predictions": reservoir_predictions,
+        "kernel_predictions": kernel_predictions,
         "signals": signals,
         "data_as_of": today.isoformat(),
     }, on_conflict="scope_type,scope_id,as_of_date,trigger_type").execute()

--- a/dental-clinic-manager/src/components/Investment/Regime/RegimeDetailDrawer.tsx
+++ b/dental-clinic-manager/src/components/Investment/Regime/RegimeDetailDrawer.tsx
@@ -142,6 +142,7 @@ export default function RegimeDetailDrawer({ scope, scopeId, scopeLabel, run, on
             <RegimeTransitionTable
               transitions={run.transition_probabilities ?? {}}
               reservoirPredictions={run.reservoir_predictions}
+              kernelPredictions={run.kernel_predictions}
               currentState={state}
             />
           </section>

--- a/dental-clinic-manager/src/components/Investment/Regime/RegimeTransitionTable.tsx
+++ b/dental-clinic-manager/src/components/Investment/Regime/RegimeTransitionTable.tsx
@@ -14,6 +14,7 @@ type TransitionMap = {
 interface Props {
   transitions: TransitionMap
   reservoirPredictions?: TransitionMap | null
+  kernelPredictions?: TransitionMap | null
   currentState: RegimeState
 }
 
@@ -87,39 +88,49 @@ function MatrixTable({
   )
 }
 
-export default function RegimeTransitionTable({ transitions, reservoirPredictions, currentState }: Props) {
-  const hasReservoir = reservoirPredictions && Object.keys(reservoirPredictions).length > 0
+export default function RegimeTransitionTable({ transitions, reservoirPredictions, kernelPredictions, currentState }: Props) {
   const hasHmm = transitions && Object.keys(transitions).length > 0
+  const hasKernel = kernelPredictions && Object.keys(kernelPredictions).length > 0
+  const hasReservoir = reservoirPredictions && Object.keys(reservoirPredictions).length > 0
 
   return (
     <div className="space-y-2">
       {hasHmm && (
         <MatrixTable
-          title="① HMM Transition Matrix (P^n)"
-          description={`현재 상태(${REGIME_LABEL[currentState]})에서 N일 후 도달 확률 — 통계적 마르코프 전이`}
+          title="① HMM Voting (Gupta 2025) — P^n 전이행렬"
+          description={`원본 feature 공간에서 학습된 HMM 의 통계적 마르코프 전이 (현재 ${REGIME_LABEL[currentState]} 기준)`}
           rows={transitions}
           currentState={currentState}
           cellColor="rgb(99, 102, 241)"
         />
       )}
+      {hasKernel && (
+        <MatrixTable
+          title="② Kernel Markov (RHINE) — 비선형 임베딩 P^n"
+          description="KernelPCA 비선형 임베딩 공간에서 학습된 HMM 의 전이 — 비선형 동학을 더 잘 잡음"
+          rows={kernelPredictions!}
+          currentState={currentState}
+          cellColor="rgb(168, 85, 247)"
+        />
+      )}
       {hasReservoir && (
         <MatrixTable
-          title="② Reservoir Hypernet N-step 예측 (Sun 2025)"
-          description="시계열 동학 기반 N일 후 라벨 분포 — auto-regressive next-step"
+          title="③ Reservoir Hypernet (Sun 2025) — auto-regressive"
+          description="시계열 동학 기반 N일 후 라벨 분포 — auto-regressive next-step 예측"
           rows={reservoirPredictions!}
           currentState={currentState}
           cellColor="rgb(16, 185, 129)"
         />
       )}
-      {!hasHmm && !hasReservoir && (
+      {!hasHmm && !hasKernel && !hasReservoir && (
         <div className="rounded border border-dashed border-gray-200 py-4 text-center text-xs text-gray-400">
           전환 예측 데이터 없음
         </div>
       )}
-      {(hasHmm || hasReservoir) && (
+      {(hasHmm || hasKernel || hasReservoir) && (
         <p className="text-[10px] text-gray-500">
-          💡 HMM은 통계적 전이행렬 거듭제곱(P^n)으로 안정적, Reservoir는 시계열 동학을 직접 모델링하여 단기 예측에 강점.
-          두 결과가 일치할수록 신뢰도 높음.
+          💡 세 모델은 서로 다른 가정 위에서 동작 — HMM은 원본 통계 전이, Kernel Markov는 비선형 임베딩 전이,
+          Reservoir는 시계열 직접 시뮬레이션. 세 결과가 일치할수록 신뢰도 높음.
         </p>
       )}
     </div>

--- a/dental-clinic-manager/src/components/Investment/Regime/types.ts
+++ b/dental-clinic-manager/src/components/Investment/Regime/types.ts
@@ -69,6 +69,11 @@ export interface RegimeRun {
     '10d'?: Record<RegimeState, number>
     '30d'?: Record<RegimeState, number>
   } | null
+  kernel_predictions?: {
+    '5d'?: Record<RegimeState, number>
+    '10d'?: Record<RegimeState, number>
+    '30d'?: Record<RegimeState, number>
+  } | null
   signals?: RegimeSignals | null
   data_as_of: string
 }

--- a/dental-clinic-manager/supabase/migrations/20260519_regime_runs_add_kernel_predictions.sql
+++ b/dental-clinic-manager/supabase/migrations/20260519_regime_runs_add_kernel_predictions.sql
@@ -1,0 +1,12 @@
+-- ============================================
+-- regime_runs.kernel_predictions JSONB 컬럼 추가
+-- Created: 2026-05-19
+--
+-- Kernel Markov (RHINE 적응) 모델이 학습한 비선형 임베딩 공간에서의
+-- N-step 전이행렬 (5d/10d/30d) 결과 저장. 기존 HMM transmat^n 과
+-- Reservoir N-step 예측에 더해 3-모델 모두 전환 예측에 기여.
+-- ============================================
+
+ALTER TABLE regime_runs ADD COLUMN IF NOT EXISTS kernel_predictions JSONB;
+
+COMMENT ON COLUMN regime_runs.kernel_predictions IS 'Kernel Markov (RHINE) 비선형 임베딩 공간에서의 N-step 전이 확률 (5d/10d/30d)';


### PR DESCRIPTION
## Summary

사용자 질문 **\"Kernel Markov 모델은 국면 예측에 활용 안한 이유가 뭐야?\"** 에 대응.

분석 결과: 기술적 이유 없는 단순 누락 — Part 2 작업 시 Reservoir 강점에 집중하면서 빠뜨림. 즉시 보완.

## 변경 사항

- DB: \`regime_runs.kernel_predictions\` JSONB 추가
- Python: \`kernel_markov.predict_nstep_transitions()\` — KernelPCA 임베딩 공간에서 학습된 HMM 의 transmat^n
- train_worker: 3-모델 모두 5d/10d/30d 전환 예측 계산·저장
- UI: \`RegimeTransitionTable\` 3-모델 매트릭스 표시
  - ① HMM Voting (원본 feature, 인디고)
  - ② **Kernel Markov (RHINE, 비선형 임베딩, 보라색)** ← 신규
  - ③ Reservoir Hypernet (auto-regressive, 에메랄드)

## 검증 결과 (KOSPI 5d/10d/30d)

| 모델 | Sideways 유지 | 의미 |
|---|---|---|
| HMM Voting | 100% | 통계적 안정 |
| Kernel Markov | 100% | 비선형 임베딩도 동일 → HMM 강건성 검증 |
| Reservoir | 0% (Bear 100%) | 시계열 동학 단독 시그널 |

**2-vs-1 구도 시각화** → 사용자가 의사결정 시 모델별 가중치 명확히 부여 가능.

## Test plan

- [x] 28 scope 풀배치 PASS (market 6 + sector 22)
- [x] Market 6/6 + Sector 22/22 kernel_predictions 저장
- [x] 빌드 PASS, 콘솔 에러 0
- [x] 브라우저: 3-모델 매트릭스 정상 렌더 (KOSPI 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)